### PR TITLE
RT#75883: do not distribute MYMETA.json

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -24,5 +24,5 @@ lib/Devel/Cover/Inc.pm$
 ^bugs/
 .git/
 .tar.bz2$
-^MYMETA.yml$
+^MYMETA.
 tags


### PR DESCRIPTION
The file MYMETA.json is incorrectly included in the distribution. See [RT#75880](https://rt.cpan.org/Ticket/Display.html?id=75883).

This patch fixed the problem by adding MYMETA.\* to MANIFEST.SKIP.
