### PR TITLE
JSON::PP -> JSON

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -164,11 +164,11 @@ Storable is required to store the coverage database.  You can download
 Storable from CPAN.
 EOM
 
-check "JSON::PP", <<EOM;
-JSON::PP is required to store the coverage database in a portable format.
+check "JSON", <<EOM;
+JSON is required to store the coverage database in a portable format.
 This is necessary in order to merge coverage data from incompatible systems.
 Storing the database in a portable format will not be available until you
-install JSON::PP.  In the meantime you may continue to use the rest of
+install JSON.  In the meantime you may continue to use the rest of
 Devel::Cover.
 EOM
 

--- a/lib/Devel/Cover/DB/IO.pm
+++ b/lib/Devel/Cover/DB/IO.pm
@@ -16,11 +16,11 @@ my $Format;
 
 BEGIN
 {
-    $Format = "Storable" if eval "use Storable; 1";
+    $Format = "JSON"     if eval "use JSON; 1";
+    # warn "JSON available\n" if $INC{"JSON.pm"};
+    $Format = "Storable" if !$Format and eval "use Storable; 1";
     # warn "Storable available\n" if $INC{"Storable.pm"};
-    $Format = "JSON"     if eval "use JSON::PP; 1";
-    # warn "JSON::PP available\n" if $INC{"JSON/PP.pm"};
-    die "Can't load either JSON::PP or Storable" unless $Format;
+    die "Can't load either JSON or Storable" unless $Format;
 }
 
 sub new

--- a/lib/Devel/Cover/DB/IO/JSON.pm
+++ b/lib/Devel/Cover/DB/IO/JSON.pm
@@ -11,7 +11,7 @@ use strict;
 use warnings;
 
 use Fcntl ":flock";
-use JSON::PP;
+use JSON;
 
 # VERSION
 
@@ -30,7 +30,7 @@ sub read
     open my $fh, "<", $file or die "Can't open $file: $!";
     flock($fh, LOCK_SH) or die "Cannot lock file: $!\n";
     local $/;
-    my $data = JSON::PP::decode_json(<$fh>);
+    my $data = JSON::decode_json(<$fh>);
     close $fh or die "Can't close $file: $!";
     $data
 }
@@ -40,7 +40,7 @@ sub write
     my $self = shift;
     my ($data, $file) = @_;
 
-    my $json = JSON::PP->new->utf8->allow_blessed;
+    my $json = JSON->new->utf8->allow_blessed;
     $json->ascii->pretty->canonical if $self->{options} =~ /\bpretty\b/i;
     open my $fh, ">", $file or die "Can't open $file: $!";
     flock($fh, LOCK_EX) or die "Cannot lock file: $!\n";


### PR DESCRIPTION
Hi, thanks for the great module - a staple in the Perl QA toolbox indeed. :-)

So recently I've been noticing particularly slow "cover" runs with thousands of to-merge JSON files, and so came up with this patch.

By switching from JSON::PP to JSON.pm, it can use JSON::XS where it's available, and fall back to JSON::PP where it is not. Hope this patch is useful, or at least amusing. :-)

Cheers,
Audrey
