### PR TITLE
protect slashes on windows so `cover -test` won't just make them disappear when they're passed to dmake

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -210,8 +210,10 @@ sub main
         # TODO - make this a little robust
         # system "$^X Makefile.PL" unless -e "Makefile";
         delete_db($dbname, @ARGV);
+        my $env_db_name = $dbname;
+        $env_db_name =~ s/\\/\\\\/g if $^O eq 'MSWin32';
         local $ENV{ -d "t" ? "HARNESS_PERL_SWITCHES" : "PERL5OPT" } =
-            ($ENV{DEVEL_COVER_TEST_OPTS} || "") . " -MDevel::Cover=-db,$dbname";
+            ($ENV{DEVEL_COVER_TEST_OPTS} || "") . " -MDevel::Cover=-db,$env_db_name";
 
         my $test = test_command();
 


### PR DESCRIPTION
On windows `cover -test` results in the cover_db dir being named something like "cpanMoocover_db" when run in D:\cpan\Moo. This is a result of the path being passed on through the ENV and having single backslashes in there, which get evaluated away somewhere. Making them double backslashes fixes things.
