### PR TITLE
fix: respect to $Devel::Cover::Silent

### DIFF
--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -232,6 +232,7 @@ sub digest
         print STDERR "Devel::Cover: Warning: can't open $file " .
                                              "for MD5 digest: $!\n"
             unless lc $file eq "-e" or
+                      $Devel::Cover::Silent or
                       $file =~ $Devel::Cover::DB::Ignore_filenames;
         # require "Cwd"; warn Carp::longmess("in " . Cwd::cwd());
     }


### PR DESCRIPTION
The issue:
without silent

```
Devel::Cover: Warning: can't open blib/lib/Net/SSLeay.pm for MD5 digest: No such file or directory
Devel::Cover: Can't find file "blib/lib/Net/SSLeay.pm" (blib/lib/Net/SSLeay.pm (autosplit into blib/lib/auto/Net/SSLeay/randomize.al)): ignored.
```

with '-silent,1' still

```
Devel::Cover: Warning: can't open blib/lib/Net/SSLeay.pm for MD5 digest: No such file or directory
```

But I do not want to see this :)

BTW the problem may be deeper - do not find correct some files (?)

P.S. Thanks for great module :)
