### PR TITLE
Execute get_magic once, and store the resulting value.

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -416,7 +416,7 @@ static void store_module(pTHX)
     dMY_CXT;
     dSP;
 
-    SvSetSV_nosteal(MY_CXT.module, TOPs);
+    SvSetSV_nosteal(MY_CXT.module, (SV*)newSVpv(SvPV_nolen(TOPs), 0));
     NDEB(D(L, "require %s\n", SvPV_nolen(MY_CXT.module)));
 }
 


### PR DESCRIPTION
This avoids a deep recursion when MY_CXT.module is later accessed as referenced in #78
