### PR TITLE
added line to support spaces in path to dbname.

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -241,6 +241,7 @@ sub main
         delete_db($dbname, @ARGV) unless defined $Options->{delete};
         my $env_db_name = $dbname;
         $env_db_name =~ s/\\/\\\\/g if $^O eq 'MSWin32';
+        $env_db_name =~ s/ /\\ /g;
         my $extra = "";
         $extra .= ",-coverage,$_" for @{$Options->{coverage}};
         $extra .= ",-ignore,$_"


### PR DESCRIPTION
Running "cover -test" would fail to run any tests if there was a space in the path name. I added a line to add a backslash before spaces so that the test could run when there is a space in the path name.
