### PR TITLE
remove dependency on CGI.pm and use HTML::Entities

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Devel::Cover history
 
 {{$NEXT}}
+ - Remove dependency on CGI (use HTML::Entities instead)
 
 Release 1.17 - 20 September 2014
  - Get cpancover to release quality.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -264,12 +264,11 @@ Browser::Open is used to launch a web browser when the -launch flag is specified
 with HTML report formats. You can download Browser::Open from CPAN.
 EOM
 
-check "CGI", <<EOM;
-CGI is used to run the HTML reports.  It used to be a part of the perl core, but
-as of perl 5.20 it will need to be downloaded from CPAN.  If you would like to
-use the HTML report, please install CGI.  Otherwise, other reports will be
-available as usual.  Because HTML reports are expected, GCI has been added to
-the prerequisites.
+check "HTML::Entities", <<EOM;
+HTML::Entities is used to run the HTML reports.  If you would like to use the
+HTML report, please install HTML::Entities.  Otherwise, other reports will be
+available as usual.  Because HTML reports are expected, HTML::Entities has been
+added to the prerequisites.
 EOM
 
 my $latest_tested = "5.020001";
@@ -322,7 +321,7 @@ my $opts = {
     PREREQ_PM        => {
                             Storable      => 0,
                             "Digest::MD5" => 0,
-                            CGI           => 0,
+                            "HTML::Entities" => 3.69,
                             $ENV{DEVEL_COVER_NO_TESTS}
                                 ? ()
                                 : ( "Test::More"  => 0, "Test::Warn"  => 0 )

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -17,7 +17,7 @@ use Devel::Cover::DB;
 use Devel::Cover::Html_Common "launch";
 use Devel::Cover::Web "write_file";
 
-use CGI;
+use HTML::Entities;
 use Getopt::Long;
 use Template 2.00;
 
@@ -291,7 +291,7 @@ sub print_conditions {
     my @types = map
                 {
                     name       => do { my $n = $_; $n =~ s/_/ /g; $n },
-                    headers    => [ map { CGI::escapeHTML($_) }
+                    headers    => [ map { encode_entities($_) }
                                     @{$r{$_}[0]{condition}->headers || []} ],
                     conditions => $r{$_},
                 }, sort keys %r;

--- a/lib/Devel/Cover/Report/Html_minimal.pm
+++ b/lib/Devel/Cover/Report/Html_minimal.pm
@@ -2,7 +2,7 @@ package Devel::Cover::Report::Html_minimal;
 BEGIN {require 5.006}
 use strict;
 use warnings;
-use CGI;
+use HTML::Entities;
 use Getopt::Long;
 use Devel::Cover::DB;
 use Devel::Cover::Html_Common "launch";
@@ -444,7 +444,7 @@ sub escape_HTML {
     my $text = shift;
     chomp $text;
 
-    $text = CGI::escapeHTML($text);
+    $text = encode_entities($text);
 
     # Do not allow FF in text
     $text =~ tr/\x0c//d;

--- a/lib/Devel/Cover/Report/Html_subtle.pm
+++ b/lib/Devel/Cover/Report/Html_subtle.pm
@@ -10,7 +10,7 @@ use Devel::Cover::Truth_Table;
 
 use Getopt::Long;
 use Template 2.00;
-use CGI;
+use HTML::Entities;
 
 my $Template;
 my %Filenames;
@@ -163,7 +163,7 @@ sub print_file {
         my %metric = get_metrics($db, $options, $file_data, $.);
         my %line = (
             number  => $.,
-            text    => CGI::escapeHTML($l),
+            text    => encode_entities($l),
             metrics => [],
         );
         $line{text} =~ s/\t/        /g;
@@ -261,7 +261,7 @@ sub print_branches {
                 class      => cvg_class($b->percentage),
                 parts      => [{text => 'T', class => $tf[0] ? 'covered' : 'uncovered'},
                 {text => 'F', class => $tf[1] ? 'covered' : 'uncovered'}],
-                text       => CGI::escapeHTML($b->text),
+                text       => encode_entities($b->text),
             };
         }
     }
@@ -301,7 +301,7 @@ sub print_conditions {
                 ref        => "line$location",
                 percentage => sprintf("%.0f", $c->[0]->percentage),
                 class      => cvg_class($c->[0]->percentage),
-                condition  => CGI::escapeHTML($c->[1]),
+                condition  => encode_entities($c->[1]),
                 coverage   => $c->[0]->html,
             };
         }


### PR DESCRIPTION
since all we are using CGI for is to encode HTML entities we should
instead use a more specific module to do this: HTML::Entities. so
we don't end up depending on an 8,000 line module for a simple call
(and i'm probably going to refactor CGI.pm to use HTML::Entities
for its escapeHTML function anyway)

---

Well i was hoping this might make a good case-study for converting
a CGI.pm dependency to Template::Toolkit, but it seems the bulk
of the HTML is _already_ using Template::Toolkit and all that is left
of CGI.pm is the call to escapeHTML. So i've replaced that with the
HTML::Entities module and thus removed the CGI.pm dependency

No automated tests here, but looks fine in the browser.
