### PR TITLE
Suggestion documentation improvement.

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1372,8 +1372,8 @@ also add any options you need at this point.  I would suggest adding this as
 early as possible in your startup script in order to collect as much coverage
 information as possible.
 
-Alternatively, add -MDevel::Cover to the parameters for the perl interpreter 
-mod_perl. In this example, Devel::Cover will be operating in silent mode. 
+Alternatively, add -MDevel::Cover to the parameters for mod_perl. 
+In this example, Devel::Cover will be operating in silent mode. 
 
  PerlSwitches -MDevel::Cover=-silent,1
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1372,6 +1372,11 @@ also add any options you need at this point.  I would suggest adding this as
 early as possible in your startup script in order to collect as much coverage
 information as possible.
 
+Alternatively, add -MDevel::Cover to the parameters for the perl interpreter 
+mod_perl. In this example, Devel::Cover will be operating in silent mode. 
+
+ PerlSwitches -MDevel::Cover=-silent,1
+
 =head1 OPTIONS
 
  -blib               - "use blib" and ignore files matching \bt/ (default true


### PR DESCRIPTION
This is how I ended up invoking Devel::Cover to get coverage from mod_perl. Two advantages to this approach: 

* It works (it is the only way I've been able to get coverage from within child processes). 
* You can stick the parameter inside a .conf file that gets included - only when you want to gather coverage information (so, no change to the application itself).

