### PR TITLE
Use Path::Spec->catfile() to fix path separator

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -155,7 +155,8 @@ sub mm_test_command {
 
 # Test command for Module::Build
 sub mb_test_command {
-    my $test = "./Build test";
+    my $builder = File::Spec->catfile(File::Spec->curdir, "Build");
+    my $test = "$builder test";
     if ($Options->{gcov}) {
         my $o = gcov_args();
         $test .= qq{ "--extra_compiler_flags=-O0 $o" "--extra_linker_flags=$o"};


### PR DESCRIPTION
In win32, current `bin/cover' failed as below.
Use Path::Spec->catfile() to fix path separator.

```
cover: running ./Build test "--extra_compiler_flags=-O0 -fprofile-arcs -ftest-coverage" "--extra_linker_flags=-fprofile-arcs -ftest-coverage"
'.' is not recognized as an internal or external command, operable program or batch file.
```
