### PR TITLE
op_sibling deprecated

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -126,6 +126,14 @@ extern "C" {
 }
 #endif
 
+/* op->op_sibling is deprecated on new perls, but the OpSIBLING macro doesn't
+   exist on older perls. We don't need to check for PERL_OP_PARENT here
+   because if PERL_OP_PARENT was set, and we needed to check op_moresib,
+   we would already have this macro. */
+#ifndef OpSIBLING
+#define OpSIBLING(o) (0 + (o)->op_sibling)
+#endif
+
 static double get_elapsed() {
 #ifdef WIN32
     dTHX;

--- a/Cover.xs
+++ b/Cover.xs
@@ -614,9 +614,9 @@ static OP *find_skipped_conditional(pTHX_ OP *o) {
         return NULL;
 
     /* Get to the end of the "a || b || c" block */
-    OP *right = cLOGOP->op_first->op_sibling;
-    while (right && cLOGOPx(right)->op_sibling)
-        right = cLOGOPx(right)->op_sibling;
+    OP *right = OpSIBLING(cLOGOP->op_first);
+    while (right && OpSIBLING(cLOGOPx(right)))
+        right = OpSIBLING(cLOGOPx(right));
 
     if (!right)
         return NULL;
@@ -784,7 +784,7 @@ static void cover_logop(pTHX) {
             (PL_op->op_type == OP_XOR)) {
             /* no short circuit */
 
-            OP *right = cLOGOP->op_first->op_sibling;
+            OP *right = OpSIBLING(cLOGOP->op_first);
 
             NDEB(op_dump(right));
 
@@ -874,7 +874,7 @@ static void cover_logop(pTHX) {
         } else {
             /* short circuit */
 #if PERL_VERSION > 14
-            OP *up = cLOGOP->op_first->op_sibling->op_next;
+            OP *up = OpSIBLING(cLOGOP->op_first)->op_next;
 #if PERL_VERSION > 18
             OP *skipped;
 #endif
@@ -887,7 +887,7 @@ static void cover_logop(pTHX) {
                 add_conditional(aTHX_ up, 3);
                 if (up->op_next == PL_op->op_next)
                     break;
-                up = cLOGOPx(up)->op_first->op_sibling->op_next;
+                up = OpSIBLING(cLOGOPx(up)->op_first)->op_next;
             }
 #endif
             add_conditional(aTHX_ PL_op, 3);


### PR DESCRIPTION
After running into this issue on another module, I did a grep.cpan.me and found that you too are still accessing the struct field op_sibling by name. This means that this module will not build against any perl build with -DPERL_OP_PARENT, which is currently the default in bleadperl.

The attached patch uses the new macro, OpSIBLING, wherever it is available, and provides it where it is not, for back-compatibility. All tests now pass.

This fixes your issue #161 - obviously you're already aware of this, but I figured it's still worth contributing this patch, which is allowing me to build Devel::Cover on my Perl.
