### PR TITLE
Find coverage for all lines of padrange

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -921,14 +921,14 @@ static void cover_padrange(pTHX) {
     dMY_CXT;
     if (!collecting(Statement)) return;
     OP *next = PL_op->op_next;
-    OP *orig = PL_op->op_sibling;
+    OP *orig = OpSIBLING(PL_op);
 
     /* Ignore padrange preparing subroutine call. */
     while (orig && orig != next) {
 	if (orig->op_type == OP_ENTERSUB) return;
 	orig = orig->op_next;
     }
-    orig = PL_op->op_sibling;
+    orig = OpSIBLING(PL_op);
     while (orig && orig != next) {
 	if (orig->op_type == OP_NEXTSTATE) {
 	    cover_statement(aTHX_ orig);

--- a/test_output/cover/padrange.5.010000
+++ b/test_output/cover/padrange.5.010000
@@ -27,7 +27,10 @@ line  err   stmt   bran   cond    sub   code
 7                                       # The latest version of this software should be available from my homepage:
 8                                       # http://www.pjcj.net
 9                                       
-10             1                        my @s;
-11             1                        for (@s) {}
+10             1                        my $a;
+11             1                        my ($b, $c);
+12             1                        my ($d);
+13             1                        my @s;
+14             1                        for (@s) {}
 
 

--- a/tests/padrange
+++ b/tests/padrange
@@ -7,5 +7,8 @@
 # The latest version of this software should be available from my homepage:
 # http://www.pjcj.net
 
+my $a;
+my ($b, $c);
+my ($d);
 my @s;
 for (@s) {}


### PR DESCRIPTION
From perl 5.20, consecutive variable declarations are optimized into a
single OP_PADRANGE. These declarations may span multiple lines.
Until now, coverage was missing for all but the first line.

This is fixed by adding coverage for subsequent lines found from
the original, non optimized version of opcodes.

This fixes issues #129 and #132.
