### PR TITLE
Provide and use OpSIBLING to get at siblings if not provided

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -45,6 +45,14 @@ extern "C" {
 
 #define MY_CXT_KEY "Devel::Cover::_guts" XS_VERSION
 
+#ifndef OpHAS_SIBLING
+#define OpHAS_SIBLING(o)      (cBOOL((o)->op_sibling))
+#endif
+
+#ifndef OpSIBLING
+#define OpSIBLING(o)          (0 + (o)->op_sibling)
+#endif
+
 #define PDEB(a) a
 #define NDEB(a) ;
 #define D PerlIO_printf
@@ -614,9 +622,9 @@ static OP *find_skipped_conditional(pTHX_ OP *o) {
         return NULL;
 
     /* Get to the end of the "a || b || c" block */
-    OP *right = cLOGOP->op_first->op_sibling;
-    while (right && cLOGOPx(right)->op_sibling)
-        right = cLOGOPx(right)->op_sibling;
+    OP *right = OpSIBLING(cLOGOP->op_first);
+    while (right && OpSIBLING(cLOGOPx(right)))
+        right = OpSIBLING(cLOGOPx(right));
 
     if (!right)
         return NULL;
@@ -784,7 +792,7 @@ static void cover_logop(pTHX) {
             (PL_op->op_type == OP_XOR)) {
             /* no short circuit */
 
-            OP *right = cLOGOP->op_first->op_sibling;
+            OP *right = OpSIBLING(cLOGOP->op_first);
 
             NDEB(op_dump(right));
 
@@ -874,7 +882,7 @@ static void cover_logop(pTHX) {
         } else {
             /* short circuit */
 #if PERL_VERSION > 14
-            OP *up = cLOGOP->op_first->op_sibling->op_next;
+            OP *up = OpSIBLING(cLOGOP->op_first)->op_next;
 #if PERL_VERSION > 18
             OP *skipped;
 #endif
@@ -887,7 +895,7 @@ static void cover_logop(pTHX) {
                 add_conditional(aTHX_ up, 3);
                 if (up->op_next == PL_op->op_next)
                     break;
-                up = cLOGOPx(up)->op_first->op_sibling->op_next;
+                up = OpSIBLING(cLOGOPx(up)->op_first)->op_next;
             }
 #endif
             add_conditional(aTHX_ PL_op, 3);


### PR DESCRIPTION
This should allow Devel::Cover to work on all versions of Perl.

On older Perls (<5.25.x?) OpSIBLING() isn't defined so we specify
one that will access ->op_sibling.

On newer Perls with PERL_OP_PARENT set to true (default now),
OpSIBLING() will already exist and point to the correct op->sibparent