### PR TITLE
Fix a typo in the POD.

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1585,7 +1585,7 @@ Both branches may be uncoverable:
     }
 
 If there is an elsif in the branch then it can be addressed as the second
-branch on the line by using the "count" attribute.  Futher elsifs are the third
+branch on the line by using the "count" attribute.  Further elsifs are the third
 and fourth "count" value, and so on:
 
 # uncoverable branch false count:2


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Devel-Cover.
We thought you might be interested in it too.

    Description: Fix a typo in the POD.
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2017-09-30
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libdevel-cover-perl.git/plain/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
