### PR TITLE
Use read+append mode on fh for flock. 

### DIFF
--- a/lib/Devel/Cover/DB/IO/Base.pm
+++ b/lib/Devel/Cover/DB/IO/Base.pm
@@ -23,7 +23,7 @@ sub _lock {
     my $self = shift;
     my ($file, $type) = @_;
     my $lock = "$file.lock";
-    open my $fh, ">>", $lock or die "Can't open $lock: $!\n";
+    open my $fh, "+>>", $lock or die "Can't open $lock: $!\n";
     flock $fh, $type         or die "Can't lock $lock: $!\n";
     $fh
 }


### PR DESCRIPTION
At my workplace our perl interpreter has -Ud_flock and uses a fcntl emulated flock, which cannot do LOCK_SH on file handle without read mode. See also https://perldoc.perl.org/functions/flock.html, which says "Note that the fcntl(2) emulation of flock(3) requires that FILEHANDLE be open with read intent to use LOCK_SH and requires that it be open with write intent to use LOCK_EX.".