### PR TITLE
Provide coverage for .cpp and .hpp files.

### DIFF
--- a/Contributors
+++ b/Contributors
@@ -52,6 +52,7 @@ Heinz Knutzen                  heinz.knutzen@gmail.com
 Helmut Wollmersdorfer          helmut@wollmersdorfer.at
 H.Merijn Brand                 h.m.brand@xs4all.nl
 Ivan Wills                     ivan.wills@gmail.com
+Jacques Germishuys             jacquesg@cpan.org
 James E Keenan                 jkeenan@cpan.org
 Jeff Wren                      jeffrey.wren@paradigm-works.com
 Jim Cromie                     jcromie@cpan.org

--- a/bin/cover
+++ b/bin/cover
@@ -269,7 +269,7 @@ sub main {
         # touch the XS, C and H files so they rebuild
         if ($Options->{gcov}) {
             my $t = $] > 5.7 ? undef : time;
-            my $xs = sub { utime $t, $t, $_ if /\.(xs|cc?|hh?)$/ };
+            my $xs = sub { utime $t, $t, $_ if /\.(xs|cc?|cpp|hh?|hpp)$/ };
             File::Find::find({ wanted => $xs, no_chdir => 0 }, ".");
         }
         # print STDERR "$_: $ENV{$_}\n" for qw(PERL5OPT HARNESS_PERL_SWITCHES);


### PR DESCRIPTION
Currently the only way to get coverage for C++ files is to make use of a ```.cc``` extension, which is not always possible.