### PR TITLE
Optionally use Term::Size instead of guessing 80 columns

### DIFF
--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -409,7 +409,7 @@ sub print_summary {
             : "n/a"
     };
 
-    my $fw = ( CAN_TERM_SIZE ? ( Term::Size::chars \*STDOUT )[0] : 80 ) - $n * 7 - 3;
+    my $fw = ( CAN_TERM_SIZE && -t STDOUT ? ( Term::Size::chars \*STDOUT )[0] : 80 ) - $n * 7 - 3;
     $fw = 28 if $fw < 28;
 
     no warnings "uninitialized";

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -23,6 +23,8 @@ use File::Path;
 
 use Devel::Cover::Dumper;  # For debugging
 
+use constant CAN_TERM_SIZE => eval { require Term::Size };
+
 my $DB = "cover.14";  # Version of the database
 
 @Devel::Cover::DB::Criteria =
@@ -407,7 +409,7 @@ sub print_summary {
             : "n/a"
     };
 
-    my $fw = 77 - $n * 7;
+    my $fw = ( CAN_TERM_SIZE ? ( Term::Size::chars \*STDOUT )[0] : 77 ) - $n * 7;
     $fw = 28 if $fw < 28;
 
     no warnings "uninitialized";

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -409,7 +409,7 @@ sub print_summary {
             : "n/a"
     };
 
-    my $fw = ( CAN_TERM_SIZE ? ( Term::Size::chars \*STDOUT )[0] : 77 ) - $n * 7;
+    my $fw = ( CAN_TERM_SIZE ? ( Term::Size::chars \*STDOUT )[0] : 80 ) - $n * 7 - 3;
     $fw = 28 if $fw < 28;
 
     no warnings "uninitialized";


### PR DESCRIPTION
This helps when your filenames are long, and you try to use a wider terminal to actually see them in the summary.

This change adds no new required dependencies, it simply optionally uses `Term::Size` if it happens to be available, otherwise falling back on prior behaviour.