### PR TITLE
Don't chdir when given a -dir flag

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Devel::Cover history
 
 {{$NEXT}}
  - Minimum supported version is now 5.10.0 (Karen Etheridge) (github 226)
+ - Don't chdir when given a -dir flag (Dave Rolsky) (github 253)
 
 Release 1.33 - 26 April 2019
  - Fix pod error (Mohammad S Anwar) (github 240)

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -342,11 +342,11 @@ sub import {
 
     if (defined $Dir) {
         $Dir = $1 if $Dir =~ /(.*)/;  # Die tainting
-        chdir $Dir or die __PACKAGE__ . ": Can't chdir $Dir: $!\n";
     } else {
         $Dir = $1 if Cwd::getcwd() =~ /(.*)/;
     }
 
+    $DB = File::Spec->catdir($Dir, $DB);
     unless (mkdir $DB) {
         die "Can't mkdir $DB: $!" unless -d $DB;
     }


### PR DESCRIPTION
Changing the current working directory can easily break test code which
expects the current directory to be the root of a project/repo.