### PR TITLE
Add cover flags to handle XS in subdirectories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Adding tests
+
+The tests found in the CPAN distribution in `t/e2e` are generated
+from the files in `tests/`. Such generating then also needs a file in
+`test_output/cover/` to be created using the `create_gold` utility. One
+way to iterate this:
+
+```sh
+# can set vars just once, obviously
+PERLVER=$(perl -e 'print $]')
+NEWTEST=circular_ref
+make gold TEST=$NEWTEST && mv test_output/cover/$NEWTEST.$PERLVER test_output/cover/$NEWTEST.5.010000 && make test TEST_FILES=t/e2e/a$NEWTEST.t
+```
+
+The `e2e` files get generated from `tests` by `perl Makefile.PL`.

--- a/bin/cover
+++ b/bin/cover
@@ -36,6 +36,7 @@ use Data::Dumper ();  # no import of Dumper (use Devel::Cover::Dumper if needed)
 my $Options = {
     add_uncoverable_point    => [],
     annotation               => [],
+    gcov_chdir               => 0,
     coverage                 => [],
     delete                   => undef,
     delete_uncoverable_point => [],
@@ -67,6 +68,7 @@ sub get_options {
                    qw(
                        add_uncoverable_point=s
                        annotation=s
+                       gcov_chdir!
                        clean_uncoverable_points!
                        coverage=s
                        delete!
@@ -301,11 +303,12 @@ sub main {
             return unless -e $graph_file;
             my $gcov_flags = "-abc";
             $gcov_flags .= "r" if $Options->{relative_only};
-            my @c = ("gcov", $gcov_flags, "-o", $File::Find::dir, $name);
+            my @args = $Options->{gcov_chdir} ? () : ("-o", $File::Find::dir);
+            my @c = ("gcov", $gcov_flags, @args, $name);
             print STDERR "cover: running @c\n";
             system @c;
         };
-        File::Find::find({ wanted => $gc, no_chdir => 1 }, ".");
+        File::Find::find({ wanted => $gc, no_chdir => !$Options->{gcov_chdir} }, ".");
         my @gc;
         my $gp = sub {
             return unless /\.gcov$/;
@@ -494,6 +497,7 @@ The following command line options are supported:
  -select_re RE         - append to REs of files to select   (default none)
  -ignore_re RE         - append to REs of files to ignore   (default none)
  -relative_only        - for XS, ignore absolute paths      (default off)
+ -gcov_chdir           - for XS, run gcov in subdirs        (default off)
  -write [db]           - write the merged database          (default off)
  -delete               - drop database(s)                   (default off)
  -dump_db              - dump database(s) (for debugging)   (default off)
@@ -604,7 +608,9 @@ in recent Perl distributions.
 
 The C<-gcov> option will try to run gcov on any XS code.  This requires that
 you are using gcc of course.  If you are using the C<-test> option will be
-turned on by default.
+turned on by default. If you have XS code in subdirectories, you will
+probably need to add the C<-gcov_chdir> option since gcov seems to work
+better with that.
 
 The C<-prefer_lib> option tells Devel::Cover to report on files in the lib
 directory even if they were used from the blib directory.

--- a/bin/cover
+++ b/bin/cover
@@ -45,6 +45,7 @@ my $Options = {
     launch                   => 0,
     make                     => $Config{make},
     prefer_lib               => 0,
+    relative_only            => 0,
     report                   => [],
     report_c0                => 75,
     report_c1                => 90,
@@ -80,6 +81,7 @@ sub get_options {
                        make=s
                        outputdir=s
                        prefer_lib!
+                       relative_only!
                        report_c0=s
                        report_c1=s
                        report_c2=s
@@ -297,8 +299,9 @@ sub main {
             my $graph_file = $_;
             $graph_file =~ s{\.\w+$}{.gcno};
             return unless -e $graph_file;
-
-            my @c = ("gcov", "-abc", "-o", $File::Find::dir, $name);
+            my $gcov_flags = "-abc";
+            $gcov_flags .= "r" if $Options->{relative_only};
+            my @c = ("gcov", $gcov_flags, "-o", $File::Find::dir, $name);
             print STDERR "cover: running @c\n";
             system @c;
         };
@@ -490,6 +493,7 @@ The following command line options are supported:
  -ignore filename      - don't report on the file           (default none)
  -select_re RE         - append to REs of files to select   (default none)
  -ignore_re RE         - append to REs of files to ignore   (default none)
+ -relative_only        - for XS, ignore absolute paths      (default off)
  -write [db]           - write the merged database          (default off)
  -delete               - drop database(s)                   (default off)
  -dump_db              - dump database(s) (for debugging)   (default off)


### PR DESCRIPTION
As discussed in, and fixes #239: XS in subdirectories doesn't work well with `cover`. By making the `no_chdir` behaviour for `File::Find`-ing the `*.gc*` files controllable (and adjusting slightly when it's disabled) seems to solve the problem, generating plausible coverage for the nearly-pathologically deeply structured PDL.

Also a `-relative_only` flag has been added, to enable using `gcov`'s flag to ignore files with absolute paths (typically `/.../CORE/inline.h`) rather than needing to add complex REs to achieve that.