### PR TITLE
Allow to mark more than one statement uncoverable

### DIFF
--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -684,14 +684,18 @@ sub uncoverable_comments {
                     }
                 }
             }
-            $count = $1 if $info =~ /count:(\d+)/;
+            # e.g.: count:1 | count:2,5 | count:1,4..7
+            $count = $1 if $info =~ /count:(\d+(?:\.\.\d+)?(?:,\d+(?:\.\.\d+)?)*)/;
+            my @counts = map { m/^(\d+)\.\.(\d+)$/ ? ($1 .. $2) : $_ } split m/,/, $count;
             $class = $1 if $info =~ /class:(\w+)/;
             $note  = $1 if $info =~ /note:(.+)/;
 
             # no warnings "uninitialized";
             # warn "pushing $criterion, $count, $type, $class, $note";
 
-            push @waiting, [$criterion, $count - 1, $type, $class, $note];
+            for my $c (@counts) {
+                push @waiting, [$criterion, $c - 1, $type, $class, $note];
+            }
 
             next unless $code =~ /\S/;
         }


### PR DESCRIPTION
Examples:

    # uncoverable statement count:1
    # uncoverable statement count:1 count:2,5
    # uncoverable statement count:1 count:1,4..7

This can be handy especially for subroutine signatures, where
a signature for two parameters results in 4 statements

Not sure where to add a test for this, though.

Issue: #287