### PR TITLE
fix call counts in overloads for newer perls

### DIFF
--- a/test_output/cover/overload_bool2.5.037001
+++ b/test_output/cover/overload_bool2.5.037001
@@ -1,0 +1,64 @@
+Reading database from ...
+
+
+-------------------- ------ ------ ------ ------ ------
+File                   stmt   bran   cond    sub  total
+-------------------- ------ ------ ------ ------ ------
+tests/overload_bool2   93.3    n/a    n/a  100.0   94.7
+Total                  93.3    n/a    n/a  100.0   94.7
+-------------------- ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/overload_bool2
+
+line  err   stmt   bran   cond    sub   code
+1                                       #!/usr/bin/perl
+2                                       
+3                                       # Copyright 2014-2022, Paul Johnson (paul@pjcj.net)
+4                                       
+5                                       # This software is free.  It is licensed under the same terms as Perl itself.
+6                                       
+7                                       # The latest version of this software should be available from my homepage:
+8                                       # http://www.pjcj.net
+9                                       
+10             1                    1   use strict;
+               1                        
+               1                        
+11             1                    1   use warnings;
+               1                        
+               1                        
+12                                      
+13                                      {
+14    ***      0                            package Cat;
+15                                      
+16             1                    1       use overload (bool => "meh");
+               1                        
+               1                        
+17                                      
+18             2                    2       sub meh { 1 }
+19                                      }
+20                                      
+21             1                        my $string = "hi";
+               1                        
+22             1                        my $x = bless \$string, "Cat";
+23                                      
+24             1                        my $fn = eval 'require $x';
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count Location               
+---------- ----- -----------------------
+BEGIN          1 tests/overload_bool2:10
+BEGIN          1 tests/overload_bool2:11
+BEGIN          1 tests/overload_bool2:16
+meh            2 tests/overload_bool2:18
+
+


### PR DESCRIPTION
The call counts for overloads are based on what perl does internally,
which has changed in some cases in new perl. Create a new output file
reflecting the new call counts.