### PR TITLE
Fix infinite-recursion with Type::Tiny / Function::Parameters

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -969,14 +969,14 @@ sub add_condition_cover {
 *is_state       = \&B::Deparse::is_state;
 *is_ifelse_cont = \&B::Deparse::is_ifelse_cont;
 
-{
-
 my %Original;
+{
 BEGIN {
     $Original{deparse}      = \&B::Deparse::deparse;
     $Original{logop}        = \&B::Deparse::logop;
     $Original{logassignop}  = \&B::Deparse::logassignop;
     $Original{const_dumper} = \&B::Deparse::const_dumper;
+    $Original{const} = \&B::Deparse::const if defined &B::Deparse::const;
 }
 
 sub const_dumper {
@@ -985,8 +985,18 @@ sub const_dumper {
     local *B::Deparse::logop        = $Original{logop};
     local *B::Deparse::logassignop  = $Original{logassignop};
     local *B::Deparse::const_dumper = $Original{const_dumper};
+    local *B::Deparse::const        = $Original{const} if $Original{const};
 
     $Original{const_dumper}->(@_);
+}
+
+sub const {
+    no warnings "redefine";
+    local *B::Deparse::deparse      = $Original{deparse};
+    local *B::Deparse::logop        = $Original{logop};
+    local *B::Deparse::logassignop  = $Original{logassignop};
+    local *B::Deparse::const_dumper = $Original{const_dumper};
+    $Original{const}->(@_);
 }
 
 sub deparse {
@@ -1254,6 +1264,7 @@ sub get_cover {
     local *B::Deparse::logop        = \&logop;
     local *B::Deparse::logassignop  = \&logassignop;
     local *B::Deparse::const_dumper = \&const_dumper;
+    local *B::Deparse::const        = \&const if $Original{const};
 
     my $de = @_ && ref $_[0]
                  ? $deparse->deparse($_[0], 0)


### PR DESCRIPTION
Since 5b9c14aabebb324554f8281a6648161ed7dc253a, using Devel::Cover with GraphQL causes an infinite recursion. This PR fixes that by adding `B::Deparse::const` to the saved subs.

I suspect this is due to using Type::Tiny or Function::Parameters, but I don't know why.

Found using (after identifying that 1.36 worked fine, and the latest (1.38) didn't):

```
git bisect start
git bisect good v1.36
# iterating:
make; make; (cd ../graphql-perl/ && perl -Mblib=../Devel--Cover -MDevel::Cover=-db,cover_db -Mblib t/directives.t) && git bisect good || git bisect bad
```