### PR TITLE
Only report progress with interactive terminal

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1276,11 +1276,15 @@ sub _report_progress {
     my ($old_pipe, $n, $start) = ($|, 0, time);
     $|++;
     print OUT __PACKAGE__, ": $msg\n";
+    my $is_interactive = -t *OUT;
     for (@items) {
-        $prog->($n++);
+        $prog->($n++)
+            if $is_interactive;
         $code->($_);
     }
     $prog->($n || 1);
+    print OUT "\r" . __PACKAGE__ . ": Done "
+        if !$is_interactive;
     print OUT "- " . (time - $start) . "s taken\n";
     $| = $old_pipe;
 }

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1283,7 +1283,7 @@ sub _report_progress {
         $code->($_);
     }
     $prog->($n || 1);
-    print OUT "\r" . __PACKAGE__ . ": Done "
+    print OUT __PACKAGE__ . ": Done "
         if !$is_interactive;
     print OUT "- " . (time - $start) . "s taken\n";
     $| = $old_pipe;


### PR DESCRIPTION
When redirecting output of coverage collection to a file, this avoids recording hundreds of instances of "\rDevel::Cover: _N_%".