### PR TITLE
use CPAN::Meta for reading MYMETA.json

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -398,9 +398,8 @@ sub populate_run {
     my $mymeta = "$Dir/MYMETA.json";
     if (-e $mymeta) {
         eval {
-            require Devel::Cover::DB::IO::JSON;
-            my $io   = Devel::Cover::DB::IO::JSON->new;
-            my $json = $io->read($mymeta);
+            require CPAN::Meta;
+            my $json = CPAN::Meta->load_file($mymeta)->as_struct;
             $Run{$_} = $json->{$_} for qw( name version abstract );
         }
     } elsif ($Dir =~ m|.*/([^/]+)$|) {


### PR DESCRIPTION
Rationale for this change: by using Devel::Cover::DB::IO::JSON for reading MYMETA.json a MYMETA.json.lock is created and not removed, thus leaving an unclean directory (unclean for git or for "make distcheck"). Probably it is better anyway to use the core module CPAN::Meta which exactly exists for the purpose of reading META/MYMETA files.

CPAN::Meta is a core perl module since perl 5.14. For perls earlier than 5.14 CPAN::Meta would be needed to installed from CPAN. I have the assumption that reading the MYMETA.json information is kind of optional, so I did not add a PREREQ_PM dependency for older perls. If I am wrong, then this should be done.

This patch addresses my comment https://github.com/pjcj/Devel--Cover/issues/263#issuecomment-792797781
However, it is unclear if the original issue author was also stumbling over the MYMETA.json.lock files, or whether lock files for the database json files were problematic for her/him.
