### PR TITLE
github workflows: allow failure when installing optional deps with older perls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
         run: |
           cpanm --notest --installdeps .
       - name: Install optional Perl deps
+        # for example Test::Deep is not installable anymore for older perls
+        continue-on-error: ${{ matrix.perl < 5.12 }}
         run: |
           # for database format
           cpanm --notest Sereal
@@ -68,6 +70,8 @@ jobs:
           cpanm --notest DBM::Deep Readonly Moose
 
       - name: Install Perl recommend deps
+        # for example Test::Deep is not installable anymore for older perls
+        continue-on-error: ${{ matrix.perl < 5.12 }}
         run:
           cpanm --notest
             Template


### PR DESCRIPTION
Test::Deep requires now at least 5.12 and is a dependency for some of the optional and recommended modules, which means that the github workflow started to fail for older perls. Fixed this by using a "continue-on-error" specification. Alternatively "if" could be used to skip the installations completely.