### PR TITLE
Restore split token used in 'html_basic' report

### DIFF
--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -101,7 +101,7 @@ sub _highlight_ppi {
     my $highlight = PPI::HTML->new(line_numbers => 1);
     my $pretty    = $highlight->html($document);
 
-    my $split     = '<span class                ="line_number">';
+    my $split     = '<span class="line_number">';
 
     no warnings "uninitialized";
 


### PR DESCRIPTION
Fixes #270 

Regression from f6ac419. When the whitespace of Devel::Cover::Reporter::Html_basic was cleaned up, whitespace was added to the token used in the 'split' calls below it. The PPI::HTML document no longer parsed correctly.

Removing the spaces between the word 'class' and the '=' in the $split string fixes the issue.