### PR TITLE
don't include dzil's .build dir in dist

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -28,3 +28,4 @@ MYMETA\.
 tags
 .perl-version
 \.db
+^\.build\b

--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,7 @@ run = perl Makefile.PL      ; needed for VersionFromScript above
 
 [GatherDir]                 ; gather files from the dist dir
 include_dotfiles = 1
+prune_directory = ^\.build$
 [ManifestSkip]              ; remove gathered files specified by MANIFEST.SKIP
 [ExecDir]                   ; mark bin as the dir to contain scripts
 [OurPkgVersion]             ; add versions to the packages


### PR DESCRIPTION
Adding .build to both prune_directory and MANIFEST.SKIP is redundant, but seems safer. Most of the existing removals are already in MANIFEST.SKIP, but using prune_directory will make builds faster by avoiding collecting the files to begin with.