### PR TITLE
Add DEVEL_COVER_USE_HARNESS_VAR to use HARNESS_PERL_SWITCHES not PERL5OPT

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -271,7 +271,7 @@ sub main {
 
         $Options->{$_} = [] for qw( ignore ignoring select select_re );
 
-        local $ENV{ -d "t" ? "HARNESS_PERL_SWITCHES" : "PERL5OPT" } =
+        local $ENV{ (-d "t" || $ENV{DEVEL_COVER_USE_HARNESS_VAR}) ? "HARNESS_PERL_SWITCHES" : "PERL5OPT" } =
             ($ENV{DEVEL_COVER_TEST_OPTS} || "") .
             " -MDevel::Cover=-db,$env_db_name$extra";
 


### PR DESCRIPTION
PDL is changing its directory layout, especially moving its `t` directory into a subdirectory. Its CI uses local::lib, meaning its tests need to not lose its environment.

Together this creates a problem, where `bin/cover` is now setting `PERL5OPT`, which leads to coverage tests repeatedly saying:

```
  make[2]: Entering directory '/home/runner/work/pdl/pdl/Basic/IO-Misc'
  "/opt/hostedtoolcache/perl/5.30.3/x64/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- Misc.bs ../../blib/arch/auto/PDL/IO/Misc/Misc.bs 644
  PERL_DL_NONLAZY=1 "/opt/hostedtoolcache/perl/5.30.3/x64/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, '../../blib/lib', '../../blib/arch')" t/*.t
  Can't locate Devel/Cover.pm in @INC (you may need to install the Devel::Cover module) (@INC contains: /opt/hostedtoolcache/perl/5.30.3/x64/lib/site_perl/5.30.3/x86_64-linux /opt/hostedtoolcache/perl/5.30.3/x64/lib/site_perl/5.30.3 /opt/hostedtoolcache/perl/5.30.3/x64/lib/5.30.3/x86_64-linux /opt/hostedtoolcache/perl/5.30.3/x64/lib/5.30.3 .).
  BEGIN failed--compilation aborted.
  t/misc.t .. ok
  All tests successful.
  Files=1, Tests=47,  0 wallclock secs ( 0.01 usr  0.01 sys +  0.44 cusr  0.07 csys =  0.53 CPU)
```

I don't know why it continues and passes despite that, but it's clearly not right. This PR creates an environment variable that allows behaving as if there were a `t` directory. I'm happy to adjust it, and document it, but this makes it go from noise to not that.

This came to my attention because another layout-related change has suddenly made Devel::Cover start imposing boolean context, possibly in the context of `//`, which is a problem I've worked around in the past, but will investigate a bit more properly this time.