### PR TITLE
Fix bug affecting outputdir option

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -270,8 +270,8 @@ sub get_dbname {
     delete_db($dbname, @ARGV);
     exit 0
   }
-  $Options->{outputdir} //= $dbname
-
+  $Options->{outputdir} //= $dbname;
+  return $dbname;
 }
 
 sub check_outputdir {


### PR DESCRIPTION
As mentioned in https://github.com/pjcj/Devel--Cover/issues/356 the `--outputdir` incorrectly overrides the db directory. The breaking change was made in https://github.com/pjcj/Devel--Cover/commit/209273bbc10e4151a0f4d2104bda4d41bbd35c5d.

The problem is that the `get_dbname` subroutine evaluates to `$Options->{outputdir}` when that is set, incorrectly returning the name of the output directory as the database name. This PR just adds a line to explicitly return the `$dbname` instead.