### PR TITLE
GH-375 Skip ticket checks on main branch

### DIFF
--- a/utils/commit-msg-hook
+++ b/utils/commit-msg-hook
@@ -86,6 +86,14 @@ my $Blocklist = join "|", @Blocklist;
 $Blocklist = qr/^(?:$Blocklist)\b/i;
 my @Errors;
 
+sub get_current_branch {
+  my $branch = `git rev-parse --abbrev-ref HEAD 2>/dev/null` // "";
+  chomp $branch;
+  $branch
+}
+
+sub on_main { get_current_branch eq "main" }
+
 sub check_line_endings ($msg) {
   my $n = 1;
   for my $m (@$msg) {
@@ -100,6 +108,7 @@ sub check_line_endings ($msg) {
 sub check_beginning ($msg) {
   return unless @$msg;
 
+  my $main  = on_main;
   my $l     = shift @$msg;
   my $merge = $l =~ /^Merge branch /;
   push @Errors, [ "Line 1 is longer than 50 characters", $l ]
@@ -108,7 +117,7 @@ sub check_beginning ($msg) {
     if !$merge && $l =~ /[-#]\w?(?:\d{3,})/;
   push @Errors,
     [ "Merge should reference ticket rather than full branch name", $l ]
-    if $merge && $l !~ /'[A-Z]{2,8}-\d+'/;
+    if !$main && $merge && $l !~ /'[A-Z]{2,8}-\d+'/;
   my $start = substr($l, 0, 1) // "";
   push @Errors, [ "Line 1 does not start with an expected character", $l ]
     if $start !~ /\w/;
@@ -125,7 +134,7 @@ sub check_beginning ($msg) {
 
   my $l3 = $msg->[1] // "";
   push @Errors, [ "Line 3 does not reference ticket id", $l3 ]
-    if !$merge && $l3 !~ /^Ticket [A-Z]{2,8}-\d+$/;
+    if !$main && !$merge && $l3 !~ /^Ticket [A-Z]{2,8}-\d+$/;
 }
 
 sub check_end ($msg) {

--- a/utils/commit-msg-hook
+++ b/utils/commit-msg-hook
@@ -14,6 +14,7 @@ my $Version = "1.00";
 
 $|++;
 
+#<<<
 my @Blocklist = (qw(
   adapts     adapting     adapted
   adds       adding       added
@@ -79,6 +80,7 @@ my @Blocklist = (qw(
   updates    updating     updated
   uses       using        used
 ));  # adapted from https://github.com/m1foley/fit-commit
+#>>>
 
 my $Blocklist = join "|", @Blocklist;
 $Blocklist = qr/^(?:$Blocklist)\b/i;

--- a/utils/commit-msg-hook
+++ b/utils/commit-msg-hook
@@ -5,10 +5,10 @@
 
 use 5.28.0;
 use warnings;
-use warnings FATAL => qw( utf8 recursion   );
-use experimental qw( signatures       );
-use open         qw( :encoding(UTF-8) );
-use feature      qw( unicode_strings  );
+use warnings FATAL => qw( utf8 recursion );
+use experimental "signatures";
+use open ":encoding(UTF-8)";
+use feature "unicode_strings";
 
 my $Version = "1.00";
 

--- a/utils/prepare-commit-msg-hook
+++ b/utils/prepare-commit-msg-hook
@@ -18,9 +18,8 @@ sub get_current_branch {
   $branch
 }
 
-sub get_ticket {
-  get_current_branch =~ /^([A-Z]{2,8}-\d+)/ ? $1 : "GH-XXXXX"
-}
+sub on_main    { get_current_branch eq "main" }
+sub get_ticket { get_current_branch =~ /^([A-Z]{2,8}-\d+)/ ? $1 : "GH-XXXXX" }
 
 sub main {
   my ($file, $type) = @ARGV;
@@ -28,7 +27,8 @@ sub main {
 
   return 0 if $type !~ /^(?:|message|template|merge)$/;
 
-  my $ticket = get_ticket();
+  my $main   = on_main;
+  my $ticket = get_ticket;
   my ($seen_ticket, $seen_scissors);
 
   local ($^I, @ARGV) = ("", $file);
@@ -39,15 +39,17 @@ sub main {
       $line =~ s/^(Merge branch ')([A-Z]{2,8}-\d+).*/$1$2'/;
       say "" if $. == 2 && $line ne "";
     } else {
-      if ($. == 1 && $line eq "") {
-        say "\n\nTicket $ticket\n";
-        $seen_ticket = 1;
-        next;
-      }
-      if ($. == 3 && !$seen_ticket) {
-        $seen_ticket = 1;
-        unless ($line =~ /^Ticket [A-Z]{2,8}-\d+$/) {
-          say "Ticket $ticket\n";
+      if (!$main) {
+        if ($. == 1 && $line eq "") {
+          say "\n\nTicket $ticket\n";
+          $seen_ticket = 1;
+          next;
+        }
+        if ($. == 3 && !$seen_ticket) {
+          $seen_ticket = 1;
+          unless ($line =~ /^Ticket [A-Z]{2,8}-\d+$/) {
+            say "Ticket $ticket\n";
+          }
         }
       }
       $seen_scissors = 1
@@ -57,7 +59,7 @@ sub main {
     say $line;
 
     if (eof) {
-      say "\nTicket $ticket" if $type ne "merge" && !$seen_ticket;
+      say "\nTicket $ticket" if !$main && $type ne "merge" && !$seen_ticket;
       say "#\n# *** HINT ***\n",
         "# Add the -v option to git commit to see your changes here\n",
         '# or run "git config --global commit.verbose true".'

--- a/utils/prepare-commit-msg-hook
+++ b/utils/prepare-commit-msg-hook
@@ -5,10 +5,10 @@
 
 use 5.28.0;
 use warnings;
-use warnings FATAL => qw( utf8 recursion   );
-use experimental qw( signatures       );
-use open         qw( :encoding(UTF-8) );
-use feature      qw( unicode_strings  );
+use warnings FATAL => qw( utf8 recursion );
+use experimental "signatures";
+use open ":encoding(UTF-8)";
+use feature "unicode_strings";
 
 $|++;
 


### PR DESCRIPTION
## Summary

The prepare-commit-msg and commit-msg hooks assume every commit is
made on a feature branch with a `GH-XXXXX` naming convention. When
committing directly on main (e.g. version bumps, changelog updates),
the prepare-commit-msg hook injects a spurious "Ticket GH-XXXXX"
line and the commit-msg hook warns about a missing ticket reference.
Both behaviours are now skipped when the current branch is main.

## Changes

- Add `on_main` helper to both hooks, returning true when the
  current branch is `main`.
- Guard all ticket-injection paths in prepare-commit-msg with
  `!$main` so no ticket line is added on main.
- Skip the "line 3 does not reference ticket id" and "merge should
  reference ticket" checks in commit-msg on main.
- Wrap the blocklist array with `#<<<`/`#>>>` to preserve its
  three-column formatting from perltidy.

## Implications

- All non-ticket checks (line length, imperative tense,
  capitalisation) still apply on main.
- Feature branches are completely unaffected.

## Issue

Closes #375