### PR TITLE
GH-377 Add cpancover-docker-pull recipe

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Add cpancover-docker-pull recipe (GH-377)
 - Fix spelling: led (Josh Soref) (GH-368)
 
 1.52 - 7 March 2026

--- a/docker/README.md
+++ b/docker/README.md
@@ -56,7 +56,7 @@ The system builds Docker images in layers, each building upon the previous:
   - Essential CPAN modules for cpancover operation
   - Compression tools (pigz)
 
-#### devel-cover-dc (Development Cover)
+#### devel-cover-dc (Devel::Cover code)
 
 - Base: devel-cover-base:latest
 - Two variants:

--- a/docker/README.md
+++ b/docker/README.md
@@ -314,6 +314,9 @@ This provides:
 
    # Remove all cpancover containers
    utils/dc cpancover-docker-rm
+
+   # Pull latest image from Docker Hub
+   utils/dc cpancover-docker-pull
    ```
 
    **Important**: Use `-e dev` for development containers:
@@ -564,7 +567,7 @@ dc -e dev cpancover-controller-test
 dc docker-build
 
 # 3. On production server, pull new image
-docker pull pjcj/cpancover:latest
+dc cpancover-docker-pull
 
 # 4. Restart coverage runs
 # (Stop existing controller first)

--- a/utils/dc
+++ b/utils/dc
@@ -303,6 +303,14 @@ recipe_cpancover-docker-rm-image() {
   $docker rmi "$docker_image"
 }
 
+cpancover_docker_pull() {
+  $docker pull "$docker_image"
+}
+
+recipe_cpancover-docker-pull() {
+  cpancover_docker_pull
+}
+
 recipe_docker-build() {
   local build="$srcdir/../docker/BUILD"
   "$build" -e "$env" "${args[@]:+${args[@]}}"


### PR DESCRIPTION
## Summary

Add a `cpancover-docker-pull` recipe to the `dc` script so that pulling
the latest Docker image on the production server uses the same `dc`
interface as the other `cpancover-docker-*` commands, and respects the
`-e dev`/prod environment flag.

## Changes

- Add `cpancover_docker_pull` function and `recipe_cpancover-docker-pull`
  wrapper in `utils/dc`
- Update `docker/README.md` to reference `dc cpancover-docker-pull` in
  the container operations and production image update sections
- Clarify devel-cover-dc section heading in `docker/README.md`

## Implications

None — additive change only. Existing workflows are unaffected.

## Issue

Closes #377