### PR TITLE
GH-381 Use cpan.metacpan.org as CPAN mirror

### DIFF
--- a/docker/BUILD
+++ b/docker/BUILD
@@ -127,6 +127,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get -y --no-install-recommends install \
+    ca-certificates \
     gcc \
     libc6-dev \
     libssl-dev \
@@ -135,7 +136,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget --progress=dot:giga http://www.cpan.org/src/5.0/$PERL.tar.gz \
+RUN wget --progress=dot:giga https://cpan.metacpan.org/src/5.0/$PERL.tar.gz \
     -O - | tar xzf - -C /usr/local/src
 
 WORKDIR /usr/local/src/$PERL

--- a/docker/devel-cover-base/Dockerfile
+++ b/docker/devel-cover-base/Dockerfile
@@ -21,7 +21,17 @@ RUN apt-get update                                                          && \
     apt-get -y --no-install-recommends install docker-ce-cli                && \
     rm -rf /var/lib/apt/lists/*
 
-RUN cpan -Ti                                                                   \
+# hadolint ignore=SC2016
+RUN mkdir -p /root/.cpan/CPAN                                               && \
+    printf '%s\n'                                                              \
+      '$CPAN::Config = {'                                                      \
+      '  urllist => ['                                                         \
+      '    q(https://cpan.metacpan.org/),'                                     \
+      '    q(https://www.cpan.org/),'                                          \
+      '  ],'                                                                   \
+      '}; 1;'                                                                  \
+      > /root/.cpan/CPAN/MyConfig.pm                                        && \
+    cpan -Ti                                                                   \
       CPAN::DistnameInfo                                                       \
       CPAN::Releases::Latest                                                   \
       Digest::MD5                                                              \

--- a/docker/perl-5.42.0/Dockerfile
+++ b/docker/perl-5.42.0/Dockerfile
@@ -10,6 +10,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get -y --no-install-recommends install \
+    ca-certificates \
     gcc \
     libc6-dev \
     libssl-dev \
@@ -18,7 +19,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget --progress=dot:giga http://www.cpan.org/src/5.0/perl-5.42.0.tar.gz \
+RUN wget --progress=dot:giga https://cpan.metacpan.org/src/5.0/perl-5.42.0.tar.gz \
     -O - | tar xzf - -C /usr/local/src
 
 WORKDIR /usr/local/src/perl-5.42.0


### PR DESCRIPTION
## Summary

The Docker image build fails because the default CPAN mirror
(`https://cpan.org`) is temporarily unreachable from cpancover.com.
Switch to `https://cpan.metacpan.org/` with `https://www.cpan.org/`
as fallback.

## Changes

- Write a CPAN `MyConfig.pm` in the `devel-cover-base` Dockerfile to
  set the mirror list before installing CPAN modules
- Switch the Perl source tarball download in BUILD from
  `http://www.cpan.org` to `https://cpan.metacpan.org`
- Add `ca-certificates` to the Perl builder stage to support HTTPS

## Implications

- The generated `perl-5.42.0/Dockerfile` is also updated (regenerated
  by BUILD on next run)
- If `cpan.metacpan.org` is also unavailable, CPAN falls back to
  `www.cpan.org`

## Issue

Closes #381