### PR TITLE
GH-383 Use /cover/staging as default results_dir

### DIFF
--- a/utils/dc
+++ b/utils/dc
@@ -58,7 +58,7 @@ parse_options() {
       env="$1"
       case "$env" in
       prod)
-        results_dir=~/cover/staging
+        results_dir=/cover/staging
         docker_image=pjcj/cpancover
         ;;
       dev)
@@ -138,7 +138,7 @@ setup() {
   dryrun=0
   env=prod
   force=0
-  results_dir=~/cover/staging
+  results_dir=/cover/staging
   verbose=0
 
   parse_options "$@"


### PR DESCRIPTION
## Summary

Change the default `results_dir` from `~/cover/staging` to `/cover/staging` in both the `prod` environment case and the fallback default, matching the actual location of cpancover data.

## Changes

- Update `prod` case default from `~/cover/staging` to `/cover/staging`
- Update fallback default (when no `--env` specified) to match

## Issue

Closes #383