### PR TITLE
GH-386 Update cpancover documentation

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -10,24 +10,24 @@ containers.
 The cpancover system uses a multi-layer Docker architecture:
 
 ```text
-┌─────────────────────────────────────────────────────────────────┐
-│                         Host System                             │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │                    Controller Container                   │  │
-│  │  (Orchestrates coverage runs, manages worker containers)  │  │
-│  └─────────────┬─────────────────────────────────────────────┘  │
-│                │                                                │
-│                ▼                                                │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │               Worker Containers (per module)              │  │
-│  │  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐       │  │
-│  │  │ Module  │  │ Module  │  │ Module  │  │ Module  │       │  │
-│  │  │ Worker  │  │ Worker  │  │ Worker  │  │ Worker  │       │  │
-│  │  └─────────┘  └─────────┘  └─────────┘  └─────────┘       │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│ Results Directory: ~/cover/staging (mounted as /remote_staging) │
-└─────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────────┐
+│                              Host System                                │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │                      Controller Container                         │  │
+│  │     (Orchestrates coverage runs, manages worker containers)       │  │
+│  └────────────────────────────────┬──────────────────────────────────┘  │
+│                                   │                                     │
+│                                   ▼                                     │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │                  Worker Containers (per module)                   │  │
+│  │      ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐       │  │
+│  │      │  Module  │  │  Module  │  │  Module  │  │  Module  │       │  │
+│  │      │  Worker  │  │  Worker  │  │  Worker  │  │  Worker  │       │  │
+│  │      └──────────┘  └──────────┘  └──────────┘  └──────────┘       │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+│                                                                         │
+│  Results: ~/cover/staging → /cover/staging (mounted as /remote_staging) │
+└─────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Docker Image Layers
@@ -227,7 +227,7 @@ The controller container:
    - Each module gets its own container
    - Container name: `{image}-{module}-{timestamp}`
    - Memory limited to 1GB
-   - Timeout of 2 hours (configurable)
+   - Timeout of 30 minutes (configurable via `CPANCOVER_TIMEOUT`)
 
 3. **Coverage Analysis**
 
@@ -252,10 +252,13 @@ Coverage results are organized as:
 
 ```text
 ~/cover/staging/
-├── module-name-version/
-│   ├── cover_db/         # Coverage database
-│   ├── coverage.html     # HTML reports
-│   └── coverage.json     # JSON summary
+├── Module-Name-1.00/
+│   ├── cover.json        # Coverage database (JSON)
+│   ├── index.html        # Module coverage report
+│   ├── structure/        # Coverage structure data
+│   └── ...               # Per-file coverage reports
+├── __failed__/           # Failed module markers
+│   └── Module-Name-1.00  # Timestamp of failure
 ├── cpancover.json        # Overall summary
 └── index.html            # Main index page
 ```
@@ -346,7 +349,7 @@ This provides:
 
 ## Environment Variables
 
-- `CPANCOVER_RESULTS_DIR`: Override default results directory
+- `CPANCOVER_TIMEOUT`: Override module build timeout in seconds (default: 1800)
 - `CPANCOVER_TEST_MODULES`: Override module list for testing (newline-separated)
 - `COVER_DEBUG`: Enable debug output in queue system
 
@@ -457,7 +460,8 @@ The system supports two environments configured via `--env`:
 #### Production Environment (`--env=prod`)
 
 - Clones from GitHub repository
-- Staging directory: `~/cover/staging`
+- Staging directory: `~/cover/staging` (symlinked to `/cover/staging` in
+  production)
 - Docker image: `pjcj/cpancover`
 - Can push to Docker Hub
 - Builds using `docker/devel-cover-git`
@@ -604,8 +608,8 @@ dc cpancover < /remote_staging/modules.txt
 # Adjust worker count (default: number of CPUs)
 dc cpancover --workers=8
 
-# Change timeout (default: 7200 seconds = 2 hours)
-dc cpancover --timeout=3600
+# Change timeout (default: 1800 seconds = 30 minutes)
+CPANCOVER_TIMEOUT=3600 dc cpancover
 
 # Run with lower memory limit
 docker run -it --memory=512m pjcj/cpancover dc cpancover-build-module \
@@ -617,8 +621,8 @@ docker run -it --memory=512m pjcj/cpancover dc cpancover-build-module \
 When a module fails coverage analysis:
 
 ```bash
-# 1. Check for __failed__ marker
-ls ~/cover/staging/*/__failed__
+# 1. Check for __failed__ markers
+ls ~/cover/staging/__failed__/
 
 # 2. Run module directly with verbose output
 dc -v cpancover-build-module Failed::Module
@@ -635,9 +639,6 @@ docker run -it --rm pjcj/cpancover_dev cpan -Ti Failed::Module
 ### Monitoring and Logs
 
 ```bash
-# View cpancover logs
-tail -f /tmp/dc.log
-
 # Monitor Docker resource usage
 docker stats
 
@@ -710,10 +711,9 @@ For automated testing in CI:
 
 ```bash
 # Build specific module and check coverage
-dc --env=dev cpancover-build-module Your::Module
-if [[ -f ~/cover/staging_dev/Your-Module-*/coverage.json ]]; then
-    coverage=$(jq .summary.Total ~/cover/staging_dev/My-Module-*/coverage.json)
-    echo "Coverage: $coverage%"
+dc -e dev cpancover-build-module Your::Module
+if [[ -f ~/cover/staging_dev/Your-Module/cover.json ]]; then
+    jq .summary.Total ~/cover/staging_dev/Your-Module/cover.json
 fi
 ```
 

--- a/docs/cpancover.md
+++ b/docs/cpancover.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Cpancover requires a bourne shell, plenv, and docker, as well as a recent
-perl. The code requires Perl 5.26.0 but earlier versions may work.
+perl. The code requires Perl 5.42.0.
 
 ## Docker
 
@@ -11,22 +11,10 @@ Each module is built in an individual docker container. This should allow its
 resources to be constrained. In addition the docker container is killed after a
 certain time.
 
-I have only run this in Ubuntu 14.04 and 16.04. The docker version in 14.04,
-0.9.1 (as of 31.05.2014) is insufficient. Version 0.11.1 is fine. I don't know
-about the versions in between.
-
-The latest version of docker can be installed on Ubuntu by following the
-[official
-instructions](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/)
+The Docker infrastructure is in the `docker/` directory of this repository. See
+`docker/README.md` for full details on building and managing Docker images.
 
 You may need to add yourself to the docker group.
-
-To build the docker container, check out the
-[devel-cover-docker](https://github.com/pjcj/devel-cover-docker) project and
-follow the instructions there.
-
-If you want to use your own docker container, edit the file `utils/dc` to point
-to the correct container.
 
 ## Plenv
 
@@ -49,18 +37,18 @@ cd /cover/dc
 Install or upgrade a cpancover perl:
 
 ```sh
-dc install-cpancover-perl 5.26.1
+dc install-cpancover-perl 5.42.0
 ```
 
 Run cpancover:
 
 ```sh
-dc cpancover-run
+dc cpancover-controller-run
 ```
 
-The `cpancover-run` command will just sit there picking up on newly uploaded
-distributions and running the coverage for them. Or, for slightly more control,
-jobs can be run as follows:
+The `cpancover-controller-run` command will just sit there picking up on newly
+uploaded distributions and running the coverage for them. Or, for slightly more
+control, jobs can be run as follows:
 
 ```sh
 dc cpancover-latest | head -2000 | dc cpancover
@@ -74,13 +62,12 @@ dc cpancover-generate-html
 
 ## Results
 
-The results of the runs will be stored in the `~/staging` directory. If this is
-not where you want them stored (which is rather likely) then the simplest
-solution is probably to make that directory a symlink to the real location. If
-you would prefer not to do that, or you want to run multiple separate cpancover
-instances (probably only for development purposes), then you can pass
-`--results_dir` to the `utils/dc` script or change the `$CPANCOVER_RESULTS_DIR`
-variable there.
+The results of the runs will be stored in the `~/cover/staging` directory. If
+this is not where you want them stored (which is rather likely) then the
+simplest solution is probably to make that directory a symlink to the real
+location. If you would prefer not to do that, or you want to run multiple
+separate cpancover instances (probably only for development purposes), then you
+can pass `--results_dir` to the `utils/dc` script.
 
 The results consist of the Devel::Cover `cover_db` directory for each package
 tested, including the generated HTML output for that DB and the JSON summary
@@ -101,15 +88,14 @@ possible.
 ## cpancover.com
 
 The server which is currently running cpancover.com has been graciously provided
-by [Bytemark](https://www.bytemark.co.uk/r/cpancover). It has plenty of memory
-and cpu power, but not a large amount of disk space. That's fine though, it has
+by [Bytemark](https://www.bytemark.co.uk). It has plenty of memory and cpu
+power, but not a large amount of disk space. That's fine though, it has
 sufficient for cpancover's needs.
 
 The server is on the account of pjcj at bytemark. Logins are owned by pjcj and
 the metacpan group.
 
-The server is currently running Ubuntu 16.04 LTS and was upgraded from 14.04
-LTS.
+The server is currently running Ubuntu 24.04 LTS.
 
 The Devel::Cover directory from which cpancover is run is in `/cover/dc`. It is
 a git checkout of the Devel::Cover repository but, ideally, that should be


### PR DESCRIPTION
## Summary

The cpancover documentation in `docker/README.md` and `docs/cpancover.md` had drifted from the current state of the infrastructure. This PR brings both files up to date.

## Changes

- Correct default module build timeout from 2 hours to 30 minutes and document `CPANCOVER_TIMEOUT` environment variable.
- Fix results directory structure, architecture diagram, and command examples in Docker README.
- Remove outdated Docker installation instructions and references to the separate devel-cover-docker repository.
- Update required Perl version to 5.42.0, Ubuntu version to 24.04, and command names (`cpancover-controller-run`).
- Update results directory path from `~/staging` to `~/cover/staging`.

## Issue

Closes #386