### PR TITLE
GH-361 Add reporter to Contributors

### DIFF
--- a/Contributors
+++ b/Contributors
@@ -107,6 +107,7 @@ Pau Amma                       pauamma@cpan.org
 Paul Hirst                     paulhirst@bearandgiraffe.org
 Paul Johnson                   paul@pjcj.net
 Paul "LeoNerd" Evans           leonerd@leonerd.org.uk
+Pete Houston                   https://github.com/openstrike
 Philippe M. Chiasson           gozer@cpan.org
 philip r brenan                philiprbrenan@gmail.com
 pjuhasz                        https://github.com/pjuhasz

--- a/Contributors
+++ b/Contributors
@@ -4,8 +4,8 @@ to fix bugs.
 
 Thank-you to one and all!
 
-Alexandr Evstigneev            hurricup@evstigneev.com
 Alex Balhatchet                alex@balhatchet.net
+Alexandr Evstigneev            hurricup@evstigneev.com
 Alexey Sokolov
 Allison Regier                 penneraa@acm.org
 Andrew Billeb                  [private]
@@ -40,25 +40,25 @@ Denis Howe                     denis.howe@gmail.com
 Dick Franks                    rwfranks@acm.org
 Dinis Rebolo                   dinisrebolo@gmail.com
 Dominic Mitchell               dom@happygiraffe.net
-Eden Hochbaum                  eden.hochbaum@gmail.com
 Ed J                           etj at cpan.org
+Eden Hochbaum                  eden.hochbaum@gmail.com
 Emiliya Boyadjieva             emiliya.boyadjieva@sap.com
 Erwan Lemonnier                erwan@cpan.org
 Felipe Gasper                  felipe@felipegasper.com
 Florian Ragwitz                rafl@debian.org
-Gábor Szabó                    szabgab@gmail.com
 Gisle Aas                      gisle@ActiveState.com
 Goro Fuji                      gfuji@cpan.org
 Graham Knop                    haarg@haarg.org
 Gregor Herrmann                gregoa@debian.org
 Guillaume Aubert               aubertg@cpan.org
 Guillermo O. Freschi           kedrot@gmail.com
+Gábor Szabó                    szabgab@gmail.com
+H.Merijn Brand                 h.m.brand@xs4all.nl
 Hannes Thorsell                hannes.thorsell@iar.com
 Haydn Newport                  haydn@catalyst.net.nz
 Heikki J Laaksonen             heikki.j.laaksonen@kolumbus.fi
 Heinz Knutzen                  heinz.knutzen@gmail.com
 Helmut Wollmersdorfer          helmut@wollmersdorfer.at
-H.Merijn Brand                 h.m.brand@xs4all.nl
 Ivan Wills                     ivan.wills@gmail.com
 Jacques Germishuys             jacquesg@cpan.org
 James E Keenan                 jkeenan@cpan.org
@@ -84,8 +84,8 @@ Larry Leszczynski              larryl@cpan.org
 Lasse Makholm                  lasse@unity3d.com
 Lee Johnson                    lee@givengain.ch
 Léon Brocard                   acme@astray.com
-Marcel Grünauer                marcel@cpan.org
 Marc-Philip                    mpw96@gmx.de
+Marcel Grünauer                marcel@cpan.org
 Mark Stosberg                  mark@summersault.com
 Matthew Horsfall               wolfsage@gmail.com
 mauke
@@ -96,30 +96,28 @@ Mitch McCracken                mrmccrac@gmail.com
 Mohammad S Anwar               mohammad.anwar@yahoo.com
 Nathan Haigh                   n.haigh@sheffield.ac.uk
 Nicholas Clark                 nick@ccl4.org
-ℕicolas ℝ.                     nicolas@atoomic.org
 Niko Tyni                      ntyni@debian.org
 Norman Nunley                  nnunley@gmail.com
 Olaf Alders                    olaf@wundersolutions.com
-Olivier Mengué                 dolmen@cpan.org
 Oliver Youle                   youle.oliver@gmail.com
+Olivier Mengué                 dolmen@cpan.org
 Opera Wang                     Opera.Wang+step@gmail.com
 Pau Amma                       pauamma@cpan.org
+Paul "LeoNerd" Evans           leonerd@leonerd.org.uk
 Paul Hirst                     paulhirst@bearandgiraffe.org
 Paul Johnson                   paul@pjcj.net
-Paul "LeoNerd" Evans           leonerd@leonerd.org.uk
 Pete Houston                   https://github.com/openstrike
-Philippe M. Chiasson           gozer@cpan.org
 philip r brenan                philiprbrenan@gmail.com
+Philippe M. Chiasson           gozer@cpan.org
 pjuhasz                        https://github.com/pjuhasz
 Reini Urban                    rurban@cpan.org
+Rob Kinyon                     rob.kinyon@gmail.com
 Robert Freimuth                rfreimuth@cpan.org
 Robin Barker                   RMBarker@cpan.org
-Rob Kinyon                     rob.kinyon@gmail.com
 Ruslan Zakirov                 Ruslan.Zakirov@gmail.com
 Ryan Voots                     simcop2387@simcop2387.info
 sago35                         sago35@gmail.com
 Sebastian Paaske Tørholm       eckankar@gmail.com
-Sébastien Aperghis-Tramoni     saper@cpan.org
 Sergiy Borodych                Sergiy.Borodych@gmail.com
 Slaven Rezić                   slaven@rezic.de
 Stefan Becker                  Stefan.Becker@nokia.com
@@ -131,6 +129,7 @@ Steve Peters                   smpeters@cpan.org
 Steve Rogerson
 Steve Sanbeg                   sanbeg@cpan.org
 Sullivan Beck                  sbeck@cpan.org
+Sébastien Aperghis-Tramoni     saper@cpan.org
 Tatsuhiko Miyagawa             miyagawa@bulknews.net
 Thomas Dorner                  dorner (AT) cpan.org
 Tina Müller                    tinita at cpan.org
@@ -141,6 +140,7 @@ waterbeetle
 Xavier Caron                   xcaron@gmail.com
 Zakariyya Mughal               zmughal@cpan.org
 Zefram                         zefram@fysh.org
+ℕicolas ℝ.                     nicolas@atoomic.org
 
 
 If you should be on this list and I have overlooked your contribution, please


### PR DESCRIPTION
## Summary

Add Pete Houston (openstrike) to the Contributors file for reporting the cpancover.com stylesheet and image 404 problems in #361. Also sort the file by locale-aware alphabetical order.

## Changes

- Add Pete Houston to the Contributors file
- Re-sort entries alphabetically (locale-aware sort moves accented/special characters appropriately)

## Issue

Closes #361