### PR TITLE
GH-389 Remove obsolete core coverage link

### DIFF
--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -646,11 +646,6 @@ $Templates{summary} = <<'EOT';
   <a href="dist/[%- start -%].html">[% start %]</a>
 [% END %]
 
-<h2> Core coverage </h2>
-
-<a href="http://cpancover.com/blead/latest/coverage.html">Perl core coverage</a>
-(under development)
-
 [% END %]
 EOT
 


### PR DESCRIPTION
## Summary

Remove the "Core coverage" section from the cpancover.com summary page. The linked Perl core coverage data was never kept up to date and is too old to be useful.

## Changes

- Remove the core coverage heading and link from the summary template in `lib/Devel/Cover/Collection.pm`

## Issue

Closes #389