### PR TITLE
GH-359 Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in Devel::Cover, please
+report it via
+[GitHub's private vulnerability reporting](https://github.com/pjcj/Devel--Cover/security/advisories/new)
+or by emailing [paul@pjcj.net](mailto:paul@pjcj.net).
+
+Please include as much detail as possible: the version of Devel::Cover, steps to
+reproduce, and the potential impact.
+
+## Supported Versions
+
+Only the latest release of Devel::Cover is supported with security fixes.
+
+## Scope
+
+Devel::Cover is a development and testing tool. It is not designed to be used in
+production environments or to process untrusted input.


### PR DESCRIPTION
## Summary

Add a security policy as requested by CPANSec. Devel::Cover is a development tool not designed for production use or untrusted input, so the policy is deliberately minimal - it provides a clear reporting path without overstating the security scope.

## Changes

- Add `SECURITY.md` with instructions to report vulnerabilities via GitHub's private vulnerability reporting or email.
- Enable private vulnerability reporting on the GitHub repository.

## Issue

Closes #359