### PR TITLE
GH-397 Fix run merge order with microsecond timestamps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,14 @@ dc all-versions <command>
 
 See `docs/perl-version-update.md` for the full step-by-step guide.
 
+## Documentation
+
+The `docs/` directory contains project documentation including contribution
+guidelines, release procedures, and a Perl version update guide. The
+`docs/technical/` subdirectory contains detailed technical documentation on
+coverage internals such as branch/condition handling, class coverage, and optree
+adjustments.
+
 ## Development Notes
 
 ### Style Guidelines

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -153,14 +153,10 @@ BEGIN {
     }
   }
 
-  @Inc = map { -d () ? ($_ eq "." ? $_ : abs_path($_)) : () } @Inc;
-
-  @Inc = remove_contained_paths(getcwd, @Inc);
-
-  @Ignore = ("/Devel/Cover[./]") unless $Self_cover = $ENV{DEVEL_COVER_SELF};
-  # $^P = 0x004 | 0x010 | 0x100 | 0x200;
-  # $^P = 0x004 | 0x100 | 0x200;
-  $^P |= 0x004 | 0x100;
+  @Inc     = map { -d () ? ($_ eq "." ? $_ : abs_path($_)) : () } @Inc;
+  @Inc     = remove_contained_paths(getcwd, @Inc);
+  @Ignore  = ("/Devel/Cover[./]") unless $Self_cover = $ENV{DEVEL_COVER_SELF};
+  $^P     |= 0x004 | 0x100;
 }
 
 sub version { $VERSION }
@@ -172,14 +168,7 @@ if (0 && $Config{useithreads}) {
 
   my $original_join;
   BEGIN { $original_join = \&threads::join }
-  # print STDERR "original_join: $original_join\n";
-
-  # $original_join = sub { print STDERR "j\n" };
-
-  # sub threads::join
   *threads::join = sub {
-    # print STDERR "threads::join- ", \&threads::join, "\n";
-    # print STDERR "original_join- $original_join\n";
     my $self = shift;
     print STDERR "(joining thread ", $self->tid, ")\n";
     my @ret = $original_join->($self, @_);
@@ -195,8 +184,6 @@ if (0 && $Config{useithreads}) {
     print STDERR "(destroying thread ", $self->tid, ")\n";
     $original_destroy->($self, @_);
   };
-
-  # print STDERR "threads::join: ", \&threads::join, "\n";
 
   my $new = \&threads::new;
   *threads::new = *threads::create = sub {
@@ -264,22 +251,18 @@ EOM
   my $run_end = 0;
 
   sub first_end {
-    # print STDERR "**** END 1 - $run_end\n";
     set_last_end() unless $run_end++
   }
 
   my $run_init = 0;
 
   sub first_init {
-    # print STDERR "**** INIT 1 - $run_init\n";
     collect_inits() unless $run_init++
   }
 }
 
 sub last_end {
-  # print STDERR "**** END 2 - [$Initialised]\n";
   report() if $Initialised;
-  # print STDERR "**** END 2 - ended\n";
 }
 
 {
@@ -380,7 +363,6 @@ sub import ($class, @o) {
   my $options = ($ENV{DEVEL_COVER_OPTIONS} || "") =~ /(.*)/ ? $1 : "";
   @o = (@o, split /,/, $options);
   defined or $_ = "" for @o;
-  # print STDERR __PACKAGE__, ": Parsing options from [@o]\n";
 
   my $blib = -d "blib";
   _parse_options(\@o, \$blib);
@@ -489,43 +471,34 @@ sub get_coverage {
     my $f = $file;
     $file =~ s/ \(autosplit into .*\)$//;
     $file =~ s/^\(eval in .*\) //;
-    # print STDERR "file is <$file>\ncoverage: ", Dumper coverage(0);
     if (
          exists coverage(0)->{module}
       && exists coverage(0)->{module}{$file}
       && !File::Spec->file_name_is_absolute($file)
     ) {
       my $m = coverage(0)->{module}{$file};
-      # print STDERR "Loaded <$file> <$m->[0]> from <$m->[1]> ";
       $file = File::Spec->rel2abs($file, $m->[1]);
-      # print STDERR "as <$file> ";
     }
 
     my $inc;
     $inc ||= $file =~ $_ for @Inc_re;
-    # warn "inc for [$file] is [$inc] @Inc_re";
     if ($inc && ($^O eq "MSWin32" || $^O eq "cygwin")) {
       # Windows' Cwd::_win32_cwd() calls eval which will recurse back
       # here if we call abs_path, so we just assume it's normalised.
       # warn "giving up on getting normalised filename from <$file>\n";
     } else {
-      # print STDERR "getting abs_path <$file> ";
       if (-e $file) {  # Windows likes the file to exist
         my $abs;
-        $abs = abs_path($file) unless -l $file; # leave symbolic links
-                                                # print STDERR "giving <$abs> ";
+        $abs  = abs_path($file) unless -l $file;  # leave symbolic links
         $file = $abs if defined $abs;
       }
     }
-    # print STDERR "finally <$file> <$Dir>\n";
 
     $file =~ s|\\|/|g       if $^O eq "MSWin32";
     $file =~ s|^\Q$Dir\E/|| if defined $Dir;
 
     $Digests ||= Devel::Cover::DB::Digests->new(db => $DB);
     $file      = $Digests->canonical_file($file);
-
-    # print STDERR "File: $f => $file\n";
 
     $Normalising = 0;
     $File_cache{$f} = $file
@@ -536,12 +509,9 @@ sub get_coverage {
 sub get_location {
   my ($op) = @_;
 
-  # print STDERR "get_location ", $op, "\n";
-  # use Carp "cluck"; cluck("from here");
   return unless $op->can("file");  # How does this happen?
   $File = $op->file;
   $Line = $op->line;
-  # print STDERR "$File:$Line\n";
 
   # If there's an eval, get the real filename.  Enabled from $^P & 0x100.
   while ($File =~ /^\(eval \d+\)\[(.*):(\d+)\]/) {
@@ -570,10 +540,6 @@ sub use_file {
 
   return 0 unless $file && $find_filename;  # global destruction, probably
 
-  # print STDERR "use_file($file)\n";
-
-  # die "bad file" unless length $file;
-
   # If you call your file something that matches $find_filename then things
   # might go awry.  But it would be silly to do that, so don't.  This little
   # optimisation provides a reasonable speedup.
@@ -583,8 +549,6 @@ sub use_file {
   while ($file =~ $find_filename) { $file = $1 || $2 || $3 || $4 }
   $file =~ s/ \(autosplit into .*\)$//;
 
-  # print STDERR "==> use_file($file)\n";
-
   return $Files{$file} if exists $Files{$file};
   return 0
     if $file =~ /\(eval \d+\)/
@@ -592,14 +556,9 @@ sub use_file {
 
   my $f = normalised_file($file);
 
-  # print STDERR "checking <$file> <$f>\n";
-  # print STDERR "checking <$file> <$f> against ",
-  # "select(@Select_re), ignore(@Ignore_re), inc(@Inc_re)\n";
-
   for (@Select_re)          { return $Files{$file} = 1 if $f =~ $_ }
   for (@Ignore_re, @Inc_re) { return $Files{$file} = 0 if $f =~ $_ }
 
-  # system "pwd; ls -l '$file'";
   $Files{$file} = -e $file ? 1 : 0;
   print STDERR __PACKAGE__ . qq[: Can't find file "$file" (@_): ignored.\n]
     unless $Files{$file}
@@ -623,7 +582,6 @@ sub check_file {
 
   my $file = $op->file;
   my $use  = use_file($file);
-  # printf STDERR "%6s $file\n", $use ? "use" : "ignore";
 
   $use
 }
@@ -632,7 +590,6 @@ sub B::GV::find_cv ($gv) {
   my $cv = $gv->CV;
   return unless $$cv;
 
-  # print STDERR "find_cv $$cv\n" if check_file($cv);
   $Cvs{$cv} ||= $cv if check_file($cv);
   if (
        $cv->can("PADLIST")
@@ -652,28 +609,21 @@ sub sub_info {
   if ($gv && !$gv->isa("B::SPECIAL")) {
     return unless $gv->can("SAFENAME");
     $name = $gv->SAFENAME;
-    # print STDERR "--[$name]--\n";
     $name =~ s/(__ANON__)\[.+:\d+\]/$1/ if defined $name;
   }
-  # my $op = sub { my ($t, $o) = @_; print "$t\n"; $o->debug };
   my $root = $cv->ROOT;
-  # $op->(root => $root);
   if ($root->can("first")) {
     my $lineseq = $root->first;
-    # $op->(lineseq => $lineseq);
     if ($lineseq->can("first")) {
       # normal case
       $start = $lineseq->first;
-      # $op->(start => $start);
       # methods defined with the class feature start with a methstart op
       $start = $start->sibling if $start->name eq "methstart";
       # signatures
       if ($start->name eq "null" && $start->can("first")) {
         my $lineseq2 = $start->first;
-        # $op->(lineseq2 => $lineseq2);
         if ($lineseq2->name eq "lineseq" && $lineseq2->can("first")) {
           my $cop = $lineseq2->first;
-          # $op->(cop => $cop);
           $start = $cop if $cop->name eq "nextstate";
         }
       }
@@ -690,8 +640,6 @@ sub add_cvs {
 }
 
 sub check_files {
-  # print STDERR "Checking files\n";
-
   add_cvs();
 
   my %seen_pkg;
@@ -718,14 +666,11 @@ sub check_files {
       local ($Line, $File);
       get_location($start);
       $line = $Line;
-      # print STDERR "$name - $File:$Line\n";
     }
     $line = 0  unless defined $line;
     $name = "" unless defined $name;
     ($line, $name)
   };
-
-  # print Dumper \%Cvs;
 
   @Cvs = map $_->[0],
     sort { $a->[1] <=> $b->[1] || $a->[2] cmp $b->[2] } map [ $_, $l->($_) ],
@@ -762,7 +707,6 @@ EOM
 
 sub _report {
   local @SIG{ qw( __DIE__ __WARN__ ) };
-  # $SIG{__DIE__} = \&Carp::confess;
 
   $Run{finish} = get_elapsed() / 1e6;
 
@@ -782,11 +726,8 @@ sub _report {
     loose_perms => $Loose_perms);
   $Structure->read_all;
   $Structure->add_criteria(@collected);
-  # print STDERR "Start structure: ", Dumper $Structure;
 
-  # print STDERR "Processing cover data\n@Inc\n";
   $Coverage = coverage(1) || die "No coverage data available.\n";
-  # print STDERR Dumper $Coverage;
 
   check_files();
 
@@ -806,7 +747,6 @@ sub _report {
       get_ends()->isa("B::AV") ? get_ends()->ARRAY : ()
     );
   }
-  # print STDERR "--- @Cvs\n";
   get_cover_progress("CV", @Cvs);
 
   _filter_cover_files();
@@ -819,16 +759,12 @@ sub _filter_cover_files {
   my %files;
   $files{$_}++ for keys %{ $Run{count} }, keys %{ $Run{vec} };
   for my $file (sort keys %files) {
-    # print STDERR "looking at $file\n";
     unless (use_file($file)) {
-      # print STDERR "deleting $file\n";
       delete $Run{count}{$file};
       delete $Run{vec}{$file};
       $Structure->delete_file($file);
       next;
     }
-
-    # $Structure->add_digest($file, \%Run);
 
     for my $run (keys %{ $Run{vec}{$file} }) {
       delete $Run{vec}{$file}{$run} unless $Run{vec}{$file}{$run}{size};
@@ -839,8 +775,6 @@ sub _filter_cover_files {
 }
 
 sub _write_coverage_db {
-  # print STDERR "End structure: ", Dumper $Structure;
-
   my $run = int(Time::HiRes::time() * 1e6) . ".$$." . sprintf "%05d",
     rand 2**16;
   my $cover = Devel::Cover::DB->new(
@@ -875,12 +809,9 @@ sub add_subroutine_cover {
   get_location($op);
   return unless $File;
 
-  # print STDERR "Subroutine $Sub_name $File:$Line: ", $op->name, "\n";
-
   my $key = get_key($op);
   my $val = $Coverage->{statement}{$key} || 0;
   my ($n, $new) = $Structure->add_count("subroutine");
-  # print STDERR "******* subroutine $n - $new\n";
   $Structure->add_subroutine($File, [ $Line, $Sub_name ]) if $new;
   $Run{count}{$File}{subroutine}[$n] += $val;
   my $vec = $Run{vec}{$File}{subroutine};
@@ -894,13 +825,10 @@ sub add_statement_cover {
   get_location($op);
   return unless $File;
 
-  # print STDERR "Stmt $File:$Line: $op $$op ", $op->name, "\n";
-
   $Run{digests}{$File} ||= $Structure->set_file($File);
   my $key = get_key($op);
   my $val = $Coverage->{statement}{$key} || 0;
   my ($n, $new) = $Structure->add_count("statement");
-  # print STDERR "Stmt $File:$Line - $n, $new\n";
   $Structure->add_statement($File, $Line) if $new;
   $Run{count}{$File}{statement}[$n] += $val;
   my $vec = $Run{vec}{$File}{statement};
@@ -916,8 +844,6 @@ sub add_statement_cover {
 sub add_branch_cover ($op, $type, $text, $file, $line) {
   return unless $Collect && $Coverage{branch};
 
-  # return unless $Seen{branch}{$$op}++;
-
   $text =~ s/^\s+//;
   $text =~ s/\s+$//;
 
@@ -925,7 +851,6 @@ sub add_branch_cover ($op, $type, $text, $file, $line) {
   my $c   = $Coverage->{condition}{$key};
 
   no warnings "uninitialized";
-  # warn "add_branch_cover $File:$Line [$type][@{[join ', ', @$c]}]\n";
 
   if (
        $type eq "and"
@@ -938,7 +863,6 @@ sub add_branch_cover ($op, $type, $text, $file, $line) {
     # True path taken if not short circuited.
     # False path taken if short circuited.
     $c = [ $c->[1] + $c->[2], $c->[3] ];
-    # print STDERR "branch $type [@$c]\n";
   } else {
     $c = $Coverage->{branch}{$key} || [ 0, 0 ];
   }
@@ -953,8 +877,6 @@ sub add_branch_cover ($op, $type, $text, $file, $line) {
     my $vec = $Run{vec}{$File}{branch};
     vec($vec->{vec}, $vec->{size}++, 1) = $_ ||= 0 ? 1 : 0 for @$c;
   }
-
-  # warn "branch $type %x [@$c] => [@{$ccount->{branch}[$n]}]\n", $$op;
 }
 
 sub add_condition_cover {
@@ -962,11 +884,7 @@ sub add_condition_cover {
 
   return unless $Collect && $Coverage{condition};
 
-  my $key = get_key($op);
-  # warn "Condition cover $$op from $File:$Line\n";
-  # print STDERR "left:  [$left]\nright: [$right]\n";
-  # use Carp "cluck"; cluck("from here");
-
+  my $key  = get_key($op);
   my $type = $op->name;
   $type =~ s/assign$//;
   $type = "or" if $type eq "dor";
@@ -982,16 +900,13 @@ sub add_condition_cover {
     my $name = $r->name;
     $name = $r->first->name if $name eq "sassign";
     # TODO - exec?  any others?
-    # print STDERR "Name [$name]", Dumper $c;
     if ($c->[5] || $name =~ $Const_right) {
       $c     = [ $c->[3], $c->[1] + $c->[2] ];
       $count = 2;
-      # print STDERR "Special short circuit\n";
     } else {
       @$c    = @{$c}[ $type eq "or" ? (3, 2, 1) : (3, 1, 2) ];
       $count = 3;
     }
-    # print STDERR "$type 3 $name [", join(",", @$c), "] $File:$Line\n";
   } elsif ($type eq "xor") {
     # !l&&!r  l&&!r  l&&r  !l&&r
     @$c    = @{$c}[ 3, 2, 4, 1 ];
@@ -1065,15 +980,12 @@ my %Original;
 
   sub _cover_statement_op ($op, $class, $null, $name) {
     if ($class eq "COP" && $Coverage{statement}) {
-      # print STDERR "COP $$op, seen [$Seen{statement}{$$op}]\n";
       my $nnnext = "";
       eval {
         my $next  = $op->next;
         my $nnext = $next && $next->next;
         $nnnext = $nnext && $nnext->next;
       };
-      # print STDERR "COP $$op, ", $next, " -> ", $nnext,
-      # " -> ", $nnnext, "\n";
       if ($nnnext && $name ne "null") {
         add_statement_cover($op) unless $Seen{statement}{$$op}++;
       }
@@ -1088,7 +1000,6 @@ my %Original;
       # get at the file and line number, but we need to get dirty
 
       bless $op, "B::COP";
-      # print STDERR "null $$op, seen [$Seen{statement}{$$op}]\n";
       add_statement_cover($op) unless $Seen{statement}{$$op}++;
       bless $op, "B::$class";
       return 1;
@@ -1154,7 +1065,6 @@ my %Original;
   }
 
   sub deparse ($self, $op, $cx) {
-
     my $deparse;
 
     if ($Collect) {
@@ -1163,16 +1073,11 @@ my %Original;
 
       my $name = $op->can("name") ? $op->name : "Unknown";
 
-      # print STDERR "$class:$name ($$op) at $File:$Line\n";
-      # print STDERR "[$Seen{statement}{$$op}] [$Seen{other}{$$op}]\n";
-      # use Carp "cluck"; cluck("from here");
-
       return "" if $name eq "padrange";
 
       unless ($Seen{statement}{$$op} || $Seen{other}{$$op}) {
         # Collect everything under here
         local ($File, $Line) = ($File, $Line);
-        # print STDERR "Collecting $$op under $File:$Line\n";
         no warnings "redefine";
         my $use_dumper = $class eq "SVOP" && $name eq "const";
         local $self->{use_dumper} = 1 if $use_dumper;
@@ -1180,8 +1085,6 @@ my %Original;
         $deparse = eval { local $^W; $Original{deparse}->($self, $op, $cx) };
         $deparse =~ s/^\010+//mg       if defined $deparse;
         $deparse = "Deparse error: $@" if $@;
-        # print STDERR "Collected $$op under $File:$Line\n";
-        # print STDERR "Collect Deparse $op $$op => <$deparse>\n";
       }
 
       # Get the coverage on this op
@@ -1191,16 +1094,12 @@ my %Original;
       }
     } else {
       local ($File, $Line) = ($File, $Line);
-      # print STDERR "Starting plain deparse at $File:$Line\n";
       $deparse = eval { local $^W; $Original{deparse}->($self, $op, $cx) };
       $deparse = "" unless defined $deparse;
       $deparse =~ s/^\010+//mg;
       $deparse = "Deparse error: $@" if $@;
-      # print STDERR "Ending plain deparse at $File:$Line\n";
-      # print STDERR "Deparse => <$deparse>\n";
     }
 
-    # print STDERR "Returning [$deparse]\n";
     $deparse
   }
 
@@ -1295,7 +1194,6 @@ my %Original;
         $left  = $self->deparse_binop_left($op, $left, $prec);
         $right = $self->deparse_binop_right($op, $right, $prec);
       }
-      # print STDERR "opname [$opname], left [$left], right [$right]\n";
       add_condition_cover($op, $opname, $left, $right);
     }
     $Original{binop}->($self, $op, $cx, $opname, $prec, $flags)
@@ -1330,12 +1228,9 @@ sub _add_pod_cover ($cv) {
   my $pkg  = $gv->STASH->NAME;
   my %opts = _parse_pod_options();
   $Run{digests}{$File} ||= $Structure->set_file($File);
-  # print STDERR "$Pod, $File:$Line ($Sub_name) [", $cv->FILE, "($pkg)]",
-  #              Dumper \%opts;
   $Pod{$pkg} ||= $Pod->new(package => $pkg, %opts);
   return unless $Pod{$pkg};
 
-  # print STDERR Dumper $Pod{$pkg};
   my $covered;
   for ($Pod{$pkg}->covered) {
     $covered = 1, last if $_ eq $Sub_name;
@@ -1345,7 +1240,6 @@ sub _add_pod_cover ($cv) {
       $covered = 0, last if $_ eq $Sub_name;
     }
   }
-  # print STDERR "covered ", $covered // "undef", "\n";
   return unless defined $covered;
 
   my ($n, $new) = $Structure->add_count("pod");
@@ -1394,10 +1288,7 @@ sub get_cover ($cv, $root = undef) {
   ($Sub_name, my $start) = sub_info($cv);
 
   get_location($start) if $start;
-  # print STDERR "[[$File:$Line]]\n";
   return unless _want_cover_for();
-
-  # printf STDERR "getting cover for $Sub_name ($start), %x\n", $$cv;
 
   _add_subroutine_structure($cv, $start);
 
@@ -1412,7 +1303,6 @@ sub get_cover ($cv, $root = undef) {
 
   my $de = $root ? $deparse->deparse($root, 0) : $deparse->deparse_sub($cv, 0);
 
-  # print STDERR "<$de>\n";
   $de
 }
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -40,9 +40,10 @@ BEGIN {
   B->import("OPpSTATEMENT") if $v;
 }
 
-use Config     qw( %Config );
-use Cwd        qw( abs_path getcwd );
-use File::Spec ();
+use Config      qw( %Config );
+use Cwd         qw( abs_path getcwd );
+use File::Spec  ();
+use Time::HiRes ();
 
 use Devel::Cover::Util qw( remove_contained_paths );
 
@@ -840,7 +841,8 @@ sub _filter_cover_files {
 sub _write_coverage_db {
   # print STDERR "End structure: ", Dumper $Structure;
 
-  my $run   = time . ".$$." . sprintf "%05d", rand 2**16;
+  my $run = int(Time::HiRes::time() * 1e6) . ".$$." . sprintf "%05d",
+    rand 2**16;
   my $cover = Devel::Cover::DB->new(
     base        => $DB,
     runs        => { $run => \%Run },

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -11,8 +11,8 @@ use v5.20.0;
 use strict;
 use warnings;
 
-use feature "signatures";
-no warnings "experimental::signatures";
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
 
 our $VERSION;
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -153,7 +153,7 @@ BEGIN {
     }
   }
 
-  @Inc = map { -d () ? ($_ eq "." ? $_ : Cwd::abs_path($_)) : () } @Inc;
+  @Inc = map { -d () ? ($_ eq "." ? $_ : abs_path($_)) : () } @Inc;
 
   @Inc = remove_contained_paths(getcwd, @Inc);
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -272,7 +272,7 @@ sub last_end {
   CHECK { set_first_init_and_end() }  # we really want to be first
 }
 
-sub CLONE {
+sub CLONE ($class) {
   print STDERR <<EOM;
 
 Unfortunately, Devel::Cover does not yet work with threads.  I have done
@@ -309,7 +309,7 @@ sub _parse_options ($o, $blib) {
     } elsif (/^-coverage/) {
       $Coverage{ +shift @$o } = 1 while @$o && $o->[0] !~ /^[-+]/;
     } elsif (/^[-+](\w+)/ && $list_opt{$1}) {
-      push @{ $list_opt{$1} }, shift @$o while @$o && $o->[0] !~ /^[-+]/;
+      push $list_opt{$1}->@*, shift @$o while @$o && $o->[0] !~ /^[-+]/;
     } else {
       warn __PACKAGE__ . ": Unknown option $_ ignored\n";
     }
@@ -393,8 +393,6 @@ sub import ($class, @o) {
 }
 
 sub populate_run {
-  my $self = shift;
-
   $Run{OS}      = $^O;
   $Run{perl}    = sprintf "%vd", $^V;
   $Run{dir}     = $Dir;
@@ -461,9 +459,7 @@ sub get_coverage {
   # the Storable backend.  I don't think it happens with the JSON backend.
   my $Normalising;
 
-  sub normalised_file {
-    my ($file) = @_;
-
+  sub normalised_file ($file) {
     return $File_cache{$file} if exists $File_cache{$file};
     return $file              if $Normalising;
     $Normalising = 1;
@@ -506,9 +502,7 @@ sub get_coverage {
 
 }
 
-sub get_location {
-  my ($op) = @_;
-
+sub get_location ($op) {
   return unless $op->can("file");  # How does this happen?
   $File = $op->file;
   $Line = $op->line;
@@ -521,16 +515,14 @@ sub get_location {
 
   if (!exists $Run{vec}{$File} && $Run{collected}) {
     my %vec;
-    @vec{ @{ $Run{collected} } } = ();
+    @vec{ $Run{collected}->@* } = ();
     delete $vec{time};
     $vec{subroutine}++ if exists $vec{pod};
-    @{ $Run{vec}{$File}{$_} }{ "vec", "size" } = ("", 0) for keys %vec;
+    $Run{vec}{$File}{$_}->@{ "vec", "size" } = ("", 0) for keys %vec;
   }
 }
 
-sub use_file {
-  my ($file) = @_;
-
+sub use_file ($file) {
   state $find_filename = qr/
     (?:^\(eval\s \d+\)\[(.+):\d+\])      |
     (?:^\(eval\sin\s\w+\)\s(.+))         |
@@ -560,7 +552,7 @@ sub use_file {
   for (@Ignore_re, @Inc_re) { return $Files{$file} = 0 if $f =~ $_ }
 
   $Files{$file} = -e $file ? 1 : 0;
-  print STDERR __PACKAGE__ . qq[: Can't find file "$file" (@_): ignored.\n]
+  print STDERR __PACKAGE__ . qq(: Can't find file "$file": ignored.\n)
     unless $Files{$file}
     || $Silent
     || $file =~ $Devel::Cover::DB::Ignore_filenames;
@@ -569,9 +561,7 @@ sub use_file {
   $Files{$file}
 }
 
-sub check_file {
-  my ($cv) = @_;
-
+sub check_file ($cv) {
   return unless ref($cv) eq "B::CV";
 
   my $op = $cv->START;
@@ -602,8 +592,7 @@ sub B::GV::find_cv ($gv) {
   }
 }
 
-sub sub_info {
-  my ($cv) = @_;
+sub sub_info ($cv) {
   my ($name, $start) = ("--unknown--", 0);
   my $gv = $cv->GV;
   if ($gv && !$gv->isa("B::SPECIAL")) {
@@ -648,18 +637,17 @@ sub check_files {
   walksymtable(
     \%main::,
     "find_cv",
-    sub {
-      return 0 if $seen_pkg{ $_[0] }++;
+    sub ($pkg) {
+      return 0 if $seen_pkg{$pkg}++;
       no strict "refs";
       $Cvs{$_} ||= $_
         for grep check_file($_), map B::svref_2object($_),
-        adjust_blocks(\%{ $_[0] });
+        adjust_blocks(\%{$pkg});
       1
     }
   );
 
-  my $l = sub {
-    my ($cv) = @_;
+  my $l = sub ($cv) {
     my $line = 0;
     my ($name, $start) = sub_info($cv);
     if ($start) {
@@ -757,7 +745,7 @@ sub _report {
 
 sub _filter_cover_files {
   my %files;
-  $files{$_}++ for keys %{ $Run{count} }, keys %{ $Run{vec} };
+  $files{$_}++ for keys $Run{count}->%*, keys $Run{vec}->%*;
   for my $file (sort keys %files) {
     unless (use_file($file)) {
       delete $Run{count}{$file};
@@ -766,7 +754,7 @@ sub _filter_cover_files {
       next;
     }
 
-    for my $run (keys %{ $Run{vec}{$file} }) {
+    for my $run (keys $Run{vec}{$file}->%*) {
       delete $Run{vec}{$file}{$run} unless $Run{vec}{$file}{$run}{size};
     }
 
@@ -803,9 +791,7 @@ sub _write_coverage_db {
   }
 }
 
-sub add_subroutine_cover {
-  my ($op) = @_;
-
+sub add_subroutine_cover ($op) {
   get_location($op);
   return unless $File;
 
@@ -819,9 +805,7 @@ sub add_subroutine_cover {
   $vec->{size} = $n + 1;
 }
 
-sub add_statement_cover {
-  my ($op) = @_;
-
+sub add_statement_cover ($op) {
   get_location($op);
   return unless $File;
 
@@ -879,9 +863,7 @@ sub add_branch_cover ($op, $type, $text, $file, $line) {
   }
 }
 
-sub add_condition_cover {
-  my ($op, $strop, $left, $right) = @_;
-
+sub add_condition_cover ($op, $strop, $left, $right) {
   return unless $Collect && $Coverage{condition};
 
   my $key  = get_key($op);
@@ -904,12 +886,12 @@ sub add_condition_cover {
       $c     = [ $c->[3], $c->[1] + $c->[2] ];
       $count = 2;
     } else {
-      @$c    = @{$c}[ $type eq "or" ? (3, 2, 1) : (3, 1, 2) ];
+      @$c    = $c->@[ $type eq "or" ? (3, 2, 1) : (3, 1, 2) ];
       $count = 3;
     }
   } elsif ($type eq "xor") {
     # !l&&!r  l&&!r  l&&r  !l&&r
-    @$c    = @{$c}[ 3, 2, 4, 1 ];
+    @$c    = $c->@[ 3, 2, 4, 1 ];
     $count = 4;
   } else {
     die qq(Unknown type "$type" for conditional);
@@ -1205,16 +1187,16 @@ sub _parse_pod_options {
   my %opts;
   if (ref $Coverage_options{pod}) {
     my $p;
-    for (@{ $Coverage_options{pod} }) {
+    for ($Coverage_options{pod}->@*) {
       if (/^package|(?:also_)?private|trustme|pod_from|nocp$/) {
         $opts{ $p = $_ } = [];
       } elsif ($p) {
-        push @{ $opts{$p} }, $_;
+        push $opts{$p}->@*, $_;
       }
     }
     for my $p (qw( private also_private trustme )) {
       next unless exists $opts{$p};
-      $_ = qr/$_/ for @{ $opts{$p} };
+      $_ = qr/$_/ for $opts{$p}->@*;
     }
   }
   $Pod = "Pod::Coverage" if delete $opts{nocp};
@@ -1306,15 +1288,13 @@ sub get_cover ($cv, $root = undef) {
   $de
 }
 
-sub _report_progress {
-  my ($msg, $code, @items) = @_;
+sub _report_progress ($msg, $code, @items) {
   if ($Silent) {
     $code->($_) for @items;
     return;
   }
   my $tot  = @items || 1;
-  my $prog = sub {
-    my ($n) = @_;
+  my $prog = sub ($n) {
     print OUT "\r" . __PACKAGE__ . ": " . int(100 * $n / $tot) . "% ";
   };
   my ($old_pipe, $n, $start) = ($|, 0, time);
@@ -1331,8 +1311,7 @@ sub _report_progress {
   $| = $old_pipe;
 }
 
-sub get_cover_progress {
-  my ($type, @cvs) = @_;
+sub get_cover_progress ($type, @cvs) {
   _report_progress("getting $type coverage", sub { get_cover($_) }, @cvs);
 }
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -7,67 +7,69 @@
 
 package Devel::Cover::DB;
 
+use v5.20.0;
 use strict;
 use warnings;
 
+use feature "signatures";
+no warnings "experimental::signatures";
+
 # VERSION
 
-use Devel::Cover::Criterion;
-use Devel::Cover::DB::File;
-use Devel::Cover::DB::Structure;
-use Devel::Cover::DB::IO;
+use Devel::Cover::Criterion     ();
+use Devel::Cover::DB::File      ();
+use Devel::Cover::DB::Structure ();
+use Devel::Cover::DB::IO        ();
 
-use Carp;
-use File::Find;
-use File::Path;
+use Carp       qw( carp croak );
+use File::Find qw( find );
+use File::Path qw( rmtree );
 
-use Devel::Cover::Dumper;  # For debugging
+use Devel::Cover::Dumper qw( Dumper );  # For debugging
 
-use constant CAN_TERM_SIZE => eval { require Term::Size };
+my $Has_term_size = eval { require Term::Size };
 
-my $DB = "cover.14";       # Version of the database
+my $DB = "cover.14";                    # Version of the database
 
 @Devel::Cover::DB::Criteria
   = (qw( statement branch path condition subroutine pod time ));
-@Devel::Cover::DB::Criteria_short
-  = (qw( stmt      bran   path cond      sub        pod time ));
+@Devel::Cover::DB::Criteria_short   = (qw( stmt bran path cond sub pod time ));
 $Devel::Cover::DB::Ignore_filenames = qr/   # Used by Devel::Cover
-    (?: [\/\\]lib[\/\\](?:Storable|POSIX).pm$ )
-    | # Moose
+  (?: [\/\\]lib[\/\\](?:Storable|POSIX).pm$ )
+  | # Moose
+  (?:
     (?:
-        (?:
-            reader | writer | constructor | destructor | accessor |
-            predicate | clearer | native \s delegation \s method |
-            # Template Toolkit
-            Parser\.yp
-        )
-        \s .* \s
-        (?: \( defined \s at \s .* \s line \s \d+ \) | defined \s at )
+      reader | writer | constructor | destructor | accessor |
+      predicate | clearer | native \s delegation \s method |
+      # Template Toolkit
+      Parser\.yp
     )
-    | # Moose
-    (?: generated \s method \s \( unknown \s origin \) )
-    | # Mouse
-    (?: (?: rw-accessor | ro-accessor ) \s for )
-    | # Template Toolkit
-    (?: Parser\.yp )
-    | # perl generated
-    (?: \/loader\/0x )
+    \s .* \s
+    (?: \( defined \s at \s .* \s line \s \d+ \) | defined \s at )
+  )
+  | # Moose
+  (?: generated \s method \s \( unknown \s origin \) )
+  | # Mouse
+  (?: (?: rw-accessor | ro-accessor ) \s for )
+  | # Template Toolkit
+  (?: Parser\.yp )
+  | # perl generated
+  (?: \/loader\/0x )
 /x;
 
-sub new {
-  my $class = shift;
-  my $self  = {
+sub new ($class, %o) {
+  my $self = {
     criteria         => \@Devel::Cover::DB::Criteria,
     criteria_short   => \@Devel::Cover::DB::Criteria_short,
     runs             => {},
     collected        => {},
     uncoverable_file => [],
-    @_,
+    %o,
   };
 
-  $self->{all_criteria}       = [ @{ $self->{criteria} },       "total" ];
-  $self->{all_criteria_short} = [ @{ $self->{criteria_short} }, "total" ];
-  $self->{base} ||= $self->{db};
+  $self->{all_criteria}         = [ $self->{criteria}->@*,       "total" ];
+  $self->{all_criteria_short}   = [ $self->{criteria_short}->@*, "total" ];
+  $self->{base}               ||= $self->{db};
   bless $self, $class;
 
   if (defined $self->{db}) {
@@ -79,18 +81,15 @@ sub new {
   $self
 }
 
-sub criteria           { @{ $_[0]->{criteria} } }
-sub criteria_short     { @{ $_[0]->{criteria_short} } }
-sub all_criteria       { @{ $_[0]->{all_criteria} } }
-sub all_criteria_short { @{ $_[0]->{all_criteria_short} } }
+sub criteria           ($self) { $self->{criteria}->@* }
+sub criteria_short     ($self) { $self->{criteria_short}->@* }
+sub all_criteria       ($self) { $self->{all_criteria}->@* }
+sub all_criteria_short ($self) { $self->{all_criteria_short}->@* }
 
-sub read {
-  my $self = shift;
-  my ($file) = @_;
-
+sub read ($self, $file) {
   my $io = Devel::Cover::DB::IO->new;
   my $db = eval { $io->read($file) };
-  if ($@ or !$db) {
+  if ($@ || !$db) {
     warn $@;
   } else {
     $self->{runs} = $db->{runs};
@@ -98,9 +97,8 @@ sub read {
   $self
 }
 
-sub write {
-  my $self = shift;
-  $self->{db} = shift if @_;
+sub write ($self, $db = undef) {
+  $self->{db} = $db if defined $db;
 
   croak "No db specified" unless length $self->{db};
   unless (mkdir $self->{db}) {
@@ -109,62 +107,51 @@ sub write {
   chmod 0777, $self->{db} if $self->{loose_perms};
   $self->validate_db;
 
-  my $db = { runs => $self->{runs} };
-  my $io = Devel::Cover::DB::IO->new;
-  $io->write($db, "$self->{db}/$DB");
+  my $data = { runs => $self->{runs} };
+  my $io   = Devel::Cover::DB::IO->new;
+  $io->write($data, "$self->{db}/$DB");
   $self->{structure}->write($self->{base}) if $self->{structure};
   $self
 }
 
-sub delete {
-  my $self = shift;
-
-  my $db = "";
-  $db         = $self->{db} if ref $self;
-  $db         = shift       if @_;
-  $self->{db} = $db         if ref $self;
+sub delete ($self, $db = undef) {
+  $db         //= $self->{db} if ref $self;
+  $db         //= "";
+  $self->{db}   = $db if ref $self;
   croak "No db specified" unless length $db;
 
   return $self unless -d $db;
 
   # TODO - just delete the directory?
-  opendir DIR, $db or die "Can't opendir $db: $!";
-  my @files = map "$db/$_", map /(.*)/ && $1, grep !/^\.\.?/, readdir DIR;
-  closedir DIR or die "Can't closedir $db: $!";
+  opendir my $dir, $db or die "Can't opendir $db: $!";
+  my @files = map "$db/$_", map /(.*)/ && $1, grep !/^\.\.?/, readdir $dir;
+  closedir $dir or die "Can't closedir $db: $!";
   rmtree(\@files) if @files;
 
   $self
 }
 
-sub clean {
-  my $self = shift;
-
+sub clean ($self) {
   # remove all lock files
-  my $rm_lock = sub {
-    unlink if /\.lock$/
-  };
+  my $rm_lock = sub { unlink if /\.lock$/ };
   find($rm_lock, $self->{db});
 }
 
-sub merge_runs {
-  my $self = shift;
-  my $db   = $self->{db};
-  # print STDERR "merge_runs from $db/runs/*\n";
-  # system "ls -al $db/runs";
+sub merge_runs ($self) {
+  my $db = $self->{db};
   return $self unless length $db;
-  opendir DIR, "$db/runs" or return $self;
-  my @runs = map "$db/runs/$_", grep !/^\.\.?/, readdir DIR;
-  closedir DIR or die "Can't closedir $db/runs: $!";
+  opendir my $dir, "$db/runs" or return $self;
+  my @runs = map "$db/runs/$_", grep !/^\.\.?/, readdir $dir;
+  closedir $dir or die "Can't closedir $db/runs: $!";
 
   $self->{changed_files} = {};
 
   # The ordering is important here.  The runs need to be merged in the order
   # they were created.  We're only at a granularity of one second, but that
-  # shouldn't be a problem unless a file is altered and the coverage run
-  # created in less than a second.  I think we're OK for now.
+  # shouldn't be a problem unless a file is altered and the coverage run created
+  # in less than a second.  I think we're OK for now.
 
   for my $run (sort @runs) {
-    # print STDERR "Devel::Cover: merging run $run <$self->{base}>\n";
     my $r = Devel::Cover::DB->new(base => $self->{base}, db => $run);
     $self->merge($r);
   }
@@ -172,11 +159,10 @@ sub merge_runs {
   $self->write($db) if @runs;
   rmtree(\@runs);
 
-  if (keys %{ $self->{changed_files} }) {
+  if (keys $self->{changed_files}->%*) {
     my $st = Devel::Cover::DB::Structure->new(base => $self->{base});
     $st->read_all;
-    for my $file (sort keys %{ $self->{changed_files} }) {
-      # print STDERR "dealing with changed file <$file>\n";
+    for my $file (sort keys $self->{changed_files}->%*) {
       $st->delete_file($file);
     }
     $st->write($self->{base});
@@ -187,12 +173,9 @@ sub merge_runs {
   $self
 }
 
-sub validate_db {
-  my $self = shift;
-
+sub validate_db ($self) {
   # Check validity of the db.  It is valid if the $DB file is there, or if it
-  # is not there but the db directory is empty, or if there is no db
-  # directory.
+  # is not there but the db directory is empty, or if there is no db directory.
   # die if the db is invalid.
 
   # just warn for now
@@ -202,56 +185,39 @@ sub validate_db {
   $self
 }
 
-sub exists {
-  my $self = shift;
-  -d $self->{db}
-}
+sub exists ($self) { -d $self->{db} }
 
-sub is_valid {
-  my $self = shift;
+sub is_valid ($self) {
   return 1 if !-e $self->{db};
   return 1 if -e "$self->{db}/$DB";
-  opendir my $fh, $self->{db} or return 0;
-  my $ignore = join "|", qw(
-    runs structure debuglog digests .AppleDouble
-  );
-  for my $file (readdir $fh) {
+  opendir my $dir, $self->{db} or return 0;
+  my $ignore = join "|", qw( runs structure debuglog digests .AppleDouble );
+  for my $file (readdir $dir) {
     next if $file eq "." || $file eq "..";
     next if $file =~ /(?:$ignore)|(?:\.lock)$/ && -e "$self->{db}/$file";
     warn "found $file in $self->{db}";
     return 0;
   }
-  closedir $fh
+  closedir $dir
 }
 
-sub collected {
-  my $self = shift;
+sub collected ($self) {
   $self->cover;
-  sort keys %{ $self->{collected} }
+  sort keys $self->{collected}->%*
 }
 
-sub merge {
-  my ($self, $from) = @_;
-
-  # print STDERR "Merging ", Dumper($self), "From ", Dumper($from);
-  # print STDERR "Merging ", $self, "From ", $from, "\n";
-  # print STDERR "$_\n" for keys %{$from->{runs}};
-
-  for my $fname (sort keys %{ $from->{runs} }) {
-    # print STDERR "fname $fname\n";
+sub merge ($self, $from) {
+  for my $fname (sort keys $from->{runs}->%*) {
     my $frun = $from->{runs}{$fname};
-    for my $file (sort keys %{ $frun->{digests} }) {
-      # print STDERR "file $file\n";
+    for my $file (sort keys $frun->{digests}->%*) {
       my $digest = $frun->{digests}{$file};
-      for my $name (sort keys %{ $self->{runs} }) {
-        # print STDERR "name $name\n";
+      for my $name (sort keys $self->{runs}->%*) {
         my $run = $self->{runs}{$name};
-        # print STDERR
-        # "digests for $file: $digest, $run->{digests}{$file}\n";
-        if ( $run->{digests}{$file}
+        if (
+             $run->{digests}{$file}
           && $digest
-          && $run->{digests}{$file} ne $digest)
-        {
+          && $run->{digests}{$file} ne $digest
+        ) {
           # File has changed.  Delete old coverage instead of merging.
           print STDOUT "Devel::Cover: Deleting old coverage for ",
             "changed file $file\n"
@@ -280,44 +246,44 @@ sub merge {
   # $_[0] = $from;
 }
 
-sub _merge_hash {
-  my ($into, $from, $noadd) = @_;
+sub _merge_hash ($into, $from, $noadd = 0) {
   return unless $from;
-  for my $fkey (keys %{$from}) {
-    # print STDERR "key [$fkey]\n";
+  for my $fkey (keys %$from) {
     my $fval = $from->{$fkey};
 
-    if (defined $into->{$fkey} and UNIVERSAL::isa($into->{$fkey}, "ARRAY")) {
+    if (defined $into->{$fkey} && UNIVERSAL::isa($into->{$fkey}, "ARRAY")) {
       _merge_array($into->{$fkey}, $fval, $noadd);
     } elsif (defined $fval && UNIVERSAL::isa($fval, "HASH")) {
-      if (defined $into->{$fkey} and UNIVERSAL::isa($into->{$fkey}, "HASH")) {
+      if (defined $into->{$fkey} && UNIVERSAL::isa($into->{$fkey}, "HASH")) {
         _merge_hash($into->{$fkey}, $fval, $noadd);
       } else {
         $into->{$fkey} = $fval;
       }
     } else {
-      # A scalar (or a blessed scalar).  We know there is no into
-      # array, or we would have just merged with it.
+      # A scalar (or a blessed scalar).  We know there is no into array, or we
+      # would have just merged with it.
       $into->{$fkey} = $fval;
     }
   }
 }
 
-sub _merge_array {
-  my ($into, $from, $noadd) = @_;
+sub _merge_array ($into, $from, $noadd = 0) {
   for my $i (@$into) {
     my $f = shift @$from;
-    if (UNIVERSAL::isa($i, "ARRAY")
-      || !defined $i && UNIVERSAL::isa($f, "ARRAY"))
-    {
+    if (
+      UNIVERSAL::isa($i, "ARRAY")
+      || !defined $i && UNIVERSAL::isa($f, "ARRAY")
+    ) {
       _merge_array($i, $f || [], $noadd);
-    } elsif (UNIVERSAL::isa($i, "HASH")
-      || !defined $i && UNIVERSAL::isa($f, "HASH"))
-    {
+    } elsif (
+      UNIVERSAL::isa($i, "HASH")
+      || !defined $i && UNIVERSAL::isa($f, "HASH")
+    ) {
       _merge_hash($i, $f || {}, $noadd);
-    } elsif (UNIVERSAL::isa($i, "SCALAR")
-      || !defined $i && UNIVERSAL::isa($f, "SCALAR"))
-    {
+    } elsif (
+      UNIVERSAL::isa($i, "SCALAR")
+      || !defined $i && UNIVERSAL::isa($f, "SCALAR")
+    ) {
       $$i += $$f;
     } else {
       if (defined $f) {
@@ -325,7 +291,7 @@ sub _merge_array {
         if (!$noadd && $f =~ /^\d+$/ && $i =~ /^\d+$/) {
           $i += $f;
         } elsif ($i ne $f) {
-          warn "<$i> does not match <$f> - using later value";
+          warn "<$i> does not match <$f> - using latter value";
           $i = $f;
         }
       }
@@ -334,33 +300,26 @@ sub _merge_array {
   push @$into, @$from;
 }
 
-sub summary {
-  my $self = shift;
-  my ($file, $criterion, $part) = @_;
+sub summary ($self, $file, $criterion, $part) {
   my $f = $self->{summary}{$file};
   return $f unless $f && defined $criterion;
   my $c = $f->{$criterion};
   $c && defined $part ? $c->{$part} : $c
 }
 
-sub calculate_summary {
-  my $self    = shift;
-  my %options = @_;
-
+sub calculate_summary ($self, %options) {
   return if exists $self->{summary} && !$options{force};
   my $s = $self->{summary} = {};
 
   my @files = $self->cover->items;
   if (my $files = delete $options{files}) {
-    my %required_files = map { ($_ => 1) } @$files;
+    my %required_files = map { $_ => 1 } @$files;
     @files = grep $required_files{$_}, @files;
   }
 
   for my $file (@files) {
     $self->cover->get($file)->calculate_summary($self, $file, \%options);
   }
-
-  # print STDERR Dumper $self;
 
   for my $file (@files) {
     $self->cover->get($file)->calculate_percentage($self, $s->{$file});
@@ -373,22 +332,16 @@ sub calculate_summary {
     $c->calculate_percentage($self, $t->{$criterion});
   }
   Devel::Cover::Criterion->calculate_percentage($self, $t->{total});
-
-  # print STDERR Dumper $self->{summary};
 }
 
-sub trimmed_file {
-  my ($f, $len) = @_;
+sub trimmed_file ($f, $len) {
   substr $f, 0, 3 - $len, "..." if length $f > $len;
   $f
 }
 
-sub print_summary {
-  my $self = shift;
-  my ($files, $criteria, $opts) = @_;
-
-  my %crit    = map(($_ => 1), $self->collected);
-  my %options = $criteria ? map(($_ => 1), grep $crit{$_}, @$criteria) : %crit;
+sub print_summary ($self, $files, $criteria, $opts) {
+  my %crit    = map { $_ => 1 } $self->collected;
+  my %options = $criteria ? map { $_ => 1 } grep $crit{$_}, @$criteria : %crit;
   $options{total} = 1 if keys %options;
 
   my $n = keys %options;
@@ -398,14 +351,13 @@ sub print_summary {
   $options{files} = $files if $files && @$files;
   $self->calculate_summary(%options, %$opts);
 
-  my $format = sub {
-    my ($part, $criterion) = @_;
+  my $format = sub ($part, $criterion) {
     $options{$criterion} && exists $part->{$criterion}
       ? do {
         my $x = sprintf "%5.2f", $part->{$criterion}{percentage};
         chop $x;
         $x
-    }
+      }
       : "n/a"
   };
 
@@ -415,7 +367,7 @@ sub print_summary {
   for (@files) { $max = length if length > $max }
   my $width
     = !$ENV{DEVEL_COVER_TEST_SUITE}
-    && CAN_TERM_SIZE
+    && $Has_term_size
     && -t STDOUT ? (Term::Size::chars(\*STDOUT))[0] : 80;
   my $fw = $width - $n * 7 - 3;
 
@@ -424,16 +376,13 @@ sub print_summary {
   no warnings "uninitialized";
   my $fmt = "%-${fw}s" . " %6s" x $n . "\n";
   printf $fmt, "-" x $fw, ("------") x $n;
-  printf $fmt, "File",
-    map  { $self->{all_criteria_short}[$_] }
-    grep { $options{ $self->{all_criteria}[$_] } }
-    (0 .. $#{ $self->{all_criteria} });
+  printf $fmt, "File", map $self->{all_criteria_short}[$_],
+    grep $options{ $self->{all_criteria}[$_] }, 0 .. $self->{all_criteria}->$#*;
   printf $fmt, "-" x $fw, ("------") x $n;
 
   for my $file (@files) {
-    printf $fmt, trimmed_file($file, $fw),
-      map { $format->($s->{$file}, $_) }
-      grep { $options{$_} } @{ $self->{all_criteria} };
+    printf $fmt, trimmed_file($file, $fw), map $format->($s->{$file}, $_),
+      grep $options{$_}, $self->{all_criteria}->@*;
 
   }
 
@@ -443,57 +392,41 @@ sub print_summary {
   select $oldfh;
 }
 
-sub add_statement {
-  my $self = shift;
-  my ($cc, $sc, $fc, $uc) = @_;
+sub add_statement ($self, $cc, $sc, $fc, $uc) {
   my %line;
   for my $i (0 .. $#$fc) {
-    # print STDERR "statement: $i\n";
-    my $l = $sc->[$i];
-    unless (defined $l) {
-      # print STDERR "sc ", scalar @$sc, ", fc ", scalar @$fc, "\n";
-      # print STDERR "sc ", Dumper($sc), "fc ", Dumper($fc);
+    my $l = $sc->[$i] // do {
       warn "Devel::Cover: ignoring extra statement\n";
       return;
-    }
+    };
     my $n = $line{$l}++;
     no warnings "uninitialized";
-    $cc->{$l}[$n][0] += $fc->[$i];
+    $cc->{$l}[$n][0]  += $fc->[$i];
     $cc->{$l}[$n][1] ||= $uc->{$l}[$n][0][1];
   }
-  # print STDERR Dumper $uc;
-  # print STDERR "cc: ", Dumper $cc;
 }
 
-sub add_time {
-  my $self = shift;
-  my ($cc, $sc, $fc) = @_;
+sub add_time ($self, $cc, $sc, $fc) {
   my %line;
   for my $i (0 .. $#$fc) {
-    my $l = $sc->[$i];
-    unless (defined $l) {
-      # print STDERR "sc ", scalar @$sc, ", fc ", scalar @$fc, "\n";
-      # print STDERR "sc ", Dumper($sc), "fc ", Dumper($fc);
+    my $l = $sc->[$i] // do {
       warn "Devel::Cover: ignoring extra statement\n";
       return;
-    }
+    };
     my $n = $line{$l}++;
     $cc->{$l}[$n] ||= do { my $c; \$c };
     no warnings "uninitialized";
-    ${ $cc->{$l}[$n] } += $fc->[$i];
+    $cc->{$l}[$n]->$* += $fc->[$i];
   }
 }
 
-sub add_branch {
-  my $self = shift;
-  my ($cc, $sc, $fc, $uc) = @_;
+sub add_branch ($self, $cc, $sc, $fc, $uc) {
   my %line;
   for my $i (0 .. $#$fc) {
-    my $l = $sc->[$i][0];
-    unless (defined $l) {
+    my $l = $sc->[$i][0] // do {
       warn "Devel::Cover: ignoring extra branch\n";
       return;
-    }
+    };
     my $n = $line{$l}++;
     no warnings "uninitialized";
     if (my $a = $cc->{$l}[$n]) {
@@ -508,12 +441,7 @@ sub add_branch {
   }
 }
 
-sub add_subroutine {
-  my $self = shift;
-  my ($cc, $sc, $fc, $uc) = @_;
-
-  # print STDERR "add_subroutine():\n", Dumper $cc, $sc, $fc, $uc;
-
+sub add_subroutine ($self, $cc, $sc, $fc, $uc) {
   # $cc = { line_number => [ [ count, sub_name, uncoverable ], [ ... ] ], .. }
   # $sc = [ [ line_number, sub_name ], [ ... ] ]
   # $fc = [ count, ... ]
@@ -522,13 +450,10 @@ sub add_subroutine {
 
   my %line;
   for my $i (0 .. $#$fc) {
-    my $l = $sc->[$i][0];
-    unless (defined $l) {
-      # print STDERR "sc ", scalar @$sc, ", fc ", scalar @$fc, "\n";
-      # print STDERR "sc ", Dumper($sc), "fc ", Dumper($fc);
+    my $l = $sc->[$i][0] // do {
       warn "Devel::Cover: ignoring extra subroutine\n";
       return;
-    }
+    };
 
     my $n = $line{$l}++;
     if (my $a = $cc->{$l}[$n]) {
@@ -547,22 +472,19 @@ sub add_subroutine {
   *add_pod       = \&add_subroutine;
 }
 
-sub uncoverable_files {
-  my $self = shift;
-  my $f    = ".uncoverable";
-  (@{ $self->{uncoverable_file} }, $f, glob("~/$f"))
+sub uncoverable_files ($self) {
+  my $f = ".uncoverable";
+  ($self->{uncoverable_file}->@*, $f, glob "~/$f")
 }
 
-sub uncoverable {
-  my $self = shift;
-
+sub uncoverable ($self) {
   my $u = {};  # holds all the uncoverable information
 
   # First populate $u with the uncoverable information directly from the
-  # .uncoverable files.  Then loop through the information converting it to
-  # the format we will use later to manage the uncoverable code.  The
-  # primary changes are converting MD5 digests of lines to line numbers, and
-  # converting filenames to MD5 digests of the files.
+  # .uncoverable files.  Then loop through the information converting it to the
+  # format we will use later to manage the uncoverable code.  The primary
+  # changes are converting MD5 digests of lines to line numbers, and converting
+  # filenames to MD5 digests of the files.
 
   for my $file ($self->uncoverable_files) {
     open my $f, "<", $file or next;
@@ -571,15 +493,12 @@ sub uncoverable {
     while (<$f>) {
       chomp;
       my ($file, $crit, $line, $count, $type, $class, $note) = split " ", $_, 7;
-      push @{ $u->{$file}{$crit}{$line}[$count] }, [ $type, $class, $note ];
+      push $u->{$file}{$crit}{$line}[$count]->@*, [ $type, $class, $note ];
     }
   }
 
-  # print STDERR Dumper $u;
   # Now change the format of the uncoverable information
-
   for my $file (sort keys %$u) {
-    # print STDERR "Reading $file\n";
     open my $fh, "<", $file or do {
       warn "Devel::Cover: Can't open $file: $!\n";
       next;
@@ -588,20 +507,15 @@ sub uncoverable {
     my %dl;                     # maps MD5 digests of lines to line numbers
     my $ln = 0;                 # line number
     while (<$fh>) {
-      # print STDERR "read [$.][$_]\n";
       $dl{ Digest::MD5->new->add($_)->hexdigest } = ++$ln;
       $df->add($_);
     }
-    close $fh;
+    close $fh or warn "Devel::Cover: Can't close $file: $!\n";
     my $f = $u->{$file};
-    # print STDERR Dumper $f;
     for my $crit (keys %$f) {
       my $c = $f->{$crit};
       for my $line (keys %$c) {
         if (exists $dl{$line}) {
-          # print STDERR
-          # "Found uncoverable $file:$crit:$line -> $dl{$line}\n";
-
           # Change key from the MD5 digest to the actual line number
           $c->{ $dl{$line} } = delete $c->{$line};
         } else {
@@ -619,9 +533,7 @@ sub uncoverable {
   $u
 }
 
-sub add_uncoverable {
-  my $self = shift;
-  my ($adds) = @_;
+sub add_uncoverable ($self, $adds) {
   for my $add (@$adds) {
     my ($file, $crit, $line, $count, $type, $class, $note) = split " ", $_, 7;
     my ($uncoverable_file) = $self->uncoverable_files;
@@ -646,20 +558,14 @@ sub add_uncoverable {
   }
 }
 
-sub delete_uncoverable {
-  my $self = shift;
+sub delete_uncoverable ($self, $deletes) {
 }
 
-sub clean_uncoverable {
-  my $self = shift;
+sub clean_uncoverable ($self) {
 }
 
-sub uncoverable_comments {
-
-  my $self = shift;
-  my ($uncoverable, $file, $digest) = @_;
-
-  my $cr    = join "|", @{ $self->{all_criteria} };
+sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
+  my $cr    = join "|", $self->{all_criteria}->@*;
   my $uc    = qr/(.*)# uncoverable ($cr)(.*)/;  # regex for uncoverable comments
   my %types = (
     branch    => { true => 0, false => 1 },
@@ -675,7 +581,6 @@ sub uncoverable_comments {
   my @waiting;
   while (<$fh>) {
     chomp;
-    # print STDERR "read [$.][$_]\n";
     next unless /$uc/ || @waiting;
     if ($2) {
       my ($code, $criterion, $info) = ($1, $2, $3);
@@ -712,11 +617,11 @@ sub uncoverable_comments {
     # found what we are waiting for
     while (my $w = shift @waiting) {
       my ($criterion, $count, $type, $class, $note) = @$w;
-      push @{ $uncoverable->{$digest}{$criterion}{$.}[$count] },
+      push $uncoverable->{$digest}{$criterion}{$.}[$count]->@*,
         [ $type, $class, $note ];
     }
   }
-  close $fh;
+  close $fh or warn "Devel::Cover: Can't close $file: $!\n";
 
   warn scalar @waiting,
     " unmatched uncoverable comments not found at end of $file\n"
@@ -726,12 +631,10 @@ sub uncoverable_comments {
   # print Dumper $uncoverable;
 }
 
-sub objectify_cover {
-  my $self = shift;
-
+sub objectify_cover ($self) {
   unless (UNIVERSAL::isa($self->{cover}, "Devel::Cover::DB::Cover")) {
     bless $self->{cover}, "Devel::Cover::DB::Cover";
-    for my $file (values %{ $self->{cover} }) {
+    for my $file (values $self->{cover}->%*) {
       bless $file, "Devel::Cover::DB::File";
       while (my ($crit, $criterion) = each %$file) {
         next if $crit eq "meta";  # ignore meta data
@@ -742,12 +645,11 @@ sub objectify_cover {
             die "<$crit:$o>" unless ref $o;
             bless $o, $class;
             bless $o, $class . "_" . $o->type if $o->can("type");
-            # print "blessed $crit, $o\n";
           }
         }
       }
     }
-    for my $r (keys %{ $self->{runs} }) {
+    for my $r (keys $self->{runs}->%*) {
       if (defined $self->{runs}{$r}) {
         bless $self->{runs}{$r}, "Devel::Cover::DB::Run";
       } else {
@@ -757,30 +659,19 @@ sub objectify_cover {
   }
 
   unless (exists &Devel::Cover::DB::Base::items) {
-    *Devel::Cover::DB::Base::items = sub {
-      my $self = shift;
-      keys %$self
-    };
+    *Devel::Cover::DB::Base::items = sub ($self) { keys %$self };
 
     {
       no warnings "once";
-      *Devel::Cover::DB::Base::values = sub {
-        my $self = shift;
-        values %$self
-      };
-
-      *Devel::Cover::DB::Base::get = sub {
-        my $self = shift;
-        my ($get) = @_;
-        $self->{$get}
-      };
+      *Devel::Cover::DB::Base::values = sub ($self) { values %$self };
+      *Devel::Cover::DB::Base::get    = sub ($self, $get) { $self->{$get} };
     }
 
     my $classes = {
-      Cover     => [qw( files file )],
-      File      => [qw( criteria criterion )],
-      Criterion => [qw( locations location )],
-      Location  => [qw( data datum )],
+      Cover     => [ qw( files     file ) ],
+      File      => [ qw( criteria  criterion ) ],
+      Criterion => [ qw( locations location ) ],
+      Location  => [ qw( data      datum ) ],
     };
     my $base = "Devel::Cover::DB::Base";
     while (my ($class, $functions) = each %$classes) {
@@ -799,13 +690,12 @@ sub objectify_cover {
           # Work around a change in bleadperl from 12251 to 14899
           my $func = $Devel::Cover::DB::AUTOLOAD || $::AUTOLOAD;
 
-          # print STDERR "autoloading <$func>\n";
           (my $f = $func) =~ s/.*:://;
           carp "Undefined subroutine $f called"
-            unless grep { $_ eq $f } @{ $self->{all_criteria} },
-            @{ $self->{all_criteria_short} };
+            unless grep $_ eq $f, $self->{all_criteria}->@*,
+            $self->{all_criteria_short}->@*;
           no strict "refs";
-          *$func = sub { shift->{$f} };
+          *$func = sub ($self) { $self->{$f} };
           goto &$func
         };
       }
@@ -813,9 +703,7 @@ sub objectify_cover {
   }
 }
 
-sub cover {
-  my $self = shift;
-
+sub cover ($self) {
   return $self->{cover} if $self->{cover_valid};
 
   my %digests;  # mapping of digests to canonical filenames
@@ -831,8 +719,7 @@ sub cover {
   my @runs = sort {
     ($self->{runs}{$b}{start} || 0) <=> ($self->{runs}{$a}{start} || 0)
       || $b cmp $a
-  } keys %{ $self->{runs} };
-  # print STDERR "runs: ", Dumper \@runs
+  } keys $self->{runs}->%*;
 
   my %warned;
   for my $run (@runs) {
@@ -840,20 +727,18 @@ sub cover {
 
     my $r = $self->{runs}{$run};
     next unless $r->{collected};  # DEVEL_COVER_SELF
-    @{ $self->{collected} }{ @{ $r->{collected} } } = ();
-    $st->add_criteria(@{ $r->{collected} });
+    $self->{collected}->@{ $r->{collected}->@* } = ();
+    $st->add_criteria($r->{collected}->@*);
     my $count = $r->{count};
-    # print STDERR "run $run, count: ", Dumper $count;
     while (my ($file, $f) = each %$count) {
       my $digest = $r->{digests}{$file};
       unless ($digest) {
         print STDERR "Devel::Cover: Can't find digest for $file\n"
           unless $Devel::Cover::Silent
           || $file =~ $Devel::Cover::DB::Ignore_filenames
-          || ($Devel::Cover::Self_cover && $file =~ q|/Devel/Cover[./]|);
+          || ($Devel::Cover::Self_cover && $file =~ "/Devel/Cover[./]");
         next;
       }
-      # print STDERR "File: $file\n";
       print STDERR "Devel::Cover: merging data for $file ",
         "into $digests{$digest}\n"
         if !$files{$file}++ && $digests{$digest};
@@ -869,31 +754,23 @@ sub cover {
       }
       my $cf = $cover->{ $digests{$digest} ||= $ff } ||= {};
 
-      # print STDERR "st ", Dumper($st),
-      # "f  ", Dumper($f),
-      # "uc ", Dumper($uncoverable->{$digest});
       while (my ($criterion, $fc) = each %$f) {
         my $get = "get_$criterion";
-        my $sc  = $st->$get($digest);
-        # print STDERR "$criterion: ", Dumper $sc, $fc;
-        unless ($sc) {
+        my $sc  = $st->$get($digest) or do {
           print STDERR "Devel::Cover: Warning: can't locate ",
             "structure for $criterion in $file\n"
             unless $warned{$file}{$criterion}++;
           next;
-        }
+        };
         my $cc  = $cf->{$criterion} ||= {};
         my $add = "add_$criterion";
-        # print STDERR "$add():\n", Dumper $cc, $sc, $fc;
         $self->$add($cc, $sc, $fc, $uncoverable->{$digest}{$criterion});
-        # print STDERR "--> $add():\n", Dumper $cc;
         # $cc - coverage being filled in
         # $sc - structure information
         # $fc - coverage from this file
         # $uc - uncoverable information
       }
     }
-    # print STDERR "Cover: ", Dumper $cover;
   }
 
   $self->objectify_cover;
@@ -901,22 +778,18 @@ sub cover {
   $self->{cover}
 }
 
-sub run_keys {
-  my $self = shift;
+sub run_keys ($self) {
   $self->cover unless $self->{cover_valid};
   sort { $self->{runs}{$b}{start} <=> $self->{runs}{$a}{start} }
-    keys %{ $self->{runs} };
+    keys $self->{runs}->%*
 }
 
-sub runs {
-  my $self = shift;
+sub runs ($self) {
   $self->cover unless $self->{cover_valid};
-  @{ $self->{runs} }{ $self->run_keys }
+  $self->{runs}->@{ $self->run_keys }
 }
 
-sub set_structure {
-  my $self = shift;
-  my ($structure) = @_;
+sub set_structure ($self, $structure) {
   $self->{_structure} = $structure;
 }
 
@@ -928,7 +801,6 @@ sub DESTROY { }
 
 sub AUTOLOAD {
   my $func = $AUTOLOAD;
-  # print STDERR "autoloading <$func>\n";
   (my $f = $func) =~ s/.*:://;
   no strict "refs";
   *$func = sub { shift->{$f} };

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -11,8 +11,8 @@ use v5.20.0;
 use strict;
 use warnings;
 
-use feature "signatures";
-no warnings "experimental::signatures";
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -21,9 +21,11 @@ use Devel::Cover::DB::File      ();
 use Devel::Cover::DB::Structure ();
 use Devel::Cover::DB::IO        ();
 
-use Carp       qw( carp croak );
-use File::Find qw( find );
-use File::Path qw( rmtree );
+use Carp         qw( carp croak );
+use File::Find   qw( find );
+use File::Path   qw( rmtree );
+use List::Util   qw( any );
+use Scalar::Util qw( blessed reftype );
 
 use Devel::Cover::Dumper qw( Dumper );  # For debugging
 
@@ -251,10 +253,10 @@ sub _merge_hash ($into, $from, $noadd = 0) {
   for my $fkey (keys %$from) {
     my $fval = $from->{$fkey};
 
-    if (defined $into->{$fkey} && UNIVERSAL::isa($into->{$fkey}, "ARRAY")) {
+    if (defined $into->{$fkey} && (reftype($into->{$fkey}) // "") eq "ARRAY") {
       _merge_array($into->{$fkey}, $fval, $noadd);
-    } elsif (defined $fval && UNIVERSAL::isa($fval, "HASH")) {
-      if (defined $into->{$fkey} && UNIVERSAL::isa($into->{$fkey}, "HASH")) {
+    } elsif (defined $fval && (reftype($fval) // "") eq "HASH") {
+      if (defined $into->{$fkey} && (reftype($into->{$fkey}) // "") eq "HASH") {
         _merge_hash($into->{$fkey}, $fval, $noadd);
       } else {
         $into->{$fkey} = $fval;
@@ -269,21 +271,14 @@ sub _merge_hash ($into, $from, $noadd = 0) {
 
 sub _merge_array ($into, $from, $noadd = 0) {
   for my $i (@$into) {
-    my $f = shift @$from;
-    if (
-      UNIVERSAL::isa($i, "ARRAY")
-      || !defined $i && UNIVERSAL::isa($f, "ARRAY")
-    ) {
+    my $f  = shift @$from;
+    my $it = reftype($i) // "";
+    my $ft = reftype($f) // "";
+    if ($it eq "ARRAY" || !defined $i && $ft eq "ARRAY") {
       _merge_array($i, $f || [], $noadd);
-    } elsif (
-      UNIVERSAL::isa($i, "HASH")
-      || !defined $i && UNIVERSAL::isa($f, "HASH")
-    ) {
+    } elsif ($it eq "HASH" || !defined $i && $ft eq "HASH") {
       _merge_hash($i, $f || {}, $noadd);
-    } elsif (
-      UNIVERSAL::isa($i, "SCALAR")
-      || !defined $i && UNIVERSAL::isa($f, "SCALAR")
-    ) {
+    } elsif ($it eq "SCALAR" || !defined $i && $ft eq "SCALAR") {
       $$i += $$f;
     } else {
       if (defined $f) {
@@ -346,8 +341,6 @@ sub print_summary ($self, $files, $criteria, $opts) {
 
   my $n = keys %options;
 
-  my $oldfh = select STDOUT;
-
   $options{files} = $files if $files && @$files;
   $self->calculate_summary(%options, %$opts);
 
@@ -375,21 +368,19 @@ sub print_summary ($self, $files, $criteria, $opts) {
 
   no warnings "uninitialized";
   my $fmt = "%-${fw}s" . " %6s" x $n . "\n";
-  printf $fmt, "-" x $fw, ("------") x $n;
-  printf $fmt, "File", map $self->{all_criteria_short}[$_],
+  printf STDOUT $fmt, "-" x $fw, ("------") x $n;
+  printf STDOUT $fmt, "File", map $self->{all_criteria_short}[$_],
     grep $options{ $self->{all_criteria}[$_] }, 0 .. $self->{all_criteria}->$#*;
-  printf $fmt, "-" x $fw, ("------") x $n;
+  printf STDOUT $fmt, "-" x $fw, ("------") x $n;
 
   for my $file (@files) {
-    printf $fmt, trimmed_file($file, $fw), map $format->($s->{$file}, $_),
-      grep $options{$_}, $self->{all_criteria}->@*;
-
+    printf STDOUT $fmt, trimmed_file($file, $fw),
+      map $format->($s->{$file}, $_), grep $options{$_},
+      $self->{all_criteria}->@*;
   }
 
-  printf $fmt, "-" x $fw, ("------") x $n;
-  print "\n\n";
-
-  select $oldfh;
+  printf STDOUT $fmt, "-" x $fw, ("------") x $n;
+  print STDOUT "\n\n";
 }
 
 sub add_statement ($self, $cc, $sc, $fc, $uc) {
@@ -602,8 +593,8 @@ sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
       $count = $1 if $info =~ /count:($c(?:,$c)*)/;
       my @counts = map { m/^(\d+)\.\.(\d+)$/ ? ($1 .. $2) : $_ } split m/,/,
         $count;
-      $class = $1 if $info =~ /class:(\w+)/;
-      $note  = $1 if $info =~ /note:(.+)/;
+      if ($info =~ /class:(\w+)/) { $class = $1 }
+      if ($info =~ /note:(.+)/)   { $note  = $1 }
 
       for my $c (@counts) {
         # no warnings "uninitialized";
@@ -632,7 +623,10 @@ sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
 }
 
 sub objectify_cover ($self) {
-  unless (UNIVERSAL::isa($self->{cover}, "Devel::Cover::DB::Cover")) {
+  unless (
+    blessed($self->{cover})
+    && $self->{cover}->isa("Devel::Cover::DB::Cover")
+  ) {
     bless $self->{cover}, "Devel::Cover::DB::Cover";
     for my $file (values $self->{cover}->%*) {
       bless $file, "Devel::Cover::DB::File";
@@ -692,7 +686,7 @@ sub objectify_cover ($self) {
 
           (my $f = $func) =~ s/.*:://;
           carp "Undefined subroutine $f called"
-            unless grep $_ eq $f, $self->{all_criteria}->@*,
+            unless any { $_ eq $f } $self->{all_criteria}->@*,
             $self->{all_criteria_short}->@*;
           no strict "refs";
           *$func = sub ($self) { $self->{$f} };
@@ -700,6 +694,50 @@ sub objectify_cover ($self) {
         };
       }
     }
+  }
+}
+
+sub _file_digest ($r, $file) {
+  my $digest = $r->{digests}{$file};
+  return $digest if $digest;
+  print STDERR "Devel::Cover: Can't find digest for $file\n"
+    unless $Devel::Cover::Silent
+    || $file =~ $Devel::Cover::DB::Ignore_filenames
+    || ($Devel::Cover::Self_cover && $file =~ "/Devel/Cover[./]");
+  undef
+}
+
+sub _cover_file (
+  $self,  $file,        $f,       $r,     $st,
+  $cover, $uncoverable, $digests, $files, $warned,
+) {
+  my $digest = _file_digest($r, $file) or return;
+
+  print STDERR "Devel::Cover: merging data for $file ",
+    "into $digests->{$digest}\n"
+    if !$files->{$file}++ && $digests->{$digest};
+
+  $self->uncoverable_comments($uncoverable, $file, $digest)
+    unless $digests->{$digest};
+
+  my $ff = $file;
+  if ($self->{prefer_lib}) {
+    $ff =~ s|^blib/||;
+    $ff = $file unless -e $ff;
+  }
+  my $cf = $cover->{ $digests->{$digest} ||= $ff } ||= {};
+
+  while (my ($criterion, $fc) = each %$f) {
+    my $get = "get_$criterion";
+    my $sc  = $st->$get($digest) or do {
+      print STDERR "Devel::Cover: Warning: can't locate ",
+        "structure for $criterion in $file\n"
+        unless $warned->{$file}{$criterion}++;
+      next;
+    };
+    my $cc  = $cf->{$criterion} ||= {};
+    my $add = "add_$criterion";
+    $self->$add($cc, $sc, $fc, $uncoverable->{$digest}{$criterion});
   }
 }
 
@@ -731,45 +769,10 @@ sub cover ($self) {
     $st->add_criteria($r->{collected}->@*);
     my $count = $r->{count};
     while (my ($file, $f) = each %$count) {
-      my $digest = $r->{digests}{$file};
-      unless ($digest) {
-        print STDERR "Devel::Cover: Can't find digest for $file\n"
-          unless $Devel::Cover::Silent
-          || $file =~ $Devel::Cover::DB::Ignore_filenames
-          || ($Devel::Cover::Self_cover && $file =~ "/Devel/Cover[./]");
-        next;
-      }
-      print STDERR "Devel::Cover: merging data for $file ",
-        "into $digests{$digest}\n"
-        if !$files{$file}++ && $digests{$digest};
-
-      $self->uncoverable_comments($uncoverable, $file, $digest)
-        unless $digests{$digest};
-
-      # Set up data structure to hold coverage being filled in
-      my $ff = $file;
-      if ($self->{prefer_lib}) {
-        $ff =~ s|^blib/||;
-        $ff = $file unless -e $ff;
-      }
-      my $cf = $cover->{ $digests{$digest} ||= $ff } ||= {};
-
-      while (my ($criterion, $fc) = each %$f) {
-        my $get = "get_$criterion";
-        my $sc  = $st->$get($digest) or do {
-          print STDERR "Devel::Cover: Warning: can't locate ",
-            "structure for $criterion in $file\n"
-            unless $warned{$file}{$criterion}++;
-          next;
-        };
-        my $cc  = $cf->{$criterion} ||= {};
-        my $add = "add_$criterion";
-        $self->$add($cc, $sc, $fc, $uncoverable->{$digest}{$criterion});
-        # $cc - coverage being filled in
-        # $sc - structure information
-        # $fc - coverage from this file
-        # $uc - uncoverable information
-      }
+      $self->_cover_file(
+        $file, $f, $r, $st, $cover,
+        $uncoverable, \%digests, \%files, \%warned
+      );
     }
   }
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -149,9 +149,8 @@ sub merge_runs ($self) {
   $self->{changed_files} = {};
 
   # The ordering is important here.  The runs need to be merged in the order
-  # they were created.  We're only at a granularity of one second, but that
-  # shouldn't be a problem unless a file is altered and the coverage run created
-  # in less than a second.  I think we're OK for now.
+  # they were created.  Run names use microsecond timestamps so lexicographic
+  # sorting matches chronological order.
 
   for my $run (sort @runs) {
     my $r = Devel::Cover::DB->new(base => $self->{base}, db => $run);

--- a/lib/Devel/Cover/Test.pm
+++ b/lib/Devel/Cover/Test.pm
@@ -45,7 +45,6 @@ sub new {
     debug            => $ENV{DEVEL_COVER_DEBUG} || 0,
     differences      => $differences,
     no_coverage      => $ENV{DEVEL_COVER_NO_COVERAGE} || 0,
-    delay_after_run  => 0,
     %params,
   }, $class;
 
@@ -189,11 +188,6 @@ sub run_command {
   if (!close $fh) {
     die "Cannot close $command: $!" if $!;
     die "Error closing $command, output was:\n", @lines;
-  }
-
-  if ($self->{delay_after_run}) {
-    eval { select undef, undef, undef, $self->{delay_after_run}; 1 }
-      or sleep int $self->{delay_after_run} + 1;
   }
 
   1

--- a/tests/change.t
+++ b/tests/change.t
@@ -45,7 +45,6 @@ my $test = Devel::Cover::Test->new(
     run_test        => $run_test,
     end             => sub { unlink $ft },
     no_report       => 0,
-    delay_after_run => 0.50,
 );
 
 $test->run_test;

--- a/tests/md5.t
+++ b/tests/md5.t
@@ -37,7 +37,6 @@ my $test = Devel::Cover::Test->new(
     db_name         => "complex_$t",
     run_test        => $run_test,
     end             => sub { unlink $ft },
-    delay_after_run => 0.50,
 );
 
 $test->run_test;


### PR DESCRIPTION
## Summary

The `md5` and `change` end-to-end tests intermittently fail with "can't locate structure" warnings because `merge_runs` sorts run directories lexicographically, but run names use integer-second timestamps. When two runs complete within the same second, PID string comparison determines sort order, which may not match chronological order. The wrong merge order causes structure data loss.

A comment from 2004 acknowledged the one-second granularity risk: "I think we're OK for now." This PR fixes the root cause and modernises the two core modules as preparatory cleanup.

## Changes

- Use microsecond-resolution timestamps (via `Time::HiRes`) in run directory names so lexicographic sort reliably matches chronological order.
- Remove the `delay_after_run` workaround from tests and `Test.pm` - no longer needed.
- Modernise `DB.pm`: add signatures, convert to postderef, replace `UNIVERSAL::isa` with `Scalar::Util`/`reftype`, replace `select STDOUT` with explicit filehandle, extract helpers from `cover` method, fix all perlcritic violations.
- Add signatures and postderef to `Cover.pm`, remove unused code.
- Enable the `postderef` feature pragma in both modules.
- Add a documentation section to `CLAUDE.md` pointing to `docs/technical/`.

## Implications

- Run directory names are now 16 digits (microseconds) instead of 10 (seconds), so existing coverage databases with pending runs will still merge correctly since the sort order is preserved - old names sort before new ones.
- `Time::HiRes` has been core since Perl 5.7.3, well within the 5.20+ requirement.
- The `delay_after_run` mechanism is fully removed. Any external code that relied on it will get a harmless unknown-key warning from `Devel::Cover::Test->new`.

## Issue

Fixes #397