### PR TITLE
GH-399 Tidy main module

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -425,10 +425,19 @@ DB = cover_db
 dump :
 \t \$(PERL) -Mblib bin/cover -dump_db \$(DB)
 
-diff : out
+GOLD_FILE = \$(PERL) -Mblib -MDevel::Cover::Test \\
+\t -e '\$\$t = Devel::Cover::Test->new(qq(\$(TEST))); \\
+\t print join qq(.), \$\$t->cover_gold'
+
+_diff : out
 \t \$(PERL) utils/makeh strip_criterion 'time' \$(TEST).out
 \t \$(PERL) utils/makeh strip_criterion ' pod' \$(TEST).out
-\t gold="`\$(PERL) -Mblib -MDevel::Cover::Test -e '\$\$t = Devel::Cover::Test->new(qq(\$(TEST))); print join qq(.), \$\$t->cover_gold'`" && \$(EDITOR) -d "\$\$gold" \$(TEST).out
+
+diff : _diff
+\t gold="`\$(GOLD_FILE)`" && diff -u "\$\$gold" \$(TEST).out
+
+ediff : _diff
+\t gold="`\$(GOLD_FILE)`" && \$(EDITOR) -d "\$\$gold" \$(TEST).out
 
 gold : pure_all
 \t \$(PERL) utils/create_gold \$(TEST)

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -20,8 +20,7 @@ BEGIN {
   # VERSION
 }
 
-use DynaLoader ();
-our @ISA = "DynaLoader";
+use parent "DynaLoader";
 
 use Devel::Cover::DB          ();
 use Devel::Cover::DB::Digests ();

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -40,7 +40,6 @@ BEGIN {
   B->import("OPpSTATEMENT") if $v;
 }
 
-use Config      qw( %Config );
 use Cwd         qw( abs_path getcwd );
 use File::Spec  ();
 use Time::HiRes ();
@@ -125,30 +124,24 @@ BEGIN {
     || ($ENV{PERL5OPT} || "") =~ /Devel::Cover/;
   *OUT = $ENV{DEVEL_COVER_DEBUG} ? *STDERR : *STDOUT;
 
-  if ($^X =~ /(apache2|httpd)$/) {
-    # mod_perl < 2.0.8
-    @Inc = @Devel::Cover::Inc::Inc;
-  } else {
-    # Can't get @INC via eval `` in taint mode, revert to default value
-    if (${^TAINT}) {
-      @Inc = @Devel::Cover::Inc::Inc;
-    } else {
-      eval {
-        local %ENV = %ENV;
-        # Clear *PERL* variables, but keep PERL5?LIB for local::lib
-        # environments
-        /perl/i and not /^PERL5?LIB$/ and delete $ENV{$_} for keys %ENV;
-        my $cmd = "$^X -MData::Dumper -e " . '"print Dumper \@INC"';
-        my $VAR1;
-        # print STDERR "Running [$cmd]\n";
-        eval `$cmd`;
-        @Inc = @$VAR1;
-      };
-      if ($@) {
-        print STDERR __PACKAGE__, ": Error getting \@INC: $@\n",
-          "Reverting to default value for Inc.\n";
-        @Inc = @Devel::Cover::Inc::Inc;
+  # Default to the value baked in by Makefile.PL; override below if we can get
+  # the real @INC from a clean subprocess.
+  @Inc = @Devel::Cover::Inc::Inc;
+  if ($^X !~ /(?:apache2|httpd)$/ && !${^TAINT}) {
+    eval {
+      local %ENV = %ENV;
+      # Clear *PERL* variables, but keep PERL5?LIB for local::lib environments
+      /perl/i && !/^PERL5?LIB$/ && delete $ENV{$_} for keys %ENV;
+      if (open my $fh, "-|", $^X, "-e", 'print join("\0", @INC)') {
+        local $/ = "\0";
+        chomp(my @inc = <$fh>);
+        close $fh or die "Can't close pipe to $^X: $!";
+        @Inc = @inc if @inc;
       }
+    };
+    if ($@) {
+      print STDERR __PACKAGE__, ": Error getting \@INC: $@\n";
+      @Inc = @Devel::Cover::Inc::Inc;
     }
   }
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -144,7 +144,7 @@ BEGIN {
   @Inc     = map { -d () ? ($_ eq "." ? $_ : abs_path($_)) : () } @Inc;
   @Inc     = remove_contained_paths(getcwd, @Inc);
   @Ignore  = ("/Devel/Cover[./]") unless $Self_cover = $ENV{DEVEL_COVER_SELF};
-  $^P     |= 0x004 | 0x100;
+  $^P     |= 0x004 | 0x100;  # save source lines; evals report file info
 }
 
 sub version { $VERSION }

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -160,52 +160,6 @@ BEGIN {
 
 sub version { $VERSION }
 
-if (0 && $Config{useithreads}) {
-  eval "use threads";
-
-  no warnings "redefine";
-
-  my $original_join;
-  BEGIN { $original_join = \&threads::join }
-  *threads::join = sub {
-    my $self = shift;
-    print STDERR "(joining thread ", $self->tid, ")\n";
-    my @ret = $original_join->($self, @_);
-    print STDERR "(returning <@ret>)\n";
-    @ret
-  };
-
-  my $original_destroy;
-  BEGIN { $original_destroy = \&threads::DESTROY }
-
-  *threads::DESTROY = sub {
-    my $self = shift;
-    print STDERR "(destroying thread ", $self->tid, ")\n";
-    $original_destroy->($self, @_);
-  };
-
-  my $new = \&threads::new;
-  *threads::new = *threads::create = sub {
-    my $class     = shift;
-    my $sub       = shift;
-    my $wantarray = wantarray;
-
-    $new->(
-      $class,
-      sub {
-        print STDERR "Starting thread\n";
-        set_coverage(keys %Coverage);
-        my $ret = [ $sub->(@_) ];
-        print STDERR "Ending thread\n";
-        report() if $Initialised;
-        print STDERR "Ended thread\n";
-        $wantarray ? @{$ret} : $ret->[0];
-      },
-      @_
-    );
-  };
-}
-
 {
 
   sub check {

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1107,8 +1107,9 @@ my %Original;
 
   sub binop ($self, $op, $cx, $opname, $prec, $flags = 0) {
     if (
-      $] >= 5.041012
-      && ($opname eq "xor" || $opname eq "^^" && !$Seen{condition}{$$op}++)
+         $] >= 5.041012
+      && ($opname eq "xor" || $opname eq "^^")
+      && !$Seen{condition}{$$op}++
     ) {
       my $left  = $op->first;
       my $right = $op->last;

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -88,7 +88,6 @@ my %Pod;                                        # Pod coverage data
 my @Cvs;        # All the Cvs we want to cover
 my %Cvs;        # All the Cvs we want to cover
 my @Subs;       # All the subs we want to cover
-my $Cv;         ## no critic (ProhibitUnusedVariables)  # Cv we are looking in
 my $Sub_name;   # Name of the sub we are looking in
 my $Sub_count;  # Count for multiple subs on same line
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -56,9 +56,6 @@ BEGIN {
   die $@ if $@ && $@ !~ m/Can't locate Pod\/Coverage.+pm in \@INC/;
 }
 
-# $SIG{__DIE__} = \&Carp::confess;
-# sub Pod::Coverage::TRACE_ALL () { 1 }
-
 my $Initialised;  # import() has been called
 
 my $Dir;                          # Directory in which coverage will be
@@ -295,8 +292,7 @@ sub _init_coverage {
     }
     delete $Coverage{$_} unless length;
   }
-  %Coverage = (all => 1) unless keys %Coverage;
-  # print STDERR "Coverage: ", Dumper \%Coverage;
+  %Coverage         = (all => 1) unless keys %Coverage;
   %Coverage_options = %Coverage;
 }
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -333,7 +333,7 @@ sub trimmed_file ($f, $len) {
   $f
 }
 
-sub print_summary ($self, $files, $criteria, $opts) {
+sub print_summary ($self, $files = undef, $criteria = undef, $opts = {}) {
   my %crit    = map { $_ => 1 } $self->collected;
   my %options = $criteria ? map { $_ => 1 } grep $crit{$_}, @$criteria : %crit;
   $options{total} = 1 if keys %options;


### PR DESCRIPTION
Closes #399

## Summary

Clean up `lib/Devel/Cover.pm` to reduce maintenance burden. Removes dead code, fixes a latent operator precedence bug, replaces a security-sensitive `eval` of backtick output, and makes several minor modernisation improvements.

## Changes

- Remove dead threads block (gated by `if (0 && ...)`) and unused `$Cv` variable.
- Replace `eval` of `Data::Dumper` backtick output for `@INC` population with a piped `open` using null-separated output. Flatten the nested conditional structure.
- Fix `print_summary` signature in `DB.pm` - the signatures migration made all parameters mandatory but `Cover.pm` calls it with no arguments.
- Refactor `diff`/`ediff` Make targets: extract duplicated gold file path computation into a `GOLD_FILE` variable, split the old `diff` target so `diff` shows `diff -u` output and `ediff` opens the editor.
- Use `parent` pragma instead of manual `@ISA` assignment for `DynaLoader`.
- Remove commented-out debugging code.
- Fix operator precedence in `binop` so the `$Seen` deduplication guard applies to both `xor` and `^^`.
- Add comment documenting `$^P` flag bits.