### PR TITLE
GH-403 Fix condition coverage for interpolated strings

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -99,6 +99,21 @@ my %Run;               # Data collected from the run
 my $Const_right = qr/^(?:const|s?refgen|gelem|die|undef|bless|anon(?:list|hash)|
                        emptyavhv|scalar|return|last|next|redo|goto)$/x;
 
+# Check whether the right operand of a logical op is a constant-like
+# expression whose truth value is fixed.  Unwraps sassign if present.
+# Also handles multiconcat (Perl 5.28+) with truthy literal text -
+# the constant string is element [1] of aux_list and does not depend
+# on the CV passed.  We check truthiness rather than mere non-emptiness
+# because "0" is the one non-empty string that is falsy in Perl.
+sub _is_const_right ($op) {
+  my $rhs  = $op->name eq "sassign" ? $op->first : $op;
+  my $name = $rhs->name;
+  return 1 if $name =~ $Const_right;
+  return 0 unless ref($rhs) eq "B::UNOP_AUX" && $name eq "multiconcat";
+  my @aux = $rhs->aux_list(main_cv);
+  $aux[1]
+}
+
 # constant ops
 
 our $File;                # Last filename we saw.  (localised)
@@ -819,11 +834,9 @@ sub add_condition_cover ($op, $strop, $left, $right) {
   my $count;
 
   if ($type eq "or" || $type eq "and") {
-    my $r    = $op->first->sibling;
-    my $name = $r->name;
-    $name = $r->first->name if $name eq "sassign";
+    my $r = $op->first->sibling;
     # TODO - exec?  any others?
-    if ($c->[5] || $name =~ $Const_right) {
+    if ($c->[5] || _is_const_right($r)) {
       $c     = [ $c->[3], $c->[1] + $c->[2] ];
       $count = 2;
     } else {

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -97,7 +97,8 @@ my %Coverage_options;  # Options for overage criteria
 my %Run;               # Data collected from the run
 
 my $Const_right = qr/^(?:const|s?refgen|gelem|die|undef|bless|anon(?:list|hash)|
-                       emptyavhv|scalar|return|last|next|redo|goto)$/x;
+                       emptyavhv|scalar|return|last|next|redo|goto|
+                       exec|exit|warn)$/x;
 
 # Check whether the right operand of a logical op is a constant-like
 # expression whose truth value is fixed.  Unwraps sassign if present.
@@ -835,7 +836,6 @@ sub add_condition_cover ($op, $strop, $left, $right) {
 
   if ($type eq "or" || $type eq "and") {
     my $r = $op->first->sibling;
-    # TODO - exec?  any others?
     if ($c->[5] || _is_const_right($r)) {
       $c     = [ $c->[3], $c->[1] + $c->[2] ];
       $count = 2;

--- a/test_output/cover/cond_or_interp.5.020000
+++ b/test_output/cover/cond_or_interp.5.020000
@@ -4,8 +4,8 @@ Reading database from ...
 -------------------- ------ ------ ------ ------ ------
 File                   stmt   bran   cond    sub  total
 -------------------- ------ ------ ------ ------ ------
-tests/cond_or_interp  100.0  100.0   86.0  100.0   92.3
-Total                 100.0  100.0   86.0  100.0   92.3
+tests/cond_or_interp  100.0  100.0   83.6  100.0   90.9
+Total                 100.0  100.0   83.6  100.0   90.9
 -------------------- ------ ------ ------ ------ ------
 
 
@@ -104,7 +104,16 @@ line  err   stmt   bran   cond    sub   code
 80                                      
 81                                        # //= with multiconcat RHS, literal text (should be 2-outcome)
 82    ***      3          * 66            $Arr[1] //= "value $v end";
-83                                      }
+83                                      
+84                                        # warn always returns 1 (correctly 2-outcome)
+85             3           100            $r = $or_lhs || warn "expected\n";
+86                                      
+87                                        # exit and exec never return normally (correctly 2-outcome).
+88                                        # Use always-truthy LHS so they never actually execute.
+89             3                          my $true = 1;
+90    ***      3          * 50            $r = $true || exit 1;
+91    ***      3          * 50            $r = $true || exec "true";
+92                                      }
 
 
 Branches
@@ -126,6 +135,9 @@ line  err      %      l     !l   expr
 ----- --- ------ ------ ------   ----
 43           100      1      2   $or_lhs || 'literal'
 63           100      1      2   $dor_lhs // "literal"
+85           100      1      2   $or_lhs || warn("expected\n")
+90    ***     50      3      0   $true || exit 1
+91    ***     50      3      0   $true || exec('true')
 
 or 3 conditions
 

--- a/test_output/cover/cond_or_interp.5.020000
+++ b/test_output/cover/cond_or_interp.5.020000
@@ -1,0 +1,152 @@
+Reading database from ...
+
+
+-------------------- ------ ------ ------ ------ ------
+File                   stmt   bran   cond    sub  total
+-------------------- ------ ------ ------ ------ ------
+tests/cond_or_interp  100.0  100.0   85.0  100.0   91.8
+Total                 100.0  100.0   85.0  100.0   91.8
+-------------------- ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/cond_or_interp
+
+line  err   stmt   bran   cond    sub   code
+1                                       #!/usr/bin/perl
+2                                       
+3                                       # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                       
+5                                       # This software is free.  It is licensed under the same terms as Perl itself.
+6                                       
+7                                       # The latest version of this software should be available from my homepage:
+8                                       # https://pjcj.net
+9                                       
+10                                      # GH-403: Devel::Cover reports unreachable !l&&!r for // and || when the RHS is
+11                                      # an interpolated string.
+12                                      #
+13                                      # Interpolated strings compile to different ops depending on structure and Perl
+14                                      # version:
+15                                      #   "literal"        -> const        (in $Const_right, works)
+16                                      #   "pre $x post"    -> multiconcat  (literal text, always truthy)
+17                                      #   "pre $x"         -> multiconcat  (literal text, always truthy)
+18                                      #   "$x$y$z"         -> multiconcat  (no literal text, can be falsy)
+19                                      #   "$x$y"           -> concat       (can be falsy)
+20                                      #   "$x"             -> stringify    (can be falsy)
+21                                      #
+22                                      # For || and //: multiconcat with literal text should be 2-outcome (like const)
+23                                      # because the literal text guarantees a truthy result. Condition tracking uses
+24                                      # truthiness for both || and //, so the dor/or distinction does not matter here.
+25                                      
+26             1                    1   use strict;
+               1                        
+               1                        
+27             1                    1   use warnings;
+               1                        
+               1                        
+28                                      
+29             1                        my @Arr;
+30                                      
+31             1                        for my $iter (0 .. 2) {
+32                                        # iter 0: LHS truthy/defined -> short-circuit
+33                                        # iter 1: LHS falsy/undef, vars non-empty -> RHS truthy/defined
+34                                        # iter 2: LHS falsy/undef, vars empty -> RHS can be falsy
+35                                      
+36             3    100                   my $or_lhs  = $iter == 0 ? 1 : 0;
+37             3    100                   my $dor_lhs = $iter == 0 ? 1 : undef;
+38             3    100                   my $v       = $iter < 2  ? "x" : "";
+39                                      
+40             3                          my $r;
+41                                      
+42                                        # || with const RHS (baseline, correctly 2-outcome)
+43             3           100            $r = $or_lhs || "literal";
+44                                      
+45                                        # || with multiconcat RHS, literal text (should be 2-outcome)
+46    ***      3          * 66            $r = $or_lhs || "value $v end";
+47    ***      3          * 66            $r = $or_lhs || "value $v";
+48                                      
+49                                        # || with multiconcat RHS, no literal text (correctly 3-outcome)
+50             3           100            $r = $or_lhs || "$v$v$v";
+51                                      
+52                                        # || with concat RHS (correctly 3-outcome)
+53             3           100            $r = $or_lhs || "$v$v";
+54                                      
+55                                        # || with stringify RHS (correctly 3-outcome)
+56             3           100            $r = $or_lhs || "$v";
+57                                      
+58                                        # // with const RHS (baseline, correctly 2-outcome)
+59             3           100            $r = $dor_lhs // "literal";
+60                                      
+61                                        # // with multiconcat RHS, literal text (should be 2-outcome)
+62    ***      3          * 66            $r = $dor_lhs // "value $v end";
+63    ***      3          * 66            $r = $dor_lhs // "value $v";
+64                                      
+65                                        # // with multiconcat RHS, no literal text (correctly 3-outcome)
+66             3           100            $r = $dor_lhs // "$v$v$v";
+67                                      
+68                                        # // with concat RHS (correctly 3-outcome)
+69             3           100            $r = $dor_lhs // "$v$v";
+70                                      
+71                                        # // with stringify RHS (correctly 3-outcome)
+72             3           100            $r = $dor_lhs // "$v";
+73                                      
+74                                        # ||= with multiconcat RHS, literal text (should be 2-outcome)
+75    ***      3          * 66            $Arr[0] ||= "value $v end";
+76                                      
+77                                        # //= with multiconcat RHS, literal text (should be 2-outcome)
+78    ***      3          * 66            $Arr[1] //= "value $v end";
+79                                      }
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+36           100      1      2   $iter == 0 ? :
+37           100      1      2   $iter == 0 ? :
+38           100      2      1   $iter < 2 ? :
+
+
+Conditions
+----------
+
+or 2 conditions
+
+line  err      %      l     !l   expr
+----- --- ------ ------ ------   ----
+43           100      1      2   $or_lhs || 'literal'
+59           100      1      2   $dor_lhs // "literal"
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+46    ***     66      1      2      0   $or_lhs || "value $v end"
+47    ***     66      1      2      0   $or_lhs || "value $v"
+50           100      1      1      1   $or_lhs || "$v$v$v"
+53           100      1      1      1   $or_lhs || "$v$v"
+56           100      1      1      1   $or_lhs || "$v"
+62    ***     66      1      2      0   $dor_lhs // "value $v end"
+63    ***     66      1      2      0   $dor_lhs // "value $v"
+66           100      1      1      1   $dor_lhs // "$v$v$v"
+69           100      1      1      1   $dor_lhs // "$v$v"
+72           100      1      1      1   $dor_lhs // "$v"
+75    ***     66      2      1      0   $Arr[0] ||= "value $v end"
+78    ***     66      2      1      0   $Arr[1] //= "value $v end"
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count Location               
+---------- ----- -----------------------
+BEGIN          1 tests/cond_or_interp:26
+BEGIN          1 tests/cond_or_interp:27
+
+

--- a/test_output/cover/cond_or_interp.5.028000
+++ b/test_output/cover/cond_or_interp.5.028000
@@ -4,8 +4,8 @@ Reading database from ...
 -------------------- ------ ------ ------ ------ ------
 File                   stmt   bran   cond    sub  total
 -------------------- ------ ------ ------ ------ ------
-tests/cond_or_interp  100.0  100.0   86.0  100.0   92.3
-Total                 100.0  100.0   86.0  100.0   92.3
+tests/cond_or_interp  100.0  100.0  100.0  100.0  100.0
+Total                 100.0  100.0  100.0  100.0  100.0
 -------------------- ------ ------ ------ ------ ------
 
 
@@ -67,8 +67,8 @@ line  err   stmt   bran   cond    sub   code
 43             3           100            $r = $or_lhs || "literal";
 44                                      
 45                                        # || with multiconcat RHS, literal text (should be 2-outcome)
-46    ***      3          * 66            $r = $or_lhs || "value $v end";
-47    ***      3          * 66            $r = $or_lhs || "value $v";
+46             3           100            $r = $or_lhs || "value $v end";
+47             3           100            $r = $or_lhs || "value $v";
 48                                      
 49                                        # || with multiconcat RHS, "0" literal text (correctly 3-outcome:
 50                                        # "0" is non-empty but falsy, so result can be falsy)
@@ -87,8 +87,8 @@ line  err   stmt   bran   cond    sub   code
 63             3           100            $r = $dor_lhs // "literal";
 64                                      
 65                                        # // with multiconcat RHS, literal text (should be 2-outcome)
-66    ***      3          * 66            $r = $dor_lhs // "value $v end";
-67    ***      3          * 66            $r = $dor_lhs // "value $v";
+66             3           100            $r = $dor_lhs // "value $v end";
+67             3           100            $r = $dor_lhs // "value $v";
 68                                      
 69                                        # // with multiconcat RHS, no literal text (correctly 3-outcome)
 70             3           100            $r = $dor_lhs // "$v$v$v";
@@ -100,10 +100,10 @@ line  err   stmt   bran   cond    sub   code
 76             3           100            $r = $dor_lhs // "$v";
 77                                      
 78                                        # ||= with multiconcat RHS, literal text (should be 2-outcome)
-79    ***      3          * 66            $Arr[0] ||= "value $v end";
+79             3           100            $Arr[0] ||= "value $v end";
 80                                      
 81                                        # //= with multiconcat RHS, literal text (should be 2-outcome)
-82    ***      3          * 66            $Arr[1] //= "value $v end";
+82             3           100            $Arr[1] //= "value $v end";
 83                                      }
 
 
@@ -125,25 +125,25 @@ or 2 conditions
 line  err      %      l     !l   expr
 ----- --- ------ ------ ------   ----
 43           100      1      2   $or_lhs || 'literal'
+46           100      1      2   $or_lhs || "value $v end"
+47           100      1      2   $or_lhs || "value $v"
 63           100      1      2   $dor_lhs // "literal"
+66           100      1      2   $dor_lhs // "value $v end"
+67           100      1      2   $dor_lhs // "value $v"
+79           100      2      1   $Arr[0] ||= "value $v end"
+82           100      2      1   $Arr[1] //= "value $v end"
 
 or 3 conditions
 
 line  err      %      l  !l&&r !l&&!r   expr
 ----- --- ------ ------ ------ ------   ----
-46    ***     66      1      2      0   $or_lhs || "value $v end"
-47    ***     66      1      2      0   $or_lhs || "value $v"
 51           100      1      1      1   $or_lhs || "0$v$v$v"
 54           100      1      1      1   $or_lhs || "$v$v$v"
 57           100      1      1      1   $or_lhs || "$v$v"
 60           100      1      1      1   $or_lhs || "$v"
-66    ***     66      1      2      0   $dor_lhs // "value $v end"
-67    ***     66      1      2      0   $dor_lhs // "value $v"
 70           100      1      1      1   $dor_lhs // "$v$v$v"
 73           100      1      1      1   $dor_lhs // "$v$v"
 76           100      1      1      1   $dor_lhs // "$v"
-79    ***     66      2      1      0   $Arr[0] ||= "value $v end"
-82    ***     66      2      1      0   $Arr[1] //= "value $v end"
 
 
 Covered Subroutines

--- a/test_output/cover/cond_or_interp.5.028000
+++ b/test_output/cover/cond_or_interp.5.028000
@@ -4,8 +4,8 @@ Reading database from ...
 -------------------- ------ ------ ------ ------ ------
 File                   stmt   bran   cond    sub  total
 -------------------- ------ ------ ------ ------ ------
-tests/cond_or_interp  100.0  100.0  100.0  100.0  100.0
-Total                 100.0  100.0  100.0  100.0  100.0
+tests/cond_or_interp  100.0  100.0   95.3  100.0   97.5
+Total                 100.0  100.0   95.3  100.0   97.5
 -------------------- ------ ------ ------ ------ ------
 
 
@@ -104,7 +104,16 @@ line  err   stmt   bran   cond    sub   code
 80                                      
 81                                        # //= with multiconcat RHS, literal text (should be 2-outcome)
 82             3           100            $Arr[1] //= "value $v end";
-83                                      }
+83                                      
+84                                        # warn always returns 1 (correctly 2-outcome)
+85             3           100            $r = $or_lhs || warn "expected\n";
+86                                      
+87                                        # exit and exec never return normally (correctly 2-outcome).
+88                                        # Use always-truthy LHS so they never actually execute.
+89             3                          my $true = 1;
+90    ***      3          * 50            $r = $true || exit 1;
+91    ***      3          * 50            $r = $true || exec "true";
+92                                      }
 
 
 Branches
@@ -132,6 +141,9 @@ line  err      %      l     !l   expr
 67           100      1      2   $dor_lhs // "value $v"
 79           100      2      1   $Arr[0] ||= "value $v end"
 82           100      2      1   $Arr[1] //= "value $v end"
+85           100      1      2   $or_lhs || warn("expected\n")
+90    ***     50      3      0   $true || exit 1
+91    ***     50      3      0   $true || exec('true')
 
 or 3 conditions
 

--- a/tests/cond_or_interp
+++ b/tests/cond_or_interp
@@ -80,4 +80,13 @@ for my $iter (0 .. 2) {
 
   # //= with multiconcat RHS, literal text (should be 2-outcome)
   $Arr[1] //= "value $v end";
+
+  # warn always returns 1 (correctly 2-outcome)
+  $r = $or_lhs || warn "expected\n";
+
+  # exit and exec never return normally (correctly 2-outcome).
+  # Use always-truthy LHS so they never actually execute.
+  my $true = 1;
+  $r = $true || exit 1;
+  $r = $true || exec "true";
 }

--- a/tests/cond_or_interp
+++ b/tests/cond_or_interp
@@ -46,6 +46,10 @@ for my $iter (0 .. 2) {
   $r = $or_lhs || "value $v end";
   $r = $or_lhs || "value $v";
 
+  # || with multiconcat RHS, "0" literal text (correctly 3-outcome:
+  # "0" is non-empty but falsy, so result can be falsy)
+  $r = $or_lhs || "0$v$v$v";
+
   # || with multiconcat RHS, no literal text (correctly 3-outcome)
   $r = $or_lhs || "$v$v$v";
 

--- a/tests/cond_or_interp
+++ b/tests/cond_or_interp
@@ -1,0 +1,79 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# GH-403: Devel::Cover reports unreachable !l&&!r for // and || when the RHS is
+# an interpolated string.
+#
+# Interpolated strings compile to different ops depending on structure and Perl
+# version:
+#   "literal"        -> const        (in $Const_right, works)
+#   "pre $x post"    -> multiconcat  (literal text, always truthy)
+#   "pre $x"         -> multiconcat  (literal text, always truthy)
+#   "$x$y$z"         -> multiconcat  (no literal text, can be falsy)
+#   "$x$y"           -> concat       (can be falsy)
+#   "$x"             -> stringify    (can be falsy)
+#
+# For || and //: multiconcat with literal text should be 2-outcome (like const)
+# because the literal text guarantees a truthy result. Condition tracking uses
+# truthiness for both || and //, so the dor/or distinction does not matter here.
+
+use strict;
+use warnings;
+
+my @Arr;
+
+for my $iter (0 .. 2) {
+  # iter 0: LHS truthy/defined -> short-circuit
+  # iter 1: LHS falsy/undef, vars non-empty -> RHS truthy/defined
+  # iter 2: LHS falsy/undef, vars empty -> RHS can be falsy
+
+  my $or_lhs  = $iter == 0 ? 1 : 0;
+  my $dor_lhs = $iter == 0 ? 1 : undef;
+  my $v       = $iter < 2  ? "x" : "";
+
+  my $r;
+
+  # || with const RHS (baseline, correctly 2-outcome)
+  $r = $or_lhs || "literal";
+
+  # || with multiconcat RHS, literal text (should be 2-outcome)
+  $r = $or_lhs || "value $v end";
+  $r = $or_lhs || "value $v";
+
+  # || with multiconcat RHS, no literal text (correctly 3-outcome)
+  $r = $or_lhs || "$v$v$v";
+
+  # || with concat RHS (correctly 3-outcome)
+  $r = $or_lhs || "$v$v";
+
+  # || with stringify RHS (correctly 3-outcome)
+  $r = $or_lhs || "$v";
+
+  # // with const RHS (baseline, correctly 2-outcome)
+  $r = $dor_lhs // "literal";
+
+  # // with multiconcat RHS, literal text (should be 2-outcome)
+  $r = $dor_lhs // "value $v end";
+  $r = $dor_lhs // "value $v";
+
+  # // with multiconcat RHS, no literal text (correctly 3-outcome)
+  $r = $dor_lhs // "$v$v$v";
+
+  # // with concat RHS (correctly 3-outcome)
+  $r = $dor_lhs // "$v$v";
+
+  # // with stringify RHS (correctly 3-outcome)
+  $r = $dor_lhs // "$v";
+
+  # ||= with multiconcat RHS, literal text (should be 2-outcome)
+  $Arr[0] ||= "value $v end";
+
+  # //= with multiconcat RHS, literal text (should be 2-outcome)
+  $Arr[1] //= "value $v end";
+}


### PR DESCRIPTION
## Summary

When the RHS of `||` or `//` is an interpolated string like `"value $val is not positive"`, Devel::Cover reports an unreachable `!l&&!r` condition at 0%. Plain string literals (`"must be positive"`) are correctly recognised as always truthy and use 2-outcome tracking, but interpolated strings were not.

The root cause is that `$Const_right` recognises the `const` op (plain strings) but not the `multiconcat` op (interpolated strings, Perl 5.28+). A `multiconcat` with truthy literal text always produces a truthy result, so it should be treated the same as `const`.

## Changes

- Add `_is_const_right` helper that checks whether the RHS op is constant-like: either matching `$Const_right`, or a `multiconcat` with truthy literal text (inspected via `B::UNOP_AUX::aux_list`).
- Use truthiness rather than non-emptiness for the multiconcat constant string check, because `"0"` is the one non-empty string that is falsy in Perl.
- Add `exec`, `exit`, and `warn` to `$Const_right`, resolving a long-standing TODO. These ops either divert control flow (like the existing `die`/`goto`/`return` entries) or always return a truthy value.
- Add `cond_or_interp` test covering all RHS op types for `||` and `//`: `const`, `multiconcat` (with and without literal text, including the `"0"` edge case), `concat`, `stringify`, plus the `||=`/`//=` assign variants and the new `warn`/`exit`/`exec` ops.

## Implications

- The fix applies to Perl 5.28+ where `multiconcat` exists. On Perl 5.20-5.26, the equivalent `concat` chain is compiled differently and is not yet handled - this is a pre-existing limitation, not a regression.
- Golden results split into two files: `5.020000` (pre-multiconcat, unchanged behaviour) and `5.028000` (fixed behaviour).
- All 108 Perl versions (5.20.0 through 5.43.8, threaded and non-threaded) pass.

## Issue

Closes #403