### PR TITLE
GH-411 Fix compile-time warning in Text2.pm

### DIFF
--- a/lib/Devel/Cover/Report/Text2.pm
+++ b/lib/Devel/Cover/Report/Text2.pm
@@ -1,6 +1,9 @@
 package Devel::Cover::Report::Text2;
-use strict;
+
+use 5.20.0;
 use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 


### PR DESCRIPTION
Closes #411

## Summary

`Text2.pm` used postfix dereference (`->@*`) but had a non-standard preamble (`use strict; use warnings;`) that did not enable the `postderef` feature. On Perl 5.20, where postfix dereference is experimental, this caused a compile-time syntax warning whenever the module was loaded (visible during `make test` via `t/internal/launch.t`).

## Changes

- Replace `use strict; use warnings;` with the project-standard preamble (`use 5.20.0`, `use feature qw( postderef signatures )`, etc.).