### PR TITLE
GH-409 Sort by start time in compress_old_versions

### DIFF
--- a/bin/cpancover
+++ b/bin/cpancover
@@ -7,8 +7,7 @@
 # The latest version of this software should be available from my homepage:
 # https://pjcj.net
 
-use 5.38.0;
-use warnings;
+use 5.42.0;
 
 # VERSION
 
@@ -43,6 +42,7 @@ my $Options = {
 };
 
 sub get_options {
+  #<<<
   die "Bad option" unless GetOptions(
     $Options, qw(
       bin_dir=s
@@ -69,6 +69,7 @@ sub get_options {
       workers=i
     )
   );
+  #>>>
 
   say "$0 version " . __PACKAGE__->VERSION and exit 0 if $Options->{version};
   pod2usage(-exitval => 0, -verbose => 0) if $Options->{help};
@@ -76,9 +77,9 @@ sub get_options {
 }
 
 sub newcp {
+  #<<<
   Devel::Cover::Collection->new(
-    map { $_ => $Options->{$_} }
-      qw(
+    map { $_ => $Options->{$_} } qw(
       bin_dir
       docker
       dryrun
@@ -92,8 +93,9 @@ sub newcp {
       timeout
       verbose
       workers
-      )
+    )
   )
+  #>>>
 }
 
 sub main {

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -423,24 +423,13 @@ class Devel::Cover::Collection {
       $name =~ s/-[^-]+$//;
       my @runs = grep { ($_->{name} // "") eq $name } $data->{runs}->@*;
       # say "$name " . @runs;
-      my $run     = $runs[0]                   // next;
-      my $version = $run->{version} =~ s/_//gr // next;
-      my $v = eval { no warnings "overflow"; version->parse($version)->numify };
-      if ($@ || !$v) {
-        $v = $version;
-        $v =~ s/[^0-9.]//g;
-        my @parts = split /\./, $v;
-        if (@parts > 2) {
-          $v = shift(@parts) . "." . join "", @parts;
-        }
-      }
-      $v ||= 0;
-      push $mods{$name}->@*, { dir => $entry, version => $v };
+      my $run = $runs[0] // next;
+      push $mods{$name}->@*, { dir => $entry, start => $run->{start} // 0 };
     }
 
     for my $name (sort keys %mods) {
       # print Dumper $mods{$name};
-      my @o = sort { $b->{version} <=> $a->{version} } $mods{$name}->@*;
+      my @o = sort { $b->{start} <=> $a->{start} } $mods{$name}->@*;
       shift @o for 1 .. $versions;
       for my $v (@o) {
 

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -8,7 +8,6 @@
 package Devel::Cover::Collection;
 
 use 5.42.0;
-use warnings;
 
 # VERSION
 

--- a/xt/collection.t
+++ b/xt/collection.t
@@ -9,7 +9,6 @@
 # https://pjcj.net
 
 use 5.42.0;
-use warnings;
 
 use Test2::V0  qw( done_testing is like ok skip_all subtest unlike );
 use File::Temp qw( tempdir );

--- a/xt/collection.t
+++ b/xt/collection.t
@@ -10,8 +10,9 @@
 
 use 5.42.0;
 
-use Test2::V0  qw( done_testing is like ok skip_all subtest unlike );
-use File::Temp qw( tempdir );
+use Test2::V0     qw( done_testing is like ok skip_all subtest unlike );
+use File::Temp    qw( tempdir );
+use JSON::MaybeXS ();
 
 use Devel::Cover::Collection ();
 
@@ -402,8 +403,8 @@ sub write_json () {
         total      => { pc => "82.50" },
         link       => "/Foo-Bar/index.html",
         log        => "build.log",
-      }
-    }
+      },
+    },
   };
 
   $c->write_json($vars);
@@ -424,6 +425,58 @@ sub write_json () {
   unlike $content, qr/"log"/,       "JSON excludes log field";
 }
 
+sub compress_old_versions () {
+  skip_all "uses fsys which requires alarm (not available on Windows)"
+    if $Is_win32;
+  my $dir = tempdir(CLEANUP => 1);
+
+  # Reproduce GH-409: CPAN versions that sort incorrectly when numified.
+  # 0.41 numifies to 0.410, less than 0.700/0.800/0.900, so the latest
+  # release was compressed and removed under the old version-based sort.
+  my @versions = (
+    { ver => "0.7",  start => 1000 },
+    { ver => "0.8",  start => 2000 },
+    { ver => "0.9",  start => 3000 },
+    { ver => "0.41", start => 4000 },
+  );
+
+  my $json = JSON::MaybeXS->new(utf8 => 1);
+  for my $v (@versions) {
+    my $mod_dir = "$dir/Net-RDAP-$v->{ver}";
+    mkdir $mod_dir or die "Can't mkdir $mod_dir: $!";
+    my $cover
+      = { runs =>
+        [ { name => "Net-RDAP", version => $v->{ver}, start => $v->{start} } ],
+      };
+    open my $fh, ">", "$mod_dir/cover.json" or die "Can't write: $!";
+    print $fh $json->encode($cover);
+    close $fh or die "Can't close: $!";
+  }
+
+  my $c = Devel::Cover::Collection->new(results_dir => $dir, dryrun => 1);
+
+  my $outfile = "$dir/compress_output.txt";
+  {
+    open my $saved, ">&", STDOUT or die "Can't dup STDOUT: $!";
+    open STDOUT, ">", $outfile  or die "Can't redirect STDOUT: $!";
+    $c->compress_old_versions(3);
+    open STDOUT, ">&", $saved   or die "Can't restore STDOUT: $!";
+  }
+  open my $ofh, "<", $outfile or die "Can't read $outfile: $!";
+  my $output = do { local $/; <$ofh> };
+  close $ofh or die "Can't close $outfile: $!";
+
+  # 4 versions, keep 3: the oldest by start time should be compressed
+  like $output, qr/^compressing Net-RDAP-0\.7$/m,
+    "oldest version by start time is compressed";
+  unlike $output, qr/^compressing Net-RDAP-0\.41$/m,
+    "latest release is kept (was removed by numeric version sort)";
+  unlike $output, qr/^compressing Net-RDAP-0\.9$/m,
+    "recent version 0.9 is kept";
+  unlike $output, qr/^compressing Net-RDAP-0\.8$/m,
+    "recent version 0.8 is kept";
+}
+
 sub template_provider_fetch () {
   my $provider = Devel::Cover::Collection::Template::Provider->new({});
 
@@ -438,6 +491,7 @@ sub template_provider_fetch () {
 }
 
 sub main () {
+  #<<<
   my @tests = qw(
     constructor_defaults
     constructor_with_args
@@ -466,8 +520,10 @@ sub main () {
     dc_file
     coverage_class_method
     write_json
+    compress_old_versions
     template_provider_fetch
   );
+  #>>>
   for my $test (@tests) {
     no strict qw( refs );
     subtest $test => \&$test;


### PR DESCRIPTION
## Summary

The `compress_old_versions` method in `Collection.pm` sorted module versions using numeric comparison on numified CPAN version strings. This is inherently ambiguous - e.g. `0.41` numifies lower than `0.9`, even though `0.41` is the newer release. The result was that the latest release got compressed and removed, then rebuilt every cpancover cycle, wasting resources.

This PR replaces the version-based sort with a sort on the `start` timestamp from `cover.json`, which is authoritative and unambiguous.

## Changes

- Replace numeric version comparison in `compress_old_versions` with a sort on the `start` timestamp from `cover.json`, removing the fragile version-parsing logic entirely
- Add a test in `xt/collection.t` that reproduces the GH-409 scenario (versions that sort incorrectly when numified) and verifies the fix
- Remove redundant `use warnings` in files already using `use 5.42.0` (which implies warnings)
- Bump `bin/cpancover` from `use 5.38.0` to `use 5.42.0`
- Add perltidy guards around intentionally formatted option lists

## Implications

- The version-parsing block (~12 lines handling `version->parse`, overflow warnings, and multi-dot fallbacks) is replaced by a single `start` field read, simplifying the code considerably
- Any `cover.json` without a `start` field falls back to `0`, sorting it oldest - safe default behaviour
- No change to the public interface or command-line options

## Issue

Closes #409