### PR TITLE
GH-410 Add partial self-coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ blib/
 .build/
 README
 cover_db*/
+dc_cover*/
 t/e2e/
 lib/Devel/Cover/Inc.pm
 pm_to_blib

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,13 @@ make show_version
 # Create test files from tests/ directory
 # (automatically done by Makefile.PL)
 
-# Self-coverage analysis
+# Self-coverage analysis (full, using DEVEL_COVER_SELF)
 make self_cover
+
+# Partial self-coverage (late-loaded modules only)
+make dc_cover          # combined report
+make dc_cover_lib      # library modules (Path, Static)
+make dc_cover_reports  # report modules via bin/cover
 
 # Create distribution
 make dist
@@ -113,9 +118,15 @@ make dist
 
 ### Core Modules
 
+Modules loaded at bootstrap (before instrumentation activates) cannot be
+covered without `DEVEL_COVER_SELF`. Late-loaded modules (reports, Path,
+Static, etc.) can be covered using `-select` - see
+`docs/technical/self-coverage.md`.
+
 **Coverage Collection**:
 
 - `Devel::Cover` - Main module that hooks into Perl's op execution
+- `Devel::Cover::Core` - Bootstrap utility (remove_contained_paths)
 - `Devel::Cover::Op` - Handles operation coverage tracking
 - `Devel::Cover::DB` - Database storage and management
 - `Devel::Cover::Inc` - Include path management (auto-generated)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -496,6 +496,15 @@ lint : precommit_all
 \
 lint_changes : precommit
 
+dc_cover_lib : pure_all
+\t utils/dc dc-cover-lib
+
+dc_cover_reports : pure_all
+\t utils/dc dc-cover-reports
+
+dc_cover : pure_all
+\t utils/dc dc-cover
+
 _delete_db : pure_all
 \t rm -rf cover_db
 

--- a/bin/cover
+++ b/bin/cover
@@ -60,7 +60,11 @@ my $Options = {
 };
 
 sub check_self_coverage () {
-  if (!$ENV{DEVEL_COVER_SELF} && $INC{"Devel/Cover.pm"}) {
+  if (
+      !$ENV{DEVEL_COVER_SELF}
+    && $INC{"Devel/Cover.pm"}
+    && !Devel::Cover::has_select()
+  ) {
     my $err = "$0 shouldn't be run with coverage turned on.\n";
     eval {
       require POSIX;

--- a/bin/cover
+++ b/bin/cover
@@ -60,6 +60,8 @@ my $Options = {
 };
 
 sub check_self_coverage () {
+  # Allow running under coverage when -select targets specific DC modules
+  # (partial self-coverage of late-loaded report/utility code).
   if (
       !$ENV{DEVEL_COVER_SELF}
     && $INC{"Devel/Cover.pm"}

--- a/docs/technical/self-coverage.md
+++ b/docs/technical/self-coverage.md
@@ -1,0 +1,136 @@
+# Partial Self-Coverage
+
+Devel::Cover cannot instrument its own modules using standard `cover` because
+they are loaded during bootstrap before instrumentation activates. The only
+existing mechanism is `DEVEL_COVER_SELF`, which enables a specialised two-pass
+XS tracing mode covering all DC modules.
+
+However, many DC modules - report generators, annotation handlers, HTML support,
+path utilities - are loaded on demand, well after bootstrap. These can be
+instrumented normally using `-select` to override the default ignore pattern.
+
+## How It Works
+
+Devel::Cover normally blocks its own modules via two mechanisms:
+
+1. **Ignore pattern** - a default `-ignore` of `/Devel/Cover[./]` added in
+   `Devel::Cover.pm` during `BEGIN`.
+2. **Hard-coded filter** - `_want_cover_for()` rejects any file matching
+   `Devel/Cover` when `$Self_cover_run` is false.
+
+The `-select` option already overrides mechanism 1 (select takes priority over
+ignore in `use_file()`). The partial self-coverage change relaxes mechanism 2:
+if `-select` patterns are active and a DC module matches one of them,
+`_want_cover_for()` lets it through.
+
+The `bin/cover` guard (which normally hard-exits if Devel::Cover is loaded) is
+also relaxed when `-select` is active, allowing report generation under
+instrumentation.
+
+## Module Classification
+
+### Bootstrap Modules (Not Coverable)
+
+Loaded via compile-time `use` chains from `Devel::Cover.pm`. Their ops are
+compiled before instrumentation activates:
+
+- `Devel::Cover` (main + XS)
+- `Devel::Cover::Core`
+- `Devel::Cover::DB`
+- `Devel::Cover::DB::Digests`
+- `Devel::Cover::DB::File`
+- `Devel::Cover::DB::Structure`
+- `Devel::Cover::DB::IO`
+- `Devel::Cover::Criterion` and all subclasses (Statement, Branch, Condition
+  variants, Subroutine, Time, Pod)
+- `Devel::Cover::Dumper`
+- `Devel::Cover::Inc`
+
+Only `DEVEL_COVER_SELF` (full two-pass XS tracing) can cover these.
+
+### Late-Loaded Modules (Coverable)
+
+Loaded at runtime via `require` or `eval "use"`. These are compiled after
+instrumentation is active:
+
+**Library modules** (tested by `t/internal/`):
+
+- `Devel::Cover::Path` - path shortening for reports
+- `Devel::Cover::Static` - static analysis of uncovered files
+
+**Report modules** (exercised by running `bin/cover`):
+
+- All `Devel::Cover::Report::*` modules
+- `Devel::Cover::Html_Common`
+- `Devel::Cover::Web`
+- `Devel::Cover::Truth_Table`
+- `Devel::Cover::Base::Editor`
+- `Devel::Cover::Annotation::*`
+
+**Other late-loaded modules:**
+
+- `Devel::Cover::Op`
+- `Devel::Cover::DB::IO::JSON`, `DB::IO::Storable`, `DB::IO::Sereal`,
+  `DB::IO::Base`
+- `Devel::Cover::Collection` (cpancover only)
+- `Devel::Cover::Test` (test harness)
+
+## Running Self-Coverage
+
+### Recipes
+
+The `utils/dc` script provides three recipes:
+
+```bash
+# Cover library modules via their dedicated tests
+dc dc-cover-lib
+
+# Cover report modules by running bin/cover under instrumentation
+dc dc-cover-reports
+
+# Run both and merge into a combined report
+dc dc-cover
+```
+
+Equivalent Makefile targets: `make dc_cover_lib`, `make dc_cover_reports`,
+`make dc_cover`.
+
+### How dc-cover-lib Works
+
+Runs `t/internal/path.t` and `t/internal/static.t` under `-MDevel::Cover` with
+`-select` matching only the modules under test. Only Path.pm and Static.pm
+appear in the coverage report.
+
+### How dc-cover-reports Works
+
+1. Generates a rich input `cover_db` by running several e2e tests under normal
+   Devel::Cover (no self-coverage). This DB contains varied coverage patterns -
+   partial branches, uncovered conditions, multiple criteria - to exercise the
+   report code paths thoroughly.
+2. Runs `bin/cover` under `-MDevel::Cover` with `-select` for report and support
+   modules, pointed at the rich input DB. This instruments the report modules as
+   they process the coverage data.
+
+### Manual Usage
+
+To cover a specific module:
+
+```bash
+perl -Iblib/lib -Iblib/arch \
+  -MDevel::Cover=-select,Devel/Cover/Path,-db,my_db,-merge,0 \
+  t/internal/path.t
+
+perl -Iblib/lib -Iblib/arch bin/cover my_db -report html_crisp
+```
+
+## Adding Coverage for New Modules
+
+When adding a new late-loaded module or writing tests for an existing one:
+
+1. Write the test in `t/internal/`.
+2. Add the module to the `-select` pattern and the test to the run list in
+   `dc_cover_lib` in `utils/dc`.
+3. Run `dc dc-cover-lib` to verify coverage appears.
+4. If the module is loaded during bootstrap via a `use` chain, check whether
+   that `use` can be converted to a runtime `require` (as was done for `Path.pm`
+   in `DB.pm`).

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -161,7 +161,8 @@ BEGIN {
   $^P     |= 0x004 | 0x100;  # save source lines; evals report file info
 }
 
-sub version { $VERSION }
+sub version    { $VERSION }
+sub has_select { scalar @Select_re }
 
 {
 
@@ -1187,9 +1188,11 @@ sub _add_pod_cover ($cv) {
 
 sub _want_cover_for {
   return unless defined $Sub_name;  # Only happens within Safe.pm, AFAIK
-  return if length $File     && !use_file($File);
-  return if !$Self_cover_run && $File =~ /Devel\/Cover/;
-  return if $Self_cover_run  && $File !~ /Devel\/Cover/;
+  return if length $File && !use_file($File);
+  if (!$Self_cover_run && $File =~ /Devel\/Cover/) {
+    return unless @Select_re && List::Util::any { $File =~ $_ } @Select_re;
+  }
+  return if $Self_cover_run && $File !~ /Devel\/Cover/;
   return
     if $Self_cover_run && $File =~ /Devel\/Cover\.pm$/ && $Sub_name eq "import";
   1

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1190,6 +1190,8 @@ sub _want_cover_for {
   return unless defined $Sub_name;  # Only happens within Safe.pm, AFAIK
   return if length $File && !use_file($File);
   if (!$Self_cover_run && $File =~ /Devel\/Cover/) {
+    # Allow partial self-coverage: if -select patterns are active and this DC
+    # module matches one, let it through for instrumentation.
     return unless @Select_re && List::Util::any { $File =~ $_ } @Select_re;
   }
   return if $Self_cover_run && $File !~ /Devel\/Cover/;

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -98,12 +98,12 @@ my $Const_right = qr/^(?:const|s?refgen|gelem|die|undef|bless|anon(?:list|hash)|
                        emptyavhv|scalar|return|last|next|redo|goto|
                        exec|exit|warn)$/x;
 
-# Check whether the right operand of a logical op is a constant-like
-# expression whose truth value is fixed.  Unwraps sassign if present.
-# Also handles multiconcat (Perl 5.28+) with truthy literal text -
-# the constant string is element [1] of aux_list and does not depend
-# on the CV passed.  We check truthiness rather than mere non-emptiness
-# because "0" is the one non-empty string that is falsy in Perl.
+# Check whether the right operand of a logical op is a constant-like expression
+# whose truth value is fixed.  Unwraps sassign if present. Also handles
+# multiconcat (Perl 5.28+) with truthy literal text - the constant string is
+# element [1] of aux_list and does not depend on the CV passed.  We check
+# truthiness rather than mere non-emptiness because "0" is the one non-empty
+# string that is falsy in Perl.
 sub _is_const_right ($op) {
   my $rhs  = $op->name eq "sassign" ? $op->first : $op;
   my $name = $rhs->name;

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -25,12 +25,11 @@ use File::Path   qw( rmtree );
 use List::Util   qw( any );
 use Scalar::Util qw( blessed reftype );
 
-use Devel::Cover::Dumper qw( Dumper );        # For debugging
-use Devel::Cover::Path   qw( common_prefix );
+use Devel::Cover::Dumper qw( Dumper );  # For debugging
 
 my $Has_term_size = eval { require Term::Size };
 
-my $DB = "cover.15";                          # Version of the database
+my $DB = "cover.15";                    # Version of the database
 
 @Devel::Cover::DB::Criteria
   = (qw( statement branch path condition subroutine pod time ));
@@ -358,7 +357,9 @@ sub print_summary ($self, $files = undef, $criteria = undef, $opts = {}) {
   my $s     = $self->{summary};
   my @files = (grep($_ ne "Total", sort keys %$s), "Total");
   my $max   = 5;
-  my ($prefix, $short) = common_prefix(@files);
+  require Devel::Cover::Path;
+  my ($prefix, $short) = Devel::Cover::Path::common_prefix(@files);
+
   for (@files) { $max = length $short->{$_} if length $short->{$_} > $max }
 
   my $width

--- a/lib/Devel/Cover/Html_Common.pm
+++ b/lib/Devel/Cover/Html_Common.pm
@@ -56,7 +56,8 @@ sub _highlight_ppi (@all_lines) {
     s{<br>\n</span>}{</span>};
   }
 
-  shift @all_lines if $all_lines[0] eq "";
+  shift @all_lines if @all_lines && $all_lines[0] eq "";
+  pop @all_lines   if @all_lines && $all_lines[-1] eq "";
   @all_lines
 }
 

--- a/t/internal/path.t
+++ b/t/internal/path.t
@@ -109,6 +109,14 @@ sub test_mixed_depths () {
     "mixed depths: short map";
 }
 
+sub test_no_shared_components () {
+  my ($prefix, $short) = common_prefix("src/Foo.pm", "lib/Bar.pm");
+  is $prefix, "", "no shared components: prefix";
+  is_deeply $short,
+    { "src/Foo.pm" => "src/Foo.pm", "lib/Bar.pm" => "lib/Bar.pm" },
+    "no shared components: short map";
+}
+
 sub main () {
   test_empty_list;
   test_single_file;
@@ -121,6 +129,7 @@ sub main () {
   test_total_only;
   test_three_levels_shared;
   test_mixed_depths;
+  test_no_shared_components;
   done_testing;
 }
 

--- a/utils/dc
+++ b/utils/dc
@@ -877,6 +877,71 @@ recipe_generate-gcov-fixtures() {
   generate_gcov_fixtures
 }
 
+Dc_cover_perl="perl -Iblib/lib -Iblib/arch"
+
+dc_cover_lib() {
+  local db="dc_cover_lib_db"
+  local select="Devel/Cover/(Path|Static|Op|DB/IO/)"
+  local launch="${1:-1}"
+
+  rm -rf "$db"
+  $Dc_cover_perl \
+    "-MDevel::Cover=-select,$select,-db,$db,-merge,0" \
+    t/internal/path.t
+  if ((launch)); then
+    $Dc_cover_perl bin/cover "$db" -report html_crisp -launch
+  fi
+}
+
+dc_cover_reports() {
+  local input_db="dc_cover_reports_input_db"
+  local db="dc_cover_reports_db"
+  local select="Devel/Cover/(Report|Annotation|Html_Common"
+  select="$select|Web|Truth_Table|Base/Editor)"
+  local launch="${1:-1}"
+
+  rm -rf "$input_db" "$db"
+
+  # Build a rich input DB to exercise report code paths
+  $Dc_cover_perl "-MDevel::Cover=-db,$input_db,-merge,1" \
+    t/e2e/acond_or.t t/e2e/apod.t t/e2e/astatement.t \
+    t/e2e/acond_and.t t/e2e/atrivial.t
+
+  # Run report generation under self-coverage
+  $Dc_cover_perl \
+    "-MDevel::Cover=-select,$select,-db,$db,-merge,0" bin/cover "$input_db" \
+    -report html_crisp -report text -report json
+
+  if ((launch)); then
+    $Dc_cover_perl bin/cover "$db" -report html_crisp -launch
+  fi
+}
+
+dc_cover() {
+  local db="dc_cover_db"
+
+  dc_cover_lib 0
+  dc_cover_reports 0
+
+  rm -rf "$db"
+  $Dc_cover_perl bin/cover \
+    dc_cover_lib_db dc_cover_reports_db \
+    -write "$db"
+  $Dc_cover_perl bin/cover "$db" -report html_crisp -launch
+}
+
+recipe_dc-cover-lib() {
+  dc_cover_lib
+}
+
+recipe_dc-cover-reports() {
+  dc_cover_reports
+}
+
+recipe_dc-cover() {
+  dc_cover
+}
+
 recipe_showcase() {
   : "${PERL:=perl}"
   "$PERL" "$srcdir/showcase" "${args[@]:?No report specified}"

--- a/utils/dc
+++ b/utils/dc
@@ -881,7 +881,7 @@ Dc_cover_perl="perl -Iblib/lib -Iblib/arch"
 
 dc_cover_lib() {
   local db="dc_cover_lib_db"
-  local select="Devel/Cover/(Path|Static|Op|DB/IO/)"
+  local select="Devel/Cover/Path"
   local launch="${1:-1}"
 
   rm -rf "$db"

--- a/utils/dc
+++ b/utils/dc
@@ -881,13 +881,16 @@ Dc_cover_perl="perl -Iblib/lib -Iblib/arch"
 
 dc_cover_lib() {
   local db="dc_cover_lib_db"
-  local select="Devel/Cover/Path"
+  local select="Devel/Cover/(Path|Static)"
   local launch="${1:-1}"
 
   rm -rf "$db"
   $Dc_cover_perl \
-    "-MDevel::Cover=-select,$select,-db,$db,-merge,0" \
+    "-MDevel::Cover=-select,$select,-db,$db,-merge,1" \
     t/internal/path.t
+  $Dc_cover_perl \
+    "-MDevel::Cover=-select,$select,-db,$db,-merge,1" \
+    t/internal/static.t
   if ((launch)); then
     $Dc_cover_perl bin/cover "$db" -report html_crisp -launch
   fi


### PR DESCRIPTION
## Summary

Devel::Cover's own modules were invisible to standard coverage instrumentation because two hard-coded guards blocked all files matching `Devel/Cover`. This PR relaxes those guards when `-select` explicitly targets DC modules, enabling coverage of late-loaded code (reports, utilities, support modules) without the heavyweight `DEVEL_COVER_SELF` two-pass mechanism.

## Changes

- Relax `_want_cover_for` to allow explicitly `-select`ed DC modules through the hard-coded filter.
- Relax the `bin/cover` guard to allow running under coverage when `-select` is active.
- Add `has_select` accessor to `Devel::Cover` for the guard check.
- Defer `use Devel::Cover::Path` in DB.pm to a runtime `require`, removing it from the bootstrap chain.
- Add `dc-cover-lib`, `dc-cover-reports`, and `dc-cover` recipes in `utils/dc` with corresponding Makefile targets.
- Add `docs/technical/self-coverage.md` documenting the mechanism, module classification, and how to extend coverage.
- Add test for paths with no shared components (100% condition coverage on Path.pm).
- Fix phantom trailing line in PPI-highlighted HTML reports.

## Implications

- No change to default behaviour - the guards only relax when `-select` is explicitly passed.
- Bootstrap modules (~4500 lines) remain uncoverable without `DEVEL_COVER_SELF`.
- Late-loaded modules (~8900 lines) are now coverable.
- Current coverage: Path.pm 100%, Static.pm 88%, report modules 12-95%.

## Issue

Closes #410