### PR TITLE
GH-329 Honour Silent mode for stale warnings

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -49,7 +49,7 @@
 --novalign-if-unless                   # vertically align if and unless
 
 --delete-repeated-commas               # delete repeated commas
---want-trailing-commas="w(h W(m [m {m" # trailing commas for arrays and hashes
+--want-trailing-commas="(m [m {m"      # trailing commas in multiline lists
 --add-trailing-commas                  # add trailing commas
 --delete-trailing-commas               # delete trailing commas
 --delete-weld-interfering-commas       # delete commas that interfere with welds

--- a/Contributors
+++ b/Contributors
@@ -90,6 +90,7 @@ Léon Brocard                   acme@astray.com
 Marc-Philip                    mpw96@gmx.de
 Marcel Grünauer                marcel@cpan.org
 Mark Stosberg                  mark@summersault.com
+martinvonwittich               https://github.com/martinvonwittich
 Matthew Horsfall               wolfsage@gmail.com
 mauke
 Max Maischein                  corion@cpan.org

--- a/bin/cover
+++ b/bin/cover
@@ -425,6 +425,7 @@ sub manage_dbs ($dbname, $test_result) {
   my $structure;
   my $read_structure = sub () {
     unless ($structure) {
+      require Devel::Cover::DB::Structure;
       $structure = Devel::Cover::DB::Structure->new(base => $dbname);
       $structure->read_all;
     }

--- a/bin/gcov2perl
+++ b/bin/gcov2perl
@@ -28,12 +28,7 @@ sub get_options () {
   die "Bad option"
     unless GetOptions(
       $Options,  # Store the options in the Options hash
-      qw(
-        db=s
-        help|h!
-        info|i!
-        version|v!
-      )
+      qw( db=s help|h! info|i! version|v! )
     );
   print "$0 version " . __PACKAGE__->VERSION . "\n" and exit 0
     if $Options->{version};
@@ -51,6 +46,7 @@ sub add_cover ($file) {
   my %run;
   $run{collected} = ["statement"];
   $run{start}     = $run{finish} = time;
+  require Devel::Cover::DB::Structure;
   my $structure = Devel::Cover::DB::Structure->new;
   $structure->add_criteria("statement");
   $structure->add_criteria("branch");

--- a/docs/technical/self-coverage.md
+++ b/docs/technical/self-coverage.md
@@ -39,7 +39,6 @@ compiled before instrumentation activates:
 - `Devel::Cover::DB`
 - `Devel::Cover::DB::Digests`
 - `Devel::Cover::DB::File`
-- `Devel::Cover::DB::Structure`
 - `Devel::Cover::DB::IO`
 - `Devel::Cover::Criterion` and all subclasses (Statement, Branch, Condition
   variants, Subroutine, Time, Pod)
@@ -55,6 +54,7 @@ instrumentation is active:
 
 **Library modules** (tested by `t/internal/`):
 
+- `Devel::Cover::DB::Structure` - abstract structure of source files
 - `Devel::Cover::Path` - path shortening for reports
 - `Devel::Cover::Static` - static analysis of uncovered files
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -666,6 +666,7 @@ sub _report {
   chdir $Dir or die __PACKAGE__ . ": Can't chdir $Dir: $!\n";
 
   $Run{collected} = \@collected;
+  require Devel::Cover::DB::Structure;
   $Structure = Devel::Cover::DB::Structure->new(base => $DB,
     loose_perms => $Loose_perms);
   $Structure->read_all;

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -14,10 +14,9 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
-use Devel::Cover::Criterion     ();
-use Devel::Cover::DB::File      ();
-use Devel::Cover::DB::Structure ();
-use Devel::Cover::DB::IO        ();
+use Devel::Cover::Criterion ();
+use Devel::Cover::DB::File  ();
+use Devel::Cover::DB::IO    ();
 
 use Carp         qw( carp croak );
 use File::Find   qw( find );
@@ -162,6 +161,7 @@ sub merge_runs ($self) {
   rmtree(\@runs);
 
   if (keys $self->{changed_files}->%*) {
+    require Devel::Cover::DB::Structure;
     my $st = Devel::Cover::DB::Structure->new(base => $self->{base});
     $st->read_all;
     for my $file (sort keys $self->{changed_files}->%*) {
@@ -767,7 +767,8 @@ sub cover ($self) {
   my %files;    # processed files
   my $cover       = $self->{cover} = {};
   my $uncoverable = {};
-  my $st          = $self->{_structure}
+  require Devel::Cover::DB::Structure;
+  my $st = $self->{_structure}
     // Devel::Cover::DB::Structure->new(base => $self->{base})->read_all;
 
   # Sometimes the start value is undefined.  It's not yet clear why, but it

--- a/lib/Devel/Cover/DB/Digests.pm
+++ b/lib/Devel/Cover/DB/Digests.pm
@@ -12,7 +12,6 @@ use warnings;
 
 # VERSION
 
-use Devel::Cover::DB::Structure;
 use Devel::Cover::DB::IO;
 
 my $File = "digests";
@@ -59,8 +58,10 @@ sub canonical_file {
   my $self = shift;
   my ($file) = @_;
 
-  my $cfile  = $file;
+  my $cfile = $file;
+  require Devel::Cover::DB::Structure;
   my $digest = Devel::Cover::DB::Structure->digest($file);
+
   if ($digest) {
     my $dfile = $self->get($digest);
     if ($dfile && $dfile ne $file) {

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -243,7 +243,7 @@ sub read_all ($self) {
 sub merge ($self, $from) {
   # TODO - make _merge_hash a public API in Devel::Cover::DB
   Devel::Cover::DB::_merge_hash(  ## no critic (ProtectPrivateSubs)
-    $self->{f}, $from->{f}, "noadd"
+    $self->{f}, $from->{f}, "noadd",
   )
 }
 

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -7,105 +7,92 @@
 
 package Devel::Cover::DB::Structure;
 
-use strict;
+use 5.20.0;
 use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
 
-use Carp;
-use Digest::MD5;
+use Carp        qw( confess croak );
+use Digest::MD5 ();
+use List::Util  qw( any );
 
-use Devel::Cover::DB;
-use Devel::Cover::DB::IO;
-use Devel::Cover::Dumper;
-
-# For comprehensive debug logging.
-use constant DEBUG => 0;
+use Devel::Cover::DB     ();
+use Devel::Cover::DB::IO ();
 
 # VERSION
 our $AUTOLOAD;
 
-sub new {
-  my $class = shift;
-  my $self  = {@_};
-  bless $self, $class
-}
+sub new ($class, %args) { bless \%args, $class }
 
-sub DESTROY { }
+sub DESTROY ($self) { }
 
-sub AUTOLOAD {
+sub AUTOLOAD {  ## no critic (RequireArgUnpacking) - goto needs @_ intact
   my $self = $_[0];
   my $func = $AUTOLOAD;
   $func =~ s/.*:://;
   my ($function, $criterion) = $func =~ /^(add|get)_(.*)/;
   croak "Undefined subroutine $func called"
-    unless $criterion && grep $_ eq $criterion, @Devel::Cover::DB::Criteria,
+    unless $criterion && any { $_ eq $criterion } @Devel::Cover::DB::Criteria,
     qw( sub_name file line );
   no strict "refs";
   if ($function eq "get") {
     my $c = $criterion eq "time" ? "statement" : $criterion;
-    if (grep $_ eq $c, qw( sub_name file line )) {
-      *$func = sub { shift->{$c} };
+    if (any { $_ eq $c } qw( sub_name file line )) {
+      *$func = sub ($self) { $self->{$c} };
     } else {
-      *$func = sub {
-        my $self   = shift;
-        my $digest = shift;
+      *$func = sub ($self, $digest) {
         # print STDERR "file: $digest, condition: $c\n";
-        for my $fval (values %{ $self->{f} }) {
+        for my $fval (values $self->{f}->%*) {
           return $fval->{$c} if $fval->{digest} eq $digest;
         }
         return
-      }
+      };
     }
   } else {
-    *$func = sub {
-      my $self = shift;
-      my $file = shift;
-      push @{ $self->{f}{$file}{$criterion} }, @_;
+    *$func = sub ($self, $file, @vals) {
+      push $self->{f}{$file}{$criterion}->@*, @vals;
     };
   }
   goto &$func
 }
 
-sub debuglog {
-  my $self = shift;
-  my $dir  = "$self->{base}/debuglog";
-  unless (mkdir $dir) {
-    confess "Can't mkdir $dir: $!" unless -d $dir;
-  }
-
-  local $\;
-  # One log file per process, as we're potentially dumping out large amounts,
-  # and might exceed the atomic write size of the OS
-  open my $fh, '>>', "$dir/$$" or confess "Can't open $dir/$$: $!";
-  print $fh "----------------" . gmtime() . "----------------\n";
-  for (@_) {
-    print $fh ref $_ ? Dumper($_) : $_;
-    print $fh "\n";
-  }
-  close $fh or confess "Can't close $dir/$$: $!";
-}
-
-sub add_criteria {
-  my $self = shift;
-  @{ $self->{criteria} }{@_} = ();
+sub add_criteria ($self, @names) {
+  $self->{criteria}->@{@names} = ();
   $self
 }
 
-sub criteria {
-  my $self = shift;
-  keys %{ $self->{criteria} }
+sub criteria ($self) { keys $self->{criteria}->%* }
+
+sub reuse ($self, $file) {
+  exists $self->{f}{$file}{start}{-1}{__COVER__}
+  # TODO - exists $self->{f}{$file}{start}{-1}
 }
 
-sub set_subroutine {
-  my $self = shift;
-  my ($sub_name, $file, $line, $scount)
-    = @{$self}{qw( sub_name file line scount )} = @_;
+sub get_count ($self, $file, $criterion) {
+  $self->{count}{$criterion}{$file}
+}
 
-  # When new code is added at runtime, via a string eval in some guise, we
-  # need information about where structure information for the subroutine
-  # is.  This information is stored in $self->{f}{$file}{start} keyed on the
-  # filename, line number, subroutine name and the count, the count being
-  # for when there are multiple subroutines of the same name on the same
-  # line (such subroutines generally being called BEGIN).
+sub add_count ($self, $criterion) {
+  # warn Carp::longmess("undefined file") unless defined $self->{file};
+  return unless defined $self->{file};  # can happen during self_cover
+  $self->{additional_count}{$criterion}{ $self->{file} }++
+    if $self->{additional};
+  (
+    $self->{count}{$criterion}{ $self->{file} }++,
+    !$self->reuse($self->{file}) || $self->{additional},
+  )
+}
+
+sub set_subroutine ($self, $sub_name, $file, $line, $scount) {
+  @$self{ qw( sub_name file line scount ) }
+    = ($sub_name, $file, $line, $scount);
+
+  # When new code is added at runtime, via a string eval in some guise, we need
+  # information about where structure information for the subroutine is.  This
+  # information is stored in $self->{f}{$file}{start} keyed on the filename,
+  # line number, subroutine name and the count, the count being for when there
+  # are multiple subroutines of the same name on the same line (such subroutines
+  # generally being called BEGIN).
 
   # print STDERR "set_subroutine start $file:$line $sub_name($scount) ",
   # Dumper $self->{f}{$file}{start};
@@ -133,7 +120,7 @@ sub set_subroutine {
         # print STDERR "reuse first $file:$line:$sub_name\n";
         $self->{count}{$_}{$file} = $self->{additional_count}{$_}{$file}
           = $self->{f}{$file}{start}{$line}{$sub_name}[$scount]{$_}
-          = $self->{f}{$file}{start}{-1}{"__COVER__"}[$scount]{$_}
+          = $self->{f}{$file}{start}{-1}{__COVER__}[$scount]{$_}
           for $self->criteria;
       }
     }
@@ -149,39 +136,14 @@ sub set_subroutine {
   # Dumper $self->{f}{$file}{start};
 }
 
-sub store_counts {
-  my $self = shift;
-  my ($file) = @_;
+sub store_counts ($self, $file) {
   $self->{count}{$_}{$file} = $self->{f}{$file}{start}{-1}{__COVER__}[0]{$_}
     = $self->get_count($file, $_)
     for $self->criteria;
   # print STDERR "store_counts: ", Dumper $self->{f}{$file}{start};
 }
 
-sub reuse {
-  my $self = shift;
-  my ($file) = @_;
-  exists $self->{f}{$file}{start}{-1}{"__COVER__"}
-  # TODO - exists $self->{f}{$file}{start}{-1}
-}
-
-sub set_file {
-  my $self = shift;
-  my ($file) = @_;
-  $self->{file} = $file;
-  my $digest = $self->digest($file);
-  if ($digest) {
-    # print STDERR "Adding $digest for $file\n";
-    $self->{f}{$file}{digest} = $digest;
-    push @{ $self->{digests}{$digest} }, $file;
-  }
-  $digest
-}
-
-sub digest {
-  my $self = shift;
-  my ($file) = @_;
-
+sub digest ($self, $file) {
   # print STDERR "Opening $file for MD5 digest\n";
 
   my $digest;
@@ -199,43 +161,29 @@ sub digest {
   $digest
 }
 
-sub get_count {
-  my $self = shift;
-  my ($file, $criterion) = @_;
-  $self->{count}{$criterion}{$file}
+sub set_file ($self, $file) {
+  $self->{file} = $file;
+  my $digest = $self->digest($file);
+  if ($digest) {
+    # print STDERR "Adding $digest for $file\n";
+    $self->{f}{$file}{digest} = $digest;
+    push $self->{digests}{$digest}->@*, $file;
+  }
+  $digest
 }
 
-sub add_count {
-  my $self = shift;
-  # warn Carp::longmess("undefined file") unless defined $self->{file};
-  return unless defined $self->{file};  # can happen during self_cover
-  my ($criterion) = @_;
-  $self->{additional_count}{$criterion}{ $self->{file} }++
-    if $self->{additional};
-  (
-    $self->{count}{$criterion}{ $self->{file} }++,
-    !$self->reuse($self->{file}) || $self->{additional},
-  )
-}
-
-sub delete_file {
-  my $self = shift;
-  my ($file) = @_;
-  delete $self->{f}{$file};
-}
+sub delete_file ($self, $file) { delete $self->{f}{$file} }
 
 # TODO - concurrent runs updating structure?
 
-sub write {
-  my $self = shift;
-  my ($dir) = @_;
+sub write ($self, $dir) {
   # print STDERR Dumper $self;
   $dir .= "/structure";
   unless (mkdir $dir) {
     confess "Can't mkdir $dir: $!" unless -d $dir;
   }
   chmod 0777, $dir if $self->{loose_perms};
-  for my $file (sort keys %{ $self->{f} }) {
+  for my $file (sort keys $self->{f}->%*) {
     $self->{f}{$file}{file} = $file;
     my $digest = $self->{f}{$file}{digest};
     $digest = $1 if defined $digest && $digest =~ /(.*)/;  # ie tainting
@@ -243,7 +191,7 @@ sub write {
       print STDERR "Can't find digest for $file"
         unless $Devel::Cover::Silent
         || $file =~ $Devel::Cover::DB::Ignore_filenames
-        || ($Devel::Cover::Self_cover && $file =~ q|/Devel/Cover[./]|);
+        || ($Devel::Cover::Self_cover && $file =~ "/Devel/Cover[./]");
       next;
     }
     my $df_final = "$dir/$digest";
@@ -257,93 +205,68 @@ sub write {
         if (-e $df_final) {
           print STDERR "Can't rename $df_temp to $df_final "
             . "(which exists): $!";
-          $self->debuglog(
-            "Can't rename $df_temp to $df_final " . "(which exists): $!")
-            if DEBUG;
         } else {
           print STDERR "Can't rename $df_temp to $df_final: $!";
-          $self->debuglog("Can't rename $df_temp to $df_final: $!") if DEBUG;
         }
       }
       unless (unlink $df_temp) {
         print STDERR "Can't remove $df_temp after failed rename: $!"
           unless $Devel::Cover::Silent;
-        $self->debuglog("Can't remove $df_temp after failed rename: $!")
-          if DEBUG;
       }
     }
   }
 }
 
-sub read {
+sub read ($self, $digest) {
+  my $file = "$self->{base}/structure/$digest";
+  my $io   = Devel::Cover::DB::IO->new;
+  my $s    = eval { $io->read($file) };
 
-  my $self     = shift;
-  my ($digest) = @_;
-  my $file     = "$self->{base}/structure/$digest";
-  my $io       = Devel::Cover::DB::IO->new;
-  my $s        = eval { $io->read($file) };
-
-  if ($@ or !$s) {
-    $self->debuglog("read retrieve $file failed: $@") if DEBUG;
+  if ($@ || !$s) {
     die $@;
-  }
-  if (DEBUG) {
-    foreach my $key (qw(file digest)) {
-      if (!defined $s->{$key}) {
-        $self->debuglog("retrieve $file had no $key entry. Got:\n", $s);
-      }
-    }
   }
   my $d = $self->digest($s->{file});
   # print STDERR "reading $digest from $file: ", Dumper $s;
   if (!$d) {
-    # No digest implies that we can't read the file. Likely this is because
-    # it's stored with a relative path. In which case, it's not valid to
-    # assume that the file has been changed, and hence that we need to
-    # "update" the structure database on disk.
+    # No digest implies that we can't read the file. Likely this is because it's
+    # stored with a relative path. In which case, it's not valid to assume that
+    # the file has been changed, and hence that we need to "update" the
+    # structure database on disk.
   } elsif ($d eq $s->{digest}) {
     $self->{f}{ $s->{file} } = $s;
   } else {
     print STDERR "Devel::Cover: Deleting old coverage ",
       "for changed file $s->{file}\n";
-    if (unlink $file) {
-      $self->debuglog(
-        "Deleting old coverage $file for changed "
-          . "$s->{file} $s->{digest} vs $d. Got:\n",
-        $s, "Have:\n", $self->{f}{$file}
-      ) if DEBUG;
-    } else {
+    unless (unlink $file) {
       print STDERR "Devel::Cover: can't delete $file: $!\n";
-      $self->debuglog(
-        "Failed to delete coverage $file for changed "
-          . "$s->{file} ($!) $s->{digest} vs $d. Got:\n",
-        $s, "Have:\n", $self->{f}{$file}
-      ) if DEBUG;
     }
   }
   $self
 }
 
-sub read_all {
-  my ($self) = @_;
+sub read_all ($self) {
   my $dir = $self->{base};
   $dir .= "/structure";
-  opendir D, $dir or return;
-  for my $d (sort grep $_ !~ /\./, readdir D) {
-    $d = $1 if $d =~ /(.*)/;  # Die tainting
+  opendir my $dh, $dir or return;
+  for my $d (sort grep !/\./, readdir $dh) {
+    $d = $1 if $d =~ /(.*)/;  # De-tainting
     $self->read($d);
   }
-  closedir D or die "Can't closedir $dir: $!";
+  closedir $dh or die "Can't closedir $dir: $!";
   $self
 }
 
-sub merge {
-  my $self = shift;
-  my ($from) = @_;
-  Devel::Cover::DB::_merge_hash($self->{f}, $from->{f}, "noadd");
+sub merge ($self, $from) {
+  # TODO - make _merge_hash a public API in Devel::Cover::DB
+  Devel::Cover::DB::_merge_hash(  ## no critic (ProtectPrivateSubs)
+    $self->{f}, $from->{f}, "noadd"
+  )
 }
 
-1
+"
+So let's shake hands and reach across those party lines
+You've got your friends just like I've got mine
+"
 
 __END__
 
@@ -351,20 +274,144 @@ __END__
 
 =head1 NAME
 
-Devel::Cover::DB::Structure - Internal: abstract structure of a source file
+Devel::Cover::DB::Structure - Manage source file structure for coverage data
 
 =head1 SYNOPSIS
 
  use Devel::Cover::DB::Structure;
 
+ my $struct = Devel::Cover::DB::Structure->new(base => $db_path);
+ $struct->add_criteria("statement", "branch");
+ my $digest = $struct->set_file($filename);
+ $struct->set_subroutine($sub_name, $file, $line, $scount);
+ $struct->write($dir);
+
+ # In a later run
+ my $struct = Devel::Cover::DB::Structure->new(base => $db_path);
+ $struct->read_all;
+ $struct->merge($other_struct);
+
 =head1 DESCRIPTION
+
+This module tracks the structural layout of source files being analysed by
+L<Devel::Cover>.  It records which subroutines, statements, branches, and
+conditions exist in each file, and maps those elements to digest-keyed storage
+so that coverage data can be matched to the correct source even across multiple
+runs.
+
+Structure information is persisted to the C<structure/> subdirectory of the
+coverage database, with one file per source digest.  When a file changes between
+runs, the stale structure entry is detected via MD5 digest comparison and
+deleted automatically.
+
+=head1 METHODS
+
+=head2 new (%args)
+
+ my $struct = Devel::Cover::DB::Structure->new(base => $path);
+
+Construct a new structure object.  All key-value pairs in C<%args> are stored as
+instance attributes.  The C<base> attribute should point to the coverage
+database directory.
+
+=head2 add_criteria (@names)
+
+ $struct->add_criteria("statement", "branch", "condition");
+
+Register coverage criteria that this structure should track.  Returns C<$self>.
+
+=head2 criteria
+
+ my @names = $struct->criteria;
+
+Return the list of registered criteria names.
+
+=head2 reuse ($file)
+
+ my $bool = $struct->reuse($file);
+
+Return true if C<$file> already has stored structure information from a previous
+run that can be reused.
+
+=head2 get_count ($file, $criterion)
+
+ my $count = $struct->get_count($file, $criterion);
+
+Return the current counter value for C<$criterion> in C<$file>.
+
+=head2 add_count ($criterion)
+
+ my ($count, $is_new) = $struct->add_count($criterion);
+
+Increment and return the counter for C<$criterion> in the current file. The
+second return value is true when the count represents a new (not reused)
+structure entry.
+
+=head2 set_subroutine ($sub_name, $file, $line, $scount)
+
+Record the start of subroutine C<$sub_name> at C<$file>:C<$line>. C<$scount>
+disambiguates multiple subroutines with the same name on the same line
+(typically C<BEGIN> blocks).
+
+Handles three cases: reusing existing structure, adding a new subroutine to a
+reused structure (e.g. a conditional C<< eval "use M" >>), and recording a
+subroutine in a new structure.
+
+=head2 store_counts ($file)
+
+Initialise counter storage for C<$file> across all registered criteria.
+
+=head2 digest ($file)
+
+ my $hex = $struct->digest($file);
+
+Return the MD5 hex digest of C<$file>, or C<undef> if the file cannot be opened.
+
+=head2 set_file ($file)
+
+ my $digest = $struct->set_file($file);
+
+Record C<$file> as the current file, compute its digest, and register the
+file-to-digest mapping.  Returns the digest.
+
+=head2 delete_file ($file)
+
+Remove all structure information for C<$file>.
+
+=head2 write ($dir)
+
+Serialise each file's structure to C<< $dir/structure/<digest> >>. Uses atomic
+rename to avoid partial writes.
+
+=head2 read ($digest)
+
+ $struct->read($digest);
+
+Load structure for C<$digest> from disk.  If the source file has changed since
+the structure was written, the stale entry is deleted. Returns C<$self>.
+
+=head2 read_all
+
+ $struct->read_all;
+
+Load all structure files from the database directory.  Returns C<$self>.
+
+=head2 merge ($from)
+
+ $struct->merge($other_struct);
+
+Merge structure information from C<$from> into this object.
+
+=head1 AUTOLOADED METHODS
+
+Methods of the form C<< add_<criterion> >> and C<< get_<criterion> >> are
+generated on first call via C<AUTOLOAD> for each coverage criterion
+(e.g. C<add_statement>, C<get_branch>), as well as for the meta-fields
+C<sub_name>, C<file>, and C<line>.
 
 =head1 SEE ALSO
 
- Devel::Cover
- Devel::Cover::DB
-
-=head1 METHODS
+L<Devel::Cover>, L<Devel::Cover::DB>
 
 =head1 LICENCE
 

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -77,8 +77,10 @@ sub debuglog {
   # and might exceed the atomic write size of the OS
   open my $fh, '>>', "$dir/$$" or confess "Can't open $dir/$$: $!";
   print $fh "----------------" . gmtime() . "----------------\n";
-  print $fh ref $_ ? Dumper($_) : $_;
-  print $fh "\n";
+  for (@_) {
+    print $fh ref $_ ? Dumper($_) : $_;
+    print $fh "\n";
+  }
   close $fh or confess "Can't close $dir/$$: $!";
 }
 

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -218,9 +218,11 @@ sub read ($self, $digest) {
     $self->{f}{ $s->{file} } = $s;
   } else {
     print STDERR "Devel::Cover: Deleting old coverage ",
-      "for changed file $s->{file}\n";
+      "for changed file $s->{file}\n"
+      unless $Devel::Cover::Silent;
     unless (unlink $file) {
-      print STDERR "Devel::Cover: can't delete $file: $!\n";
+      print STDERR "Devel::Cover: can't delete $file: $!\n"
+        unless $Devel::Cover::Silent;
     }
   }
   $self

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -41,7 +41,6 @@ sub AUTOLOAD {  ## no critic (RequireArgUnpacking) - goto needs @_ intact
       *$func = sub ($self) { $self->{$c} };
     } else {
       *$func = sub ($self, $digest) {
-        # print STDERR "file: $digest, condition: $c\n";
         for my $fval (values $self->{f}->%*) {
           return $fval->{$c} if $fval->{digest} eq $digest;
         }
@@ -73,7 +72,6 @@ sub get_count ($self, $file, $criterion) {
 }
 
 sub add_count ($self, $criterion) {
-  # warn Carp::longmess("undefined file") unless defined $self->{file};
   return unless defined $self->{file};  # can happen during self_cover
   $self->{additional_count}{$criterion}{ $self->{file} }++
     if $self->{additional};
@@ -94,14 +92,11 @@ sub set_subroutine ($self, $sub_name, $file, $line, $scount) {
   # are multiple subroutines of the same name on the same line (such subroutines
   # generally being called BEGIN).
 
-  # print STDERR "set_subroutine start $file:$line $sub_name($scount) ",
-  # Dumper $self->{f}{$file}{start};
   $self->{additional} = 0;
   if ($self->reuse($file)) {
     # reusing a structure
     if (exists $self->{f}{$file}{start}{$line}{$sub_name}[$scount]) {
       # sub already exists - normal case
-      # print STDERR "reuse $file:$line:$sub_name\n";
       $self->{count}{$_}{$file}
         = $self->{f}{$file}{start}{$line}{$sub_name}[$scount]{$_}
         for $self->criteria;
@@ -110,14 +105,12 @@ sub set_subroutine ($self, $sub_name, $file, $line, $scount) {
       $self->{additional} = 1;
       if (exists $self->{additional_count}{ ($self->criteria)[0] }{$file}) {
         # already had such a sub in module
-        # print STDERR "reuse additional $file:$line:$sub_name\n";
         $self->{count}{$_}{$file}
           = $self->{f}{$file}{start}{$line}{$sub_name}[$scount]{$_}
           = ($self->add_count($_))[0]
           for $self->criteria;
       } else {
         # first such a sub in module
-        # print STDERR "reuse first $file:$line:$sub_name\n";
         $self->{count}{$_}{$file} = $self->{additional_count}{$_}{$file}
           = $self->{f}{$file}{start}{$line}{$sub_name}[$scount]{$_}
           = $self->{f}{$file}{start}{-1}{__COVER__}[$scount]{$_}
@@ -126,26 +119,20 @@ sub set_subroutine ($self, $sub_name, $file, $line, $scount) {
     }
   } else {
     # first time sub seen in new structure
-    # print STDERR "new $file:$line:$sub_name\n";
     $self->{count}{$_}{$file}
       = $self->{f}{$file}{start}{$line}{$sub_name}[$scount]{$_}
       = $self->get_count($file, $_)
       for $self->criteria;
   }
-  # print STDERR "set_subroutine start $file:$line $sub_name($scount) ",
-  # Dumper $self->{f}{$file}{start};
 }
 
 sub store_counts ($self, $file) {
   $self->{count}{$_}{$file} = $self->{f}{$file}{start}{-1}{__COVER__}[0]{$_}
     = $self->get_count($file, $_)
     for $self->criteria;
-  # print STDERR "store_counts: ", Dumper $self->{f}{$file}{start};
 }
 
 sub digest ($self, $file) {
-  # print STDERR "Opening $file for MD5 digest\n";
-
   my $digest;
   if (open my $fh, "<", $file) {
     binmode $fh;
@@ -156,7 +143,6 @@ sub digest ($self, $file) {
       unless lc $file eq "-e"
       or $Devel::Cover::Silent
       or $file =~ $Devel::Cover::DB::Ignore_filenames;
-    # require "Cwd"; print STDERR Carp::longmess("in " . Cwd::cwd());
   }
   $digest
 }
@@ -165,7 +151,6 @@ sub set_file ($self, $file) {
   $self->{file} = $file;
   my $digest = $self->digest($file);
   if ($digest) {
-    # print STDERR "Adding $digest for $file\n";
     $self->{f}{$file}{digest} = $digest;
     push $self->{digests}{$digest}->@*, $file;
   }
@@ -177,7 +162,6 @@ sub delete_file ($self, $file) { delete $self->{f}{$file} }
 # TODO - concurrent runs updating structure?
 
 sub write ($self, $dir) {
-  # print STDERR Dumper $self;
   $dir .= "/structure";
   unless (mkdir $dir) {
     confess "Can't mkdir $dir: $!" unless -d $dir;
@@ -197,9 +181,8 @@ sub write ($self, $dir) {
     my $df_final = "$dir/$digest";
     my $df_temp  = "$dir/.$digest.$$";
     # TODO - determine if Structure has changed to save writing it
-    # my $f = $df; my $n = 1; $df = $f . "." . $n++ while -e $df;
     my $io = Devel::Cover::DB::IO->new;
-    $io->write($self->{f}{$file}, $df_temp);  # unless -e $df;
+    $io->write($self->{f}{$file}, $df_temp);               # unless -e $df;
     unless (rename $df_temp, $df_final) {
       unless ($Devel::Cover::Silent) {
         if (-e $df_final) {
@@ -226,7 +209,6 @@ sub read ($self, $digest) {
     die $@;
   }
   my $d = $self->digest($s->{file});
-  # print STDERR "reading $digest from $file: ", Dumper $s;
   if (!$d) {
     # No digest implies that we can't read the file. Likely this is because it's
     # stored with a relative path. In which case, it's not valid to assume that

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -786,13 +786,20 @@ a:visited { color: var(--link-visited); }
   border: none;
   padding: 0;
   text-align: left;
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .header-stats {
   display: flex;
   gap: 16px;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 .stat-badge {
@@ -834,7 +841,6 @@ a:visited { color: var(--link-visited); }
 }
 
 .theme-toggle {
-  margin-left: auto;
   background: none;
   border: 1px solid var(--border);
   border-radius: 4px;
@@ -1627,6 +1633,19 @@ $Assets{js} = <<'JS';
     render();
   }
 
+  /* --- Truncated filename tooltip --- */
+  var fileH1 = document.querySelector(".header h1");
+  if (fileH1) {
+    function updateH1Title() {
+      if (fileH1.scrollWidth > fileH1.clientWidth)
+        fileH1.title = fileH1.textContent.trim();
+      else
+        fileH1.removeAttribute("title");
+    }
+    updateH1Title();
+    window.addEventListener("resize", updateH1Title);
+  }
+
   /* --- Line detail expand/collapse (source view) --- */
   var sourceTable = document.querySelector(".source-table");
   if (sourceTable) {
@@ -2080,10 +2099,6 @@ $Templates{file} = <<'EOT';
       data-tip="[% s.covered %] / [% s.total %]"
       data-criterion="[% c %]">
 [% R.short.$c %] [% s.pc %]%
-<span class="cov-bar">
-<span class="cov-bar-fill"
-  style="width:[% s.pc %]%"></span>
-</span>
 </span>
 [% END %]
 [% END %]
@@ -2101,10 +2116,6 @@ risk 0
 <span class="stat-badge [% total.total.class %] has-tip"
       data-tip="[% total.total.covered %] / [% total.total.total %]">
 total [% total.total.pc %]%
-<span class="cov-bar">
-<span class="cov-bar-fill"
-  style="width:[% total.total.pc %]%"></span>
-</span>
 </span>
 [% END %]
 <span class="stat-badge stat-risk risk-hover has-tip"

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -463,6 +463,11 @@ sub report ($pkg, $db, $options) {
       grep { $options->{show}{ ($db->criteria)[$_] } }
         (0 .. $db->criteria - 1)
     ],
+    short => do {
+      my @c = $db->criteria;
+      my @s = $db->criteria_short;
+      +{ (map { $c[$_] => $s[$_] } 0 .. $#c), total => "total" }
+    },
     filenames => {
       map { $_ => do { (my $f = $_) =~ s/\W/-/g; $f } } $options->{file}->@*
     },
@@ -1797,29 +1802,29 @@ $Templates{index} = <<'EOT';
 <div class="header-inner">
 <h1>Coverage Report</h1>
 <div class="header-stats">
-[% IF total.total.pc != "n/a" %]
-<span class="stat-badge [% total.total.class %] has-tip"
-      data-tip="[% total.total.covered %] / [% total.total.total %]">
-Total: [% total.total.pc %]%
-<span class="cov-bar">
-<span class="cov-bar-fill"
-  style="width:[% total.total.pc %]%"></span>
-</span>
-</span>
-[% END %]
 [% FOREACH c = R.showing %]
 [% s = total.$c %]
 [% NEXT IF c == "time" %]
 [% NEXT UNLESS s.pc %]
 <span class="stat-badge [% s.class %] has-tip"
       data-tip="[% s.covered %] / [% s.total %]">
-[% c %] [% s.pc %]%
+[% R.short.$c %] [% s.pc %]%
 [% IF s.pc != 'n/a' %]
 <span class="cov-bar">
 <span class="cov-bar-fill"
   style="width:[% s.pc %]%"></span>
 </span>
 [% END %]
+</span>
+[% END %]
+[% IF total.total.pc != "n/a" %]
+<span class="stat-badge [% total.total.class %] has-tip"
+      data-tip="[% total.total.covered %] / [% total.total.total %]">
+total [% total.total.pc %]%
+<span class="cov-bar">
+<span class="cov-bar-fill"
+  style="width:[% total.total.pc %]%"></span>
+</span>
 </span>
 [% END %]
 </div>
@@ -1932,10 +1937,10 @@ Group by directory</label>
 <th data-sort="file">File</th>
 [% FOREACH c = R.showing %]
 [% NEXT IF c == "time" %]
-<th data-sort="[% c %]">[% c %]</th>
+<th data-sort="[% c %]">[% R.short.$c %]</th>
 [% END %]
-<th data-sort="total">Total</th>
-<th data-sort="risk">Risk</th>
+<th data-sort="total">total</th>
+<th data-sort="risk">risk</th>
 </tr>
 </thead>
 <tbody>
@@ -2040,14 +2045,14 @@ $Templates{file} = <<'EOT';
 [% IF file.uncompiled %]
 <span class="stat-badge untested-stat has-tip"
       data-tip="[% c %]: 0" data-criterion="[% c %]">
-[% c %] 0.0%
+[% R.short.$c %] 0.0%
 </span>
 [% ELSE %]
 [% NEXT UNLESS s.pc AND s.pc != 'n/a' %]
 <span class="stat-badge [% s.class %] has-tip"
       data-tip="[% s.covered %] / [% s.total %]"
       data-criterion="[% c %]">
-[% c %] [% s.pc %]%
+[% R.short.$c %] [% s.pc %]%
 <span class="cov-bar">
 <span class="cov-bar-fill"
   style="width:[% s.pc %]%"></span>

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -805,15 +805,23 @@ a:visited { color: var(--link-visited); }
 .stat-badge {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
   font-size: var(--font-size-small);
+  font-variant-numeric: tabular-nums;
   padding: 2px 8px;
   border-radius: 4px;
   border: 1px solid;
   transition: opacity 0.15s ease;
+  width: 96px;
 }
 
 .stat-badge:hover { opacity: 0.85; }
+.stat-na {
+  background: var(--bg-alt);
+  border-color: var(--border);
+  color: var(--fg-muted);
+}
 .stat-risk {
   background: var(--prefix-bg);
   border-color: var(--prefix-border);
@@ -2207,11 +2215,10 @@ $Templates{file} = <<'EOT';
 [% R.short.$c %] 0.0%
 </span>
 [% ELSE %]
-[% NEXT UNLESS s.pc AND s.pc != 'n/a' %]
-<span class="stat-badge [% s.class %] has-tip"
+<span class="stat-badge [% s.class || 'stat-na' %] has-tip"
       data-tip="[% s.covered %] / [% s.total %]"
       data-criterion="[% c %]">
-[% R.short.$c %] [% s.pc %]%
+[% R.short.$c %] [% s.pc %][% IF s.pc != 'n/a' %]%[% END %]
 </span>
 [% END %]
 [% END %]

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1785,8 +1785,11 @@ $Assets{js} = <<'JS';
       ".header .stat-badge[data-criterion]");
     var activeCriterion = null;
 
+    var detailIdx = -1;
+
     function clearFilter() {
       activeCriterion = null;
+      detailIdx = -1;
       details.forEach(function(d) { d.hidden = true; });
       sourceTable.querySelectorAll(".has-detail td.chevron")
         .forEach(function(ch) { ch.textContent = "\u25b6"; });
@@ -1813,13 +1816,12 @@ $Assets{js} = <<'JS';
           if (ch) ch.textContent = match ? "\u25bc" : "\u25b6";
         }
       );
+      detailIdx = -1;
       var first = sourceTable.querySelector(
         ".line-detail:not([hidden])");
       if (first) {
         var target = first.previousElementSibling || first;
-        target.scrollIntoView({ behavior: "smooth", block: "center" });
-        target.style.outline = "2px solid var(--link)";
-        setTimeout(function() { target.style.outline = ""; }, 1500);
+        scrollHighlight(target);
       }
     }
 
@@ -1840,23 +1842,49 @@ $Assets{js} = <<'JS';
       "tr[data-cov='0'], tr[data-cov='2']");
     var currentIdx = -1;
 
-    function jumpTo(idx) {
-      if (idx < 0 || idx >= uncovered.length) return;
-      currentIdx = idx;
-      var el = uncovered[idx];
+    function scrollHighlight(el) {
       el.scrollIntoView({ behavior: "smooth", block: "center" });
       el.style.outline = "2px solid var(--link)";
       setTimeout(function() { el.style.outline = ""; }, 1500);
     }
 
+    function openDetails() {
+      var rows = [];
+      sourceTable.querySelectorAll(".has-detail").forEach(
+        function(row) {
+          var d = row.nextElementSibling;
+          if (d && d.classList.contains("line-detail") && !d.hidden)
+            rows.push(row);
+        }
+      );
+      return rows;
+    }
+
+    function jumpTo(idx) {
+      if (idx < 0 || idx >= uncovered.length) return;
+      currentIdx = idx;
+      scrollHighlight(uncovered[idx]);
+    }
+
     document.addEventListener("keydown", function(e) {
       var tag = e.target.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA") return;
-      var len = uncovered.length;
-      if (e.key === "j") {
-        jumpTo(currentIdx + 1 < len ? currentIdx + 1 : 0);
-      } else if (e.key === "k") {
-        jumpTo(currentIdx > 0 ? currentIdx - 1 : len - 1);
+      if (e.key === "j" || e.key === "k") {
+        if (activeCriterion) {
+          var open = openDetails();
+          if (!open.length) return;
+          if (e.key === "j")
+            detailIdx = (detailIdx + 1) % open.length;
+          else
+            detailIdx = (detailIdx - 1 + open.length) % open.length;
+          scrollHighlight(open[detailIdx]);
+        } else {
+          var len = uncovered.length;
+          if (e.key === "j")
+            jumpTo(currentIdx + 1 < len ? currentIdx + 1 : 0);
+          else
+            jumpTo(currentIdx > 0 ? currentIdx - 1 : len - 1);
+        }
       }
       else if (e.key === "[") {
         var prev = document.querySelector(".nav-prev");

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -812,10 +812,25 @@ a:visited { color: var(--link-visited); }
   border-color: var(--prefix-border);
   color: var(--fg);
 }
-.stat-badge[data-criterion] { cursor: pointer; }
+.stat-badge[data-criterion] {
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.stat-badge[data-criterion]:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.15);
+  opacity: 1;
+}
 .stat-badge.badge-active {
   outline: 2px solid var(--link);
   outline-offset: -1px;
+}
+.filter-label {
+  font-size: 11px;
+  color: var(--fg-muted);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
 }
 
 .theme-toggle {
@@ -2050,6 +2065,7 @@ $Templates{file} = <<'EOT';
 [% END %]
 </h1>
 <div class="header-stats">
+<span class="filter-label">filter:</span>
 [% FOREACH c = R.showing %]
 [% NEXT IF c == "time" %]
 [% s = total.$c %]

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -283,6 +283,17 @@ sub _build_source_lines ($file) {
 
     _line_partial(\%line, \@bd, \@tts, \@sd);
 
+    my @errors;
+    push @errors, "branch"
+      if any { $_->{true_count} == 0 || $_->{false_count} == 0 } @bd;
+    push @errors, "condition" if any {
+      any { !$_->{covered} }
+        $_->{rows}->@*
+    } @tts;
+    push @errors, "subroutine" if any { !$_->{covered} } @sd;
+    push @errors, "pod"        if $line{pod_uncovered};
+    $line{errors} = join ",", @errors if @errors;
+
     push @lines, \%line;
     last line if $l =~ /^__(END|DATA)__/;
   }
@@ -791,6 +802,11 @@ a:visited { color: var(--link-visited); }
 }
 
 .stat-badge:hover { opacity: 0.85; }
+.stat-badge[data-criterion] { cursor: pointer; }
+.stat-badge.badge-active {
+  outline: 2px solid var(--link);
+  outline-offset: -1px;
+}
 
 .theme-toggle {
   margin-left: auto;
@@ -1599,6 +1615,53 @@ $Assets{js} = <<'JS';
       }
     );
 
+    /* --- Badge criterion filter --- */
+    var badges = document.querySelectorAll(
+      ".header .stat-badge[data-criterion]");
+    var activeCriterion = null;
+
+    function clearFilter() {
+      activeCriterion = null;
+      details.forEach(function(d) { d.hidden = true; });
+      sourceTable.querySelectorAll(".has-detail td.chevron")
+        .forEach(function(ch) { ch.textContent = "\u25b6"; });
+      badges.forEach(function(b) {
+        b.classList.remove("badge-active");
+      });
+    }
+
+    function applyFilter(crit) {
+      activeCriterion = crit;
+      badges.forEach(function(b) {
+        b.classList.toggle("badge-active",
+          b.getAttribute("data-criterion") === crit);
+      });
+      sourceTable.querySelectorAll(".has-detail").forEach(
+        function(row) {
+          var d = row.nextElementSibling;
+          if (!d || !d.classList.contains("line-detail"))
+            return;
+          var errors = row.getAttribute("data-errors") || "";
+          var match = errors.split(",").indexOf(crit) >= 0;
+          d.hidden = !match;
+          var ch = row.querySelector("td.chevron");
+          if (ch) ch.textContent = match ? "\u25bc" : "\u25b6";
+        }
+      );
+    }
+
+    badges.forEach(function(badge) {
+      badge.addEventListener("click", function(e) {
+        e.preventDefault();
+        var crit = badge.getAttribute("data-criterion");
+        if (crit === activeCriterion || crit === "statement") {
+          clearFilter();
+        } else {
+          applyFilter(crit);
+        }
+      });
+    });
+
     /* --- Keyboard navigation --- */
     var uncovered = document.querySelectorAll(
       "tr[data-cov='0'], tr[data-cov='2']");
@@ -1976,13 +2039,14 @@ $Templates{file} = <<'EOT';
 [% s = total.$c %]
 [% IF file.uncompiled %]
 <span class="stat-badge untested-stat has-tip"
-      data-tip="[% c %]: 0">
+      data-tip="[% c %]: 0" data-criterion="[% c %]">
 [% c %] 0.0%
 </span>
 [% ELSE %]
 [% NEXT UNLESS s.pc AND s.pc != 'n/a' %]
 <span class="stat-badge [% s.class %] has-tip"
-      data-tip="[% s.covered %] / [% s.total %]">
+      data-tip="[% s.covered %] / [% s.total %]"
+      data-criterion="[% c %]">
 [% c %] [% s.pc %]%
 <span class="cov-bar">
 <span class="cov-bar-fill"
@@ -2031,7 +2095,8 @@ $Templates{file} = <<'EOT';
       [%- ELSIF line.partial %]2[% ELSE %]1[% END %]"
     [%- END %]
     class="[% IF is_uncov %]src-c0[% END -%]
-      [%- IF has_detail %] has-detail[% END %]">
+      [%- IF has_detail %] has-detail[% END %]"
+    [%- IF line.errors %] data-errors="[% line.errors %]"[% END -%]>
 <td role="cell" class="ln">
 <a id="L[% line.number %]"
   href="#L[% line.number %]">[% line.number %]</a>

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1786,10 +1786,12 @@ $Assets{js} = <<'JS';
     var activeCriterion = null;
 
     var detailIdx = -1;
+    var currentRow = null;
 
     function clearFilter() {
       activeCriterion = null;
       detailIdx = -1;
+      currentRow = null;
       details.forEach(function(d) { d.hidden = true; });
       sourceTable.querySelectorAll(".has-detail td.chevron")
         .forEach(function(ch) { ch.textContent = "\u25b6"; });
@@ -1820,8 +1822,8 @@ $Assets{js} = <<'JS';
       var first = sourceTable.querySelector(
         ".line-detail:not([hidden])");
       if (first) {
-        var target = first.previousElementSibling || first;
-        scrollHighlight(target);
+        currentRow = first.previousElementSibling || first;
+        scrollHighlight(currentRow);
       }
     }
 
@@ -1863,7 +1865,8 @@ $Assets{js} = <<'JS';
     function jumpTo(idx) {
       if (idx < 0 || idx >= uncovered.length) return;
       currentIdx = idx;
-      scrollHighlight(uncovered[idx]);
+      currentRow = uncovered[idx];
+      scrollHighlight(currentRow);
     }
 
     var badgeKeys = {
@@ -1882,7 +1885,8 @@ $Assets{js} = <<'JS';
             detailIdx = (detailIdx + 1) % open.length;
           else
             detailIdx = (detailIdx - 1 + open.length) % open.length;
-          scrollHighlight(open[detailIdx]);
+          currentRow = open[detailIdx];
+          scrollHighlight(currentRow);
         } else {
           var len = uncovered.length;
           if (e.key === "j")
@@ -1898,6 +1902,14 @@ $Assets{js} = <<'JS';
         } else {
           applyFilter(crit);
         }
+      }
+      else if (e.key === "Enter" && currentRow) {
+        if (!currentRow.classList.contains("has-detail")) return;
+        var d = currentRow.nextElementSibling;
+        if (!d || !d.classList.contains("line-detail")) return;
+        d.hidden = !d.hidden;
+        var ch = currentRow.querySelector("td.chevron");
+        if (ch) ch.textContent = d.hidden ? "\u25b6" : "\u25bc";
       }
       else if (e.key === "[") {
         var prev = document.querySelector(".nav-prev");
@@ -2338,6 +2350,7 @@ breakdown.</dd>
 <dt>Keyboard</dt>
 <dd><kbd>j</kbd> / <kbd>k</kbd> next/prev uncovered line
 (or open detail when filtered)
+&middot; <kbd>Enter</kbd> toggle detail on current line
 &middot; <kbd>s</kbd> <kbd>b</kbd> <kbd>c</kbd> <kbd>u</kbd>
 <kbd>p</kbd> toggle filter for stmt / bran / cond / sub / pod
 &middot; <kbd>[</kbd> / <kbd>]</kbd> prev/next file

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -840,7 +840,7 @@ a:visited { color: var(--link-visited); }
   text-transform: uppercase;
 }
 
-.theme-toggle {
+.theme-toggle, .help-toggle {
   background: none;
   border: 1px solid var(--border);
   border-radius: 4px;
@@ -851,7 +851,76 @@ a:visited { color: var(--link-visited); }
   transition: background 0.15s ease, border-color 0.15s ease;
 }
 
-.theme-toggle:hover { background: var(--bg-alt); }
+.theme-toggle:hover, .help-toggle:hover { background: var(--bg-alt); }
+
+.help-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 100;
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+.help-overlay:not([hidden]) {
+  display: flex;
+}
+
+.help-panel {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 24px 32px;
+  max-width: 520px;
+  width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+}
+
+.help-panel h3 {
+  margin: 0 0 12px 0;
+  font-size: 16px;
+}
+
+.help-panel dt {
+  font-weight: 600;
+  font-size: var(--font-size-small);
+  margin-top: 10px;
+}
+
+.help-panel dd {
+  margin: 2px 0 0 0;
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+}
+
+.help-panel kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--header-bg);
+  font-family: var(--font-code);
+  font-size: 11px;
+}
+
+.help-panel .help-close {
+  float: right;
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  color: var(--fg-muted);
+  padding: 0;
+  line-height: 1;
+}
+
+.help-panel .help-close:hover { color: var(--fg); }
 
 /* --- Coverage classes --- */
 
@@ -1424,6 +1493,31 @@ $Assets{js} = <<'JS';
     toggle.textContent = isDark ? "\u2600" : "\u263e";
   }
 
+  /* --- Help overlay --- */
+  var helpOverlay = document.querySelector(".help-overlay");
+  var helpBtn = document.querySelector(".help-toggle");
+  if (helpOverlay) {
+    function showHelp()  { helpOverlay.hidden = false; }
+    function hideHelp()  { helpOverlay.hidden = true; }
+    if (helpBtn) helpBtn.addEventListener("click", function() {
+      if (helpOverlay.hidden) showHelp(); else hideHelp();
+    });
+    helpOverlay.addEventListener("click", function(e) {
+      if (e.target === helpOverlay) hideHelp();
+    });
+    var closeBtn = helpOverlay.querySelector(".help-close");
+    if (closeBtn) closeBtn.addEventListener("click", function(e) {
+      e.stopPropagation();
+      hideHelp();
+    });
+    document.addEventListener("keydown", function(e) {
+      var tag = e.target.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      if (e.key === "Escape" && !helpOverlay.hidden) hideHelp();
+      else if (e.key === "?" && helpOverlay.hidden) showHelp();
+    });
+  }
+
   /* --- Index page table (sort, filter, group) --- */
   var table = document.querySelector(".file-table");
   if (table) {
@@ -1743,10 +1837,6 @@ $Assets{js} = <<'JS';
         var next = document.querySelector(".nav-next");
         if (next) window.location = next.href;
       }
-      else if (e.key === "?") {
-        var help = document.querySelector(".help-overlay");
-        if (help) help.hidden = !help.hidden;
-      }
     });
 
     /* --- Scroll minimap --- */
@@ -1873,7 +1963,30 @@ total [% total.total.pc %]%
 </span>
 [% END %]
 </div>
+<button class="help-toggle" aria-label="Help">?</button>
 <button class="theme-toggle" aria-label="Toggle dark mode">&#x263e;</button>
+</div>
+</div>
+
+<div class="help-overlay" hidden>
+<div class="help-panel">
+<button class="help-close" aria-label="Close">&times;</button>
+<h3>Coverage report help</h3>
+<dl>
+<dt>Sorting</dt>
+<dd>Click any column header to sort; click again to reverse.</dd>
+<dt>Filtering</dt>
+<dd>Type in the filter box to filter files (supports regex).
+Toggle "Hide 100% covered" to focus on incomplete files.</dd>
+<dt>Grouping</dt>
+<dd>Toggle "Group by directory" to organise files into
+collapsible groups. Click a directory row to collapse it.</dd>
+<dt>Risk</dt>
+<dd>Hover the risk column for a breakdown: branch errors +
+condition errors + coverage gap.</dd>
+<dt>Tooltips</dt>
+<dd>Hover any badge or coverage cell for covered/total counts.</dd>
+</dl>
 </div>
 </div>
 
@@ -2131,7 +2244,33 @@ risk [% file.risk | format('%d') %]
 </span>
 [% END %]
 </div>
+<button class="help-toggle" aria-label="Help">?</button>
 <button class="theme-toggle" aria-label="Toggle dark mode">&#x263e;</button>
+</div>
+</div>
+
+<div class="help-overlay" hidden>
+<div class="help-panel">
+<button class="help-close" aria-label="Close">&times;</button>
+<h3>File coverage help</h3>
+<dl>
+<dt>Filter badges</dt>
+<dd>Click a criterion badge (stmt, bran, etc.) to expand all
+lines with errors of that type. Click again to close.</dd>
+<dt>Line details</dt>
+<dd>Click any line with a &#x25b6; chevron to expand branch,
+condition, or subroutine detail.</dd>
+<dt>Minimap</dt>
+<dd>The strip on the right shows coverage at a glance. Click to
+jump to that line.</dd>
+<dt>Tooltips</dt>
+<dd>Hover badges for covered/total counts. Hover risk for a
+breakdown.</dd>
+<dt>Keyboard</dt>
+<dd><kbd>j</kbd> / <kbd>k</kbd> next/prev uncovered line
+&middot; <kbd>[</kbd> / <kbd>]</kbd> prev/next file
+&middot; <kbd>?</kbd> toggle this help</dd>
+</dl>
 </div>
 </div>
 
@@ -2278,17 +2417,6 @@ Condition: [% tt.expr %]
   class="nav-next">[% next_file.short %] &raquo;</a>
 [% END %]
 </span>
-</div>
-
-<div class="help-overlay" hidden>
-<h3>Keyboard shortcuts</h3>
-<table>
-<tr><td><kbd>j</kbd></td><td>Next uncovered/partial line</td></tr>
-<tr><td><kbd>k</kbd></td><td>Previous uncovered/partial line</td></tr>
-<tr><td><kbd>[</kbd></td><td>Previous file</td></tr>
-<tr><td><kbd>]</kbd></td><td>Next file</td></tr>
-<tr><td><kbd>?</kbd></td><td>Toggle this help</td></tr>
-</table>
 </div>
 
 </div>

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1816,7 +1816,7 @@ $Assets{js} = <<'JS';
           if (ch) ch.textContent = match ? "\u25bc" : "\u25b6";
         }
       );
-      detailIdx = -1;
+      detailIdx = 0;
       var first = sourceTable.querySelector(
         ".line-detail:not([hidden])");
       if (first) {
@@ -1866,6 +1866,11 @@ $Assets{js} = <<'JS';
       scrollHighlight(uncovered[idx]);
     }
 
+    var badgeKeys = {
+      s: "statement", b: "branch", c: "condition",
+      u: "subroutine", p: "pod"
+    };
+
     document.addEventListener("keydown", function(e) {
       var tag = e.target.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA") return;
@@ -1884,6 +1889,14 @@ $Assets{js} = <<'JS';
             jumpTo(currentIdx + 1 < len ? currentIdx + 1 : 0);
           else
             jumpTo(currentIdx > 0 ? currentIdx - 1 : len - 1);
+        }
+      }
+      else if (badgeKeys[e.key]) {
+        var crit = badgeKeys[e.key];
+        if (crit === activeCriterion || crit === "statement") {
+          clearFilter();
+        } else {
+          applyFilter(crit);
         }
       }
       else if (e.key === "[") {
@@ -2324,6 +2337,9 @@ jump to that line.</dd>
 breakdown.</dd>
 <dt>Keyboard</dt>
 <dd><kbd>j</kbd> / <kbd>k</kbd> next/prev uncovered line
+(or open detail when filtered)
+&middot; <kbd>s</kbd> <kbd>b</kbd> <kbd>c</kbd> <kbd>u</kbd>
+<kbd>p</kbd> toggle filter for stmt / bran / cond / sub / pod
 &middot; <kbd>[</kbd> / <kbd>]</kbd> prev/next file
 &middot; <kbd>?</kbd> toggle this help</dd>
 </dl>

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -807,6 +807,11 @@ a:visited { color: var(--link-visited); }
 }
 
 .stat-badge:hover { opacity: 0.85; }
+.stat-risk {
+  background: var(--prefix-bg);
+  border-color: var(--prefix-border);
+  color: var(--fg);
+}
 .stat-badge[data-criterion] { cursor: pointer; }
 .stat-badge.badge-active {
   outline: 2px solid var(--link);
@@ -1048,6 +1053,12 @@ a:visited { color: var(--link-visited); }
 }
 
 .header .has-tip::after {
+  bottom: auto;
+  top: 100%;
+  margin-top: 4px;
+}
+
+.header .risk-tip {
   bottom: auto;
   top: 100%;
   margin-top: 4px;
@@ -2059,6 +2070,38 @@ $Templates{file} = <<'EOT';
 </span>
 </span>
 [% END %]
+[% END %]
+[% IF file.uncompiled %]
+<span class="stat-badge untested-stat has-tip"
+      data-tip="total: 0">
+total 0.0%
+</span>
+<span class="stat-badge stat-risk has-tip"
+      data-tip="risk: 0">
+risk 0
+</span>
+[% ELSE %]
+[% IF total.total.pc != 'n/a' %]
+<span class="stat-badge [% total.total.class %] has-tip"
+      data-tip="[% total.total.covered %] / [% total.total.total %]">
+total [% total.total.pc %]%
+<span class="cov-bar">
+<span class="cov-bar-fill"
+  style="width:[% total.total.pc %]%"></span>
+</span>
+</span>
+[% END %]
+<span class="stat-badge stat-risk risk-hover has-tip"
+      data-tip="risk score">
+risk [% file.risk | format('%d') %]
+<table class="risk-tip">
+<tr><td>Branch errors</td><td>[% file.risk_branch %]</td></tr>
+<tr><td>Condition errors</td><td>[% file.risk_cond %]</td></tr>
+<tr><td>Coverage gap</td><td>[% file.risk_gap %]%</td></tr>
+<tr class="risk-total"><td>Risk</td>
+<td>[% file.risk | format('%d') %]</td></tr>
+</table>
+</span>
 [% END %]
 </div>
 <button class="theme-toggle" aria-label="Toggle dark mode">&#x263e;</button>

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1767,15 +1767,19 @@ $Assets{js} = <<'JS';
     var details = sourceTable.querySelectorAll(".line-detail");
     details.forEach(function(d) { d.hidden = true; });
 
+    function toggleDetail(row) {
+      if (!row || !row.classList.contains("has-detail")) return;
+      var d = row.nextElementSibling;
+      if (!d || !d.classList.contains("line-detail")) return;
+      d.hidden = !d.hidden;
+      var ch = row.querySelector("td.chevron");
+      if (ch) ch.textContent = d.hidden ? "\u25b6" : "\u25bc";
+    }
+
     sourceTable.querySelectorAll(".has-detail").forEach(
       function(row) {
         row.addEventListener("click", function() {
-          var d = row.nextElementSibling;
-          if (d && d.classList.contains("line-detail")) {
-            d.hidden = !d.hidden;
-            var ch = row.querySelector("td.chevron");
-            if (ch) ch.textContent = d.hidden ? "\u25b6" : "\u25bc";
-          }
+          toggleDetail(row);
         });
       }
     );
@@ -1827,15 +1831,18 @@ $Assets{js} = <<'JS';
       }
     }
 
+    function toggleFilter(crit) {
+      if (crit === activeCriterion || crit === "statement") {
+        clearFilter();
+      } else {
+        applyFilter(crit);
+      }
+    }
+
     badges.forEach(function(badge) {
       badge.addEventListener("click", function(e) {
         e.preventDefault();
-        var crit = badge.getAttribute("data-criterion");
-        if (crit === activeCriterion || crit === "statement") {
-          clearFilter();
-        } else {
-          applyFilter(crit);
-        }
+        toggleFilter(badge.getAttribute("data-criterion"));
       });
     });
 
@@ -1896,20 +1903,10 @@ $Assets{js} = <<'JS';
         }
       }
       else if (badgeKeys[e.key]) {
-        var crit = badgeKeys[e.key];
-        if (crit === activeCriterion || crit === "statement") {
-          clearFilter();
-        } else {
-          applyFilter(crit);
-        }
+        toggleFilter(badgeKeys[e.key]);
       }
       else if (e.key === "Enter" && currentRow) {
-        if (!currentRow.classList.contains("has-detail")) return;
-        var d = currentRow.nextElementSibling;
-        if (!d || !d.classList.contains("line-detail")) return;
-        d.hidden = !d.hidden;
-        var ch = currentRow.querySelector("td.chevron");
-        if (ch) ch.textContent = d.hidden ? "\u25b6" : "\u25bc";
+        toggleDetail(currentRow);
       }
       else if (e.key === "[") {
         var prev = document.querySelector(".nav-prev");

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -747,9 +747,10 @@ body {
   font-family: var(--font-body);
   font-size: var(--font-size-base);
   color: var(--fg);
-  background: var(--bg);
-  background-image: radial-gradient(
-    ellipse at 50% 0%, var(--bg-alt) 0%, var(--bg) 70%);
+  background:
+    radial-gradient(
+      ellipse at 50% 0%, var(--bg-alt) 0%, var(--bg) 70%)
+    no-repeat var(--bg);
   line-height: 1.5;
 }
 

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1813,6 +1813,14 @@ $Assets{js} = <<'JS';
           if (ch) ch.textContent = match ? "\u25bc" : "\u25b6";
         }
       );
+      var first = sourceTable.querySelector(
+        ".line-detail:not([hidden])");
+      if (first) {
+        var target = first.previousElementSibling || first;
+        target.scrollIntoView({ behavior: "smooth", block: "center" });
+        target.style.outline = "2px solid var(--link)";
+        setTimeout(function() { target.style.outline = ""; }, 1500);
+      }
     }
 
     badges.forEach(function(badge) {

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1452,6 +1452,18 @@ td.chevron {
   font-size: var(--font-size-small);
 }
 
+.file-nav > span {
+  flex: 1;
+}
+
+.file-nav > span:nth-child(2) {
+  text-align: center;
+}
+
+.file-nav > span:last-child {
+  text-align: right;
+}
+
 /* --- Footer --- */
 
 .footer {

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -606,29 +606,6 @@ sub test_write_no_digest_ignored () {
   is $stderr, "", "write no digest ignored: no warning for ignored file";
 }
 
-sub test_debuglog () {
-  my $base = fresh_base("debuglog");
-  my $st   = Devel::Cover::DB::Structure->new(base => $base);
-
-  # Call with a scalar and a hashref to exercise both branches of the
-  # ref-check ternary
-  $st->debuglog("plain text", { key => "value" });
-
-  my $logfile = "$base/debuglog/$$";
-  ok -f $logfile, "debuglog: creates log file";
-
-  open my $fh, "<", $logfile or die "Cannot open $logfile: $!";
-  my $content = do { local $/; <$fh> };
-  close $fh or die "Cannot close $logfile: $!";
-
-  like $content, qr/plain text/, "debuglog: writes scalar args";
-  like $content, qr/'key'/,      "debuglog: writes Dumper output for refs";
-
-  # Call again to exercise the "dir already exists" branch
-  $st->debuglog("second call");
-  ok 1, "debuglog: second call succeeds (dir exists)";
-}
-
 sub test_write_no_digest_self_cover_no_match () {
   local $Devel::Cover::Self_cover = 1;
   my $base = fresh_base("no_digest_self_nm");
@@ -702,7 +679,6 @@ sub main () {
   test_digest_ignored_file;
   test_write_no_digest_self_cover;
   test_write_no_digest_ignored;
-  test_debuglog;
   test_write_no_digest_self_cover_no_match;
   test_autoload_no_criterion;
   test_digest_dash_e;

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -40,15 +40,19 @@ sub md5_file ($path) {
   Digest::MD5->new->addfile($fh)->hexdigest
 }
 
-sub capture_stderr :prototype(&) ($code) {
-  my $stderr = "";
-  open my $save, ">&", \*STDERR or die "Cannot dup STDERR: $!";
-  close STDERR or die "Cannot close STDERR: $!";
-  open STDERR, ">", \$stderr or die "Cannot redirect STDERR: $!";
-  $code->();
-  close STDERR or die "Cannot close STDERR: $!";
-  open STDERR, ">&", $save or die "Cannot restore STDERR: $!";
-  $stderr
+{
+  no feature "signatures";
+  sub capture_stderr (&) {
+    my ($code) = @_;
+    my $stderr = "";
+    open my $save, ">&", \*STDERR or die "Cannot dup STDERR: $!";
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">", \$stderr or die "Cannot redirect STDERR: $!";
+    $code->();
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">&", $save or die "Cannot restore STDERR: $!";
+    $stderr
+  }
 }
 
 sub fresh_base ($label) {

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -179,6 +179,24 @@ sub test_read_changed () {
     "read changed: warning printed";
 }
 
+sub test_read_changed_silent () {
+  local $Devel::Cover::Silent = 1;
+  my $base = fresh_base("read_chg_s");
+  my $file = write_source("changed_s.pm", "package ChangedS;\n1\n");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->set_file($file);
+  $st->write($base);
+
+  # Modify the source file so the digest no longer matches
+  write_source("changed_s.pm", "package ChangedS;\nsub x { 1 }\n1\n");
+
+  my $st2    = Devel::Cover::DB::Structure->new(base => $base);
+  my $stderr = capture_stderr { $st2->read_all };
+  ok !exists $st2->{f}{$file}, "read changed silent: entry not loaded";
+  is $stderr, "", "read changed silent: no warning";
+}
+
 sub test_read_all_empty () {
   my $base = fresh_base("read_empty");
   my $st   = Devel::Cover::DB::Structure->new(base => $base);
@@ -648,6 +666,7 @@ sub main () {
   test_write_read;
   test_read_unchanged;
   test_read_changed;
+  test_read_changed_silent;
   test_read_all_empty;
   test_read_all_no_dir;
   test_merge;

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -625,6 +625,28 @@ sub test_debuglog () {
   ok 1, "debuglog: second call succeeds (dir exists)";
 }
 
+sub test_write_no_digest_self_cover_no_match () {
+  local $Devel::Cover::Self_cover = 1;
+  my $base = fresh_base("no_digest_self_nm");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  # Path does not match /Devel/Cover[./] so the Self_cover guard
+  # doesn't suppress the warning
+  $st->{f}{"/lib/Some/Other.pm"} = { data => 1 };
+
+  my $stderr = capture_stderr { $st->write($base) };
+  like $stderr, qr/Can't find digest/,
+    "write no digest self_cover no match: warns";
+}
+
+sub test_autoload_no_criterion () {
+  my $st = Devel::Cover::DB::Structure->new;
+  # "get_" has an empty criterion, so the regex captures undef
+  my $ok = eval { $st->get_; 1 };
+  ok !$ok, "autoload no criterion: croaks";
+  like $@, qr/Undefined subroutine/, "autoload no criterion: correct error";
+}
+
 sub test_digest_dash_e () {
   my $st     = Devel::Cover::DB::Structure->new;
   my $stderr = capture_stderr {
@@ -677,6 +699,8 @@ sub main () {
   test_write_no_digest_self_cover;
   test_write_no_digest_ignored;
   test_debuglog;
+  test_write_no_digest_self_cover_no_match;
+  test_autoload_no_criterion;
   test_digest_dash_e;
   done_testing;
 }

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -20,7 +20,7 @@ use Digest::MD5 ();
 use File::Path  qw( make_path );
 use File::Spec  ();
 use File::Temp  qw( tempdir );
-use Test::More import => [ qw( done_testing is is_deeply like ok ) ];
+use Test::More import => [ qw( done_testing is is_deeply like ok pass ) ];
 
 use Devel::Cover::DB::Structure ();
 
@@ -348,6 +348,292 @@ sub test_write_no_digest_silent () {
   is $stderr, "", "write no digest silent: no warning";
 }
 
+sub test_write_creates_structure_dir () {
+  my $base = File::Spec->catdir($Tmpdir, "write_mkdir");
+  make_path($base);
+  # Don't pre-create structure/ - let write() do it
+  my $file = write_source("mkdir.pm", "package MkDir;\n1\n");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->set_file($file);
+  $st->write($base);
+
+  ok -d "$base/structure", "write mkdir: creates structure dir";
+}
+
+sub test_write_rename_failure () {
+  my $base   = fresh_base("rename_fail");
+  my $file   = write_source("renamefail.pm", "package RenameFail;\n1\n");
+  my $digest = md5_file($file);
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->set_file($file);
+
+  # Pre-create target as a directory so rename fails
+  mkdir "$base/structure/$digest"
+    or die "Cannot mkdir $base/structure/$digest: $!";
+
+  my $stderr = capture_stderr { $st->write($base) };
+  rmdir "$base/structure/$digest";
+
+  like $stderr, qr/Can't rename/, "write rename fail: warns on STDERR";
+}
+
+sub test_write_rename_failure_silent () {
+  local $Devel::Cover::Silent = 1;
+  my $base   = fresh_base("rename_fail_s");
+  my $file   = write_source("renamefails.pm", "package RenameFailS;\n1\n");
+  my $digest = md5_file($file);
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+
+  $st->set_file($file);
+
+  mkdir "$base/structure/$digest"
+    or die "Cannot mkdir $base/structure/$digest: $!";
+
+  my $stderr = capture_stderr { $st->write($base) };
+  rmdir "$base/structure/$digest";
+
+  is $stderr, "", "write rename fail silent: no warning";
+}
+
+sub test_autoload_get_time () {
+  my $file   = write_source("time.pm", "package Time;\n1\n");
+  my $digest = md5_file($file);
+  my $st     = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+
+  # time criterion maps to statement internally
+  $st->{f}{$file}{statement} = [ [ $file, 1 ] ];
+
+  my $got = $st->get_time($digest);
+  is_deeply $got, [ [ $file, 1 ] ], "autoload get_time: maps to statement data";
+}
+
+sub test_set_file_missing () {
+  my $st    = Devel::Cover::DB::Structure->new;
+  my $bogus = File::Spec->catfile($Tmpdir, "no_such_setfile.pm");
+
+  my $stderr = capture_stderr {
+    my $digest = $st->set_file($bogus);
+    ok !defined $digest, "set_file missing: returns undef"
+  };
+  ok !exists $st->{f}{$bogus}{digest}, "set_file missing: no digest stored";
+}
+
+sub test_add_count_no_file () {
+  my $st = Devel::Cover::DB::Structure->new;
+  $st->add_criteria("statement");
+  # $self->{file} is undef - should return early
+  my @result = $st->add_count("statement");
+  is @result, 0, "add_count no file: returns empty";
+}
+
+sub test_set_subroutine_new () {
+  my $file = write_source("setsub_new.pm", "package SetSubNew;\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->add_criteria("statement");
+
+  # Increment count so get_count returns something
+  $st->add_count("statement");
+  $st->add_count("statement");
+
+  $st->set_subroutine("mysub", $file, 10, 0);
+
+  is $st->{sub_name}, "mysub", "set_sub new: sets sub_name";
+  is $st->{file},     $file,   "set_sub new: sets file";
+  is $st->{line},     10,      "set_sub new: sets line";
+  ok exists $st->{f}{$file}{start}{10}{mysub}[0]{statement},
+    "set_sub new: creates start entry";
+  is $st->{f}{$file}{start}{10}{mysub}[0]{statement}, 2,
+    "set_sub new: start entry has correct count";
+}
+
+sub test_set_subroutine_reuse_existing () {
+  my $file = write_source("setsub_reuse.pm", "package SetSubReuse;\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->add_criteria("statement");
+
+  # Set up a reusable structure with __COVER__ and an existing sub
+  $st->{f}{$file}{start}{-1}{__COVER__} = [ { statement => 0 } ];
+  $st->{f}{$file}{start}{10}{oldsub}    = [ { statement => 5 } ];
+
+  $st->set_subroutine("oldsub", $file, 10, 0);
+
+  is $st->{count}{statement}{$file}, 5,
+    "set_sub reuse existing: restores count from start";
+  ok !$st->{additional}, "set_sub reuse existing: additional flag is false";
+}
+
+sub test_set_subroutine_reuse_additional_first () {
+  my $file = write_source("setsub_add1.pm", "package SetSubAdd1;\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->add_criteria("statement");
+
+  # Set up reusable structure but without the sub we'll request
+  $st->{f}{$file}{start}{-1}{__COVER__} = [ { statement => 10 } ];
+
+  $st->set_subroutine("newsub", $file, 20, 0);
+
+  ok $st->{additional},
+    "set_sub reuse additional first: additional flag is true";
+  is $st->{count}{statement}{$file}, 10,
+    "set_sub reuse additional first: count from __COVER__";
+}
+
+sub test_set_subroutine_reuse_additional_repeat () {
+  my $file = write_source("setsub_add2.pm", "package SetSubAdd2;\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->add_criteria("statement");
+
+  # Set up reusable structure without the sub
+  $st->{f}{$file}{start}{-1}{__COVER__} = [ { statement => 10 } ];
+  # Simulate that we've already seen an additional sub in this file
+  $st->{additional_count}{statement}{$file} = 1;
+
+  $st->set_subroutine("another", $file, 30, 0);
+
+  ok $st->{additional},
+    "set_sub reuse additional repeat: additional flag is true";
+  # Count should come from add_count, not from __COVER__
+  ok defined $st->{f}{$file}{start}{30}{another}[0]{statement},
+    "set_sub reuse additional repeat: start entry created";
+}
+
+sub test_add_count_with_additional () {
+  my $file = write_source("addcount_add.pm", "package AddCountAdd;\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->add_criteria("statement");
+  $st->{additional} = 1;
+
+  my ($n, $new) = $st->add_count("statement");
+  is $n, 0, "add_count additional: returns count";
+  is $st->{additional_count}{statement}{$file}, 1,
+    "add_count additional: increments additional_count";
+}
+
+sub test_add_count_reuse_not_additional () {
+  my $file = write_source("addcount_reuse.pm", "package AddCountReuse;\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->add_criteria("statement");
+
+  # Set up reuse so the || branch in add_count is tested
+  $st->{f}{$file}{start}{-1}{__COVER__} = [ { statement => 0 } ];
+  $st->{additional} = 0;
+
+  my ($n, $new) = $st->add_count("statement");
+  ok !$new, "add_count reuse not additional: new is false";
+}
+
+sub test_read_corrupt () {
+  my $base = fresh_base("read_corrupt");
+
+  # Write a corrupt file into the structure directory
+  my $corrupt = "$base/structure/deadbeef0123456789abcdef01234567";
+  open my $fh, ">", $corrupt or die "Cannot write $corrupt: $!";
+  print $fh "this is not valid serialised data";
+  close $fh or die "Cannot close $corrupt: $!";
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  my $ok = eval { $st->read_all; 1 };
+  ok !$ok, "read corrupt: dies on corrupt data";
+}
+
+sub test_read_source_deleted () {
+  my $base = fresh_base("read_deleted");
+  my $file = write_source("deleted.pm", "package Deleted;\n1\n");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->set_file($file);
+  $st->write($base);
+
+  # Remove the source file so digest returns undef
+  unlink $file or die "Cannot unlink $file: $!";
+
+  local $Devel::Cover::Silent = 1;
+  my $st2 = Devel::Cover::DB::Structure->new(base => $base);
+  $st2->read_all;
+
+  # The !$d branch: entry not loaded, but also not deleted
+  ok !exists $st2->{f}{$file}, "read source deleted: entry not loaded";
+}
+
+sub test_destroy () {
+  my $st = Devel::Cover::DB::Structure->new;
+  $st->DESTROY;
+  pass "DESTROY: can be called explicitly";
+}
+
+sub test_digest_ignored_file () {
+  my $st     = Devel::Cover::DB::Structure->new;
+  my $ignore = "/some/lib/Storable.pm";
+  my $stderr = capture_stderr {
+    my $d = $st->digest($ignore);
+    ok !defined $d, "digest ignored: returns undef"
+  };
+  is $stderr, "", "digest ignored: no warning for ignored file";
+}
+
+sub test_write_no_digest_self_cover () {
+  local $Devel::Cover::Self_cover = 1;
+  my $base = fresh_base("no_digest_self");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->{f}{"/lib/Devel/Cover/Foo.pm"} = { data => 1 };
+
+  my $stderr = capture_stderr { $st->write($base) };
+  is $stderr, "", "write no digest self_cover: no warning for DC module";
+}
+
+sub test_write_no_digest_ignored () {
+  my $base = fresh_base("no_digest_ign");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->{f}{"/some/lib/POSIX.pm"} = { data => 1 };
+
+  my $stderr = capture_stderr { $st->write($base) };
+  is $stderr, "", "write no digest ignored: no warning for ignored file";
+}
+
+sub test_debuglog () {
+  my $base = fresh_base("debuglog");
+  my $st   = Devel::Cover::DB::Structure->new(base => $base);
+
+  # Call with a scalar and a hashref to exercise both branches of the
+  # ref-check ternary
+  $st->debuglog("plain text", { key => "value" });
+
+  my $logfile = "$base/debuglog/$$";
+  ok -f $logfile, "debuglog: creates log file";
+
+  open my $fh, "<", $logfile or die "Cannot open $logfile: $!";
+  my $content = do { local $/; <$fh> };
+  close $fh or die "Cannot close $logfile: $!";
+
+  like $content, qr/plain text/, "debuglog: writes scalar args";
+  like $content, qr/'key'/,      "debuglog: writes Dumper output for refs";
+
+  # Call again to exercise the "dir already exists" branch
+  $st->debuglog("second call");
+  ok 1, "debuglog: second call succeeds (dir exists)";
+}
+
+sub test_digest_dash_e () {
+  my $st     = Devel::Cover::DB::Structure->new;
+  my $stderr = capture_stderr {
+    my $d = $st->digest("-e");
+    ok !defined $d, "digest -e: returns undef"
+  };
+  is $stderr, "", "digest -e: suppresses warning for -e";
+}
+
 sub main () {
   test_new;
   test_digest;
@@ -372,6 +658,26 @@ sub main () {
   test_write_loose_perms;
   test_write_no_digest;
   test_write_no_digest_silent;
+  test_write_creates_structure_dir;
+  test_write_rename_failure;
+  test_write_rename_failure_silent;
+  test_autoload_get_time;
+  test_set_file_missing;
+  test_add_count_no_file;
+  test_set_subroutine_new;
+  test_set_subroutine_reuse_existing;
+  test_set_subroutine_reuse_additional_first;
+  test_set_subroutine_reuse_additional_repeat;
+  test_add_count_with_additional;
+  test_add_count_reuse_not_additional;
+  test_read_corrupt;
+  test_read_source_deleted;
+  test_destroy;
+  test_digest_ignored_file;
+  test_write_no_digest_self_cover;
+  test_write_no_digest_ignored;
+  test_debuglog;
+  test_digest_dash_e;
   done_testing;
 }
 

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -1,0 +1,378 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Digest::MD5 ();
+use File::Path  qw( make_path );
+use File::Spec  ();
+use File::Temp  qw( tempdir );
+use Test::More import => [ qw( done_testing is is_deeply like ok ) ];
+
+use Devel::Cover::DB::Structure ();
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+
+sub write_source ($name, $content) {
+  my $path = File::Spec->catfile($Tmpdir, $name);
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $content;
+  close $fh or die "Cannot close $path: $!";
+  $path
+}
+
+sub md5_file ($path) {
+  open my $fh, "<", $path or die "Cannot open $path: $!";
+  binmode $fh;
+  Digest::MD5->new->addfile($fh)->hexdigest
+}
+
+sub capture_stderr :prototype(&) ($code) {
+  my $stderr = "";
+  open my $save, ">&", \*STDERR or die "Cannot dup STDERR: $!";
+  close STDERR or die "Cannot close STDERR: $!";
+  open STDERR, ">", \$stderr or die "Cannot redirect STDERR: $!";
+  $code->();
+  close STDERR or die "Cannot close STDERR: $!";
+  open STDERR, ">&", $save or die "Cannot restore STDERR: $!";
+  $stderr
+}
+
+sub fresh_base ($label) {
+  my $base = File::Spec->catdir($Tmpdir, $label);
+  make_path("$base/structure");
+  $base
+}
+
+sub test_new () {
+  my $base = fresh_base("new");
+  my $st   = Devel::Cover::DB::Structure->new(base => $base);
+  ok $st, "new: returns an object";
+  is ref $st, "Devel::Cover::DB::Structure", "new: correct class";
+}
+
+sub test_digest () {
+  my $file     = write_source("digest.pm", "package Digest;\n1\n");
+  my $expected = md5_file($file);
+
+  my $st = Devel::Cover::DB::Structure->new;
+  is $st->digest($file), $expected, "digest: matches MD5 of file";
+}
+
+sub test_digest_missing () {
+  my $st     = Devel::Cover::DB::Structure->new;
+  my $bogus  = File::Spec->catfile($Tmpdir, "no_such_file.pm");
+  my $stderr = capture_stderr {
+    my $d = $st->digest($bogus);
+    ok !defined $d, "digest missing: returns undef"
+  };
+  like $stderr, qr/can't open/, "digest missing: warns on STDERR";
+}
+
+sub test_digest_missing_silent () {
+  local $Devel::Cover::Silent = 1;
+  my $st     = Devel::Cover::DB::Structure->new;
+  my $bogus  = File::Spec->catfile($Tmpdir, "no_such_silent.pm");
+  my $stderr = capture_stderr {
+    my $d = $st->digest($bogus);
+    ok !defined $d, "digest missing silent: returns undef"
+  };
+  is $stderr, "", "digest missing silent: no warning on STDERR";
+}
+
+sub test_set_file () {
+  my $file     = write_source("setfile.pm", "package SetFile;\n1\n");
+  my $expected = md5_file($file);
+
+  my $st     = Devel::Cover::DB::Structure->new;
+  my $digest = $st->set_file($file);
+  is $digest,                 $expected, "set_file: returns correct digest";
+  is $st->{f}{$file}{digest}, $expected, "set_file: stores digest in {f}";
+  is_deeply $st->{digests}{$expected}, [$file],
+    "set_file: records file in {digests}";
+}
+
+sub test_criteria () {
+  my $st = Devel::Cover::DB::Structure->new;
+  $st->add_criteria("statement", "branch");
+  my @c = sort $st->criteria;
+  is_deeply \@c, [ qw( branch statement ) ], "criteria: round-trip";
+}
+
+sub test_delete_file () {
+  my $st = Devel::Cover::DB::Structure->new;
+  $st->{f}{"/fake/file.pm"} = { digest => "abc", data => 1 };
+  $st->delete_file("/fake/file.pm");
+  ok !exists $st->{f}{"/fake/file.pm"}, "delete_file: entry removed";
+}
+
+sub test_write_read () {
+  my $base   = fresh_base("write_read");
+  my $file   = write_source("writeread.pm", "package WriteRead;\n1\n");
+  my $digest = md5_file($file);
+
+  # Build a structure with one file entry
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->add_criteria("statement");
+  $st->set_file($file);
+  $st->{f}{$file}{statement} = [ [ $file, 1 ] ];
+  $st->write($base);
+
+  # Read it back into a fresh object
+  my $st2 = Devel::Cover::DB::Structure->new(base => $base);
+  $st2->read_all;
+
+  ok exists $st2->{f}{$file}, "write/read: file entry present";
+  is $st2->{f}{$file}{digest}, $digest, "write/read: digest preserved";
+  is_deeply $st2->{f}{$file}{statement}, [ [ $file, 1 ] ],
+    "write/read: data preserved";
+}
+
+sub test_read_unchanged () {
+  my $base   = fresh_base("read_unch");
+  my $file   = write_source("unchanged.pm", "package Unchanged;\n1\n");
+  my $digest = md5_file($file);
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->set_file($file);
+  $st->write($base);
+
+  # Read back without modifying the source file
+  my $st2    = Devel::Cover::DB::Structure->new(base => $base);
+  my $stderr = capture_stderr { $st2->read_all };
+  ok exists $st2->{f}{$file}, "read unchanged: entry loaded";
+  is $stderr, "", "read unchanged: no warning";
+}
+
+sub test_read_changed () {
+  my $base = fresh_base("read_chg");
+  my $file = write_source("changed.pm", "package Changed;\n1\n");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->set_file($file);
+  $st->write($base);
+
+  # Modify the source file so the digest no longer matches
+  write_source("changed.pm", "package Changed;\nsub x { 1 }\n1\n");
+
+  my $st2    = Devel::Cover::DB::Structure->new(base => $base);
+  my $stderr = capture_stderr { $st2->read_all };
+  ok !exists $st2->{f}{$file}, "read changed: entry not loaded";
+  like $stderr, qr/Deleting old coverage.*changed\.pm/,
+    "read changed: warning printed";
+}
+
+sub test_read_all_empty () {
+  my $base = fresh_base("read_empty");
+  my $st   = Devel::Cover::DB::Structure->new(base => $base);
+  $st->read_all;
+  is_deeply $st->{f}, undef, "read_all empty: no entries loaded";
+}
+
+sub test_read_all_no_dir () {
+  my $base = File::Spec->catdir($Tmpdir, "no_structure_dir");
+  make_path($base);
+  # No structure/ subdirectory
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->read_all;
+  ok !$st->{f}, "read_all no dir: returns gracefully";
+}
+
+sub test_merge () {
+  my $st1 = Devel::Cover::DB::Structure->new;
+  $st1->{f}{"/a.pm"} = { digest => "aaa", statement => [ [ "/a.pm", 1 ] ] };
+
+  my $st2 = Devel::Cover::DB::Structure->new;
+  $st2->{f}{"/b.pm"} = { digest => "bbb", statement => [ [ "/b.pm", 2 ] ] };
+
+  $st1->merge($st2);
+  ok exists $st1->{f}{"/a.pm"}, "merge: original entry retained";
+  ok exists $st1->{f}{"/b.pm"}, "merge: new entry added";
+  is $st1->{f}{"/b.pm"}{digest}, "bbb", "merge: new entry data correct";
+}
+
+sub test_autoload_add_get () {
+  my $file = write_source("autoload.pm", "package Autoload;\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->add_criteria("statement", "branch", "subroutine");
+
+  # add_statement should push data into {f}{$file}{statement}
+  $st->add_statement($file, [ $file, 10 ]);
+  $st->add_statement($file, [ $file, 20 ]);
+  is_deeply $st->{f}{$file}{statement}, [ [ $file, 10 ], [ $file, 20 ] ],
+    "autoload add: add_statement pushes entries";
+
+  $st->add_branch($file, [ $file, 15, { text => "if block" } ]);
+  is_deeply $st->{f}{$file}{branch}, [ [ $file, 15, { text => "if block" } ] ],
+    "autoload add: add_branch pushes entry";
+
+  $st->add_subroutine($file, [ $file, 5 ]);
+  is_deeply $st->{f}{$file}{subroutine}, [ [ $file, 5 ] ],
+    "autoload add: add_subroutine pushes entry";
+}
+
+sub test_autoload_get_by_digest () {
+  my $file   = write_source("autoget.pm", "package AutoGet;\n1\n");
+  my $digest = md5_file($file);
+  my $st     = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->add_criteria("statement");
+
+  $st->add_statement($file, [ $file, 1 ]);
+
+  my $got = $st->get_statement($digest);
+  is_deeply $got, [ [ $file, 1 ] ],
+    "autoload get: get_statement retrieves by digest";
+
+  my $miss = $st->get_statement("nonexistent_digest");
+  ok !defined $miss, "autoload get: returns undef for unknown digest";
+}
+
+sub test_autoload_get_meta () {
+  my $st = Devel::Cover::DB::Structure->new;
+  $st->{file}     = "/some/file.pm";
+  $st->{line}     = 42;
+  $st->{sub_name} = "frobnicate";
+
+  is $st->get_file,     "/some/file.pm", "autoload get_file: returns file";
+  is $st->get_line,     42,              "autoload get_line: returns line";
+  is $st->get_sub_name, "frobnicate",    "autoload get_sub_name: returns name";
+}
+
+sub test_autoload_bad_method () {
+  my $st = Devel::Cover::DB::Structure->new;
+  my $ok = eval { $st->add_nonsense; 1 };
+  ok !$ok, "autoload bad: unknown method croaks";
+  like $@, qr/Undefined subroutine/, "autoload bad: correct error message";
+}
+
+sub test_add_count () {
+  my $file = write_source("addcount.pm", "package AddCount;\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->add_criteria("statement", "branch");
+
+  my ($n1, $new1) = $st->add_count("statement");
+  is $n1, 0, "add_count: first call returns 0";
+  ok $new1, "add_count: first call is new";
+
+  my ($n2, $new2) = $st->add_count("statement");
+  is $n2, 1, "add_count: second call returns 1";
+  ok $new2, "add_count: second call still new (no reuse)";
+
+  is $st->get_count($file, "statement"), 2,
+    "get_count: reflects incremented count";
+}
+
+sub test_store_counts () {
+  my $file = write_source("storecounts.pm", "package StoreCounts;\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->add_criteria("statement");
+
+  # Increment the count a few times
+  $st->add_count("statement");
+  $st->add_count("statement");
+  $st->add_count("statement");
+
+  $st->store_counts($file);
+
+  # store_counts should snapshot current count into the start structure
+  ok exists $st->{f}{$file}{start}{-1}{__COVER__},
+    "store_counts: creates __COVER__ start entry";
+  is $st->{f}{$file}{start}{-1}{__COVER__}[0]{statement}, 3,
+    "store_counts: records correct count";
+}
+
+sub test_reuse () {
+  my $st = Devel::Cover::DB::Structure->new;
+
+  ok !$st->reuse("/new.pm"), "reuse: false for unknown file";
+
+  $st->{f}{"/old.pm"}{start}{-1}{__COVER__} = [ { statement => 5 } ];
+  ok $st->reuse("/old.pm"), "reuse: true when __COVER__ start exists";
+}
+
+sub test_write_loose_perms () {
+  my $base = fresh_base("loose");
+  my $file = write_source("loose.pm", "package Loose;\n1\n");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base, loose_perms => 1);
+  $st->set_file($file);
+  $st->write($base);
+
+  my $dir_perms = (stat "$base/structure")[2] & 07777;
+  is $dir_perms, 0777, "write loose_perms: structure dir is 0777";
+}
+
+sub test_write_no_digest () {
+  my $base = fresh_base("no_digest");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  # Manually insert an entry with no digest
+  $st->{f}{"/fake.pm"} = { data => 1 };
+
+  my $stderr = capture_stderr { $st->write($base) };
+  like $stderr, qr/Can't find digest/,
+    "write no digest: warns about missing digest";
+
+  # Verify nothing was written
+  opendir my $dh, "$base/structure" or die "Cannot opendir: $!";
+  my @files = grep !/^\./, readdir $dh;
+  closedir $dh;
+  is @files, 0, "write no digest: no file written";
+}
+
+sub test_write_no_digest_silent () {
+  local $Devel::Cover::Silent = 1;
+  my $base = fresh_base("no_digest_silent");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->{f}{"/fake.pm"} = { data => 1 };
+
+  my $stderr = capture_stderr { $st->write($base) };
+  is $stderr, "", "write no digest silent: no warning";
+}
+
+sub main () {
+  test_new;
+  test_digest;
+  test_digest_missing;
+  test_digest_missing_silent;
+  test_set_file;
+  test_criteria;
+  test_delete_file;
+  test_write_read;
+  test_read_unchanged;
+  test_read_changed;
+  test_read_all_empty;
+  test_read_all_no_dir;
+  test_merge;
+  test_autoload_add_get;
+  test_autoload_get_by_digest;
+  test_autoload_get_meta;
+  test_autoload_bad_method;
+  test_add_count;
+  test_store_counts;
+  test_reuse;
+  test_write_loose_perms;
+  test_write_no_digest;
+  test_write_no_digest_silent;
+  done_testing;
+}
+
+main;

--- a/utils/dc
+++ b/utils/dc
@@ -881,10 +881,13 @@ Dc_cover_perl="perl -Iblib/lib -Iblib/arch"
 
 dc_cover_lib() {
   local db="dc_cover_lib_db"
-  local select="Devel/Cover/(Path|Static)"
+  local select="Devel/Cover/(DB/Structure|Path|Static)"
   local launch="${1:-1}"
 
   rm -rf "$db"
+  $Dc_cover_perl \
+    "-MDevel::Cover=-select,$select,-db,$db,-merge,1" \
+    t/internal/structure.t
   $Dc_cover_perl \
     "-MDevel::Cover=-select,$select,-db,$db,-merge,1" \
     t/internal/path.t


### PR DESCRIPTION
## Summary

Silent mode (`$Devel::Cover::Silent`, enabled by default via `$HARNESS_PERL_SWITCHES` and `$PERL5OPT`) did not suppress the "Deleting old coverage for changed file" message. This caused spurious STDERR output that broke user tests which check program output under coverage.

## Changes

**Bug fix (GH-329):**
- Guard the "Deleting old coverage" and unlink error messages with `$Devel::Cover::Silent` in `DB::Structure::read`
- Add test verifying suppression under Silent mode

**Structure.pm modernisation:**
- Defer loading of DB::Structure to runtime (was compile-time)
- Modernise to signatures, postderef, `List::Util::any`
- Remove dead debug prints, expand test coverage from zero to 82 tests
- Remove unused `debuglog` method and `DEBUG` constant

**html_crisp report enhancements:**
- Badge filter: click criterion badges to expand matching detail rows
- Keyboard navigation: j/k cycles open details when filtered, s/b/c/u/p toggle badge filters, Enter toggles detail on current line
- Scroll to first match on badge filter click
- Help overlay, file page header layout, and visual polish

**Other:**
- Simplify perltidy trailing comma rules
- Fix `capture_stderr` prototype for 5.20 compatibility
- Fix background gradient tiling artefact

## Implications

- Users running coverage via `PERL5OPT` or `HARNESS_PERL_SWITCHES` will no longer see unexpected STDERR output when source files change between runs.
- The deferred Structure load means the module is no longer pulled in at `use Devel::Cover` time, reducing startup overhead.

## Issue

Closes #329