### PR TITLE
GH-420 Add cpan-module recipe to dc

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -600,7 +600,7 @@ sub check_files {
         for grep check_file($_), map B::svref_2object($_),
         adjust_blocks(\%{$pkg});
       1
-    }
+    },
   );
 
   my $l = sub ($cv) {
@@ -668,7 +668,7 @@ sub _report {
   $Run{collected} = \@collected;
   require Devel::Cover::DB::Structure;
   $Structure = Devel::Cover::DB::Structure->new(base => $DB,
-    loose_perms => $Loose_perms);
+    loose_perms => $Loose_perms,);
   $Structure->read_all;
   $Structure->add_criteria(@collected);
 
@@ -689,7 +689,7 @@ sub _report {
     # get_ends includes INIT blocks
     get_cover_progress(
       "END/INIT block",
-      get_ends()->isa("B::AV") ? get_ends()->ARRAY : ()
+      get_ends()->isa("B::AV") ? get_ends()->ARRAY : (),
     );
   }
   get_cover_progress("CV", @Cvs);
@@ -726,7 +726,7 @@ sub _write_coverage_db {
     base        => $DB,
     runs        => { $run => \%Run },
     structure   => $Structure,
-    loose_perms => $Loose_perms
+    loose_perms => $Loose_perms,
   );
 
   my $dbrun = "$DB/runs";

--- a/utils/dc
+++ b/utils/dc
@@ -953,6 +953,67 @@ recipe_showcase() {
   "$PERL" "$srcdir/showcase" "${args[@]:?No report specified}"
 }
 
+cpan_module() {
+  local module="${1:?No module specified}"
+  local dc_root
+  dc_root=$(cd "$srcdir/.." && pwd)
+  local workdir="$dc_root/tmp/runs"
+
+  pi "Running coverage on CPAN module: $module"
+
+  # Download and extract
+  mkdir -p "$workdir"
+  cd "$workdir"
+
+  local info
+  info=$(cpanm --info "$module") ||
+    pf "Can't find module: $module"
+
+  local dist=${info##*/}        # e.g. Gedcom-1.22.tar.gz
+  local distdir=${dist%.tar.gz} # e.g. Gedcom-1.22
+
+  if [[ -d "$distdir" ]] && ! ((force)); then
+    pi "Using existing $workdir/$distdir (use --force to re-download)"
+  else
+    rm -rf "$distdir"
+    local author=${info%%/*}
+    local url="https://cpan.metacpan.org/authors/id"
+    url+="/${author:0:1}/${author:0:2}/$info"
+    curl -sL "$url" -o "$dist"
+    tar xzf "$dist"
+    rm "$dist"
+  fi
+
+  cd "$distdir"
+
+  # Install dependencies into a local directory (not system-wide)
+  local locallib="$workdir/$distdir/local"
+  pi "Installing dependencies to $locallib"
+  cpanm -n -L "$locallib" --installdeps .
+
+  # Build (with local deps visible)
+  pi "Building $module"
+  export PERL5LIB="$locallib/lib/perl5${PERL5LIB:+:$PERL5LIB}"
+  if [[ -f Makefile.PL ]]; then
+    perl Makefile.PL && make
+  elif [[ -f Build.PL ]]; then
+    perl Build.PL && ./Build
+  else
+    pf "No Makefile.PL or Build.PL found"
+  fi
+
+  # Run tests with coverage using local Devel::Cover
+  pi "Running tests with coverage (local Devel::Cover)"
+  export DEVEL_COVER_TEST_OPTS="-Mblib=$dc_root"
+  perl "-Mblib=$dc_root" "$dc_root/bin/cover" -test -report html_crisp -launch
+
+  pi "Done. Results in: $(pwd)/cover_db"
+}
+
+recipe_cpan-module() {
+  cpan_module "${args[@]:?No module specified}"
+}
+
 run_recipe() {
   recipe="recipe_$recipe"
   shift

--- a/utils/dc
+++ b/utils/dc
@@ -31,11 +31,111 @@ pf() {
 }
 
 usage() {
-  cat <<EOT
-$script --help
-$script --trace --verbose
-$script --env=dev cpancover-controller-run-once
-$script --results_dir=/cover/dev --image=pjcj/cpancover_dev cpancover-run
+  cat <<'EOT'
+Usage: dc [options] <recipe> [args]
+
+Examples:
+  dc --help
+  dc --trace --verbose
+  dc --env=dev cpancover-controller-run-once
+  dc --results_dir=/cover/dev --image=pjcj/cpancover_dev cpancover-run
+
+Options:
+  -d, --dryrun                         Dry run (no destructive actions)
+  -e, --env ENV                        Environment: prod (default) or dev
+  -f, --force                          Force operations (e.g. re-download)
+  -h, --help                           Show this help
+  -i, --image IMAGE                    Docker image to use
+  -r, --results_dir DIR                Results directory
+  -t, --trace                          Enable shell tracing (set -x)
+  -v, --verbose                        Verbose output
+
+Development:
+  all-versions <cmd>                   Run a command across all Perl versions.
+  build-and-test-all                   Clean build and run all tests.
+  cpan-module <module>                 Download a CPAN module and run its tests
+                                       under coverage.
+  dc-cover                             Combined self-coverage for lib and report
+                                       modules.
+  dc-cover-lib                         Self-coverage for library modules (Path,
+                                       Static, Structure).
+  dc-cover-reports                     Self-coverage for report modules.
+  generate-gcov-fixtures               Regenerate gcov test fixtures from
+                                       .c.fixture files.
+  nice-cpus                            Print the number of available CPUs.
+  showcase <report>                    Run the showcase script for a report.
+  update-copyright [from] [to]         Update copyright year in all tracked
+                                       files.
+
+Installation:
+  install-cpancover-perl <version>     Install Perl as the "cpancover" plenv
+                                       version.
+  install-dc-dev-perl <version>        Install Perl as "dc-dev" with dev
+                                       dependencies.
+  install-dependencies                 Install runtime dependencies via cpm.
+  install-development-dependencies     Install development tools (Dist::Zilla,
+                                       critic, tidy, etc.).
+  install-perl <name> <version>        Install a named Perl version via plenv.
+  install-test-dependencies            Install extra test dependencies.
+
+cpancover:
+  cpancover [args]                     Run cpancover with arbitrary arguments.
+  cpancover-add <module>               Add a module to the Minion queue.
+  cpancover-build-module <module>      Build coverage for a single CPAN module.
+  cpancover-build-stdin                Build coverage for modules listed on
+                                       stdin.
+  cpancover-compress                   Compress all results directories.
+  cpancover-compress-new               Compress only new results directories.
+  cpancover-compress-old-versions [n]  Compress old dist versions, keeping n
+                                       latest (default 3).
+  cpancover-generate-html              Generate HTML reports, compress results,
+                                       and update JSON.
+  cpancover-latest                     List the latest CPAN modules to process.
+  cpancover-run-loop                   Run build cycles in a loop (10 min
+                                       interval).
+  cpancover-run-once                   Fetch latest modules and run one build
+                                       cycle.
+  cpancover-serve [port]               Serve results locally via Caddy (default
+                                       port 8080).
+  cpancover-test                       Run a test module through the full build
+                                       pipeline.
+  cpancover-uncompress-dir <subdir>    Decompress a results subdirectory.
+
+cpancover (Docker):
+  cpancover-controller-run             Start a controller container running the
+                                       build loop.
+  cpancover-controller-run-once        Start a controller container for one
+                                       build cycle.
+  cpancover-controller-shell           Open a shell in a controller container.
+  cpancover-controller-test            Run a test module via the controller
+                                       pipeline.
+  cpancover-docker-kill                Kill running cpancover containers.
+  cpancover-docker-module <mod> <name> Build coverage for a module in Docker
+                                       (called by Collection.pm).
+  cpancover-docker-ps                  List running cpancover containers.
+  cpancover-docker-pull                Pull the latest cpancover Docker image.
+  cpancover-docker-rm                  Remove cpancover containers and prune.
+  cpancover-docker-rm-image            Stop containers and remove the Docker
+                                       image.
+  cpancover-docker-shell               Open a shell in a cpancover container.
+  cpancover-start-minion               Start the Minion web dashboard on port
+                                       30000.
+  cpancover-start-queue                Start the Minion worker queue (4 jobs).
+  docker-build                         Build the cpancover Docker image.
+  docker-name <name>                   Generate a unique Docker container name.
+  docker-prune-tags [keep]             Delete old tags from Docker Hub (default
+                                       keep 20).
+  docker-show-tags                     List versioned tags on Docker Hub.
+
+Caddy:
+  cpancover-check-caddy                Compare running Caddyfile with generated
+                                       config.
+  cpancover-configure-caddy            Install and reload the production
+                                       Caddyfile.
+
+Shell completion:
+  options                              List options and recipes (for completion
+                                       scripts).
 EOT
   exit 0
 }
@@ -492,7 +592,6 @@ recipe_cpancover-docker-shell() {
     "$docker_image" /bin/bash
 }
 
-# Called from Collection.pm
 recipe_cpancover-docker-module() {
   local module="${1:?No module specified}"
   local name="${2:?No name specified}"


### PR DESCRIPTION
## Summary

Add a recipe to run any CPAN module's test suite under Devel::Cover using the local blib build, and add descriptive help text to all dc recipes.

## Changes

- Add `cpan-module` recipe that downloads a CPAN module, installs its dependencies into a per-module directory, builds it, and runs tests with coverage using the local Devel::Cover, opening the html_crisp report automatically.
- Add grouped, categorised help text with descriptions for every recipe.
- Add trailing commas to multi-line structures in Devel::Cover.pm for cleaner future diffs.

## Implications

- The `cpan-module` recipe requires `cpanm` and `curl` to be available.
- Module sources are cached in `tmp/runs/` and reused unless `--force` is passed.

## Issue

Closes #420