### PR TITLE
GH-422 Optimise runtime coverage speed

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -189,22 +189,26 @@ static int cpu() {
  *
 */
 
-/* Fowler/Noll/Vo (FNV) hash function, variant 1a */
-static size_t fnv1a_hash(const char* cp)
-{
+/* Fowler/Noll/Vo (FNV) hash function, variant 1a
+ * Hash filename bytes and line number directly, avoiding snprintf. */
+static size_t fnv1a_hash_file_line(const char *file, long line) {
     size_t hash = 0x811c9dc5;
-    while (*cp) {
-        hash ^= (unsigned char) *cp++;
+    const unsigned char *p;
+    size_t i;
+    while (*file) {
+        hash ^= (unsigned char)*file++;
+        hash *= 0x01000193;
+    }
+    p = (const unsigned char *)&line;
+    for (i = 0; i < sizeof(line); i++) {
+        hash ^= p[i];
         hash *= 0x01000193;
     }
     return hash;
 }
 
-#define FILEINFOSZ 1024
-
 static char *get_key(OP *o) {
     static struct unique uniq;
-    static char mybuf[FILEINFOSZ];
 
     uniq.addr          = o;
     uniq.op            = *o;
@@ -212,10 +216,8 @@ static char *get_key(OP *o) {
     uniq.op.op_targ    = 0;  /* might change            */
     if (o->op_type == OP_NEXTSTATE || o->op_type == OP_DBSTATE) {
         /* cop, has file location information */
-        char *file = CopFILE((COP *)o);
-        long  line = CopLINE((COP *)o);
-        snprintf(mybuf, FILEINFOSZ - 1, "%s:%ld", file, line);
-        uniq.fileinfohash = fnv1a_hash(mybuf);
+        uniq.fileinfohash = fnv1a_hash_file_line(
+            CopFILE((COP *)o), CopLINE((COP *)o));
     } else {
         /* no file location information available */
         uniq.fileinfohash = 0;

--- a/Cover.xs
+++ b/Cover.xs
@@ -278,7 +278,7 @@ static size_t fnv1a_hash_file_line(const char *file, long line) {
  * The old code copied the entire OP struct (40 bytes), then zeroed
  * op_ppaddr (we replace it during instrumentation) and op_targ
  * (can change at runtime).  That left 20 meaningful bytes:
- * op_next (8), op_sibparent (8), and the type/flags bitfields (4).
+ * op_next (8), op_sibling/op_sibparent (8), and the type/flags bitfields (4).
  * This function mixes those same fields into a single size_t.
  *
  * 0x00000100000001B3 is the FNV-1a 64-bit prime.  It is used here
@@ -288,7 +288,7 @@ static size_t fnv1a_hash_file_line(const char *file, long line) {
  */
 static size_t hash_op_identity(const OP *o) {
     size_t h = (size_t)o->op_next;
-    h ^= (size_t)o->op_sibparent * 0x00000100000001B3ULL;
+    h ^= (size_t)OpSIBLING(o) * 0x00000100000001B3ULL;
     h ^= ((size_t)o->op_type << 16)
        |  ((size_t)o->op_flags << 8)
        |   (size_t)o->op_private;

--- a/Cover.xs
+++ b/Cover.xs
@@ -344,7 +344,7 @@ static int check_if_collecting(pTHX_ COP *cop) {
 
 #if CAN_PROFILE
 
-static void cover_time(pTHX)
+static void cover_time(pTHX_ const char *key)
 {
     dMY_CXT;
     SV **count;
@@ -368,8 +368,8 @@ static void cover_time(pTHX)
 #endif
             sv_setnv(*count, c);
         }
-        if (PL_op) {
-            memcpy(MY_CXT.profiling_key, get_key(PL_op), KEY_SZ);
+        if (key) {
+            memcpy(MY_CXT.profiling_key, key, KEY_SZ);
             MY_CXT.profiling_key_valid = 1;
         } else {
             MY_CXT.profiling_key_valid = 0;
@@ -385,8 +385,7 @@ static int collecting_here(pTHX) {
     if (MY_CXT.collecting_here) return 1;
 
 #if CAN_PROFILE
-    cover_time(aTHX);
-    MY_CXT.profiling_key_valid = 0;
+    cover_time(aTHX_ NULL);
 #endif
 
     NDEB(D(L, "op %p is %s\n", PL_op, OP_NAME(PL_op)));
@@ -428,16 +427,14 @@ static void call_report(pTHX) {
     SPAGAIN;
 }
 
-static void cover_statement(pTHX_ OP *op) {
+static void cover_statement(pTHX_ OP *op, const char *ch) {
     dMY_CXT;
 
-    char *ch;
     SV  **count;
     IV    c;
 
     if (!collecting(Statement)) return;
 
-    ch    = get_key(op);
     count = hv_fetch(MY_CXT.statements, ch, KEY_SZ, 1);
     c     = SvTRUE(*count) ? SvIV(*count) + 1 : 1;
 
@@ -448,11 +445,11 @@ static void cover_statement(pTHX_ OP *op) {
 }
 
 static void cover_current_statement(pTHX) {
+    const char *ch = get_key(PL_op);
 #if CAN_PROFILE
-    cover_time(aTHX);
+    cover_time(aTHX_ ch);
 #endif
-
-    cover_statement(aTHX_ PL_op);
+    cover_statement(aTHX_ PL_op, ch);
 }
 
 static void add_branch(pTHX_ OP *op, int br) {
@@ -962,7 +959,7 @@ static void cover_padrange(pTHX) {
     orig = OpSIBLING(PL_op);
     while (orig && orig != next) {
         if (orig->op_type == OP_NEXTSTATE) {
-            cover_statement(aTHX_ orig);
+            cover_statement(aTHX_ orig, get_key(orig));
         }
         orig = orig->op_next;
     }
@@ -1272,7 +1269,7 @@ static int runops_cover(pTHX) {
     }
 
 #if CAN_PROFILE
-    cover_time(aTHX);
+    cover_time(aTHX_ NULL);
 #endif
 
     MY_CXT.collecting_here = 1;

--- a/Cover.xs
+++ b/Cover.xs
@@ -47,13 +47,45 @@ extern "C" {
 # define CAN_PROFILE 0
 #endif
 
-struct unique {  /* Well, we'll be fairly unlucky if it's not */
-    OP    *addr;          /* op address                               */
-    size_t op_identity;   /* hash of meaningful OP fields             */
-    size_t fileinfohash;  /* hashed file location (cops) or 0        */
+struct unique {          /* Well, we'll be fairly unlucky if it's not */
+    OP    *addr;         /* op address                                */
+    size_t op_identity;  /* hash of meaningful OP fields              */
+    size_t fileinfohash; /* hashed file location or 0                 */
 };
 
 #define KEY_SZ sizeof(struct unique)
+
+/*
+ * C-level cache mapping OP * -> statement count.  Avoids the full
+ * get_key + hv_fetch path for repeat statement executions (~95% of
+ * all hits in a typical program).  Uses open addressing with linear
+ * probing, keyed by the raw op pointer.
+ *
+ * On a cache hit, only one pointer comparison (op_next) is needed as
+ * a slab-reuse guard; the full identity hash is stored solely for key
+ * reconstruction at flush time.
+ *
+ * Cached counts are flushed into the Perl statements HV when the
+ * coverage() XS function is called (i.e. at report time).
+ */
+
+typedef struct {
+    OP     *addr;         /* key: op address (NULL = empty slot)    */
+    OP     *op_next;      /* slab reuse guard: o->op_next at insert */
+    size_t  op_identity;  /* for struct unique key at flush time    */
+    size_t  fileinfohash; /* for struct unique key at flush time    */
+    IV      stmt_count;   /* accumulated statement count            */
+} dc_stmt_slot;
+
+typedef struct {
+    dc_stmt_slot *slots;
+    size_t        capacity; /* always power of 2                    */
+    size_t        count;    /* occupied slots                       */
+    size_t        mask;     /* capacity - 1                         */
+} dc_stmt_cache;
+
+#define DC_STMT_CACHE_INIT_CAP 1024
+#define DC_STMT_CACHE_LOAD_PCT 70
 
 typedef struct {
     unsigned      covering;
@@ -76,6 +108,7 @@ typedef struct {
     int           replace_ops;
     /* - fix up whatever is broken with module_relative on Windows here */
 
+    dc_stmt_cache stmt_cache;
     Perl_ppaddr_t ppaddr[MAXO];
 } my_cxt_t;
 
@@ -108,9 +141,10 @@ extern "C" {
 #endif
 
 /* op->op_sibling is deprecated on new perls, but the OpSIBLING macro doesn't
-   exist on older perls. We don't need to check for PERL_OP_PARENT here
-   because if PERL_OP_PARENT was set, and we needed to check op_moresib,
-   we would already have this macro. */
+ * exist on older perls. We don't need to check for PERL_OP_PARENT here because
+ * if PERL_OP_PARENT was set, and we needed to check op_moresib, we would
+ * already have this macro.
+ */
 #ifndef OpSIBLING
 #define OpSIBLING(o) (0 + (o)->op_sibling)
 #endif
@@ -185,11 +219,11 @@ static int cpu() {
  *   authors deliberately took no steps to patent the FNV algorithm. Therefore
  *   it is safe to say that the FNV authors have no patent claims on the FNV
  *   algorithm as published.
- *
-*/
+ */
 
 /* Fowler/Noll/Vo (FNV) hash function, variant 1a
- * Hash filename bytes and line number directly, avoiding snprintf. */
+ * Hash filename bytes and line number directly, avoiding snprintf.
+ */
 static size_t fnv1a_hash_file_line(const char *file, long line) {
     size_t hash = 0x811c9dc5;
     const unsigned char *p;
@@ -222,7 +256,8 @@ static size_t fnv1a_hash_file_line(const char *file, long line) {
  * 0x00000100000001B3 is the FNV-1a 64-bit prime.  It is used here
  * as a mixing multiplier rather than as part of a true FNV-1a hash
  * - its sparse-high / dense-low bit pattern spreads input bits
- * well across the result. */
+ * well across the result.
+ */
 static size_t hash_op_identity(const OP *o) {
     size_t h = (size_t)o->op_next;
     h ^= (size_t)o->op_sibparent * 0x00000100000001B3ULL;
@@ -366,6 +401,111 @@ static int check_if_collecting(pTHX_ COP *cop) {
     return MY_CXT.collecting_here;
 }
 
+static void dc_stmt_cache_init(dc_stmt_cache *c) {
+    c->capacity = DC_STMT_CACHE_INIT_CAP;
+    c->count    = 0;
+    c->mask     = c->capacity - 1;
+    Newxz(c->slots, c->capacity, dc_stmt_slot);
+}
+
+static void dc_stmt_grow(dc_stmt_cache *c);
+
+/* Look up by address.  Returns the slot if found (caller must check op_next for
+ * slab reuse), or NULL if not in the cache.
+ */
+static dc_stmt_slot *dc_stmt_lookup(dc_stmt_cache *c, OP *addr) {
+    size_t idx;
+    if (!c->slots) return NULL;
+    idx = ((size_t)addr >> 4) & c->mask;
+    for (;;) {
+        dc_stmt_slot *s = &c->slots[idx];
+        if (!s->addr)        return NULL;  /* empty = not found */
+        if (s->addr == addr) return s;     /* found             */
+        idx = (idx + 1) & c->mask;
+    }
+}
+
+/* Insert a new entry.  Caller must ensure addr is not already present.  Returns
+ * the new slot with stmt_count = 0.
+ */
+static dc_stmt_slot *dc_stmt_insert(dc_stmt_cache *c, OP *addr,
+                                     OP *op_next, size_t op_identity,
+                                     size_t fileinfohash) {
+    size_t idx;
+    dc_stmt_slot *s;
+
+    if (!c->slots) dc_stmt_cache_init(c);
+
+    /* Grow if above load factor */
+    if (c->count * 100 >= c->capacity * DC_STMT_CACHE_LOAD_PCT)
+        dc_stmt_grow(c);
+
+    idx = ((size_t)addr >> 4) & c->mask;
+    for (;;) {
+        s = &c->slots[idx];
+        if (!s->addr) break;  /* found empty slot */
+        idx = (idx + 1) & c->mask;
+    }
+
+    s->addr         = addr;
+    s->op_next      = op_next;
+    s->op_identity  = op_identity;
+    s->fileinfohash = fileinfohash;
+    s->stmt_count   = 0;
+    c->count++;
+    return s;
+}
+
+static void dc_stmt_grow(dc_stmt_cache *c) {
+    dc_stmt_slot *old_slots = c->slots;
+    size_t        old_cap   = c->capacity;
+    size_t        i;
+
+    c->capacity *= 2;
+    c->mask      = c->capacity - 1;
+    c->count     = 0;
+    Newxz(c->slots, c->capacity, dc_stmt_slot);
+
+    for (i = 0; i < old_cap; i++) {
+        dc_stmt_slot *old = &old_slots[i];
+        if (old->addr) {
+            dc_stmt_slot *s = dc_stmt_insert(c, old->addr,
+                old->op_next, old->op_identity, old->fileinfohash);
+            s->stmt_count = old->stmt_count;
+        }
+    }
+    Safefree(old_slots);
+}
+
+/* Flush all cached counts into the Perl statements HV, then zero the cached
+ * counts.  The cache structure stays intact so that subsequent executions still
+ * get cache hits.
+ */
+static void dc_stmt_cache_flush(pTHX_ dc_stmt_cache *c, HV *statements) {
+    size_t i;
+
+    if (!c->slots) return;
+
+    for (i = 0; i < c->capacity; i++) {
+        dc_stmt_slot *s = &c->slots[i];
+        if (s->addr && s->stmt_count) {
+            SV **sv;
+            IV   existing;
+
+            /* Reconstruct the struct unique key from cached fields */
+            struct unique uniq;
+            uniq.addr         = s->addr;
+            uniq.op_identity  = s->op_identity;
+            uniq.fileinfohash = s->fileinfohash;
+
+            sv = hv_fetch(statements, (char *)&uniq, KEY_SZ, 1);
+            existing = SvTRUE(*sv) ? SvIV(*sv) : 0;
+            sv_setiv(*sv, existing + s->stmt_count);
+            s->stmt_count = 0;
+        }
+    }
+}
+
 #if CAN_PROFILE
 
 static void cover_time(pTHX_ const char *key)
@@ -469,11 +609,72 @@ static void cover_statement(pTHX_ OP *op, const char *ch) {
 }
 
 static void cover_current_statement(pTHX) {
-    const char *ch = get_key(PL_op);
+    dMY_CXT;
+
 #if CAN_PROFILE
-    cover_time(aTHX_ ch);
+    /* When time coverage is enabled we need the full key for the profiling_key
+     * bookkeeping, so bypass the cache entirely.
+     */
+    if (collecting(Time)) {
+        const char *ch = get_key(PL_op);
+        cover_time(aTHX_ ch);
+        cover_statement(aTHX_ PL_op, ch);
+        return;
+    }
 #endif
-    cover_statement(aTHX_ PL_op, ch);
+
+    if (!collecting(Statement)) return;
+
+    /* Fast path: C-level statement cache (time coverage is off) */
+    {
+        dc_stmt_slot *slot = dc_stmt_lookup(&MY_CXT.stmt_cache, PL_op);
+        if (slot) {
+            /* Address found - check op_next as slab reuse guard. Two different
+             * ops at the same address with the same op_next is unlikely.
+             */
+            if (slot->op_next == PL_op->op_next) {
+                slot->stmt_count++;
+                return;
+            }
+            /* Slab reuse: flush stale count, update slot in place */
+            if (slot->stmt_count) {
+                struct unique uniq;
+                SV **sv;
+                IV   existing;
+                uniq.addr         = slot->addr;
+                uniq.op_identity  = slot->op_identity;
+                uniq.fileinfohash = slot->fileinfohash;
+                sv = hv_fetch(MY_CXT.statements,
+                              (char *)&uniq, KEY_SZ, 1);
+                existing = SvTRUE(*sv) ? SvIV(*sv) : 0;
+                sv_setiv(*sv, existing + slot->stmt_count);
+            }
+            slot->op_next     = PL_op->op_next;
+            slot->op_identity = hash_op_identity(PL_op);
+            slot->fileinfohash =
+                (PL_op->op_type == OP_NEXTSTATE
+              || PL_op->op_type == OP_DBSTATE)
+                ? fnv1a_hash_file_line(
+                      CopFILE((COP *)PL_op), CopLINE((COP *)PL_op))
+                : 0;
+            slot->stmt_count = 1;
+            return;
+        }
+
+        /* Cache miss: insert and count the first execution */
+        {
+            size_t identity = hash_op_identity(PL_op);
+            size_t filehash =
+                (PL_op->op_type == OP_NEXTSTATE
+              || PL_op->op_type == OP_DBSTATE)
+                ? fnv1a_hash_file_line(
+                      CopFILE((COP *)PL_op), CopLINE((COP *)PL_op))
+                : 0;
+            dc_stmt_slot *s = dc_stmt_insert(&MY_CXT.stmt_cache,
+                PL_op, PL_op->op_next, identity, filehash);
+            s->stmt_count = 1;
+        }
+    }
 }
 
 static void add_branch(pTHX_ OP *op, int br) {
@@ -1190,6 +1391,7 @@ static void initialise(pTHX) {
 #endif
 
         MY_CXT.profiling_key_valid = 0;
+        Zero(&MY_CXT.stmt_cache, 1, dc_stmt_cache);
         MY_CXT.module              = newSVpv("", 0);
         MY_CXT.lastfile            = newSVpvn("", 1);
         MY_CXT.covering            = All;
@@ -1497,6 +1699,8 @@ coverage(final)
         dMY_CXT;
     CODE:
         NDEB(D(L, "Getting coverage %d\n", final));
+        if (MY_CXT.statements)
+            dc_stmt_cache_flush(aTHX_ &MY_CXT.stmt_cache, MY_CXT.statements);
         if (final) finalise_conditions(aTHX);
         if (MY_CXT.cover)
             RETVAL = newRV_inc((SV*) MY_CXT.cover);

--- a/Cover.xs
+++ b/Cover.xs
@@ -104,6 +104,7 @@ typedef struct {
     bool          profiling_key_valid;
     SV           *module,
                  *lastfile;
+    char         *lastfile_ptr;  /* cached CopFILE pointer */
     int           tid;
     int           replace_ops;
     /* - fix up whatever is broken with module_relative on Windows here */
@@ -325,51 +326,65 @@ static int check_if_collecting(pTHX_ COP *cop) {
     int tainted = PL_tainted;
 #endif
     char *file = CopFILE(cop);
-    int in_re_eval = strnEQ(file, "(reeval ", 8);
     NDEB(D(L, "check_if_collecting at: %s:%ld\n", file, (long)CopLINE(cop)));
-    if (file && strNE(SvPV_nolen(MY_CXT.lastfile), file)) {
-        int found = 0;
-        if (MY_CXT.files) {
-            SV **f = hv_fetch(MY_CXT.files, file, strlen(file), 0);
-            if (f) {
-                MY_CXT.collecting_here = SvIV(*f);
-                found = 1;
-                NDEB(D(L, "File: %s:%ld [%d]\n",
-                           file, (long)CopLINE(cop), MY_CXT.collecting_here));
+
+    /* Fast path: same CopFILE pointer as last time means same file.  Skip the
+     * SV unpack, strcmp, and reeval check.
+     */
+    if (file != MY_CXT.lastfile_ptr) {
+        if (file && strNE(SvPV_nolen(MY_CXT.lastfile), file)) {
+            int found = 0;
+            if (MY_CXT.files) {
+                SV **f = hv_fetch(MY_CXT.files, file, strlen(file), 0);
+                if (f) {
+                    MY_CXT.collecting_here = SvIV(*f);
+                    found = 1;
+                    NDEB(D(L, "File: %s:%ld [%d]\n",
+                               file, (long)CopLINE(cop),
+                               MY_CXT.collecting_here));
+                }
             }
+
+            if (!found && MY_CXT.replace_ops
+                    && !strnEQ(file, "(reeval ", 8)) {
+                dSP;
+                int count;
+                SV *rv;
+
+                ENTER;
+                SAVETMPS;
+
+                PUSHMARK(SP);
+                XPUSHs(sv_2mortal(newSVpv(file, 0)));
+                PUTBACK;
+
+                count = call_pv("Devel::Cover::use_file", G_SCALAR);
+
+                SPAGAIN;
+
+                if (count != 1)
+                    croak("use_file returned %d values\n", count);
+
+                rv = POPs;
+                MY_CXT.collecting_here = SvTRUE(rv) ? 1 : 0;
+
+                NDEB(D(L, "-- %s - %d\n", file,
+                          MY_CXT.collecting_here));
+
+                PUTBACK;
+                FREETMPS;
+                LEAVE;
+            }
+
+            sv_setpv(MY_CXT.lastfile, file);
         }
 
-        if (!found && MY_CXT.replace_ops && !in_re_eval) {
-            dSP;
-            int count;
-            SV *rv;
-
-            ENTER;
-            SAVETMPS;
-
-            PUSHMARK(SP);
-            XPUSHs(sv_2mortal(newSVpv(file, 0)));
-            PUTBACK;
-
-            count = call_pv("Devel::Cover::use_file", G_SCALAR);
-
-            SPAGAIN;
-
-            if (count != 1)
-                croak("use_file returned %d values\n", count);
-
-            rv = POPs;
-            MY_CXT.collecting_here = SvTRUE(rv) ? 1 : 0;
-
-            NDEB(D(L, "-- %s - %d\n", file, MY_CXT.collecting_here));
-
-            PUTBACK;
-            FREETMPS;
-            LEAVE;
-        }
-
-        sv_setpv(MY_CXT.lastfile, file);
+        /* Update pointer even when strings match, so a new pointer for the same
+         * file gets the fast path next time.
+         */
+        MY_CXT.lastfile_ptr = file;
     }
+
     NDEB(D(L, "%s - %d\n",
               SvPV_nolen(MY_CXT.lastfile), MY_CXT.collecting_here));
 
@@ -1394,6 +1409,7 @@ static void initialise(pTHX) {
         Zero(&MY_CXT.stmt_cache, 1, dc_stmt_cache);
         MY_CXT.module              = newSVpv("", 0);
         MY_CXT.lastfile            = newSVpvn("", 1);
+        MY_CXT.lastfile_ptr        = NULL;
         MY_CXT.covering            = All;
         MY_CXT.tid                 = tid++;
 

--- a/Cover.xs
+++ b/Cover.xs
@@ -87,6 +87,32 @@ typedef struct {
 #define DC_STMT_CACHE_INIT_CAP 1024
 #define DC_STMT_CACHE_LOAD_PCT 70
 
+/*
+ * C-level cache mapping OP * -> AV * for condition and branch arrays.
+ * Avoids the get_key + hv_fetch path on repeat executions.  Unlike the
+ * statement cache, no flush is needed: the cached AV pointer IS the
+ * authoritative object living in the conditions or branches HV.
+ *
+ * The same cache serves both condition and branch ops because the two
+ * sets are disjoint (logops vs OP_COND_EXPR).
+ */
+
+typedef struct {
+    OP  *addr;      /* key: op address (NULL = empty slot) */
+    OP  *op_next;   /* slab reuse guard                    */
+    AV  *av;        /* cached AV pointer                   */
+} dc_av_slot;
+
+typedef struct {
+    dc_av_slot *slots;
+    size_t      capacity; /* always power of 2 */
+    size_t      count;    /* occupied slots     */
+    size_t      mask;     /* capacity - 1       */
+} dc_av_cache;
+
+#define DC_AV_CACHE_INIT_CAP 256
+#define DC_AV_CACHE_LOAD_PCT 70
+
 typedef struct {
     unsigned      covering;
     int           collecting_here;
@@ -110,6 +136,7 @@ typedef struct {
     /* - fix up whatever is broken with module_relative on Windows here */
 
     dc_stmt_cache stmt_cache;
+    dc_av_cache   av_cache;
     Perl_ppaddr_t ppaddr[MAXO];
 } my_cxt_t;
 
@@ -521,6 +548,69 @@ static void dc_stmt_cache_flush(pTHX_ dc_stmt_cache *c, HV *statements) {
     }
 }
 
+static void dc_av_cache_init(dc_av_cache *c) {
+    c->capacity = DC_AV_CACHE_INIT_CAP;
+    c->count    = 0;
+    c->mask     = c->capacity - 1;
+    Newxz(c->slots, c->capacity, dc_av_slot);
+}
+
+static void dc_av_grow(dc_av_cache *c);
+
+static dc_av_slot *dc_av_lookup(dc_av_cache *c, OP *addr) {
+    size_t idx;
+    if (!c->slots) return NULL;
+    idx = ((size_t)addr >> 4) & c->mask;
+    for (;;) {
+        dc_av_slot *s = &c->slots[idx];
+        if (!s->addr)        return NULL;
+        if (s->addr == addr) return s;
+        idx = (idx + 1) & c->mask;
+    }
+}
+
+static dc_av_slot *dc_av_insert(dc_av_cache *c, OP *addr,
+                                 OP *op_next, AV *av) {
+    size_t idx;
+    dc_av_slot *s;
+
+    if (!c->slots) dc_av_cache_init(c);
+
+    if (c->count * 100 >= c->capacity * DC_AV_CACHE_LOAD_PCT)
+        dc_av_grow(c);
+
+    idx = ((size_t)addr >> 4) & c->mask;
+    for (;;) {
+        s = &c->slots[idx];
+        if (!s->addr) break;
+        idx = (idx + 1) & c->mask;
+    }
+
+    s->addr    = addr;
+    s->op_next = op_next;
+    s->av      = av;
+    c->count++;
+    return s;
+}
+
+static void dc_av_grow(dc_av_cache *c) {
+    dc_av_slot *old_slots = c->slots;
+    size_t      old_cap   = c->capacity;
+    size_t      i;
+
+    c->capacity *= 2;
+    c->mask      = c->capacity - 1;
+    c->count     = 0;
+    Newxz(c->slots, c->capacity, dc_av_slot);
+
+    for (i = 0; i < old_cap; i++) {
+        dc_av_slot *old = &old_slots[i];
+        if (old->addr)
+            dc_av_insert(c, old->addr, old->op_next, old->av);
+    }
+    Safefree(old_slots);
+}
+
 #if CAN_PROFILE
 
 static void cover_time(pTHX_ const char *key)
@@ -698,13 +788,24 @@ static void add_branch(pTHX_ OP *op, int br) {
     AV  *branches;
     SV **count;
     int  c;
-    SV **tmp = hv_fetch(MY_CXT.branches, get_key(op), KEY_SZ, 1);
+    dc_av_slot *slot = dc_av_lookup(&MY_CXT.av_cache, op);
 
-    if (SvROK(*tmp)) {
-        branches = (AV *) SvRV(*tmp);
+    if (slot && slot->op_next == op->op_next) {
+        branches = slot->av;
     } else {
-        *tmp = newRV_inc((SV*) (branches = newAV()));
-        av_unshift(branches, 2);
+        SV **tmp = hv_fetch(MY_CXT.branches, get_key(op), KEY_SZ, 1);
+        if (SvROK(*tmp)) {
+            branches = (AV *) SvRV(*tmp);
+        } else {
+            *tmp = newRV_inc((SV*) (branches = newAV()));
+            av_unshift(branches, 2);
+        }
+        if (slot) {
+            slot->op_next = op->op_next;
+            slot->av      = branches;
+        } else {
+            dc_av_insert(&MY_CXT.av_cache, op, op->op_next, branches);
+        }
     }
 
     count = av_fetch(branches, br, 1);
@@ -717,12 +818,29 @@ static AV *get_conditional_array(pTHX_ OP *op) {
     dMY_CXT;
 
     AV  *conds;
-    SV **cref = hv_fetch(MY_CXT.conditions, get_key(op), KEY_SZ, 1);
+    dc_av_slot *slot = dc_av_lookup(&MY_CXT.av_cache, op);
 
-    if (SvROK(*cref))
-        conds = (AV *) SvRV(*cref);
-    else
-        *cref = newRV_inc((SV*) (conds = newAV()));
+    if (slot) {
+        if (slot->op_next == op->op_next)
+            return slot->av;
+        /* Slab reuse: update slot in place below */
+    }
+
+    /* Slow path: hv_fetch */
+    {
+        SV **cref = hv_fetch(MY_CXT.conditions, get_key(op), KEY_SZ, 1);
+        if (SvROK(*cref))
+            conds = (AV *) SvRV(*cref);
+        else
+            *cref = newRV_inc((SV*) (conds = newAV()));
+    }
+
+    if (slot) {
+        slot->op_next = op->op_next;
+        slot->av      = conds;
+    } else {
+        dc_av_insert(&MY_CXT.av_cache, op, op->op_next, conds);
+    }
 
     return conds;
 }
@@ -1407,6 +1525,7 @@ static void initialise(pTHX) {
 
         MY_CXT.profiling_key_valid = 0;
         Zero(&MY_CXT.stmt_cache, 1, dc_stmt_cache);
+        Zero(&MY_CXT.av_cache, 1, dc_av_cache);
         MY_CXT.module              = newSVpv("", 0);
         MY_CXT.lastfile            = newSVpvn("", 1);
         MY_CXT.lastfile_ptr        = NULL;

--- a/Cover.xs
+++ b/Cover.xs
@@ -48,10 +48,9 @@ extern "C" {
 #endif
 
 struct unique {  /* Well, we'll be fairly unlucky if it's not */
-    OP *addr,
-        op;
-    /* include hashed file location information, where available (cops) */
-    size_t fileinfohash;
+    OP    *addr;          /* op address                               */
+    size_t op_identity;   /* hash of meaningful OP fields             */
+    size_t fileinfohash;  /* hashed file location (cops) or 0        */
 };
 
 #define KEY_SZ sizeof(struct unique)
@@ -207,13 +206,38 @@ static size_t fnv1a_hash_file_line(const char *file, long line) {
     return hash;
 }
 
+/* Fast fingerprint of the OP fields that distinguish one op from
+ * another at the same address (slab reuse guard).  Replaces copying
+ * the full 40-byte OP struct and zeroing two fields.  Only needs
+ * to be collision-resistant enough that two unrelated ops sharing
+ * an address produce different values; fileinfohash provides a
+ * second check for COPs.
+ *
+ * The old code copied the entire OP struct (40 bytes), then zeroed
+ * op_ppaddr (we replace it during instrumentation) and op_targ
+ * (can change at runtime).  That left 20 meaningful bytes:
+ * op_next (8), op_sibparent (8), and the type/flags bitfields (4).
+ * This function mixes those same fields into a single size_t.
+ *
+ * 0x00000100000001B3 is the FNV-1a 64-bit prime.  It is used here
+ * as a mixing multiplier rather than as part of a true FNV-1a hash
+ * - its sparse-high / dense-low bit pattern spreads input bits
+ * well across the result. */
+static size_t hash_op_identity(const OP *o) {
+    size_t h = (size_t)o->op_next;
+    h ^= (size_t)o->op_sibparent * 0x00000100000001B3ULL;
+    h ^= ((size_t)o->op_type << 16)
+       |  ((size_t)o->op_flags << 8)
+       |   (size_t)o->op_private;
+    h *= 0x00000100000001B3ULL;
+    return h;
+}
+
 static char *get_key(OP *o) {
     static struct unique uniq;
 
-    uniq.addr          = o;
-    uniq.op            = *o;
-    uniq.op.op_ppaddr  = 0;  /* we mess with this field */
-    uniq.op.op_targ    = 0;  /* might change            */
+    uniq.addr        = o;
+    uniq.op_identity = hash_op_identity(o);
     if (o->op_type == OP_NEXTSTATE || o->op_type == OP_DBSTATE) {
         /* cop, has file location information */
         uniq.fileinfohash = fnv1a_hash_file_line(

--- a/docs/technical/xs-profiling.md
+++ b/docs/technical/xs-profiling.md
@@ -1,0 +1,284 @@
+# Profiling XS Runtime Overhead
+
+This document explains how to profile the C-level runtime overhead of
+Devel::Cover's XS code. The techniques here measure where time is
+spent *during test execution* (the instrumented op dispatch loop), not
+the END-time Perl processing (DB writes, deparsing, report generation).
+
+## Prerequisites
+
+- macOS (for the `sample` command; see [Other Platforms](#other-platforms)
+  for Linux alternatives)
+- A non-trivial benchmark workload (the Gedcom test suite works well)
+- Devel::NYTProf (optional, for Perl-level END-time profiling)
+
+## Build with debug symbols
+
+The `sample` tool needs DWARF symbols to map instruction addresses back
+to C function names. Build Cover.bundle with `-g`:
+
+```bash
+make OPTIMIZE="-O2 -g"
+```
+
+This keeps optimisation on (so the profile reflects real performance)
+while adding the symbol tables needed for profiling.
+
+## Choose a benchmark
+
+The Gedcom genealogy library provides a good workload - it exercises
+many ops across a realistic codebase. The benchmark lives in
+`tmp/runs/Gedcom-1.22/` and uses the `royal.ged` data file.
+
+```bash
+cd tmp/runs/Gedcom-1.22
+```
+
+### Baseline timing
+
+Measure without coverage first:
+
+```bash
+time perl -Mblib -e '
+  use Gedcom;
+  for my $i (1..20) {
+    my $ged = Gedcom->new("royal.ged");
+    $ged->validate;
+    $ged->resolve_xrefs;
+  }
+'
+```
+
+Then with coverage:
+
+```bash
+DC="-Mblib=$HOME/g/perl/Devel--Cover"
+time perl $DC -MDevel::Cover=-silent,1,-db,/tmp/dc_bench_db -Mblib -e '
+  use Gedcom;
+  for my $i (1..20) {
+    my $ged = Gedcom->new("royal.ged");
+    $ged->validate;
+    $ged->resolve_xrefs;
+  }
+'
+```
+
+The difference is the total overhead. In March 2026 this was 0.12s vs
+0.92s (before optimisation) and 0.12s vs 0.52s (after hotspot #1).
+
+## Sampling with macOS `sample`
+
+Run the benchmark in the background and attach `sample` to it:
+
+```bash
+DC="-Mblib=$HOME/g/perl/Devel--Cover"
+perl $DC -MDevel::Cover=-silent,1,-db,/tmp/dc_bench_db -Mblib -e '
+  use Gedcom;
+  for my $i (1..20) {
+    my $ged = Gedcom->new("royal.ged");
+    $ged->validate;
+    $ged->resolve_xrefs;
+  }
+' > /dev/null 2>/dev/null &
+PID=$!
+sleep 0.3
+sample "$PID" 5 -file /tmp/dc_sample.txt
+wait "$PID"
+```
+
+Key points:
+
+- `sleep 0.3` gives the process time to start before sampling begins
+- `sample "$PID" 5` samples for 5 seconds at 1ms intervals
+- `-file /tmp/dc_sample.txt` saves the output for analysis
+- The 20-iteration loop ensures the process runs long enough for
+  sampling to capture runtime behaviour rather than just startup/shutdown
+
+### Timing the sleep
+
+If the process finishes before `sample` attaches, increase the
+iteration count. If `sample` captures mostly END-time processing,
+increase iterations or reduce the sample duration. The goal is to
+capture the `Perl_runops_standard` loop, not the cleanup phase.
+
+## Analysing the sample output
+
+The `sample` tool produces a hierarchical call tree. Each line shows a
+sample count and a function name:
+
+```text
++     ! 513 dc_nextstate  (in Cover.bundle) + 240
+        +     ! : 498 cover_time  (in Cover.bundle) + 92
+        +     ! : | 245 cover_time.cold.1  (in Cover.bundle) + 48
+```
+
+Child entries are *subsets* of their parent, not additions. In this
+example, 498 of the 513 `dc_nextstate` samples went into `cover_time`,
+and 245 of those 498 went into the cold path at offset +48.
+
+### Aggregation script
+
+To get a flat breakdown of all Cover.bundle functions, extracting
+leaf-only samples (self-time, excluding time spent in callees):
+
+```bash
+perl -0777 -ne '
+  my @all = split /\n/;
+  my (%leaf, %inclusive);
+  for my $i (0 .. $#all) {
+    next unless $all[$i] =~
+      /(\d+)\s+([\w.]+)\s+\(in Cover\.bundle\)/;
+    my ($count, $func) = ($1, $2);
+    $func =~ s/\.cold\.\d+//;        # merge cold paths
+    $inclusive{$func} += $count;
+
+    # Leaf test: next meaningful line has equal or less depth
+    my $cur_depth = () = $all[$i] =~ /\|/g;
+    my $is_leaf   = 1;
+    for my $j ($i + 1 .. $#all) {
+      next if $all[$j] =~ /^\s*$/;
+      last unless $all[$j] =~ /\d+\s+\S+/;
+      my $next_depth = () = $all[$j] =~ /\|/g;
+      $is_leaf = 0 if $next_depth > $cur_depth;
+      last;
+    }
+    $leaf{$func} += $count if $is_leaf;
+  }
+
+  my $total = 0;
+  $total += $_ for values %leaf;
+  print "Leaf (self-time) samples in Cover.bundle: $total\n\n";
+  for (sort { $leaf{$b} <=> $leaf{$a} } keys %leaf) {
+    printf "%6d  %5.1f%%  %s\n",
+      $leaf{$_}, 100 * $leaf{$_} / $total, $_;
+    last if $leaf{$_} < 3;
+  }
+' /tmp/dc_sample.txt
+```
+
+### Reading the call tree directly
+
+For understanding call chains, grep for specific functions:
+
+```bash
+# Show the dc_nextstate call tree
+grep -A 30 'dc_nextstate.*Cover.bundle' /tmp/dc_sample.txt
+
+# Show all top-level dc_* op handlers
+grep -E '^\s+\+\s+!\s+\d+\s+dc_' /tmp/dc_sample.txt
+
+# Count cover_ function mentions
+grep -c 'cover_' /tmp/dc_sample.txt
+```
+
+The hierarchical view is essential for understanding *where within a
+function* the time is spent - the `+ offset` value on each line
+corresponds to an instruction offset, and the child entries show which
+callees dominate.
+
+## Perl-level profiling with NYTProf
+
+For profiling the END-time Perl code (DB writes, deparsing, report
+generation), use Devel::NYTProf:
+
+```bash
+cd tmp/runs/Gedcom-1.22
+DC="-Mblib=$HOME/g/perl/Devel--Cover"
+perl $DC -MDevel::Cover=-silent,1,-db,/tmp/dc_bench_db \
+  -d:NYTProf -Mblib -e '
+  use Gedcom;
+  my $ged = Gedcom->new("royal.ged");
+  $ged->validate;
+  $ged->resolve_xrefs;
+'
+nytprofhtml
+```
+
+NYTProf cannot see inside XS/C functions, so it is only useful for
+Perl-side costs. For the XS runtime, use `sample` as described above.
+
+## Interpreting results
+
+### Architecture of the XS runtime
+
+The XS code replaces Perl's op dispatch functions with instrumented
+versions:
+
+| Original op  | Replacement  | What it covers        |
+| ------------ | ------------ | --------------------- |
+| pp_nextstate | dc_nextstate | statement + time      |
+| pp_and       | dc_and       | branch/condition      |
+| pp_or        | dc_or        | branch/condition      |
+| pp_dor       | dc_dor       | branch/condition      |
+| pp_cond_expr | dc_cond_expr | branch/condition      |
+| pp_entersub  | dc_entersub  | subroutine            |
+| pp_padrange  | dc_padrange  | statement (multi-pad) |
+
+Each replacement op follows the same pattern:
+
+1. `check_if_collecting` - is this file being covered?
+2. If yes, call the appropriate `cover_*` function
+3. Call the original op via the saved function pointer
+
+### What to look for
+
+The main cost centres in the XS runtime are:
+
+- **get_key / fnv1a_hash_file_line** - computing the unique key for
+  each op (hashes the filename bytes and line number)
+- **cover_time** - gettimeofday + hash lookup + arithmetic (only when
+  time coverage is enabled)
+- **cover_statement** - hash lookup + counter increment
+- **cover_logop / get_conditional_array / add_conditional** - condition
+  tracking with hash lookups
+- **check_if_collecting** - strcmp/strncmp filename matching
+- **Perl_hv_common / SipHash** - Perl's hash implementation, called
+  from all the above via hv_fetch with KEY_SZ-byte keys
+
+When optimising, focus on the functions with the highest *self-time*
+(leaf samples). Inclusive counts tell you where time flows, but
+self-time tells you where the CPU is actually stalled.
+
+## Other platforms
+
+### Linux
+
+Use `perf` instead of `sample`:
+
+```bash
+# Record
+perf record -g -p "$PID" -- sleep 5
+
+# Report (flat profile)
+perf report --no-children --sort=dso,symbol
+
+# Report (call tree)
+perf report --children --sort=dso,symbol
+```
+
+The analysis approach is the same - look for Cover.so functions with
+high self-time.
+
+### Instruments (macOS)
+
+Xcode's Instruments app provides a GUI alternative to `sample` with
+flame graphs and timeline views. Use the "Time Profiler" instrument,
+attach to the running benchmark process, and filter by the Cover.bundle
+module.
+
+## Example profile (March 2026, post-hotspot #1)
+
+After eliminating snprintf from get_key() and deduplicating get_key()
+calls per statement, the profile showed:
+
+| Area                     | % of DC overhead | Dominant cost         |
+| ------------------------ | ---------------- | --------------------- |
+| cover_time               | 37%              | gettimeofday, SipHash |
+| dc_nextstate self        | 18%              | fnv1a_hash_file_line  |
+| cover_logop / conditions | 17%              | get_conditional_array |
+| check_if_collecting      | 10%              | strcmp, strncmp       |
+| cover_statement          | 10%              | hv_fetch, sv_setiv    |
+| op handler overhead      | 7%               | dc_and, dc_or self    |
+
+Total overhead at this point: ~0.40s on the Gedcom benchmark (down from
+0.80s before hotspot #1).

--- a/docs/technical/xs-profiling.md
+++ b/docs/technical/xs-profiling.md
@@ -1,34 +1,35 @@
 # Profiling XS Runtime Overhead
 
 This document explains how to profile the C-level runtime overhead of
-Devel::Cover's XS code. The techniques here measure where time is
-spent *during test execution* (the instrumented op dispatch loop), not
-the END-time Perl processing (DB writes, deparsing, report generation).
+Devel::Cover's XS code. The techniques here measure where time is spent *during
+test execution* (the instrumented op dispatch loop), not the END-time Perl
+processing (DB writes, deparsing, report generation).
 
 ## Prerequisites
 
-- macOS (for the `sample` command; see [Other Platforms](#other-platforms)
-  for Linux alternatives)
+- macOS (for the `sample` command; see [Other Platforms](#other-platforms) for
+  Linux alternatives)
 - A non-trivial benchmark workload (the Gedcom test suite works well)
 - Devel::NYTProf (optional, for Perl-level END-time profiling)
 
 ## Build with debug symbols
 
-The `sample` tool needs DWARF symbols to map instruction addresses back
-to C function names. Build Cover.bundle with `-g`:
+The `sample` tool needs DWARF symbols to map instruction addresses back to C
+function names. Build Cover.bundle with `-g`:
 
 ```bash
 make OPTIMIZE="-O2 -g"
 ```
 
-This keeps optimisation on (so the profile reflects real performance)
-while adding the symbol tables needed for profiling.
+This keeps optimisation on (so the profile reflects real performance) while
+adding the symbol tables needed for profiling.
 
 ## Choose a benchmark
 
-The Gedcom genealogy library provides a good workload - it exercises
-many ops across a realistic codebase. The benchmark lives in
-`tmp/runs/Gedcom-1.22/` and uses the `royal.ged` data file.
+The Gedcom genealogy library provides a good workload - it exercises many ops
+across a realistic codebase. The benchmark lives in `tmp/runs/Gedcom-1.22/` and
+uses the `royal.ged` data file. This can be created with
+`dc cpan-module Gedcom`.
 
 ```bash
 cd tmp/runs/Gedcom-1.22
@@ -63,8 +64,8 @@ time perl $DC -MDevel::Cover=-silent,1,-db,/tmp/dc_bench_db -Mblib -e '
 '
 ```
 
-The difference is the total overhead. In March 2026 this was 0.12s vs
-0.92s (before optimisation) and 0.12s vs 0.52s (after hotspot #1).
+The difference is the total overhead. In March 2026 this was 0.12s vs 0.92s
+(before optimisation) and 0.12s vs 0.52s (after hotspot #1).
 
 ## Sampling with macOS `sample`
 
@@ -79,7 +80,7 @@ perl $DC -MDevel::Cover=-silent,1,-db,/tmp/dc_bench_db -Mblib -e '
     $ged->validate;
     $ged->resolve_xrefs;
   }
-' > /dev/null 2>/dev/null &
+' >/dev/null 2>/dev/null &
 PID=$!
 sleep 0.3
 sample "$PID" 5 -file /tmp/dc_sample.txt
@@ -91,20 +92,20 @@ Key points:
 - `sleep 0.3` gives the process time to start before sampling begins
 - `sample "$PID" 5` samples for 5 seconds at 1ms intervals
 - `-file /tmp/dc_sample.txt` saves the output for analysis
-- The 20-iteration loop ensures the process runs long enough for
-  sampling to capture runtime behaviour rather than just startup/shutdown
+- The 20-iteration loop ensures the process runs long enough for sampling to
+  capture runtime behaviour rather than just startup/shutdown
 
 ### Timing the sleep
 
-If the process finishes before `sample` attaches, increase the
-iteration count. If `sample` captures mostly END-time processing,
-increase iterations or reduce the sample duration. The goal is to
-capture the `Perl_runops_standard` loop, not the cleanup phase.
+If the process finishes before `sample` attaches, increase the iteration count.
+If `sample` captures mostly END-time processing, increase iterations or reduce
+the sample duration. The goal is to capture the `Perl_runops_standard` loop, not
+the cleanup phase.
 
 ## Analysing the sample output
 
-The `sample` tool produces a hierarchical call tree. Each line shows a
-sample count and a function name:
+The `sample` tool produces a hierarchical call tree. Each line shows a sample
+count and a function name:
 
 ```text
 +     ! 513 dc_nextstate  (in Cover.bundle) + 240
@@ -112,14 +113,14 @@ sample count and a function name:
         +     ! : | 245 cover_time.cold.1  (in Cover.bundle) + 48
 ```
 
-Child entries are *subsets* of their parent, not additions. In this
-example, 498 of the 513 `dc_nextstate` samples went into `cover_time`,
-and 245 of those 498 went into the cold path at offset +48.
+Child entries are *subsets* of their parent, not additions. In this example, 498
+of the 513 `dc_nextstate` samples went into `cover_time`, and 245 of those 498
+went into the cold path at offset +48.
 
 ### Aggregation script
 
-To get a flat breakdown of all Cover.bundle functions, extracting
-leaf-only samples (self-time, excluding time spent in callees):
+To get a flat breakdown of all Cover.bundle functions, extracting leaf-only
+samples (self-time, excluding time spent in callees):
 
 ```bash
 perl -0777 -ne '
@@ -171,15 +172,14 @@ grep -E '^\s+\+\s+!\s+\d+\s+dc_' /tmp/dc_sample.txt
 grep -c 'cover_' /tmp/dc_sample.txt
 ```
 
-The hierarchical view is essential for understanding *where within a
-function* the time is spent - the `+ offset` value on each line
-corresponds to an instruction offset, and the child entries show which
-callees dominate.
+The hierarchical view is essential for understanding *where within a function*
+the time is spent - the `+ offset` value on each line corresponds to an
+instruction offset, and the child entries show which callees dominate.
 
 ## Perl-level profiling with NYTProf
 
-For profiling the END-time Perl code (DB writes, deparsing, report
-generation), use Devel::NYTProf:
+For profiling the END-time Perl code (DB writes, deparsing, report generation),
+use Devel::NYTProf:
 
 ```bash
 cd tmp/runs/Gedcom-1.22
@@ -194,25 +194,30 @@ perl $DC -MDevel::Cover=-silent,1,-db,/tmp/dc_bench_db \
 nytprofhtml
 ```
 
-NYTProf cannot see inside XS/C functions, so it is only useful for
-Perl-side costs. For the XS runtime, use `sample` as described above.
+NYTProf cannot see inside XS/C functions, so it is only useful for Perl-side
+costs. For the XS runtime, use `sample` as described above.
 
 ## Interpreting results
 
 ### Architecture of the XS runtime
 
-The XS code replaces Perl's op dispatch functions with instrumented
-versions:
+The XS code replaces Perl's op dispatch functions with instrumented versions:
 
 | Original op  | Replacement  | What it covers        |
 | ------------ | ------------ | --------------------- |
 | pp_nextstate | dc_nextstate | statement + time      |
-| pp_and       | dc_and       | branch/condition      |
-| pp_or        | dc_or        | branch/condition      |
-| pp_dor       | dc_dor       | branch/condition      |
-| pp_cond_expr | dc_cond_expr | branch/condition      |
-| pp_entersub  | dc_entersub  | subroutine            |
+| pp_dbstate   | dc_dbstate   | statement (debugger)  |
 | pp_padrange  | dc_padrange  | statement (multi-pad) |
+| pp_entersub  | dc_entersub  | subroutine            |
+| pp_and       | dc_and       | branch/condition      |
+| pp_andassign | dc_andassign | branch/condition      |
+| pp_or        | dc_or        | branch/condition      |
+| pp_orassign  | dc_orassign  | branch/condition      |
+| pp_dor       | dc_dor       | branch/condition      |
+| pp_dorassign | dc_dorassign | branch/condition      |
+| pp_cond_expr | dc_cond_expr | branch/condition      |
+| pp_require   | dc_require   | file tracking         |
+| pp_exec      | dc_exec      | exec tracking         |
 
 Each replacement op follows the same pattern:
 
@@ -224,20 +229,24 @@ Each replacement op follows the same pattern:
 
 The main cost centres in the XS runtime are:
 
-- **get_key / fnv1a_hash_file_line** - computing the unique key for
-  each op (hashes the filename bytes and line number)
-- **cover_time** - gettimeofday + hash lookup + arithmetic (only when
-  time coverage is enabled)
-- **cover_statement** - hash lookup + counter increment
-- **cover_logop / get_conditional_array / add_conditional** - condition
-  tracking with hash lookups
-- **check_if_collecting** - strcmp/strncmp filename matching
-- **Perl_hv_common / SipHash** - Perl's hash implementation, called
-  from all the above via hv_fetch with KEY_SZ-byte keys
+- **get_key / hash_op_identity / fnv1a_hash_file_line** - computing the unique
+  key for each op (hashes OP fields and file+line)
+- **dc_stmt_cache / dc_av_cache** - C-level open-addressing caches that bypass
+  get_key + hv_fetch for ~95% of repeat hits; a cache miss falls through to the
+  full path
+- **cover_time** - gettimeofday + hash lookup + arithmetic (only when time
+  coverage is enabled)
+- **cover_statement** - hash lookup + counter increment (on cache miss)
+- **cover_logop / get_conditional_array / add_conditional** - condition tracking
+  with hash lookups (on cache miss)
+- **check_if_collecting** - CopFILE pointer comparison on the fast path; falls
+  back to strcmp and the Perl-level use_file callback on a file change
+- **Perl_hv_common / SipHash** - Perl's hash implementation, called via hv_fetch
+  with KEY_SZ-byte keys (on cache miss or flush)
 
-When optimising, focus on the functions with the highest *self-time*
-(leaf samples). Inclusive counts tell you where time flows, but
-self-time tells you where the CPU is actually stalled.
+When optimising, focus on the functions with the highest *self-time* (leaf
+samples). Inclusive counts tell you where time flows, but self-time tells you
+where the CPU is actually stalled.
 
 ## Other platforms
 
@@ -256,20 +265,19 @@ perf report --no-children --sort=dso,symbol
 perf report --children --sort=dso,symbol
 ```
 
-The analysis approach is the same - look for Cover.so functions with
-high self-time.
+The analysis approach is the same - look for Cover.so functions with high
+self-time.
 
 ### Instruments (macOS)
 
-Xcode's Instruments app provides a GUI alternative to `sample` with
-flame graphs and timeline views. Use the "Time Profiler" instrument,
-attach to the running benchmark process, and filter by the Cover.bundle
-module.
+Xcode's Instruments app provides a GUI alternative to `sample` with flame graphs
+and timeline views. Use the "Time Profiler" instrument, attach to the running
+benchmark process, and filter by the Cover.bundle module.
 
-## Example profile (March 2026, post-hotspot #1)
+## Example profile (March 2026, early in GH-422)
 
-After eliminating snprintf from get_key() and deduplicating get_key()
-calls per statement, the profile showed:
+After eliminating snprintf from get_key() and deduplicating get_key() calls per
+statement, but *before* the caching and struct-shrink work, the profile showed:
 
 | Area                     | % of DC overhead | Dominant cost         |
 | ------------------------ | ---------------- | --------------------- |
@@ -280,5 +288,11 @@ calls per statement, the profile showed:
 | cover_statement          | 10%              | hv_fetch, sv_setiv    |
 | op handler overhead      | 7%               | dc_and, dc_or self    |
 
-Total overhead at this point: ~0.40s on the Gedcom benchmark (down from
-0.80s before hotspot #1).
+Total overhead at this point: ~0.40s on the Gedcom benchmark (down from 0.80s
+before the first hotspot fix).
+
+Subsequent optimisations on the same branch (struct unique shrink, CopFILE
+pointer cache, dc_stmt_cache, dc_av_cache) reduced the overhead further.
+Re-profile with the current code to get up-to-date numbers - the distribution
+will have shifted as the caches now absorb most of the get_key and hv_fetch
+cost.

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -307,7 +307,9 @@ sub _init_coverage {
     }
     delete $Coverage{$_} unless length;
   }
-  %Coverage         = (all => 1) unless keys %Coverage;
+  unless (keys %Coverage) {
+    %Coverage = map { $_ => 1 } grep $_ ne "time", keys %Criteria;
+  }
   %Coverage_options = %Coverage;
 }
 
@@ -1453,7 +1455,7 @@ In this example, Devel::Cover will be operating in silent mode.
                         if blib directory exists, false otherwise)
   -coverage criterion - Turn on coverage for the specified criterion.  Criteria
                         include statement, branch, condition, path, subroutine,
-                        pod, time, all and none (default all available)
+                        pod, time, all and none (default all except time)
   -db cover_db        - Store results in coverage db (default ./cover_db)
   -dir path           - Directory in which coverage will be collected (default
                         cwd)


### PR DESCRIPTION
## Summary

Reduce the per-op overhead of runtime coverage collection in the XS layer. The Gedcom benchmark (a real-world workload exercising statement, branch, and condition coverage across 20 iterations) shows a 63% reduction in coverage overhead: from ~1.70s down to ~0.63s over a 0.58s baseline.

## Changes

**Hot-path key generation (2 commits)**
- Replace snprintf + FNV1a with direct FNV1a hashing over raw filename bytes and line number in get_key()
- Deduplicate the get_key call in cover_current_statement so the key is computed once and shared

**Struct shrink (1 commit)**
- Reduce struct unique from 56 to 24 bytes by replacing the 40-byte OP copy with an 8-byte hash of the meaningful fields

**Time coverage default (1 commit)**
- Exclude time coverage from default criteria since reports already skip it, removing ~11% overhead for the common case

**C-level statement cache (1 commit)**
- Open-addressing hash table mapping OP * to a C integer count, bypassing the full get_key + hv_fetch + SV increment path for ~95% of statement hits

**CopFILE pointer cache (1 commit)**
- Cache the CopFILE pointer in check_if_collecting to skip SvPV_nolen + strcmp on the hot path when the file has not changed

**AV pointer cache (1 commit)**
- Cache condition and branch AV pointers in a unified open-addressing hash table, avoiding get_key + hv_fetch for repeat condition/branch ops

**Documentation (1 commit)**
- XS runtime profiling guide with macOS sample-based methodology

## Implications

- The time coverage default change means users who want time data must pass `-coverage time` or `-coverage all`. Reports already excluded time by default, so visible output is unchanged.
- All caches use op_next comparison as a slab-reuse guard (Debian #800424, GH #143) to handle Perl's op memory recycling.
- The AV pointer cache stores pointers into the existing Perl HVs, requiring no flush step - modifications through the cached pointer take immediate effect.

## Issue

Closes #422