### PR TITLE
GH-426 Fix || coverage in sort blocks

### DIFF
--- a/.codespell
+++ b/.codespell
@@ -1,3 +1,6 @@
+despatch
+despatched
+
 Master
 
 Aas

--- a/Cover.xs
+++ b/Cover.xs
@@ -106,8 +106,8 @@ typedef struct {
 typedef struct {
   dc_av_slot *slots;
   size_t      capacity; /* always power of 2 */
-  size_t      count;    /* occupied slots     */
-  size_t      mask;     /* capacity - 1       */
+  size_t      count;    /* occupied slots    */
+  size_t      mask;     /* capacity - 1      */
 } dc_av_cache;
 
 #define DC_AV_CACHE_INIT_CAP 256
@@ -137,6 +137,8 @@ typedef struct {
 
   dc_stmt_cache stmt_cache;
   dc_av_cache   av_cache;
+  AV           *deferred_conditionals; /* sort-block conditions
+                                        * awaiting resolution */
   Perl_ppaddr_t ppaddr[MAXO];
 } my_cxt_t;
 
@@ -1124,6 +1126,24 @@ static void cover_cond(pTHX)
   }
 }
 
+/*
+ * Resolve conditions deferred from sort blocks.  The stack top holds the sort
+ * comparator's final value - the right operand of the outermost || whose
+ * right->op_next was NULL.
+ */
+static void resolve_deferred_conditionals(pTHX_ AV *dc, I32 base) {
+  if (av_len(dc) >= base) {
+    dSP;
+    int true_ish = SvTRUE(TOPs);
+    while (av_len(dc) >= base) {
+      SV *sv = av_pop(dc);
+      OP *cond_op = INT2PTR(OP *, SvIV(sv));
+      add_conditional(aTHX_ cond_op, true_ish ? 2 : 1);
+      SvREFCNT_dec(sv);
+    }
+  }
+}
+
 static void cover_logop(pTHX) {
   /*
    * For OP_AND, if the first operand is false, we have short circuited the
@@ -1232,7 +1252,15 @@ static void cover_logop(pTHX) {
           : right->op_next;
         while (next && next->op_type == OP_NULL)
           next = next->op_next;
-        if (!next) return;  /* in fold_constants */
+        if (!next) {
+          /*
+           * Sort block (or fold_constants): right->op_next is NULL so we can't
+           * hijack it.  Defer resolution to runops exit where the stack top
+           * holds the right operand's value.
+           */
+          av_push(MY_CXT.deferred_conditionals, newSViv(PTR2IV(PL_op)));
+          return;
+        }
         NDEB(op_dump(PL_op));
         NDEB(op_dump(next));
 
@@ -1526,6 +1554,7 @@ static void initialise(pTHX) {
     MY_CXT.profiling_key_valid = 0;
     Zero(&MY_CXT.stmt_cache, 1, dc_stmt_cache);
     Zero(&MY_CXT.av_cache, 1, dc_av_cache);
+    MY_CXT.deferred_conditionals      = newAV();
     MY_CXT.module              = newSVpv("", 0);
     MY_CXT.lastfile            = newSVpvn("", 1);
     MY_CXT.lastfile_ptr        = NULL;
@@ -1539,6 +1568,7 @@ static void initialise(pTHX) {
 
 static int runops_cover(pTHX) {
   dMY_CXT;
+  I32 deferred_base = av_len(MY_CXT.deferred_conditionals) + 1;
 
   NDEB(D(L, "entering runops_cover\n"));
 
@@ -1623,8 +1653,11 @@ static int runops_cover(pTHX) {
     }
 
     call_fptr:
-    if (!(PL_op = PL_op->op_ppaddr(aTHX)))
+    if (!(PL_op = PL_op->op_ppaddr(aTHX))) {
+      resolve_deferred_conditionals(aTHX_
+        MY_CXT.deferred_conditionals, deferred_base);
       break;
+    }
 
     PERL_ASYNC_CHECK();
   }
@@ -1642,11 +1675,17 @@ static int runops_cover(pTHX) {
 }
 
 static int runops_orig(pTHX) {
+  dMY_CXT;
+  I32 deferred_base = av_len(MY_CXT.deferred_conditionals) + 1;
+
   NDEB(D(L, "entering runops_orig\n"));
 
   while ((PL_op = PL_op->op_ppaddr(aTHX))) {
     PERL_ASYNC_CHECK();
   }
+
+  resolve_deferred_conditionals(aTHX_
+    MY_CXT.deferred_conditionals, deferred_base);
 
   NDEB(D(L, "exiting runops_orig\n"));
 
@@ -1926,6 +1965,7 @@ BOOT:
     initialise(aTHX);
     if (MY_CXT.replace_ops) {
       replace_ops(aTHX);
+      PL_runops = runops_orig;
 #if defined HAS_GETTIMEOFDAY
       elapsed();
 #elif defined HAS_TIMES

--- a/docs/technical/package.md
+++ b/docs/technical/package.md
@@ -73,7 +73,7 @@ if ($nnnext && $name ne "null") {
 ```
 
 A `B::COP` with `name="null"` is always an optimised-away `ex-nextstate`. Its
-runtime `op_next` may be valid, but the op itself is never dispatched, so it
+runtime `op_next` may be valid, but the op itself is never despatched, so it
 must not be registered as a coverable statement.
 
 ## Bare `package` Inside a Block

--- a/docs/technical/pending-and-deferred-conditionals.md
+++ b/docs/technical/pending-and-deferred-conditionals.md
@@ -1,0 +1,267 @@
+# Pending and Deferred Conditionals
+
+When a logical operator like `||` does not short-circuit, Devel::Cover needs to
+see the right operand's value before it can record the condition outcome. Two
+mechanisms handle this, depending on whether there is a subsequent op to
+intercept.
+
+`Pending_conditionals` is the normal mechanism: it hijacks the op that follows
+the right operand and reads the stack when that op is reached.
+
+`deferred_conditionals` handles the case where there is no subsequent op to
+hijack - specifically, sort block comparators where the final op's `op_next` is
+NULL.
+
+Both feed into the same condition array (slots [1] and [2]) and ultimately
+produce the same branch and condition coverage data.
+
+## Background: the condition array
+
+Each logical op has a 6-element condition array (see
+`branches_and_conditions.md` for the full layout). The slots relevant here are:
+
+```text
+[1]  not short-circuited, right operand was false
+[2]  not short-circuited, right operand was true
+[3]  short-circuited (left operand determined the result)
+```
+
+The short-circuit path (slot [3]) is straightforward: `cover_logop()` records it
+immediately via `add_conditional(op, 3)` because the left operand's value is
+known at the time the logical op is despatched. No deferred work is needed.
+
+The non-short-circuit path (slots [1] and [2]) is harder: the right operand
+hasn't been evaluated yet. Devel::Cover must wait until the right operand
+finishes, then read its value to decide between slot [1] (false) and slot [2]
+(true).
+
+## Pending_conditionals: the hijack mechanism
+
+`Pending_conditionals` is a global HV (process-wide, protected by `DC_mutex` in
+threaded builds). It stores condition data that is waiting for a specific op to
+be reached.
+
+### How it works
+
+When `cover_logop()` handles the non-short-circuit path:
+
+1. It finds the op that will execute after the right operand:
+   `next = right->op_next` (skipping any OP_NULL nodes).
+
+2. It creates (or reuses) an entry in `Pending_conditionals` keyed by `next`'s
+   address. The entry is an AV containing:
+
+   - `[0]` the target op pointer (`next`)
+   - `[1]` the original `op_ppaddr` of `next`
+   - `[2+]` the logical ops waiting for resolution at this target
+
+3. It replaces `next->op_ppaddr` with `get_condition` (or `get_condition_dor`
+   for `//` operators).
+
+4. When the normal Perl execution loop reaches `next`, it calls the hijacked
+   `op_ppaddr`, which is now `get_condition`.
+
+5. `get_condition()` reads `TOPs` (the stack top, which holds the right
+   operand's value), calls `add_condition()` to record slot [1] or [2] for each
+   pending logical op, restores the original `op_ppaddr`, and returns `PL_op` so
+   the hijacked op runs normally.
+
+Multiple logical ops can share the same target. For example, in
+`$a || $b || $c`, when `$a` is false and `$b` is also false, both `||` ops are
+waiting on the same `next` op (the one after `$c`). They are all stored in the
+same `Pending_conditionals` entry and resolved together.
+
+### Limitations
+
+The mechanism relies on `right->op_next` being non-NULL. There must be an op to
+hijack. This works in the vast majority of cases because most code has a
+continuation op after any expression. However, it fails when `right->op_next` is
+NULL, which happens in two known cases:
+
+- **Compile-time constant folding**: the op tree was simplified away. This was
+  the original reason for the bail-out, noted in the comment
+  `/* in fold_constants */`.
+
+- **Sort block comparators**: the ops inside a sort block have NULL `op_next`
+  pointers because `pp_sort` reads the result directly from the stack. There is
+  no continuation op.
+
+### Where to find it in Cover.xs
+
+- Declaration: line ~148 (`static HV *Pending_conditionals`)
+- Setup in `cover_logop()`: lines ~1248-1278 (hv_fetch, av_push, ppaddr
+  replacement)
+- Resolution in `get_condition()`: lines ~1048-1069
+- End-of-run cleanup in `finalise_conditions()`: lines ~1092-1115
+
+## deferred_conditionals: the runops-exit mechanism
+
+`deferred_conditionals` is a per-thread AV stored in `my_cxt_t`. It holds OP
+pointers for conditions that could not be hijacked because `right->op_next` was
+NULL.
+
+### Why sort blocks have NULL op_next
+
+Sort blocks are special in Perl's internals. The op tree for a sort comparator
+like:
+
+```perl
+sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @data
+```
+
+looks like:
+
+```text
+or(other->-) sK/1 ->(end)     # or's op_next is NULL
+   ncmp[t6] sK/2 ->-
+   scmp[t9] sK/2 ->(end)      # right's op_next is NULL
+```
+
+The `(end)` notation means `op_next` is NULL. `pp_sort` invokes the comparator
+via `CALLRUNOPS`, which runs the ops until PL_op becomes NULL. `pp_sort` then
+reads the result directly from `*PL_stack_sp`. There is nowhere for the ops to
+"go next" because `pp_sort` handles the transition.
+
+### How it works
+
+1. In `cover_logop()`, when `right->op_next` is NULL (after skipping OP_NULLs),
+   instead of bailing out, we push the current op onto
+   `MY_CXT.deferred_conditionals`:
+
+   ```c
+   av_push(MY_CXT.deferred_conditionals, newSViv(PTR2IV(PL_op)));
+   ```
+
+2. The original `pp_or` then executes, falls through to the right operand, and
+   the right operand runs. When the right operand's final op returns NULL, the
+   runops loop exits.
+
+3. At the runops loop exit (in both `runops_cover` and `runops_orig`),
+   `resolve_deferred_conditionals()` is called. It checks for entries pushed
+   during this invocation (from `deferred_base` upwards). The stack top at this
+   point holds the sort comparator's final value - the right operand of the
+   outermost `||`. The function reads `SvTRUE(TOPs)` to decide between slot [1]
+   (right false) and slot [2] (right true), then pops and resolves each deferred
+   entry via `add_conditional`.
+
+4. The result is identical to what `get_condition` would record for the normal
+   hijack path.
+
+### Why only the outermost || is affected
+
+For chained comparators like `A || B || C`, Perl compiles this as
+`(A || B) || C`. The inner `||`'s right operand (`B`) has `op_next` pointing to
+the outer `||` - a valid, non-NULL op. So the normal hijack mechanism works for
+inner `||` nodes. Only the outermost `||` (whose right operand's `op_next` is
+NULL because it is the sort block's final value) triggers the deferred path.
+
+This means there is exactly one deferred entry per sort comparator invocation.
+The stack value at runops exit is the right operand's value for that outermost
+`||`.
+
+### The deferred_base guard
+
+Each invocation of `runops_cover` or `runops_orig` saves the current length of
+the deferred array on entry:
+
+```c
+I32 deferred_base = av_len(MY_CXT.deferred_conditionals) + 1;
+```
+
+On exit, it only processes entries from `deferred_base` upwards - entries pushed
+during this invocation. This guard handles two scenarios:
+
+**Nested sorts.** `pp_sort` calls `CALLRUNOPS` for each comparison. If a sort
+comparator itself contains another sort, the call stack becomes:
+
+```text
+runops (outer comparison)       deferred_base = 0
+  cover_logop pushes entry      array = [op_outer]
+  pp_sort (inner) calls runops
+    runops (inner comparison)   deferred_base = 1
+      cover_logop pushes entry  array = [op_outer, op_inner]
+    inner runops exit:          resolves op_inner (index 1)
+                                array = [op_outer]
+  outer runops exit:            resolves op_outer (index 0)
+                                array = []
+```
+
+Without the guard, the inner runops would resolve `op_outer` using the inner
+sort's stack value.
+
+**Exceptions.** If a sort comparator dies (e.g., via a function call that
+throws), the longjmp bypasses the runops loop exit. Deferred entries from the
+failed comparator remain in the array. When the next sort runs (after eval
+catches the exception), `deferred_base` is set past the stale entries, so they
+are ignored:
+
+```text
+eval {
+  sort { ... || boom() } @data   # boom() dies
+  # cover_logop pushed entry, die skipped loop exit
+  # array = [stale_op]
+};
+# now array still has [stale_op]
+
+sort { ... || ... } @other       # deferred_base = 1
+# new entries at index 1+, only those are resolved
+```
+
+The stale entries remain in the array for the lifetime of the program but are
+harmless - they are small SVs holding OP pointers that are never dereferenced.
+
+### Thread safety
+
+`deferred_conditionals` is per-thread (`MY_CXT`), so no mutex is needed. The
+push in `cover_logop` and the resolution in the runops functions all operate on
+the same thread's data.
+
+### Dual runops support
+
+Devel::Cover has two execution modes:
+
+- **runops_cover mode**: `PL_runops` is set to `runops_cover`, which provides a
+  full despatch loop with coverage collection in a switch statement.
+
+- **replace_ops mode**: individual op ppaddr functions are replaced with `dc_*`
+  wrappers (e.g., `dc_or` wraps `pp_or`). The runops loop is Devel::Cover's
+  `runops_orig`, a lightweight loop.
+
+The deferred resolution code is present in both `runops_cover` and `runops_orig`
+so that it works regardless of mode. In replace_ops mode, `PL_runops` is set to
+`runops_orig` to ensure the resolution code is reached.
+
+### Where to find it in Cover.xs
+
+- Field declaration: `my_cxt_t.deferred_conditionals` (line ~140)
+- Initialisation in `initialise()`: `MY_CXT.deferred_conditionals = newAV()`
+  (line ~1537)
+- Push in `cover_logop()`: the `if (!next)` block (lines ~1253-1260)
+- Helper: `resolve_deferred_conditionals()` (line ~1134)
+- Call from `runops_cover()`: loop exit (line ~1657)
+- Call from `runops_orig()`: after the while loop (line ~1687)
+- Boot: `PL_runops = runops_orig` in replace_ops branch (line ~1967)
+
+## Comparison
+
+| Aspect           | Pending_conditionals   | deferred_conditionals  |
+| ---------------- | ---------------------- | ---------------------- |
+| Trigger          | Hijacked op despatched | runops loop exits      |
+| Storage          | Global HV (with mutex) | Per-thread AV          |
+| Key              | Target op address      | Array index            |
+| Multiple pending | Yes (share one hijack) | Yes (resolved at exit) |
+| Requires op_next | Yes                    | No                     |
+| Use case         | Normal logop code      | Sort block logops      |
+
+## Test coverage
+
+The `tests/sort_or` test script exercises the deferred mechanism with six cases:
+
+- Cases 1-2: basic sort blocks with `||` (fall-through and mixed)
+- Case 3: ternary in sort block (control, uses `cover_cond`)
+- Case 4: nested sorts with `||` (tests `deferred_base` guard)
+- Case 5: exception in sort comparator via function call (tests that stale
+  deferred entries don't corrupt state)
+- Case 6: sort after exception (tests `deferred_base` skips stale entries)
+
+Golden output: `test_output/cover/sort_or.<version>`

--- a/docs/technical/xs-profiling.md
+++ b/docs/technical/xs-profiling.md
@@ -2,7 +2,7 @@
 
 This document explains how to profile the C-level runtime overhead of
 Devel::Cover's XS code. The techniques here measure where time is spent *during
-test execution* (the instrumented op dispatch loop), not the END-time Perl
+test execution* (the instrumented op despatch loop), not the END-time Perl
 processing (DB writes, deparsing, report generation).
 
 ## Prerequisites
@@ -201,7 +201,7 @@ costs. For the XS runtime, use `sample` as described above.
 
 ### Architecture of the XS runtime
 
-The XS code replaces Perl's op dispatch functions with instrumented versions:
+The XS code replaces Perl's op despatch functions with instrumented versions:
 
 | Original op  | Replacement  | What it covers        |
 | ------------ | ------------ | --------------------- |

--- a/test_output/cover/sort_or.5.020000
+++ b/test_output/cover/sort_or.5.020000
@@ -1,0 +1,119 @@
+Reading database from ...
+
+
+------------- ------ ------ ------ ------ ------
+File            stmt   bran   cond    sub  total
+------------- ------ ------ ------ ------ ------
+tests/sort_or  100.0   66.6    n/a  100.0   88.2
+Total          100.0   66.6    n/a  100.0   88.2
+------------- ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/sort_or
+
+line  err   stmt   bran   cond    sub   code
+1                                       #!/usr/bin/perl
+2                                       
+3                                       # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                       
+5                                       # This software is free.  It is licensed under the same terms as Perl itself.
+6                                       
+7                                       # The latest version of this software should be available from my homepage:
+8                                       # https://pjcj.net
+9                                       
+10             1                    1   use strict;
+               1                        
+               1                        
+11             1                    1   use warnings;
+               1                        
+               1                        
+12                                      
+13                                      # Case 1: all equal counts - <=> always returns 0, || never short-circuits
+14             1                        my @equal = (
+15                                        { val => "Alpha", cnt => 2 },
+16                                        { val => "alpha", cnt => 2 },
+17                                        { val => "ALPHA", cnt => 2 },
+18                                      );
+19    ***      1   * 50                 my @r1 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @equal;
+               2                        
+20                                      
+21                                      # Case 2: mixed counts - <=> returns both 0 and non-zero
+22             1                        my @mixed = (
+23                                        { val => "Alpha", cnt => 2 },
+24                                        { val => "alpha", cnt => 2 },
+25                                        { val => "ALPHA", cnt => 1 },
+26                                      );
+27             1    100                 my @r2 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @mixed;
+               3                        
+28                                      
+29                                      # Case 3: same logic but with ternary instead of ||
+30             3                        my @r3 = sort {
+31             1                          my $r = $b->{cnt} <=> $a->{cnt};
+32             3    100                   $r ? $r : $a->{val} cmp $b->{val}
+33                                      } @mixed;
+34                                      
+35                                      # Case 4: nested sort - inner sort with || inside outer sort with ||
+36             1                        my @outer = (
+37                                        { key => 2, inner => [ { a => 1, b => "y" }, { a => 1, b => "x" } ] },
+38                                        { key => 2, inner => [ { a => 3, b => "b" }, { a => 3, b => "a" } ] },
+39                                      );
+40    ***      1   * 50                 my @r4 = sort {
+41             1                          $a->{key} <=> $b->{key}
+42    ***      1   * 50                     || (sort { $a->{a} <=> $b->{a} || $a->{b} cmp $b->{b} } @{$a->{inner}})[0]{b}
+               1                        
+43                                             cmp
+44    ***      1   * 50                        (sort { $a->{a} <=> $b->{a} || $a->{b} cmp $b->{b} } @{$b->{inner}})[0]{b}
+               1                        
+45                                      } @outer;
+46                                      
+47                                      # Case 5: exception in sort comparator via function call - the deferred
+48                                      # entry from the || is pushed but the die bypasses runops loop exit.
+49                                      # The stale entry must not corrupt subsequent sorts (tests deferred_base).
+50             1                    1   sub boom { die "bail" }
+51             1                        eval {
+52    ***      1   *  0                   my @r5 = sort {
+53             1                            $b->{cnt} <=> $a->{cnt} || boom()
+54                                        } @equal;
+55                                      };
+56                                      
+57                                      # Case 6: sort after exception - verify deferred state is clean
+58             1    100                 my @r6 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @mixed;
+               3                        
+59                                      
+60                                      # Case 7: low-precedence 'or' - same OP_OR opcode as ||
+61             1    100                 my @r7 = sort { $b->{cnt} <=> $a->{cnt} or $a->{val} cmp $b->{val} } @mixed;
+               3                        
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+19    ***     50      2      0   unless $$b{"cnt"} <=> $$a{"cnt"}
+27           100      1      2   unless $$b{"cnt"} <=> $$a{"cnt"}
+32           100      2      1   $r ? :
+40    ***     50      1      0   unless $$a{"a"} <=> $$b{"a"}
+42    ***     50      1      0   unless $$a{"a"} <=> $$b{"a"}
+44    ***     50      1      0   unless $$a{"key"} <=> $$b{"key"}
+52    ***      0      0      0   unless $$b{"cnt"} <=> $$a{"cnt"}
+58           100      1      2   unless $$b{"cnt"} <=> $$a{"cnt"}
+61           100      1      2   unless $$b{"cnt"} <=> $$a{"cnt"}
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count Location        
+---------- ----- ----------------
+BEGIN          1 tests/sort_or:10
+BEGIN          1 tests/sort_or:11
+boom           1 tests/sort_or:50
+
+

--- a/test_output/cover/sort_or.5.022000
+++ b/test_output/cover/sort_or.5.022000
@@ -1,0 +1,121 @@
+Reading database from ...
+
+
+------------- ------ ------ ------ ------ ------
+File            stmt   bran   cond    sub  total
+------------- ------ ------ ------ ------ ------
+tests/sort_or  100.0   66.6    n/a  100.0   88.2
+Total          100.0   66.6    n/a  100.0   88.2
+------------- ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/sort_or
+
+line  err   stmt   bran   cond    sub   code
+1                                       #!/usr/bin/perl
+2                                       
+3                                       # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                       
+5                                       # This software is free.  It is licensed under the same terms as Perl itself.
+6                                       
+7                                       # The latest version of this software should be available from my homepage:
+8                                       # https://pjcj.net
+9                                       
+10             1                    1   use strict;
+               1                        
+               1                        
+11             1                    1   use warnings;
+               1                        
+               1                        
+12                                      
+13                                      # Case 1: all equal counts - <=> always returns 0, || never short-circuits
+14             1                        my @equal = (
+15                                        { val => "Alpha", cnt => 2 },
+16                                        { val => "alpha", cnt => 2 },
+17                                        { val => "ALPHA", cnt => 2 },
+18                                      );
+19    ***      1   * 50                 my @r1 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @equal;
+               2                        
+20                                      
+21                                      # Case 2: mixed counts - <=> returns both 0 and non-zero
+22             1                        my @mixed = (
+23                                        { val => "Alpha", cnt => 2 },
+24                                        { val => "alpha", cnt => 2 },
+25                                        { val => "ALPHA", cnt => 1 },
+26                                      );
+27             1    100                 my @r2 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @mixed;
+               3                        
+28                                      
+29                                      # Case 3: same logic but with ternary instead of ||
+30                                      my @r3 = sort {
+31             1                          my $r = $b->{cnt} <=> $a->{cnt};
+               3                        
+32                                        $r ? $r : $a->{val} cmp $b->{val}
+33             3    100                 } @mixed;
+34                                      
+35                                      # Case 4: nested sort - inner sort with || inside outer sort with ||
+36             1                        my @outer = (
+37                                        { key => 2, inner => [ { a => 1, b => "y" }, { a => 1, b => "x" } ] },
+38                                        { key => 2, inner => [ { a => 3, b => "b" }, { a => 3, b => "a" } ] },
+39                                      );
+40                                      my @r4 = sort {
+41             1                          $a->{key} <=> $b->{key}
+42    ***      1   * 50                     || (sort { $a->{a} <=> $b->{a} || $a->{b} cmp $b->{b} } @{$a->{inner}})[0]{b}
+               1                        
+43                                             cmp
+44    ***      1   * 50                        (sort { $a->{a} <=> $b->{a} || $a->{b} cmp $b->{b} } @{$b->{inner}})[0]{b}
+               1                        
+45    ***      1   * 50                 } @outer;
+46                                      
+47                                      # Case 5: exception in sort comparator via function call - the deferred
+48                                      # entry from the || is pushed but the die bypasses runops loop exit.
+49                                      # The stale entry must not corrupt subsequent sorts (tests deferred_base).
+50             1                    1   sub boom { die "bail" }
+51             1                        eval {
+52                                        my @r5 = sort {
+53    ***      1   *  0                     $b->{cnt} <=> $a->{cnt} || boom()
+               1                        
+54                                        } @equal;
+55                                      };
+56                                      
+57                                      # Case 6: sort after exception - verify deferred state is clean
+58             1    100                 my @r6 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @mixed;
+               3                        
+59                                      
+60                                      # Case 7: low-precedence 'or' - same OP_OR opcode as ||
+61             1    100                 my @r7 = sort { $b->{cnt} <=> $a->{cnt} or $a->{val} cmp $b->{val} } @mixed;
+               3                        
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+19    ***     50      2      0   unless $main::b->{'cnt'} <=> $main::a->{'cnt'}
+27           100      1      2   unless $main::b->{'cnt'} <=> $main::a->{'cnt'}
+33           100      2      1   $r ? :
+42    ***     50      1      0   unless $main::a->{'a'} <=> $main::b->{'a'}
+44    ***     50      1      0   unless $main::a->{'a'} <=> $main::b->{'a'}
+45    ***     50      1      0   unless $main::a->{'key'} <=> $main::b->{'key'}
+53    ***      0      0      0   unless $main::b->{'cnt'} <=> $main::a->{'cnt'}
+58           100      1      2   unless $main::b->{'cnt'} <=> $main::a->{'cnt'}
+61           100      1      2   unless $main::b->{'cnt'} <=> $main::a->{'cnt'}
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count Location        
+---------- ----- ----------------
+BEGIN          1 tests/sort_or:10
+BEGIN          1 tests/sort_or:11
+boom           1 tests/sort_or:50
+
+

--- a/test_output/cover/sort_or.5.043008
+++ b/test_output/cover/sort_or.5.043008
@@ -1,0 +1,121 @@
+Reading database from ...
+
+
+------------- ------ ------ ------ ------ ------
+File            stmt   bran   cond    sub  total
+------------- ------ ------ ------ ------ ------
+tests/sort_or  100.0   66.6    n/a  100.0   88.2
+Total          100.0   66.6    n/a  100.0   88.2
+------------- ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/sort_or
+
+line  err   stmt   bran   cond    sub   code
+1                                       #!/usr/bin/perl
+2                                       
+3                                       # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                       
+5                                       # This software is free.  It is licensed under the same terms as Perl itself.
+6                                       
+7                                       # The latest version of this software should be available from my homepage:
+8                                       # https://pjcj.net
+9                                       
+10             1                    1   use strict;
+               1                        
+               1                        
+11             1                    1   use warnings;
+               1                        
+               1                        
+12                                      
+13                                      # Case 1: all equal counts - <=> always returns 0, || never short-circuits
+14             1                        my @equal = (
+15                                        { val => "Alpha", cnt => 2 },
+16                                        { val => "alpha", cnt => 2 },
+17                                        { val => "ALPHA", cnt => 2 },
+18                                      );
+19    ***      1   * 50                 my @r1 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @equal;
+               2                        
+20                                      
+21                                      # Case 2: mixed counts - <=> returns both 0 and non-zero
+22             1                        my @mixed = (
+23                                        { val => "Alpha", cnt => 2 },
+24                                        { val => "alpha", cnt => 2 },
+25                                        { val => "ALPHA", cnt => 1 },
+26                                      );
+27             1    100                 my @r2 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @mixed;
+               3                        
+28                                      
+29                                      # Case 3: same logic but with ternary instead of ||
+30                                      my @r3 = sort {
+31             1                          my $r = $b->{cnt} <=> $a->{cnt};
+               3                        
+32                                        $r ? $r : $a->{val} cmp $b->{val}
+33             3    100                 } @mixed;
+34                                      
+35                                      # Case 4: nested sort - inner sort with || inside outer sort with ||
+36             1                        my @outer = (
+37                                        { key => 2, inner => [ { a => 1, b => "y" }, { a => 1, b => "x" } ] },
+38                                        { key => 2, inner => [ { a => 3, b => "b" }, { a => 3, b => "a" } ] },
+39                                      );
+40                                      my @r4 = sort {
+41             1                          $a->{key} <=> $b->{key}
+42    ***      1   * 50                     || (sort { $a->{a} <=> $b->{a} || $a->{b} cmp $b->{b} } @{$a->{inner}})[0]{b}
+               1                        
+43                                             cmp
+44    ***      1   * 50                        (sort { $a->{a} <=> $b->{a} || $a->{b} cmp $b->{b} } @{$b->{inner}})[0]{b}
+               1                        
+45    ***      1   * 50                 } @outer;
+46                                      
+47                                      # Case 5: exception in sort comparator via function call - the deferred
+48                                      # entry from the || is pushed but the die bypasses runops loop exit.
+49                                      # The stale entry must not corrupt subsequent sorts (tests deferred_base).
+50             1                    1   sub boom { die "bail" }
+51             1                        eval {
+52                                        my @r5 = sort {
+53    ***      1   *  0                     $b->{cnt} <=> $a->{cnt} || boom()
+               1                        
+54                                        } @equal;
+55                                      };
+56                                      
+57                                      # Case 6: sort after exception - verify deferred state is clean
+58             1    100                 my @r6 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @mixed;
+               3                        
+59                                      
+60                                      # Case 7: low-precedence 'or' - same OP_OR opcode as ||
+61             1    100                 my @r7 = sort { $b->{cnt} <=> $a->{cnt} or $a->{val} cmp $b->{val} } @mixed;
+               3                        
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+19    ***     50      2      0   $main::b->{'cnt'} <=> $main::a->{'cnt'} or $main::a->{'val'} cmp $main::b->{'val'}
+27           100      1      2   $main::b->{'cnt'} <=> $main::a->{'cnt'} or $main::a->{'val'} cmp $main::b->{'val'}
+33           100      2      1   $r ? :
+42    ***     50      1      0   $main::a->{'a'} <=> $main::b->{'a'} or $main::a->{'b'} cmp $main::b->{'b'}
+44    ***     50      1      0   $main::a->{'a'} <=> $main::b->{'a'} or $main::a->{'b'} cmp $main::b->{'b'}
+45    ***     50      1      0   $main::a->{'key'} <=> $main::b->{'key'} or +(sort {$main::a->{'a'} <=> $main::b->{'a'} or $main::a->{'b'} cmp $main::b->{'b'};} @{$$a{"inner"};})[0]->{'b'} cmp +(sort {$main::a->{'a'} <=> $main::b->{'a'} or $main::a->{'b'} cmp $main::b->{'b'};} @{$$b{"inner"};})[0]->{'b'}
+53    ***      0      0      0   $main::b->{'cnt'} <=> $main::a->{'cnt'} or boom()
+58           100      1      2   $main::b->{'cnt'} <=> $main::a->{'cnt'} or $main::a->{'val'} cmp $main::b->{'val'}
+61           100      1      2   $main::b->{'cnt'} <=> $main::a->{'cnt'} or $main::a->{'val'} cmp $main::b->{'val'}
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count Location        
+---------- ----- ----------------
+BEGIN          1 tests/sort_or:10
+BEGIN          1 tests/sort_or:11
+boom           1 tests/sort_or:50
+
+

--- a/tests/sort_or
+++ b/tests/sort_or
@@ -1,0 +1,61 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use strict;
+use warnings;
+
+# Case 1: all equal counts - <=> always returns 0, || never short-circuits
+my @equal = (
+  { val => "Alpha", cnt => 2 },
+  { val => "alpha", cnt => 2 },
+  { val => "ALPHA", cnt => 2 },
+);
+my @r1 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @equal;
+
+# Case 2: mixed counts - <=> returns both 0 and non-zero
+my @mixed = (
+  { val => "Alpha", cnt => 2 },
+  { val => "alpha", cnt => 2 },
+  { val => "ALPHA", cnt => 1 },
+);
+my @r2 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @mixed;
+
+# Case 3: same logic but with ternary instead of ||
+my @r3 = sort {
+  my $r = $b->{cnt} <=> $a->{cnt};
+  $r ? $r : $a->{val} cmp $b->{val}
+} @mixed;
+
+# Case 4: nested sort - inner sort with || inside outer sort with ||
+my @outer = (
+  { key => 2, inner => [ { a => 1, b => "y" }, { a => 1, b => "x" } ] },
+  { key => 2, inner => [ { a => 3, b => "b" }, { a => 3, b => "a" } ] },
+);
+my @r4 = sort {
+  $a->{key} <=> $b->{key}
+    || (sort { $a->{a} <=> $b->{a} || $a->{b} cmp $b->{b} } @{$a->{inner}})[0]{b}
+       cmp
+       (sort { $a->{a} <=> $b->{a} || $a->{b} cmp $b->{b} } @{$b->{inner}})[0]{b}
+} @outer;
+
+# Case 5: exception in sort comparator via function call - the deferred
+# entry from the || is pushed but the die bypasses runops loop exit.
+# The stale entry must not corrupt subsequent sorts (tests deferred_base).
+sub boom { die "bail" }
+eval {
+  my @r5 = sort {
+    $b->{cnt} <=> $a->{cnt} || boom()
+  } @equal;
+};
+
+# Case 6: sort after exception - verify deferred state is clean
+my @r6 = sort { $b->{cnt} <=> $a->{cnt} || $a->{val} cmp $b->{val} } @mixed;
+
+# Case 7: low-precedence 'or' - same OP_OR opcode as ||
+my @r7 = sort { $b->{cnt} <=> $a->{cnt} or $a->{val} cmp $b->{val} } @mixed;


### PR DESCRIPTION
## Summary

`cover_logop()` silently dropped branch/condition data for `||` (and `or`) inside sort block comparators. The short-circuit path worked because it records immediately via `add_conditional`; the fall-through path relied on hijacking `right->op_next`, which is NULL in sort blocks because `pp_sort` reads the result directly from the stack.

## Changes

- Add `deferred_conditionals` (per-thread AV in `my_cxt_t`) to hold OP pointers when `right->op_next` is NULL and the normal hijack mechanism cannot be used. Resolution happens at runops loop exit where the stack top holds the right operand's value - the same contract `pp_sort` relies on.
- A `deferred_base` stack-discipline guard ensures nested sorts and exceptions don't corrupt each other's deferred entries.
- In `replace_ops` mode, set `PL_runops = runops_orig` so the resolution code at loop exit is reached (the default Perl runops has no hook point).
- Add `tests/sort_or` with 7 cases: basic fall-through, mixed short-circuit/fall-through, ternary control, nested sorts, exception recovery, post-exception sort, and low-precedence `or`.
- Add technical documentation explaining the relationship between `Pending_conditionals` and `deferred_conditionals`.

## Implications

- Negligible runtime cost: one `av_len` (struct field read) per runops entry; resolution only fires in sort blocks with `||`.
- If a sort comparator dies, deferred SVs leak (stay in the AV permanently) but are harmless and bounded.

## Issue

Closes #426