### PR TITLE
GH-444 Make Html_crisp the default

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -409,7 +409,7 @@ sub manage_dbs ($dbname, $test_result) {
   my $db = Devel::Cover::DB->new(
     db               => $dbname,
     prefer_lib       => $Options->{prefer_lib},
-    uncoverable_file => $Options->{uncoverable_file}
+    uncoverable_file => $Options->{uncoverable_file},
   );
   $db = $db->merge_runs;
   scan_select_dirs($db);
@@ -629,7 +629,7 @@ reports may be available if they've been installed from external packages.
 
 =over 4
 
-=item html|html_minimal (default)
+=item html|html_crisp (default)
 
 HTML reporting. Percentage thresholds are colour-coded and configurable
 via -report_c0 <integer>, -report_c1 <integer> and -report_c2 <integer>.:
@@ -638,6 +638,11 @@ via -report_c0 <integer>, -report_c1 <integer> and -report_c2 <integer>.:
     |   ..   |   ..   |   ..   |
        <c0      <c1      <c2   c3
        red     yellow   orange green
+
+=item html_minimal
+
+Minimal HTML reporting. Percentage thresholds are colour-coded and
+configurable.
 
 =item html_basic
 

--- a/lib/Devel/Cover/Report/Html.pm
+++ b/lib/Devel/Cover/Report/Html.pm
@@ -12,7 +12,7 @@ use warnings;
 
 # VERSION
 
-use base "Devel::Cover::Report::Html_minimal";
+use base "Devel::Cover::Report::Html_crisp";
 
 1;
 
@@ -33,7 +33,7 @@ Devel::Cover::Report::Html - HTML backend for Devel::Cover
 This module provides a HTML reporting mechanism for coverage data.  It
 is designed to be called from the C<cover> program.  This is an empty
 class derived from the default HTML output module,
-Devel::Cover::Report::Html_minimal.
+Devel::Cover::Report::Html_crisp.
 
 =head1 SEE ALSO
 

--- a/utils/dc
+++ b/utils/dc
@@ -1011,7 +1011,7 @@ dc_cover_lib() {
     "-MDevel::Cover=-select,$select,-db,$db,-merge,1" \
     t/internal/static.t
   if ((launch)); then
-    $Dc_cover_perl bin/cover "$db" -report html_crisp -launch
+    $Dc_cover_perl bin/cover "$db" -report html -launch
   fi
 }
 
@@ -1035,7 +1035,7 @@ dc_cover_reports() {
     -report html_crisp -report text -report json
 
   if ((launch)); then
-    $Dc_cover_perl bin/cover "$db" -report html_crisp -launch
+    $Dc_cover_perl bin/cover "$db" -report html -launch
   fi
 }
 
@@ -1049,7 +1049,7 @@ dc_cover() {
   $Dc_cover_perl bin/cover \
     dc_cover_lib_db dc_cover_reports_db \
     -write "$db"
-  $Dc_cover_perl bin/cover "$db" -report html_crisp -launch
+  $Dc_cover_perl bin/cover "$db" -report html -launch
 }
 
 recipe_dc-cover-lib() {
@@ -1133,7 +1133,7 @@ cpan_module() {
   # Run tests with coverage using local Devel::Cover
   pi "Running tests with coverage (local Devel::Cover)"
   export DEVEL_COVER_TEST_OPTS="-Mblib=$dc_root"
-  perl "-Mblib=$dc_root" "$dc_root/bin/cover" -test -report html_crisp -launch
+  perl "-Mblib=$dc_root" "$dc_root/bin/cover" -test -report html -launch
 
   pi "Done. Results in: $(pwd)/cover_db"
 }


### PR DESCRIPTION
## Summary

Switch the default HTML report from Html_minimal to Html_crisp so that `cover -report html` and bare `cover` use the new report module.

## Changes

- Change `Html.pm` base class from `Html_minimal` to `Html_crisp`
- Update `bin/cover` POD to document `html|html_crisp` as the default and list `html_minimal` as a separate option

## Implications

- Users who run `cover` without specifying a report format will now get Html_crisp output instead of Html_minimal
- `cover -report html_minimal` still works for anyone who prefers the old default

## Issue

Closes #444