### PR TITLE
GH-449 Add loop condition branch coverage

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1517,12 +1517,6 @@ sub _logop_parent_cx ($op, $highprec, $lowprec) {
 sub _walk_logop ($cv, $op) {
   return unless $Collect;
   return if $Seen{cond_expr}{$$op};
-  # Skip while/until loop conditions (and → null* → leaveloop)
-  my $_p = _op_parent($op);
-  if ($_p && $$_p) {
-    $_p = _op_parent($_p) while $_p && $$_p && $_p->name eq "null";
-    return if $_p && $$_p && $_p->name eq "leaveloop";
-  }
   my $name   = $op->name;
   my $params = $Logop_params{$name} || return;
   my ($lowop, $lowprec, $highop, $highprec, $blockname) = @$params;

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1538,9 +1538,22 @@ sub _walk_logop ($cv, $op) {
     $blockname = undef if $cx >= 1;
   }
 
+  # Loop conditions (and -> null* -> leaveloop) are always branches in statement
+  # form, regardless of OPpSTATEMENT.
+  my $is_loop_cond = 0;
+  {
+    my $_p = _op_parent($op);
+    if ($_p && $$_p) {
+      $_p           = _op_parent($_p) while $_p && $$_p && $_p->name eq "null";
+      $is_loop_cond = 1 if $_p && $$_p && $_p->name eq "leaveloop";
+    }
+  }
+
   $Shared_deparse ||= B::Deparse->new;
   my ($is_statement, $is_branch)
-    = _classify_op($Shared_deparse, $op, $cx, $blockname);
+    = $is_loop_cond
+    ? (1, 1)
+    : _classify_op($Shared_deparse, $op, $cx, $blockname);
 
   if ($is_statement && is_scope($right)) {
     my $l = _deparse_expr($cv, $left, 1, 1);

--- a/test_output/cover/loop_condition.5.020000
+++ b/test_output/cover/loop_condition.5.020000
@@ -4,8 +4,8 @@ Reading database from ...
 -------------------- ------ ------ ------ ------ ------
 File                   stmt   bran   cond    sub  total
 -------------------- ------ ------ ------ ------ ------
-tests/loop_condition   92.3   50.0    n/a  100.0   81.5
-Total                  92.3   50.0    n/a  100.0   81.5
+tests/loop_condition   94.2   66.6   66.6  100.0   81.4
+Total                  94.2   66.6   66.6  100.0   81.4
 -------------------- ------ ------ ------ ------ ------
 
 
@@ -39,39 +39,51 @@ line  err   stmt   bran   cond    sub   code
 15                                      
 16                                      # while - true and false branches
 17             1                        my $I = 0;
-18             1                        while ($I < 3) {
+18             1    100                 while ($I < 3) {
 19             3                          $I++;
 20                                      }
 21                                      
 22                                      # until - true and false branches
 23             1                        my $J = 0;
-24             1                        until ($J >= 3) {
+24             1    100                 until ($J >= 3) {
 25             3                          $J++;
 26                                      }
 27                                      
 28                                      # C-style for - true and false branches
 29             1                        my $Sum = 0;
-30             1                        for (my $k = 0; $k < 3; $k++) {
+30             1    100                 for (my $k = 0; $k < 3; $k++) {
 31             3                          $Sum += $k;
 32                                      }
 33                                      
 34                                      # while that is never entered (false branch only)
 35             1                        my $Never = 0;
-36             1                        while ($Never) {
+36    ***      1   * 50                 while ($Never) {
 37    ***     *0                          $Never++;
 38                                      }
 39                                      
 40                                      # until that is never entered (true branch only)
 41             1                        my $Always = 1;
-42             1                        until ($Always) {
+42    ***      1   * 50                 until ($Always) {
 43    ***     *0                          $Always--;
 44                                      }
 45                                      
-46    ***      1   * 50                 die "i: $I"           unless $I == 3;
-47    ***      1   * 50                 die "j: $J"           unless $J == 3;
-48    ***      1   * 50                 die "sum: $Sum"       unless $Sum == 3;
-49    ***      1   * 50                 die "never: $Never"   unless $Never == 0;
-50    ***      1   * 50                 die "always: $Always" unless $Always == 1;
+46                                      # compound condition - branch and condition coverage
+47             1                        my $X     = 1;
+48             1                        my $Y     = 1;
+49             1                        my $Count = 0;
+50    ***      1    100   * 66          while ($X && $Y) {
+51             2                          $Count++;
+52             2    100                   $Y = 0 if $Count >= 2;
+53                                      }
+54                                      
+55    ***      1   * 50                 die "i: $I"           unless $I == 3;
+56    ***      1   * 50                 die "j: $J"           unless $J == 3;
+57    ***      1   * 50                 die "sum: $Sum"       unless $Sum == 3;
+58    ***      1   * 50                 die "never: $Never"   unless $Never == 0;
+59    ***      1   * 50                 die "always: $Always" unless $Always == 1;
+60    ***      1   * 50                 die "count: $Count"   unless $Count == 2;
+61    ***      1   * 50                 die "x: $X"           unless $X == 1;
+62    ***      1   * 50                 die "y: $Y"           unless $Y == 0;
 
 
 Branches
@@ -79,11 +91,31 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-46    ***     50      0      1   unless $I == 3
-47    ***     50      0      1   unless $J == 3
-48    ***     50      0      1   unless $Sum == 3
-49    ***     50      0      1   unless $Never == 0
-50    ***     50      0      1   unless $Always == 1
+18           100      3      1   if ($I < 3)
+24           100      3      1   unless ($J >= 3)
+30           100      3      1   if ($k < 3)
+36    ***     50      0      1   if ($Never)
+42    ***     50      0      1   unless ($Always)
+50           100      2      1   if ($X and $Y)
+52           100      1      1   if $Count >= 2
+55    ***     50      0      1   unless $I == 3
+56    ***     50      0      1   unless $J == 3
+57    ***     50      0      1   unless $Sum == 3
+58    ***     50      0      1   unless $Never == 0
+59    ***     50      0      1   unless $Always == 1
+60    ***     50      0      1   unless $Count == 2
+61    ***     50      0      1   unless $X == 1
+62    ***     50      0      1   unless $Y == 0
+
+
+Conditions
+----------
+
+and 3 conditions
+
+line  err      %     !l  l&&!r   l&&r   expr
+----- --- ------ ------ ------ ------   ----
+50    ***     66      0      1      2   $X and $Y
 
 
 Covered Subroutines

--- a/test_output/cover/loop_condition.5.020000
+++ b/test_output/cover/loop_condition.5.020000
@@ -1,0 +1,97 @@
+Reading database from ...
+
+
+-------------------- ------ ------ ------ ------ ------
+File                   stmt   bran   cond    sub  total
+-------------------- ------ ------ ------ ------ ------
+tests/loop_condition   92.3   50.0    n/a  100.0   81.5
+Total                  92.3   50.0    n/a  100.0   81.5
+-------------------- ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/loop_condition
+
+line  err   stmt   bran   cond    sub   code
+1                                       #!/usr/bin/perl
+2                                       
+3                                       # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                       
+5                                       # This software is free.  It is licensed under the same terms as Perl itself.
+6                                       
+7                                       # The latest version of this software should be available from my homepage:
+8                                       # https://pjcj.net
+9                                       
+10                                      # Branch coverage for block-form loop conditions.
+11                                      # See GH-449.
+12                                      
+13             1                    1   use strict;
+               1                        
+               1                        
+14             1                    1   use warnings;
+               1                        
+               1                        
+15                                      
+16                                      # while - true and false branches
+17             1                        my $I = 0;
+18             1                        while ($I < 3) {
+19             3                          $I++;
+20                                      }
+21                                      
+22                                      # until - true and false branches
+23             1                        my $J = 0;
+24             1                        until ($J >= 3) {
+25             3                          $J++;
+26                                      }
+27                                      
+28                                      # C-style for - true and false branches
+29             1                        my $Sum = 0;
+30             1                        for (my $k = 0; $k < 3; $k++) {
+31             3                          $Sum += $k;
+32                                      }
+33                                      
+34                                      # while that is never entered (false branch only)
+35             1                        my $Never = 0;
+36             1                        while ($Never) {
+37    ***     *0                          $Never++;
+38                                      }
+39                                      
+40                                      # until that is never entered (true branch only)
+41             1                        my $Always = 1;
+42             1                        until ($Always) {
+43    ***     *0                          $Always--;
+44                                      }
+45                                      
+46    ***      1   * 50                 die "i: $I"           unless $I == 3;
+47    ***      1   * 50                 die "j: $J"           unless $J == 3;
+48    ***      1   * 50                 die "sum: $Sum"       unless $Sum == 3;
+49    ***      1   * 50                 die "never: $Never"   unless $Never == 0;
+50    ***      1   * 50                 die "always: $Always" unless $Always == 1;
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+46    ***     50      0      1   unless $I == 3
+47    ***     50      0      1   unless $J == 3
+48    ***     50      0      1   unless $Sum == 3
+49    ***     50      0      1   unless $Never == 0
+50    ***     50      0      1   unless $Always == 1
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count Location               
+---------- ----- -----------------------
+BEGIN          1 tests/loop_condition:13
+BEGIN          1 tests/loop_condition:14
+
+

--- a/test_output/cover/padrange2.5.020000
+++ b/test_output/cover/padrange2.5.020000
@@ -4,8 +4,8 @@ Reading database from ...
 --------------- ------ ------ ------ ------ ------
 File              stmt   bran   cond    sub  total
 --------------- ------ ------ ------ ------ ------
-tests/padrange2  100.0   50.0    n/a  100.0   92.8
-Total            100.0   50.0    n/a  100.0   92.8
+tests/padrange2  100.0   75.0    n/a  100.0   93.7
+Total            100.0   75.0    n/a  100.0   93.7
 --------------- ------ ------ ------ ------ ------
 
 
@@ -32,7 +32,7 @@ line  err   stmt   bran   cond    sub   code
 8                                       }
 9                                       
 10             1                        my %h = (a => 1, b => 2);
-11             1                        while (my ($k, $v) = each %h) {
+11             1    100                 while (my ($k, $v) = each %h) {
 12             2                          print "$k $v\n";
 13                                      }
 
@@ -43,6 +43,7 @@ Branches
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
 6     ***     50      1      0   if (() = 'foo' =~ /(.)/) { }
+11           100      2      1   if (() = each %h)
 
 
 Covered Subroutines

--- a/test_output/cover/padrange2.5.022000
+++ b/test_output/cover/padrange2.5.022000
@@ -4,8 +4,8 @@ Reading database from ...
 --------------- ------ ------ ------ ------ ------
 File              stmt   bran   cond    sub  total
 --------------- ------ ------ ------ ------ ------
-tests/padrange2  100.0   50.0    n/a  100.0   92.8
-Total            100.0   50.0    n/a  100.0   92.8
+tests/padrange2  100.0   75.0    n/a  100.0   93.7
+Total            100.0   75.0    n/a  100.0   93.7
 --------------- ------ ------ ------ ------ ------
 
 
@@ -32,7 +32,7 @@ line  err   stmt   bran   cond    sub   code
 8                                       }
 9                                       
 10             1                        my %h = (a => 1, b => 2);
-11             1                        while (my ($k, $v) = each %h) {
+11             1    100                 while (my ($k, $v) = each %h) {
 12             2                          print "$k $v\n";
 13                                      }
 
@@ -43,6 +43,7 @@ Branches
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
 6     ***     50      1      0   if (my(@x) = 'foo' =~ /(.)/) { }
+11           100      2      1   if (() = each %h)
 
 
 Covered Subroutines

--- a/test_output/cover/uncoverable_error.5.020000
+++ b/test_output/cover/uncoverable_error.5.020000
@@ -4,8 +4,8 @@ Reading database from ...
 ----------------------- ------ ------ ------ ------ ------
 File                      stmt   bran   cond    sub  total
 ----------------------- ------ ------ ------ ------ ------
-tests/uncoverable_error   82.3   62.5   83.3  100.0   78.7
-Total                     82.3   62.5   83.3  100.0   78.7
+tests/uncoverable_error   82.3   70.0   83.3  100.0   80.0
+Total                     82.3   70.0   83.3  100.0   80.0
 ----------------------- ------ ------ ------ ------ ------
 
 
@@ -56,7 +56,7 @@ line  err   stmt   bran   cond    sub   code
 36            -0                                $y = 1;
 37                                          }
 38                                      
-39             1                            while ($y < 4) {
+39             1    100                     while ($y < 4) {
 40                                              # uncoverable branch false
 41                                              # uncoverable condition left
 42                                              # uncoverable condition right
@@ -83,6 +83,7 @@ line  err      %   true  false   branch
 20          - 50     -0     -1   if ($x > 1)
 24    ***      0      0      0   if ($x > 3)
 34          - 50     -0      1   if ($x > 0 and $y > 0)
+39           100      2      1   if ($y < 4)
 43    ***   -100      1     -1   if ($x > 0 and $y > 0) { }
 
 

--- a/test_output/cover/uncoverable_error_ignore.5.020000
+++ b/test_output/cover/uncoverable_error_ignore.5.020000
@@ -4,8 +4,8 @@ Reading database from ...
 ------------------------------ ------ ------ ------ ------ ------
 File                             stmt   bran   cond    sub  total
 ------------------------------ ------ ------ ------ ------ ------
-tests/uncoverable_error_ignore   82.3   75.0   66.6  100.0   78.7
-Total                            82.3   75.0   66.6  100.0   78.7
+tests/uncoverable_error_ignore   82.3   80.0   66.6  100.0   80.0
+Total                            82.3   80.0   66.6  100.0   80.0
 ------------------------------ ------ ------ ------ ------ ------
 
 
@@ -56,7 +56,7 @@ line  err   stmt   bran   cond    sub   code
 36            -0                                $y = 1;
 37                                          }
 38                                      
-39             1                            while ($y < 4) {
+39             1    100                     while ($y < 4) {
 40                                              # uncoverable branch false
 41                                              # uncoverable condition left
 42                                              # uncoverable condition right
@@ -83,6 +83,7 @@ line  err      %   true  false   branch
 22          - 50     -0     -1   if ($x > 1)
 26    ***      0      0      0   if ($x > 3)
 34          - 50     -0      1   if ($x > 0 and $y > 0)
+39           100      2      1   if ($y < 4)
 43          -100      1     -1   if ($x > 0 and $y > 0) { }
 
 

--- a/tests/loop_condition
+++ b/tests/loop_condition
@@ -43,8 +43,20 @@ until ($Always) {
   $Always--;
 }
 
+# compound condition - branch and condition coverage
+my $X     = 1;
+my $Y     = 1;
+my $Count = 0;
+while ($X && $Y) {
+  $Count++;
+  $Y = 0 if $Count >= 2;
+}
+
 die "i: $I"           unless $I == 3;
 die "j: $J"           unless $J == 3;
 die "sum: $Sum"       unless $Sum == 3;
 die "never: $Never"   unless $Never == 0;
 die "always: $Always" unless $Always == 1;
+die "count: $Count"   unless $Count == 2;
+die "x: $X"           unless $X == 1;
+die "y: $Y"           unless $Y == 0;

--- a/tests/loop_condition
+++ b/tests/loop_condition
@@ -1,0 +1,50 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Branch coverage for block-form loop conditions.
+# See GH-449.
+
+use strict;
+use warnings;
+
+# while - true and false branches
+my $I = 0;
+while ($I < 3) {
+  $I++;
+}
+
+# until - true and false branches
+my $J = 0;
+until ($J >= 3) {
+  $J++;
+}
+
+# C-style for - true and false branches
+my $Sum = 0;
+for (my $k = 0; $k < 3; $k++) {
+  $Sum += $k;
+}
+
+# while that is never entered (false branch only)
+my $Never = 0;
+while ($Never) {
+  $Never++;
+}
+
+# until that is never entered (true branch only)
+my $Always = 1;
+until ($Always) {
+  $Always--;
+}
+
+die "i: $I"           unless $I == 3;
+die "j: $J"           unless $J == 3;
+die "sum: $Sum"       unless $Sum == 3;
+die "never: $Never"   unless $Never == 0;
+die "always: $Always" unless $Always == 1;


### PR DESCRIPTION
## Summary

Block-form while, until and C-style for loop conditions were not getting branch coverage, even though they are genuine branches (true = enter/continue body, false = exit loop). Statement-modifier while/until and do-while/do-until forms were already covered, making this an inconsistency.

## Changes

- Remove the leaveloop guard in `_walk_logop` that silently skipped loop condition logops.
- Detect loop conditions via the leaveloop parent chain and force statement-form classification, ensuring clean labels (e.g. `if ($I < 3)` rather than `$I < 3 and do { ... }`) on Perl 5.43.8+ where the `OPpSTATEMENT` flag is not set on loop condition ops.
- Add e2e test exercising while, until, C-style for, never-entered loops and compound conditions.
- Update golden files for padrange2, uncoverable_error and uncoverable_error_ignore which contain while loops that now produce branch coverage.

## Implications

- Coverage numbers will change for any code containing block-form while, until or C-style for loops. Branch counts will increase and overall percentages may shift.
- This is a prerequisite for computing cyclomatic complexity during coverage collection, since loop conditions are CC decision points.

## Issue

Closes #449