### PR TITLE
Add SLOP risk scoring to coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Devel-Cover-*
 callgrind.out.*
 staging/
 queue.db
+.claude/plans/

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -28,7 +28,7 @@ color-severity-lowest = cyan
 
 
 # Map blocks should have a single statement.
-[BuiltinFunctions::ProhibitComplexMappings]
+[-BuiltinFunctions::ProhibitComplexMappings]
 # set_themes                         = complexity core maintenance pbp
 # add_themes                         =
 # severity                           = 3

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -14,7 +14,6 @@
 --space-signature-paren=2              # space before signature parentheses
 --keyword-paren-inner-tightness=0      # space inside keyword parentheses
 --keyword-paren-inner-tightness-list="qw"  # only for qw
---qw-as-function                       # format inside qw
 --break-open-compact-parens=*          # always leave parens open
 
 --space-backslash-quote=0              # no space between backslash and quote
@@ -54,7 +53,6 @@
 --delete-trailing-commas               # delete trailing commas
 --delete-weld-interfering-commas       # delete commas that interfere with welds
 
---multiple-token-tightness=q*          # no space in [qw( and friends
 --trim-pod                             # trim POD trailing whitespace
 --delete-interbracket-arrows           # delete arrows between brackets
 

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -10,6 +10,7 @@
 --no-outdent-long-comments             # don't outdent long comments
 
 --paren-tightness=2                    # keep parentheses tight
+--square-bracket-tightness=2           # keep square brackets tight
 --space-prototype-paren=2              # space before prototype parentheses
 --space-signature-paren=2              # space before signature parentheses
 --keyword-paren-inner-tightness=0      # space inside keyword parentheses
@@ -48,7 +49,7 @@
 --novalign-if-unless                   # vertically align if and unless
 
 --delete-repeated-commas               # delete repeated commas
---want-trailing-commas="(m [m {m"      # trailing commas in multiline lists
+--want-trailing-commas="(b [b {b"      # trailing commas in bare lists
 --add-trailing-commas                  # add trailing commas
 --delete-trailing-commas               # delete trailing commas
 --delete-weld-interfering-commas       # delete commas that interfere with welds

--- a/Cover.xs
+++ b/Cover.xs
@@ -1862,6 +1862,17 @@ static void dc_walk_ops_r(pTHX_ OP *op, SV *callback, CV *cv, HV *parent_map) {
       dc_walk_callback(aTHX_ op, callback, "xor", cv);
       break;
 
+#if PERL_VERSION >= 26
+    case OP_ARGDEFELEM:
+      dc_walk_callback(aTHX_ op, callback, "argdefelem", cv);
+      break;
+#endif
+#if PERL_VERSION >= 43
+    case OP_PARAMTEST:
+      dc_walk_callback(aTHX_ op, callback, "argdefelem", cv);
+      break;
+#endif
+
     case OP_NULL:
       if (op->op_targ == OP_NEXTSTATE || op->op_targ == OP_DBSTATE) {
         /*

--- a/Cover.xs
+++ b/Cover.xs
@@ -1846,8 +1846,9 @@ static void dc_walk_ops_r(pTHX_ OP *op, SV *callback, CV *cv, HV *parent_map) {
     case OP_AND:
     case OP_OR:
     case OP_DOR:
-      /* Skip loop-internal logops (e.g. AND inside for) */
-      if (cLOGOPx(op)->op_first->op_type != OP_ITER)
+      if (cLOGOPx(op)->op_first->op_type == OP_ITER)
+        dc_walk_callback(aTHX_ op, callback, "iter", cv);
+      else
         dc_walk_callback(aTHX_ op, callback, "logop", cv);
       break;
 

--- a/bin/cover
+++ b/bin/cover
@@ -83,7 +83,7 @@ sub get_options () {
     unless GetOptions(
       $Options,  # Store the options in the Options hash.
       "write:s" => sub ($, $val) {
-        @$Options{ qw( write summary ) } = ($val, 0)
+        @$Options{qw( write summary )} = ($val, 0)
       },
       #<<<
       qw(
@@ -475,6 +475,8 @@ sub manage_dbs ($dbname, $test_result) {
   $Options->{show}        = { map { $_ => 1 } $Options->{coverage}->@* };
   $Options->{show}{total} = 1 if keys %{ $Options->{show} };
 
+  $read_structure->();
+  $db->set_structure($structure);
   $db->calculate_summary(map { $_ => 1 } $Options->{coverage}->@*);
 
   print "\n\n" unless $Options->{silent};

--- a/docs/technical/slop.md
+++ b/docs/technical/slop.md
@@ -1,0 +1,524 @@
+# SLOP: Scaled Likelihood Of Problems
+
+SLOP is Devel::Cover's risk-scoring metric. It combines cyclomatic complexity
+and code coverage into a single number that answers: "where should I spend my
+testing effort?" This document records the research, the decisions, and the
+design.
+
+## Motivation
+
+Coverage percentages tell you how much of a file is tested, but not how
+dangerous the untested parts are. A file at 80% coverage could be low risk (the
+missing 20% is simple, linear code) or high risk (the missing 20% contains
+deeply nested logic with many branches). A single metric combining complexity
+and coverage answers: "which files most need attention?"
+
+## Literature Review
+
+### McCabe's Cyclomatic Complexity (1976)
+
+Thomas McCabe's seminal paper ["A Complexity Measure"][mccabe] (IEEE TSE,
+SE-2(4), pp. 308-320) defines cyclomatic complexity as a property of the control
+flow graph:
+
+```text
+v(G) = e - n + 2p
+```
+
+where e = edges, n = nodes, p = connected components. For a single subroutine (p
+= 1) this simplifies to `e - n + 2`.
+
+### [NIST SP 500-235][nist]: Structured Testing (Watson & McCabe, 1996)
+
+The authoritative practical guide. Provides the counting rule that most tools
+implement:
+
+> "If all decisions are binary and there are p binary decision predicates, v(G)
+> = p + 1."
+
+Section 4.1 (p. 25) explicitly addresses short-circuit operators:
+
+> "Boolean operators add either one or nothing to complexity, depending on
+> whether they have short-circuit evaluation semantics that can lead to
+> conditional execution of side-effects."
+
+In Perl, `&&`, `||`, `//`, `and`, `or` all use short-circuit evaluation, so each
+adds +1 to CC. The NIST document also covers loops (each loop condition is a
+decision point with two outgoing edges) and ternary operators (equivalent to
+if-else).
+
+### [The CRAP Metric][crap] (Savoia & Evans, 2007)
+
+CRAP (Change Risk Anti-Patterns) is the only published, widely adopted formula
+that combines complexity and coverage into a risk score:
+
+```text
+CRAP(m) = CC(m)^2 * (1 - cov(m)/100)^3 + CC(m)
+```
+
+The formula is multiplicative: complex code with low coverage is far riskier
+than either factor alone. The exponents make it non-linear - a method with CC=10
+and 0% coverage scores 110 (10^2 + 10), whilst at 100% coverage it scores just
+10\.
+
+The CRAP threshold of 30 is the accepted "unacceptable" boundary. At CC=10, you
+need at least 42% coverage to stay below it. At CC=25, you need 80%.
+
+### Other Relevant Research
+
+- **Malaiya & Denton (1999)** -
+  ["Estimating Defect Density Using Test Coverage"][malaiya]. Log-Poisson model
+  showing coverage predicts residual defects.
+- **Elbaum et al. (2002)** - ["Test Case Prioritization"][elbaum] (IEEE TSE).
+  APFD metric for coverage-based prioritisation.
+- **Nagappan & Ball (2005)** - ["Relative Code Churn"][nagappan] (ICSE). Churn
+  predicts defects at 89% accuracy. This informed the decision to not pursue
+  VCS-integration approaches (option 7 below) - powerful but unavailable when
+  running coverage on a CPAN distribution, which has no VCS history.
+- **Felderer & Schieferdecker (2014)** -
+  ["Taxonomy of Risk-Based Testing"][felderer]. Classification of risk-based
+  approaches in testing.
+
+## Survey of Other Coverage Tools
+
+An investigation of 10 coverage tools across different ecosystems found almost
+none compute a composite risk score:
+
+| Tool               | Risk score?   | Approach                      |
+| ------------------ | ------------- | ----------------------------- |
+| Istanbul/nyc (JS)  | No            | Raw percentages only          |
+| JaCoCo (Java)      | No            | CRAP requested 2014, declined |
+| Coverage.py        | No            | `--sort=miss` by missed count |
+| gcov/lcov          | No            | `--missed --sort` by count    |
+| SimpleCov (Ruby)   | No            | Percentages only              |
+| **PHPUnit**        | **Yes: CRAP** | Per-method CRAP score         |
+| **NDepend (.NET)** | **Yes: CRAP** | Per-method CRAP + PageRank    |
+| SonarQube          | Indirect      | Tech debt ratio, coverage sep |
+| Codecov/Coveralls  | No            | Manual "critical file" labels |
+| **OtterWise**      | **Yes: CRAP** | Per-method CRAP score         |
+
+The only published, widely adopted coverage-based risk formula is CRAP. Most
+tools report raw numbers and let users sort by percentage or missed count.
+PHPUnit and NDepend are the two most prominent implementations.
+
+## Options Considered
+
+Seven approaches were evaluated before settling on CRAP + SLOP:
+
+### Option 1: Missed count
+
+`risk = missed_statements + missed_branches + missed_conditions`. What lcov's
+`--sort=miss` does. Simple, size-weighted, and directly answers "where would
+adding tests have the most impact?" - but has no published backing as a risk
+metric, and does not capture the interaction between complexity and coverage.
+
+### Option 2: Weighted missed count
+
+Like option 1 but with configurable weights per criterion (e.g.
+`W_s=1, W_b=2, W_c=2, W_u=1`). Acknowledges that branch gaps are more
+consequential than statement misses, but the default weights are an opinion with
+no empirical basis, and adding user-configurable knobs is undesirable.
+
+### Option 3: CRAP (chosen)
+
+The standard formula from Savoia & Evans. Well-studied, widely adopted, captures
+the key insight that complex + untested = risky. Non-linear: punishes the
+combination more than either factor alone. Cyclomatic complexity, which CRAP
+requires, is computed during the optree walk.
+
+### Option 4: CRAP-lite
+
+Approximates CC as `total_branch_points + 1`, avoiding the need for real CC
+computation. Rejected because genuine CC turned out to be straightforward to
+compute during the existing walk, and the approximation misses `foreach` loops
+and `while`/`until`/`for` loops (whose branch points are suppressed by
+Devel::Cover's leaveloop guard).
+
+### Option 5: Normalised coverage gap
+
+A weighted average of uncovered fractions per criterion, ranging from 0 to
+sum(weights). Size-blind: a 5-line file at 0% scores the same as a 5000-line
+file at 0%. If the goal is "where to spend effort", size matters.
+
+### Option 6: Geometric mean of uncovered fractions
+
+`risk = (u_stmt * u_branch * u_cond * u_sub) ^ (1/4)`. Naturally penalises
+weakness on any single criterion, but if any criterion is 100% covered the
+entire product becomes 0 regardless of the others. Size-blind, no published
+backing.
+
+### Option 7: Change-frequency weighted
+
+`risk = commits_in_last_N_months * (1 - coverage / 100)`. Based on Nagappan &
+Ball (ICSE 2005) - empirically the strongest predictor of actual defects.
+However, it requires VCS history, which is unavailable when running coverage on
+a CPAN distribution and is a significant new feature beyond a formula change.
+
+### Comparison
+
+| Option          | Available? | Size-aware? | Published? | Complexity |
+| --------------- | ---------- | ----------- | ---------- | ---------- |
+| 1 Missed count  | Yes        | Yes         | No\*       | Trivial    |
+| 2 Weighted miss | Yes        | Yes         | No         | Low        |
+| 3 CRAP          | Yes        | Yes         | Yes        | Medium     |
+| 4 CRAP-lite     | Yes        | Yes         | Approx     | Medium     |
+| 5 Normalised    | Yes        | No          | No         | Low        |
+| 6 Geometric     | Yes        | No          | No         | Low        |
+| 7 Churn-based   | No (VCS)   | Yes         | Yes        | High       |
+
+\* lcov uses missed count for sorting but does not call it "risk".
+
+## Why CRAP, and Why SLOP
+
+CRAP was the clear winner: it is the only published, peer-reviewed, widely
+adopted coverage-based risk formula. It required cyclomatic complexity, which
+Devel::Cover did not previously compute, but the existing optree walk provided a
+natural place to count decision points with minimal new code.
+
+However, CRAP has a usability problem: its range is enormous. A simple method
+with CC=1 at 100% coverage scores 1. A complex method with CC=50 at 0% coverage
+scores 2,550. Even moderate codebases can produce scores in the tens or even
+hundreds of thousands. This makes it difficult to scan a table and quickly
+assess relative risk.
+
+SLOP compresses this range using a natural logarithm:
+
+```text
+slop = crap > 1 ? ln(crap) * 10 : 0
+```
+
+This maps the CRAP range of approximately 1-20,000 to roughly 0-100. Each +10
+SLOP represents approximately 2.7x worse CRAP (one e-fold). The standard CRAP
+threshold of 30 maps to SLOP ~34.
+
+The name "Scaled Likelihood Of Problems" was chosen to:
+
+- Describe what it measures (likelihood of problems, scaled for readability)
+- Be memorable and slightly irreverent (like CRAP itself)
+- Distinguish it from raw CRAP in reports and documentation
+
+### Display strategy
+
+SLOP is the primary displayed value in all reports. Raw CRAP remains accessible
+in Html_crisp tooltips for users who want the standard metric. This gives the
+best of both worlds: a scannable, bounded number in the table, with the
+published metric one hover away.
+
+## Architectural Placement
+
+Risk scoring is computed in `DB::calculate_summary` (via `summarise_complexity`)
+rather than in individual reporters. This means all reporters and CLI tools get
+SLOP data for free without duplicating the formula. The DB layer gains an
+opinion about what "risk" means, but the alternative - each reporter computing
+its own risk - leads to duplication and divergence. A shared utility module was
+considered but adds indirection for no practical benefit when there is exactly
+one formula.
+
+## Computing Cyclomatic Complexity
+
+### NIST counting rules for Perl
+
+The NIST SP 500-235 counting rules, applied to Perl constructs:
+
+| Construct             | CC  | Reason (per NIST)            |
+| --------------------- | --- | ---------------------------- |
+| `if`                  | +1  | 2 outgoing edges             |
+| `elsif`               | +1  | additional decision          |
+| `else`                | 0   | not a new decision           |
+| `unless`              | +1  | equivalent to `if`           |
+| `while` / `until`     | +1  | loop condition               |
+| `for` (C-style)       | +1  | condition check              |
+| `foreach` / `for-in`  | +1  | implicit "more items?" check |
+| `do {} while/until`   | +1  | bottom-test condition        |
+| short-circuit logical | +1  | `&&` `and` `or` `//` etc.    |
+| short-circuit assign  | +1  | `&&=` `//=` etc.             |
+| `? :` (ternary)       | +1  | equivalent to if-else        |
+| `xor`                 | +1  | decision node                |
+| `try`/`catch`         | 0   | not a source decision        |
+
+Note that `else` does **not** contribute. The `if` already has two outgoing
+edges; the else is simply one of those edges.
+
+`foreach` counts because at the CFG level there is a decision node with two
+outgoing edges: "more elements - enter body" vs "exhausted - exit loop". This is
+structurally identical to a `while` loop. McCabe's 1976 paper and NIST SP
+500-235 do not mention `foreach` by name (the construct did not exist in the
+languages of the era), but the graph-theoretic definition is unambiguous.
+
+### CC in other Perl tools
+
+Two CPAN modules compute CC. Both describe themselves as approximations, and
+each makes different trade-offs against the NIST definition.
+
+**Perl::Critic::Utils::McCabe** counts keywords (`if`, `else`, `elsif`,
+`unless`, `until`, `while`, `for`, `foreach`) and operators (`&&`, `||`, `?`,
+`and`, `or`, `xor`, `&&=`, `||=`, `<<=`, `>>=`). Differences from NIST: it
+includes `else` (not a decision per NIST - the `if` already has two edges) and
+the bit-shift assigns `<<=`/`>>=`, but omits `//` and `//=`.
+
+**Perl::Metrics::Simple** uses a broader token set including comparison
+operators (`eq`, `==`, `cmp`, etc.), flow control (`next`, `last`, `goto`), list
+ops (`grep`, `map`), and negation (`!`, `not`, `!~`). This captures a wider
+notion of "complexity" than the strict CFG-based NIST definition; the additional
+tokens are not decision points in the control flow graph but may reflect
+cognitive complexity.
+
+For example, given this subroutine:
+
+```perl
+sub config {
+    my $host = shift // "localhost";  # short-circuit
+    my $port = shift // 8080;         # short-circuit
+    if ($port > 1024) {               # two edges
+        return "$host:$port";
+    } else {                          # not a new decision
+        die "privileged port";
+    }
+}
+```
+
+| Tool                  | CC  | Counts                       |
+| --------------------- | --- | ---------------------------- |
+| NIST definition       | 4   | 2x // + if + base            |
+| Perl::Critic          | 3   | if + else + base (misses //) |
+| Perl::Metrics::Simple | 6   | if + else + 2x // + >        |
+| Devel::Cover          | 4   | 2x // + if + base            |
+
+Perl::Critic under-counts because `//` is not in its operator set, and
+over-counts because it includes `else`. Here the two errors partially cancel.
+Perl::Metrics::Simple counts the `>` comparison, which is not a control flow
+decision.
+
+Each tool serves a different purpose. Perl::Critic's approximation works well
+for its policy checks. Perl::Metrics::Simple's broader count reflects
+readability concerns. For CRAP scoring, the strict NIST definition is the right
+choice because the formula's exponents amplify any inflation in the CC value.
+
+### Counting during the optree walk
+
+Devel::Cover already walks the Perl optree for every subroutine during coverage
+collection. The XS walker (`dc_walk_ops_r` in Cover.xs) fires callbacks for op
+types that map directly to CC decision points. The CC counter in
+`_get_cover_walk` (lib/Devel/Cover.pm) simply increments a `$decisions` counter
+for each decision-type callback:
+
+| Callback type | Perl constructs                  | CC  |
+| ------------- | -------------------------------- | --- |
+| `cond_expr`   | if/elsif/ternary                 | +1  |
+| `logop`       | `&&` `and` `or` `//` while/until | +1  |
+| `logassignop` | `&&=` `//=` etc.                 | +1  |
+| `xor`         | xor/^^                           | +1  |
+| `iter`        | foreach loops (XS callback)      | +1  |
+| `argdefelem`  | signature defaults (5.26+/5.43+) | +1  |
+
+CC = `$decisions + 1` (the "+1" is the base path through the subroutine).
+
+The `iter` and `argdefelem` callbacks required XS changes; see "Loop conditions
+and the OP_ITER distinction" below for details.
+
+Signature defaults (`OP_ARGDEFELEM` on 5.26+, `OP_PARAMTEST` on 5.43+) are
+counted because each default is a conditional: "was an argument supplied? if
+not, use the default". This creates a decision point in the control flow graph.
+
+### Loop conditions and the OP_ITER distinction
+
+The XS walker (Cover.xs) originally suppressed the callback for logops whose
+first child is `OP_ITER`:
+
+```c
+if (cLOGOPx(op)->op_first->op_type != OP_ITER)
+    dc_walk_callback(aTHX_ op, callback, "logop", cv);
+```
+
+This meant `foreach` loops were invisible to the CC counter. A new `"iter"`
+callback type was added to count them.
+
+Block-form `while`, `until`, and C-style `for` loops compile to logops whose
+first child is the condition expression (not `OP_ITER`). These pass through the
+XS walker and fire `"logop"` callbacks. However, the Perl-level `_walk_logop`
+discards them when the parent is a `leaveloop` op (to avoid double-counting with
+branch coverage). The CC counter in `_get_cover_walk` increments `$decisions`
+before `_walk_logop` is called, so these loops are correctly included in CC even
+though they may not generate branch coverage entries.
+
+Summary of loop construct handling:
+
+| Construct              | CC? | Branch? | Notes           |
+| ---------------------- | --- | ------- | --------------- |
+| `while (COND) {}`      | Yes | No      | leaveloop guard |
+| `until (COND) {}`      | Yes | No      | leaveloop guard |
+| `for (INIT;COND;INCR)` | Yes | No      | leaveloop guard |
+| `foreach my $x (@l)`   | Yes | No      | iter callback   |
+| `do {} while (COND)`   | Yes | Yes     | parent=leave    |
+| `EXPR while COND`      | Yes | Yes     | parent=leave    |
+| `while (1) {}`         | No  | N/A     | constant-folded |
+
+### Per-subroutine vs per-file granularity
+
+CC is computed per-subroutine rather than per-file. Per-sub granularity costs
+little extra (the walk already processes one CV at a time) and enables proper
+per-method CRAP scoring as PHPUnit does, plus per-sub detail in the subroutine
+coverage section.
+
+## The Formulae
+
+### CRAP
+
+```text
+CRAP(m) = CC(m)^2 * (1 - cov(m)/100)^3 + CC(m)
+```
+
+Where:
+
+- CC(m) is the cyclomatic complexity of subroutine m
+- cov(m) is the combined statement+branch+condition coverage percentage
+
+At 100% coverage, CRAP equals CC (complexity alone). At 0% coverage, CRAP equals
+CC^2 + CC. The cubic exponent on the coverage gap makes the penalty steep: going
+from 90% to 80% coverage hurts much more than going from 50% to 40%.
+
+### SLOP
+
+```text
+slop = crap > 1 ? ln(crap) * 10 : 0
+```
+
+The minimum possible CRAP score is 1 (a subroutine with CC=1 at 100% coverage:
+1^2 * 0^3 + 1 = 1). Since ln(1) = 0, SLOP is zero for a perfect score. The `> 1`
+guard makes this explicit and avoids any floating-point edge cases near the
+boundary. The factor of 10 scales the range to roughly 0-100.
+
+### Coverage for CRAP
+
+The original CRAP paper specifies basis path coverage - exercising a basis set
+of linearly independent paths through the control flow graph. In practice, no
+major implementation uses this. PHPUnit and GMetrics use line coverage; NDepend
+uses branch/statement coverage. CPAN distributions have no basis path coverage
+tool available.
+
+Devel::Cover uses combined statement, branch, and condition coverage for lines
+within the subroutine's start and end lines:
+
+```perl
+for my $name (qw( statement branch condition )) {
+    # sum $covered and $total across lines $start..$end
+}
+$total ? 100 * $covered / $total : 100
+```
+
+This is stronger than line coverage alone (the most common substitute) but
+weaker than full basis path coverage. A subroutine with no coverable points
+(e.g. a constant) gets 100%.
+
+## Colour Thresholds
+
+The `slop_class` function maps SLOP values to the existing c0-c3 CSS classes
+used throughout Devel::Cover for coverage colouring. The thresholds are
+log-transforms of established CRAP boundaries:
+
+| SLOP range | CSS class | CRAP equivalent | Meaning        |
+| ---------- | --------- | --------------- | -------------- |
+| < 16       | c3        | < 5             | Low risk       |
+| 16-34      | c2        | 5-30            | Moderate risk  |
+| 34-41      | c1        | 30-60           | High risk      |
+| >= 41      | c0        | >= 60           | Very high risk |
+
+The CRAP threshold of 30 (the accepted "unacceptable" boundary) maps to SLOP
+~34, sitting at the c2/c1 boundary.
+
+## Aggregation Levels
+
+CRAP is defined per-subroutine, but developers need risk scores at multiple
+levels. The aggregation strategy:
+
+### Per-subroutine
+
+The CRAP formula applied directly. This is the canonical level.
+
+### Per-file
+
+File CC is computed as `sum(sub CCs) - count + 1`. The subtraction avoids
+double-counting the base paths: if a file has three subroutines with CC 3, 5,
+and 2, the file CC is `(3+5+2) - 3 + 1 = 8` rather than `10`. File coverage is
+the combined statement+branch+condition coverage from the summary. File CRAP and
+SLOP follow from these.
+
+### Per-directory
+
+Same approach as per-file but aggregating across all files in the directory.
+
+### Module-level (Total)
+
+Treats the entire codebase as one body. Module CC is
+`sum(all sub CCs) - total count + 1`. Module coverage is the combined coverage
+from the Total summary. This is useful as a progress tracker: the same codebase
+measured over time, so the size sensitivity is a feature. Improving coverage or
+reducing complexity both lower the score.
+
+## Report Display
+
+### Text report
+
+CC and SLOP columns appear in the subroutine detail section, showing per-sub
+values alongside the subroutine name and line number.
+
+### Html_crisp report
+
+- **Index page**: SLOP column in the file table, sortable. Tooltips show a
+  frosted-glass popup with the top SLOP subroutines and their raw CRAP scores.
+- **Top SLOP section**: Highlights the highest-SLOP files with inline pills.
+- **Module badge**: A neutral stat-badge in the header showing the module-level
+  SLOP score.
+- **Directory rows**: Directory total rows include SLOP with tooltips.
+- **File pages**: Per-line SLOP detail in the subroutine section.
+
+## Key Files
+
+| File                                   | Role                             |
+| -------------------------------------- | -------------------------------- |
+| `lib/Devel/Cover.pm`                   | CC counting in `_get_cover_walk` |
+| `Cover.xs`                             | XS walker callbacks              |
+| `lib/Devel/Cover/DB.pm`                | CRAP/SLOP formulae, aggregation  |
+| `lib/Devel/Cover/DB/Structure.pm`      | CC and end-line storage          |
+| `lib/Devel/Cover/Report/Text.pm`       | Text report CC/SLOP columns      |
+| `lib/Devel/Cover/Report/Html_crisp.pm` | HTML report, tooltips            |
+| `lib/Devel/Cover/Web.pm`               | Shared CSS and tooltip base      |
+| `bin/cover`                            | Structure wiring in `manage_dbs` |
+
+## References
+
+1. T. J. McCabe, ["A Complexity Measure,"][mccabe] in *IEEE Transactions on
+   Software Engineering*, vol. SE-2, no. 4, pp. 308-320, Dec. 1976.
+
+2. A. H. Watson and T. J. McCabe,
+   ["Structured Testing: A Testing Methodology Using the Cyclomatic Complexity Metric,"][nist]
+   NIST Special Publication 500-235, Aug. 1996.
+
+3. A. Savoia, ["Pardon My French, But This Code Is C.R.A.P.,"][crap] Artima
+   Developer, Jul. 2007.
+
+4. Y. K. Malaiya and J. Denton,
+   ["Estimating Defect Density Using Test Coverage,"][malaiya] Technical Report
+   CS-98-104, Colorado State University, 1999.
+
+5. S. Elbaum, A. G. Malishevsky, and G. Rothermel,
+   ["Test Case Prioritization: A Family of Empirical Studies,"][elbaum] in *IEEE
+   Transactions on Software Engineering*, vol. 28, no. 2, pp. 159-182, Feb.
+   2002\.
+
+6. N. Nagappan and T. Ball,
+   ["Use of Relative Code Churn Measures to Predict System Defect Density,"][nagappan]
+   in *Proc. 27th International Conference on Software Engineering (ICSE)*, St.
+   Louis, MO, May 2005, pp. 284-292.
+
+7. M. Felderer and I. Schieferdecker,
+   ["A Taxonomy of Risk-Based Testing,"][felderer] in *Int. J. Softw. Tools
+   Technol. Transfer*, vol. 16, pp. 559-568, 2014.
+
+[crap]: https://www.artima.com/weblogs/viewpost.jsp?thread=210575
+[elbaum]: https://digitalcommons.unl.edu/cgi/viewcontent.cgi?article=1018&context=csearticles
+[felderer]: https://arxiv.org/abs/1912.11519
+[malaiya]: https://scispace.com/pdf/estimating-defect-density-using-test-coverage-5141799zod.pdf
+[mccabe]: http://www.literateprogramming.com/mccabe.pdf
+[nagappan]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/icse05churn.pdf
+[nist]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication500-235.pdf

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1283,14 +1283,17 @@ sub get_cover ($cv, $root = undef) {
 
   my $sub_id = _add_subroutine_structure($cv, $start);
 
-  my $cc;
+  my ($cc, $end_line);
   if ($Use_deparse) {
     _get_cover_deparse($cv, $root);
   } else {
-    $cc = _get_cover_walk($cv, $root);
+    ($cc, $end_line) = _get_cover_walk($cv, $root);
   }
 
-  $Structure->set_complexity($sub_id, $cc) if $sub_id && defined $cc;
+  if ($sub_id && defined $cc) {
+    $Structure->set_complexity($sub_id, $cc);
+    $Structure->set_end_line($sub_id, $end_line) if defined $end_line;
+  }
 }
 
 sub _get_cover_deparse ($cv, $root) {
@@ -1636,11 +1639,13 @@ sub _get_cover_walk ($cv, $root) {
   my $op = $root || $cv->ROOT;
   return unless $$op;
   my $decisions = 0;
+  my $max_line  = $Line // 0;
   walk_ops(
     $op,
     sub ($op, $type, $cv_ref) {
       if ($type eq "statement" || $type eq "null_statement") {
         _walk_statement($op, $type);
+        $max_line = $Line if defined $Line && $Line > $max_line;
       } elsif ($type eq "cond_expr") {
         $decisions++;
         _walk_cond_expr($cv_ref, $op);
@@ -1660,7 +1665,7 @@ sub _get_cover_walk ($cv, $root) {
     $cv,
     \%Parent_map,
   );
-  $decisions + 1
+  ($decisions + 1, $max_line)
 }
 
 sub _report_progress ($msg, $code, @items) {

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -679,7 +679,7 @@ EOM
 }
 
 sub _report {
-  local @SIG{ qw( __DIE__ __WARN__ ) };
+  local @SIG{qw( __DIE__ __WARN__ )};
 
   $Run{finish} = get_elapsed() / 1e6;
 
@@ -1256,6 +1256,7 @@ sub _want_cover_for {
 sub _add_subroutine_structure ($cv, $start) {
   return unless $start;
   no warnings "uninitialized";
+  my $sub_id;
   if (
        $File eq $Structure->get_file
     && $Line == $Structure->get_line
@@ -1266,11 +1267,12 @@ sub _add_subroutine_structure ($cv, $start) {
     # TODO - multiple anonymous subs on the same line
   } else {
     my $count = $Sub_count->{$File}{$Line}{$Sub_name}++;
-    $Structure->set_subroutine($Sub_name, $File, $Line, $count);
+    $sub_id = $Structure->set_subroutine($Sub_name, $File, $Line, $count);
     add_subroutine_cover($start)
       if $Coverage{subroutine} || $Coverage{pod};  # pod requires subs
   }
   _add_pod_cover($cv) if $Pod && $Coverage{pod};
+  $sub_id
 }
 
 sub get_cover ($cv, $root = undef) {
@@ -1279,13 +1281,16 @@ sub get_cover ($cv, $root = undef) {
   get_location($start) if $start;
   return unless _want_cover_for();
 
-  _add_subroutine_structure($cv, $start);
+  my $sub_id = _add_subroutine_structure($cv, $start);
 
+  my $cc;
   if ($Use_deparse) {
     _get_cover_deparse($cv, $root);
   } else {
-    _get_cover_walk($cv, $root);
+    $cc = _get_cover_walk($cv, $root);
   }
+
+  $Structure->set_complexity($sub_id, $cc) if $sub_id && defined $cc;
 }
 
 sub _get_cover_deparse ($cv, $root) {
@@ -1630,24 +1635,32 @@ sub _walk_xor ($cv, $op) {
 sub _get_cover_walk ($cv, $root) {
   my $op = $root || $cv->ROOT;
   return unless $$op;
+  my $decisions = 0;
   walk_ops(
     $op,
     sub ($op, $type, $cv_ref) {
       if ($type eq "statement" || $type eq "null_statement") {
         _walk_statement($op, $type);
       } elsif ($type eq "cond_expr") {
+        $decisions++;
         _walk_cond_expr($cv_ref, $op);
       } elsif ($type eq "logop") {
+        $decisions++;
         _walk_logop($cv_ref, $op);
       } elsif ($type eq "logassignop") {
+        $decisions++;
         _walk_logassignop($cv_ref, $op);
       } elsif ($type eq "xor") {
+        $decisions++;
         _walk_xor($cv_ref, $op);
+      } elsif ($type eq "iter") {
+        $decisions++;
       }
     },
     $cv,
     \%Parent_map,
   );
+  $decisions + 1
 }
 
 sub _report_progress ($msg, $code, @items) {

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1660,6 +1660,8 @@ sub _get_cover_walk ($cv, $root) {
         _walk_xor($cv_ref, $op);
       } elsif ($type eq "iter") {
         $decisions++;
+      } elsif ($type eq "argdefelem") {
+        $decisions++;
       }
     },
     $cv,

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -752,8 +752,7 @@ $Templates{module_by_start} = <<'EOT';
       </td>
       [% FOREACH criterion = criteria %]
         [% pc = vals.$m.$criterion.pc %]
-        <td class="[%- vals.$m.$criterion.class %] has-tip"
-          data-tip="[%- vals.$m.$criterion.details -%]">
+        <td class="[%- vals.$m.$criterion.class %] tip-hover">
           [% pc %]
           [% IF pc != 'n/a' %]
           <span class="cov-bar">
@@ -761,6 +760,7 @@ $Templates{module_by_start} = <<'EOT';
             style="width:[% pc %]%"></span>
           </span>
           [% END %]
+          <span class="glass-tip">[%- vals.$m.$criterion.details -%]</span>
         </td>
       [% END %]
     </tr>

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -387,7 +387,7 @@ sub summarise_complexity ($self, $s, $files) {
     my $file_cov  = _file_coverage($s->{$file});
     my $file_crap = _crap($file_cc, $file_cov);
     my $file_slop = _slop($file_crap);
-    $s->{$file}{crap} = {
+    $s->{$file}{slop} = {
       max       => $crap_max,
       mean      => $crap_sum / $crap_count,
       count     => $crap_count,
@@ -415,7 +415,7 @@ sub summarise_complexity ($self, $s, $files) {
     };
   }
   if ($crap_total_count) {
-    $s->{Total}{crap} = {
+    $s->{Total}{slop} = {
       max       => $crap_total_max,
       mean      => $crap_total_sum / $crap_total_count,
       count     => $crap_total_count,

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -492,6 +492,10 @@ sub summarise_complexity ($self, $s, $files) {
     };
   }
   if ($crap_total_count) {
+    my $module_cc   = $total_sum - $total_count + 1;
+    my $module_cov  = _file_coverage($s->{Total});
+    my $module_crap = _crap($module_cc, $module_cov);
+    my $module_slop = _slop($module_crap);
     $s->{Total}{slop} = {
       max       => $crap_total_max,
       mean      => $crap_total_sum / $crap_total_count,
@@ -500,6 +504,10 @@ sub summarise_complexity ($self, $s, $files) {
       : 0,
       file_slop => $fcrap_total_count ? $fslop_total_sum / $fcrap_total_count
       : 0,
+      module_cc   => $module_cc,
+      module_cov  => $module_cov,
+      module_crap => $module_crap,
+      module_slop => $module_slop,
     };
   }
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -1059,7 +1059,13 @@ sub AUTOLOAD {
   goto &$func
 }
 
-1
+"
+You seen the glory and the shame
+Beauty and the pain
+Weakness and the strength
+Waiting for the fame
+Don't you think you ought to give it all you got?
+"
 
 __END__
 
@@ -1084,16 +1090,256 @@ This module provides access to a database of code coverage information.
 
 =head2 new
 
- my $db = Devel::Cover::DB->new(db => "my_coverage_db");
+  my $db = Devel::Cover::DB->new(db => "my_coverage_db");
 
-Constructs the DB from the specified database.
+Construct a DB from the specified database directory. If the directory contains
+a valid database file it is read automatically.
+
+=head2 criteria
+
+  my @c = $db->criteria;
+
+Return the list of coverage criteria names (e.g. C<statement>, C<branch>,
+C<condition>, ...).
+
+=head2 criteria_short
+
+  my @c = $db->criteria_short;
+
+Return the abbreviated criteria names (e.g. C<stmt>, C<bran>, C<cond>, ...).
+
+=head2 all_criteria
+
+  my @c = $db->all_criteria;
+
+Like L</criteria> but includes C<total>.
+
+=head2 all_criteria_short
+
+  my @c = $db->all_criteria_short;
+
+Like L</criteria_short> but includes C<total>.
+
+=head2 files
+
+  my @f = $db->files;
+
+Return the list of extra files registered with the database (e.g. uncompiled
+files added via the C<files> option).
+
+=head2 read
+
+  $db->read($file);
+
+Read a serialised database from C<$file>. Populates C<runs> and
+C<files>. Returns C<$self>.
+
+=head2 write
+
+  $db->write; $db->write($db_path);
+
+Write the database to disk. If C<$db_path> is given it overrides the current
+C<db> attribute. Also writes the structure if one is attached. Returns C<$self>.
+
+=head2 delete
+
+  $db->delete; $db->delete($db_path);
+
+Remove all contents of the database directory. Returns C<$self>.
+
+=head2 clean
+
+  $db->clean;
+
+Remove stale C<.lock> files from the database directory.
+
+=head2 merge_runs
+
+  $db->merge_runs;
+
+Merge individual run files from C<< $db/runs/ >> into the main database, write
+the merged result, and delete the run files. Handles changed-file detection: if
+a file's digest differs between runs the old coverage is discarded. Returns
+C<$self>.
+
+=head2 validate_db
+
+  $db->validate_db;
+
+Warn to STDERR if the database directory looks invalid. Returns C<$self>.
+
+=head2 exists
+
+  my $bool = $db->exists;
+
+Return true if the database directory exists on disk.
+
+=head2 is_valid
+
+  my $valid = $db->is_valid;
+
+Return true if the database is valid (or looks valid - the check is
+intentionally lax).
+
+=head2 collected
+
+  my @criteria = $db->collected;
+
+Return the sorted list of criteria that were actually collected during coverage
+runs.
+
+=head2 merge
+
+  $db->merge($other_db);
+
+Merge run and collection data from C<$other_db> into C<$self>. Detects changed
+files by comparing digests across runs.
+
+=head2 summary
+
+  my $all  = $db->summary($file);
+  my $crit = $db->summary($file, "statement");
+  my $val  = $db->summary($file, "statement", "percentage");
+
+Access the summary hash for C<$file>. With one argument returns the entire file
+summary. With two, the summary for a single criterion. With three, a specific
+part of that criterion's summary.
+
+=head2 dir_summary
+
+  my $all  = $db->dir_summary($dir);
+  my $crit = $db->dir_summary($dir, "statement");
+
+Access the directory-level summary hash for C<$dir>. Populated by
+L</summarise_complexity> during L</calculate_summary>.
+
+=head2 slop_sub_lookup
+
+  my $lookup = $db->slop_sub_lookup($file);
+
+Return a hashref mapping C<"$line\0$name"> to per-subroutine SLOP detail from
+the summary data for C<$file>. Returns an empty hashref when no SLOP data
+exists.
+
+=head2 summarise_complexity
+
+  $db->summarise_complexity($summary, \@files);
+
+Compute per-file, per-directory, and total complexity and SLOP scores, storing
+results into the C<$summary> hash. Called automatically by
+L</calculate_summary>.
+
+=head2 calculate_summary
+
+  $db->calculate_summary(statement => 1, branch => 1);
+
+Calculate coverage summaries for all files, filtered by the criteria given as
+true-valued keys. Populates C<< $db->{summary} >> and triggers
+L</summarise_complexity>.
+
+=head2 trimmed_file
+
+  my $short = Devel::Cover::DB::trimmed_file($filename, $max_len);
+
+Truncate C<$filename> to C<$max_len> characters, replacing the leading portion
+with C<...> if necessary. This is a plain function, not a method.
+
+=head2 print_summary
+
+  $db->print_summary; $db->print_summary(\@files, \@criteria, \%opts);
+
+Print a tabular coverage summary to STDOUT. If C<@files> or C<@criteria> are
+given they restrict the output.
+
+=head2 add_statement
+
+  $db->add_statement($cc, $sc, $fc, $uc);
+
+Merge statement coverage counts from a single run into the accumulated cover
+hash. C<$cc> is the accumulated hash, C<$sc> the structure, C<$fc> the run
+counts, and C<$uc> uncoverable data.
+
+=head2 add_time
+
+  $db->add_time($cc, $sc, $fc, $);
+
+Merge time coverage data. Same interface as L</add_statement> but accumulates
+into scalar references.
+
+=head2 add_branch
+
+  $db->add_branch($cc, $sc, $fc, $uc);
+
+Merge branch coverage counts. Handles multi-valued branch data (true/false/else
+counts).
+
+=head2 add_subroutine
+
+  $db->add_subroutine($cc, $sc, $fc, $uc);
+
+Merge subroutine coverage counts.
+
+=head2 add_condition
+
+Alias for L</add_branch>.
+
+=head2 add_pod
+
+Alias for L</add_subroutine>.
+
+=head2 uncoverable_files
+
+  my @files = $db->uncoverable_files;
+
+Return the list of C<.uncoverable> files to consult, including any specified via
+the C<uncoverable_file> option, the local C<.uncoverable>, and
+C<~/.uncoverable>.
+
+=head2 uncoverable
+
+  my $uc = $db->uncoverable;
+
+Read all C<.uncoverable> files and return a hashref of uncoverable data keyed by
+file digest, criterion, line number, and count.
+
+=head2 add_uncoverable
+
+  $db->add_uncoverable(\@adds);
+
+Append entries to the first uncoverable file.
+
+=head2 delete_uncoverable
+
+  $db->delete_uncoverable(\@deletes);
+
+Remove entries from the uncoverable file. Currently unimplemented.
+
+=head2 clean_uncoverable
+
+  $db->clean_uncoverable;
+
+Clean up the uncoverable file. Currently unimplemented.
+
+=head2 uncoverable_comments
+
+  $db->uncoverable_comments($uncoverable, $file, $digest);
+
+Scan C<$file> for C<# uncoverable> comments and merge them into the
+C<$uncoverable> hash under C<$digest>.
+
+=head2 objectify_cover
+
+  $db->objectify_cover;
+
+Bless the raw cover hash into the appropriate C<Devel::Cover::DB::*> classes so
+that the OO accessors work.
 
 =head2 cover
 
- my $cover = $db->cover;
+  my $cover = $db->cover;
 
-Returns a Devel::Cover::DB::Cover object.  From here all the coverage
-data may be accessed.
+Return a L<Devel::Cover::DB::Cover> object. From here all the coverage data may
+be accessed.
 
   my $cover = $db->cover;
   for my $file ($cover->items) {
@@ -1110,11 +1356,11 @@ data may be accessed.
   }
 
 Data for different criteria will be in different formats, so that will need
-special handling.  This is not yet documented so your best bet for now is to
-look at some of the simpler reports and/or the source.
+special handling. This is not yet documented so your best bet for now is to look
+at some of the simpler reports and/or the source.
 
 The methods in the above example are actually aliases for methods in
-Devel::Cover::DB::Base (the base class for all Devel::Cover::DB::* classes):
+Devel::Cover::DB::Base (the base class for all C<Devel::Cover::DB::*> classes):
 
 =over
 
@@ -1130,13 +1376,28 @@ Devel::Cover::DB::Criterion->location, and Devel::Cover::DB::Location->datum
 
 =back
 
-Instead of calling $file->criterion("x") you can also call $file->x.
+Instead of calling C<< $file->criterion("x") >> you can also call
+C<< $file->x >>.
 
-=head2 is_valid
+=head2 run_keys
 
- my $valid = $db->is_valid;
+  my @keys = $db->run_keys;
 
-Returns true if $db is valid (or looks valid, the function is too lax).
+Return run identifiers sorted by start time (most recent first).
+
+=head2 runs
+
+  my @runs = $db->runs;
+
+Return L<Devel::Cover::DB::Run> objects sorted by start time (most recent
+first).
+
+=head2 set_structure
+
+  $db->set_structure($struct);
+
+Attach a L<Devel::Cover::DB::Structure> object for use by
+L</summarise_complexity>.
 
 =head1 SEE ALSO
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -322,10 +322,21 @@ sub _crap ($cc, $cov_pct) {
   $cc**2 * (1 - $cov_pct / 100)**3 + $cc
 }
 
+sub _file_coverage ($s_file) {
+  my ($covered, $total) = (0, 0);
+  for my $name (qw( statement branch condition )) {
+    my $c = $s_file->{$name} or next;
+    $total   += $c->{total} || 0;
+    $covered += ($c->{total} || 0) - ($c->{error} || 0);
+  }
+  $total ? 100 * $covered / $total : 100
+}
+
 sub summarise_complexity ($self, $s, $files) {
   my $st = $self->{_structure} or return;
-  my ($total_sum,      $total_count,      $total_max)      = (0, 0, 0);
+  my ($total_sum, $total_count, $total_max)                = (0, 0, 0);
   my ($crap_total_sum, $crap_total_count, $crap_total_max) = (0, 0, 0);
+  my ($fcrap_total_sum, $fcrap_total_count)                = (0, 0);
   for my $file (@$files) {
     my $file_obj = $self->cover->get($file);
     my $digest   = $file_obj->{meta}{digest};
@@ -365,12 +376,20 @@ sub summarise_complexity ($self, $s, $files) {
     next unless $count;
     $s->{$file}{complexity}
       = { max => $max, mean => $sum / $count, count => $count };
+    my $file_cc   = $sum - $count + 1;
+    my $file_cov  = _file_coverage($s->{$file});
+    my $file_crap = _crap($file_cc, $file_cov);
     $s->{$file}{crap} = {
-      max   => $crap_max,
-      mean  => $crap_sum / $crap_count,
-      count => $crap_count,
-      subs  => \@subs,
+      max       => $crap_max,
+      mean      => $crap_sum / $crap_count,
+      count     => $crap_count,
+      subs      => \@subs,
+      file_cc   => $file_cc,
+      file_cov  => $file_cov,
+      file_crap => $file_crap,
     };
+    $fcrap_total_sum += $file_crap;
+    $fcrap_total_count++;
     $total_max         = $max if $max > $total_max;
     $total_sum        += $sum;
     $total_count      += $count;
@@ -387,9 +406,12 @@ sub summarise_complexity ($self, $s, $files) {
   }
   if ($crap_total_count) {
     $s->{Total}{crap} = {
-      max   => $crap_total_max,
-      mean  => $crap_total_sum / $crap_total_count,
-      count => $crap_total_count,
+      max       => $crap_total_max,
+      mean      => $crap_total_sum / $crap_total_count,
+      count     => $crap_total_count,
+      file_crap => $fcrap_total_count
+      ? $fcrap_total_sum / $fcrap_total_count
+      : 0,
     };
   }
 }

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -322,6 +322,10 @@ sub _crap ($cc, $cov_pct) {
   $cc**2 * (1 - $cov_pct / 100)**3 + $cc
 }
 
+sub _slop ($crap) {
+  $crap > 1 ? log($crap) * 10 : 0
+}
+
 sub _file_coverage ($s_file) {
   my ($covered, $total) = (0, 0);
   for my $name (qw( statement branch condition )) {
@@ -337,6 +341,8 @@ sub summarise_complexity ($self, $s, $files) {
   my ($total_sum, $total_count, $total_max)                = (0, 0, 0);
   my ($crap_total_sum, $crap_total_count, $crap_total_max) = (0, 0, 0);
   my ($fcrap_total_sum, $fcrap_total_count)                = (0, 0);
+  my $fslop_total_sum = 0;
+
   for my $file (@$files) {
     my $file_obj = $self->cover->get($file);
     my $digest   = $file_obj->{meta}{digest};
@@ -369,6 +375,7 @@ sub summarise_complexity ($self, $s, $files) {
               cc   => $cc,
               cov  => $cov,
               crap => $crap,
+              slop => _slop($crap),
             };
         }
       }
@@ -379,6 +386,7 @@ sub summarise_complexity ($self, $s, $files) {
     my $file_cc   = $sum - $count + 1;
     my $file_cov  = _file_coverage($s->{$file});
     my $file_crap = _crap($file_cc, $file_cov);
+    my $file_slop = _slop($file_crap);
     $s->{$file}{crap} = {
       max       => $crap_max,
       mean      => $crap_sum / $crap_count,
@@ -387,8 +395,10 @@ sub summarise_complexity ($self, $s, $files) {
       file_cc   => $file_cc,
       file_cov  => $file_cov,
       file_crap => $file_crap,
+      file_slop => $file_slop,
     };
     $fcrap_total_sum += $file_crap;
+    $fslop_total_sum += $file_slop;
     $fcrap_total_count++;
     $total_max         = $max if $max > $total_max;
     $total_sum        += $sum;
@@ -409,8 +419,9 @@ sub summarise_complexity ($self, $s, $files) {
       max       => $crap_total_max,
       mean      => $crap_total_sum / $crap_total_count,
       count     => $crap_total_count,
-      file_crap => $fcrap_total_count
-      ? $fcrap_total_sum / $fcrap_total_count
+      file_crap => $fcrap_total_count ? $fcrap_total_sum / $fcrap_total_count
+      : 0,
+      file_slop => $fcrap_total_count ? $fslop_total_sum / $fcrap_total_count
       : 0,
     };
   }

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -302,6 +302,12 @@ sub summary ($self, $file, $criterion = undef, $part = undef) {
   $c && defined $part ? $c->{$part} : $c
 }
 
+sub dir_summary ($self, $dir, $criterion = undef) {
+  my $d = $self->{dir_summary}{$dir};
+  return $d unless $d && defined $criterion;
+  $d->{$criterion}
+}
+
 sub _sub_coverage ($file_obj, $start, $end) {
   my ($covered, $total) = (0, 0);
   for my $name (qw( statement branch condition )) {
@@ -336,12 +342,104 @@ sub _file_coverage ($s_file) {
   $total ? 100 * $covered / $total : 100
 }
 
+sub _file_dir ($file) {
+  my $dir = $file =~ s|/[^/]+$||r;
+  $dir eq $file ? "" : $dir
+}
+
+sub _file_cc_data ($file_obj, $cc_hash, $end_hash) {
+  my ($max,      $sum,      $count)      = (0, 0, 0);
+  my ($crap_max, $crap_sum, $crap_count) = (0, 0, 0);
+  my @subs;
+
+  for my $line (sort { $a <=> $b } keys %$cc_hash) {
+    for my $sub_name (sort keys %{ $cc_hash->{$line} }) {
+      my $cc_arr  = $cc_hash->{$line}{$sub_name};
+      my $end_arr = $end_hash->{$line}{$sub_name} // [];
+      for my $scount (0 .. $#$cc_arr) {
+        my $cc = $cc_arr->[$scount];
+        next unless defined $cc;
+        $max  = $cc if $cc > $max;
+        $sum += $cc;
+        $count++;
+        my $end  = $end_arr->[$scount] // $line;
+        my $cov  = _sub_coverage($file_obj, $line, $end);
+        my $crap = _crap($cc, $cov);
+        $crap_max  = $crap if $crap > $crap_max;
+        $crap_sum += $crap;
+        $crap_count++;
+        push @subs, {
+            name => $sub_name,
+            line => $line + 0,
+            cc   => $cc,
+            cov  => $cov,
+            crap => $crap,
+            slop => _slop($crap),
+          };
+      }
+    }
+  }
+
+  return unless $count;
+  {
+    max        => $max,
+    sum        => $sum,
+    count      => $count,
+    crap_max   => $crap_max,
+    crap_sum   => $crap_sum,
+    crap_count => $crap_count,
+    subs       => \@subs,
+  }
+}
+
+sub _summarise_dir_complexity ($self, $s, $dir_files, $dir_stats) {
+  my $ds_hash = $self->{dir_summary} = {};
+  for my $dir (keys %$dir_files) {
+    my $d = $ds_hash->{$dir} = {};
+    for my $criterion (qw( statement branch condition total )) {
+      my ($covered, $total, $error) = (0, 0, 0);
+      for my $f ($dir_files->{$dir}->@*) {
+        my $c = $s->{$f}{$criterion} or next;
+        $covered += $c->{covered} || 0;
+        $total   += $c->{total}   || 0;
+        $error   += $c->{error}   || 0;
+      }
+      $d->{$criterion} = {
+        covered    => $covered,
+        total      => $total,
+        error      => $error,
+        percentage => $total ? 100 - $error * 100 / $total : 100,
+      };
+    }
+
+    my $ds = $dir_stats->{$dir};
+    if ($ds && $ds->{cc_count}) {
+      my $dir_cc   = $ds->{cc_sum} - $ds->{cc_count} + 1;
+      my $dir_cov  = _file_coverage($d);
+      my $dir_crap = _crap($dir_cc, $dir_cov);
+      my $dir_slop = _slop($dir_crap);
+      $d->{slop} = {
+        file_cc   => $dir_cc,
+        file_cov  => $dir_cov,
+        file_crap => $dir_crap,
+        file_slop => $dir_slop,
+      };
+    }
+  }
+}
+
 sub summarise_complexity ($self, $s, $files) {
   my $st = $self->{_structure} or return;
   my ($total_sum, $total_count, $total_max)                = (0, 0, 0);
   my ($crap_total_sum, $crap_total_count, $crap_total_max) = (0, 0, 0);
   my ($fcrap_total_sum, $fcrap_total_count)                = (0, 0);
   my $fslop_total_sum = 0;
+  my %dir_stats;
+  my %dir_files;
+
+  for my $file (@$files) {
+    push $dir_files{ _file_dir($file) }->@*, $file;
+  }
 
   for my $file (@$files) {
     my $file_obj = $self->cover->get($file);
@@ -349,38 +447,12 @@ sub summarise_complexity ($self, $s, $files) {
     next unless $digest;
     my $cc_hash  = $st->get_complexity($digest) or next;
     my $end_hash = $st->get_end_lines($digest) || {};
-    my ($max, $sum, $count)                = (0, 0, 0);
-    my ($crap_max, $crap_sum, $crap_count) = (0, 0, 0);
-    my @subs;
+    my $d        = _file_cc_data($file_obj, $cc_hash, $end_hash) or next;
 
-    for my $line (sort { $a <=> $b } keys %$cc_hash) {
-      for my $sub_name (sort keys %{ $cc_hash->{$line} }) {
-        my $cc_arr  = $cc_hash->{$line}{$sub_name};
-        my $end_arr = $end_hash->{$line}{$sub_name} // [];
-        for my $scount (0 .. $#$cc_arr) {
-          my $cc = $cc_arr->[$scount];
-          next unless defined $cc;
-          $max  = $cc if $cc > $max;
-          $sum += $cc;
-          $count++;
-          my $end  = $end_arr->[$scount] // $line;
-          my $cov  = _sub_coverage($file_obj, $line, $end);
-          my $crap = _crap($cc, $cov);
-          $crap_max  = $crap if $crap > $crap_max;
-          $crap_sum += $crap;
-          $crap_count++;
-          push @subs, {
-              name => $sub_name,
-              line => $line + 0,
-              cc   => $cc,
-              cov  => $cov,
-              crap => $crap,
-              slop => _slop($crap),
-            };
-        }
-      }
-    }
-    next unless $count;
+    my $max   = $d->{max};
+    my $sum   = $d->{sum};
+    my $count = $d->{count};
+
     $s->{$file}{complexity}
       = { max => $max, mean => $sum / $count, count => $count };
     my $file_cc   = $sum - $count + 1;
@@ -388,24 +460,29 @@ sub summarise_complexity ($self, $s, $files) {
     my $file_crap = _crap($file_cc, $file_cov);
     my $file_slop = _slop($file_crap);
     $s->{$file}{slop} = {
-      max       => $crap_max,
-      mean      => $crap_sum / $crap_count,
-      count     => $crap_count,
-      subs      => \@subs,
+      max       => $d->{crap_max},
+      mean      => $d->{crap_sum} / $d->{crap_count},
+      count     => $d->{crap_count},
+      subs      => $d->{subs},
       file_cc   => $file_cc,
       file_cov  => $file_cov,
       file_crap => $file_crap,
       file_slop => $file_slop,
     };
+    my $dir = _file_dir($file);
+    my $ds  = $dir_stats{$dir} ||= { cc_sum => 0, cc_count => 0 };
+    $ds->{cc_sum}   += $sum;
+    $ds->{cc_count} += $count;
+
     $fcrap_total_sum += $file_crap;
     $fslop_total_sum += $file_slop;
     $fcrap_total_count++;
     $total_max         = $max if $max > $total_max;
     $total_sum        += $sum;
     $total_count      += $count;
-    $crap_total_max    = $crap_max if $crap_max > $crap_total_max;
-    $crap_total_sum   += $crap_sum;
-    $crap_total_count += $crap_count;
+    $crap_total_max    = $d->{crap_max} if $d->{crap_max} > $crap_total_max;
+    $crap_total_sum   += $d->{crap_sum};
+    $crap_total_count += $d->{crap_count};
   }
   if ($total_count) {
     $s->{Total}{complexity} = {
@@ -425,6 +502,8 @@ sub summarise_complexity ($self, $s, $files) {
       : 0,
     };
   }
+
+  $self->_summarise_dir_complexity($s, \%dir_files, \%dir_stats);
 }
 
 sub calculate_summary ($self, %options) {
@@ -844,6 +923,7 @@ sub objectify_cover ($self) {
 }
 
 sub _file_digest ($r, $file) {
+  no warnings "once";
   my $digest = $r->{digests}{$file};
   return $digest if $digest;
   print STDERR "Devel::Cover: Can't find digest for $file\n"
@@ -895,9 +975,10 @@ sub cover ($self) {
   my %files;    # processed files
   my $cover       = $self->{cover} = {};
   my $uncoverable = {};
-  require Devel::Cover::DB::Structure;
-  my $st = $self->{_structure}
-    // Devel::Cover::DB::Structure->new(base => $self->{base})->read_all;
+  my $st          = $self->{_structure} // do {
+    require Devel::Cover::DB::Structure;  ## no perlimports
+    Devel::Cover::DB::Structure->new(base => $self->{base})->read_all;
+  };
 
   # Sometimes the start value is undefined.  It's not yet clear why, but it
   # probably has something to do with the code under test forking.  We'll

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -302,38 +302,94 @@ sub summary ($self, $file, $criterion = undef, $part = undef) {
   $c && defined $part ? $c->{$part} : $c
 }
 
+sub _sub_coverage ($file_obj, $start, $end) {
+  my ($covered, $total) = (0, 0);
+  for my $name (qw( statement branch condition )) {
+    my $crit = $file_obj->{$name} or next;
+    for my $line ($start .. $end) {
+      my $loc = $crit->{$line} or next;
+      for my $obj (@$loc) {
+        my $t = $obj->total;
+        $total   += $t;
+        $covered += $t - $obj->error;
+      }
+    }
+  }
+  $total ? 100 * $covered / $total : 100
+}
+
+sub _crap ($cc, $cov_pct) {
+  $cc**2 * (1 - $cov_pct / 100)**3 + $cc
+}
+
 sub summarise_complexity ($self, $s, $files) {
-  my $st          = $self->{_structure} or return;
-  my $total_sum   = 0;
-  my $total_count = 0;
-  my $total_max   = 0;
+  my $st = $self->{_structure} or return;
+  my ($total_sum,      $total_count,      $total_max)      = (0, 0, 0);
+  my ($crap_total_sum, $crap_total_count, $crap_total_max) = (0, 0, 0);
   for my $file (@$files) {
-    my $digest = $self->cover->get($file)->{meta}{digest};
+    my $file_obj = $self->cover->get($file);
+    my $digest   = $file_obj->{meta}{digest};
     next unless $digest;
-    my $cc_hash = $st->get_complexity($digest) or next;
-    my ($max, $sum, $count) = (0, 0, 0);
-    for my $line_data (values %$cc_hash) {
-      for my $sub_data (values %$line_data) {
-        for my $cc (@$sub_data) {
+    my $cc_hash  = $st->get_complexity($digest) or next;
+    my $end_hash = $st->get_end_lines($digest) || {};
+    my ($max, $sum, $count)                = (0, 0, 0);
+    my ($crap_max, $crap_sum, $crap_count) = (0, 0, 0);
+    my @subs;
+
+    for my $line (sort { $a <=> $b } keys %$cc_hash) {
+      for my $sub_name (sort keys %{ $cc_hash->{$line} }) {
+        my $cc_arr  = $cc_hash->{$line}{$sub_name};
+        my $end_arr = $end_hash->{$line}{$sub_name} // [];
+        for my $scount (0 .. $#$cc_arr) {
+          my $cc = $cc_arr->[$scount];
           next unless defined $cc;
           $max  = $cc if $cc > $max;
           $sum += $cc;
           $count++;
+          my $end  = $end_arr->[$scount] // $line;
+          my $cov  = _sub_coverage($file_obj, $line, $end);
+          my $crap = _crap($cc, $cov);
+          $crap_max  = $crap if $crap > $crap_max;
+          $crap_sum += $crap;
+          $crap_count++;
+          push @subs, {
+              name => $sub_name,
+              line => $line + 0,
+              cc   => $cc,
+              cov  => $cov,
+              crap => $crap,
+            };
         }
       }
     }
     next unless $count;
     $s->{$file}{complexity}
       = { max => $max, mean => $sum / $count, count => $count };
-    $total_max    = $max if $max > $total_max;
-    $total_sum   += $sum;
-    $total_count += $count;
+    $s->{$file}{crap} = {
+      max   => $crap_max,
+      mean  => $crap_sum / $crap_count,
+      count => $crap_count,
+      subs  => \@subs,
+    };
+    $total_max         = $max if $max > $total_max;
+    $total_sum        += $sum;
+    $total_count      += $count;
+    $crap_total_max    = $crap_max if $crap_max > $crap_total_max;
+    $crap_total_sum   += $crap_sum;
+    $crap_total_count += $crap_count;
   }
   if ($total_count) {
     $s->{Total}{complexity} = {
       max   => $total_max,
       mean  => $total_sum / $total_count,
       count => $total_count,
+    };
+  }
+  if ($crap_total_count) {
+    $s->{Total}{crap} = {
+      max   => $crap_total_max,
+      mean  => $crap_total_sum / $crap_total_count,
+      count => $crap_total_count,
     };
   }
 }

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -302,6 +302,42 @@ sub summary ($self, $file, $criterion = undef, $part = undef) {
   $c && defined $part ? $c->{$part} : $c
 }
 
+sub summarise_complexity ($self, $s, $files) {
+  my $st          = $self->{_structure} or return;
+  my $total_sum   = 0;
+  my $total_count = 0;
+  my $total_max   = 0;
+  for my $file (@$files) {
+    my $digest = $self->cover->get($file)->{meta}{digest};
+    next unless $digest;
+    my $cc_hash = $st->get_complexity($digest) or next;
+    my ($max, $sum, $count) = (0, 0, 0);
+    for my $line_data (values %$cc_hash) {
+      for my $sub_data (values %$line_data) {
+        for my $cc (@$sub_data) {
+          next unless defined $cc;
+          $max  = $cc if $cc > $max;
+          $sum += $cc;
+          $count++;
+        }
+      }
+    }
+    next unless $count;
+    $s->{$file}{complexity}
+      = { max => $max, mean => $sum / $count, count => $count };
+    $total_max    = $max if $max > $total_max;
+    $total_sum   += $sum;
+    $total_count += $count;
+  }
+  if ($total_count) {
+    $s->{Total}{complexity} = {
+      max   => $total_max,
+      mean  => $total_sum / $total_count,
+      count => $total_count,
+    };
+  }
+}
+
 sub calculate_summary ($self, %options) {
   return if exists $self->{summary} && !$options{force};
   my $s = $self->{summary} = {};
@@ -327,6 +363,8 @@ sub calculate_summary ($self, %options) {
     $c->calculate_percentage($self, $t->{$criterion});
   }
   Devel::Cover::Criterion->calculate_percentage($self, $t->{total});
+
+  $self->summarise_complexity($s, \@files);
 }
 
 sub trimmed_file ($f, $len) {
@@ -681,10 +719,10 @@ sub objectify_cover ($self) {
     }
 
     my $classes = {
-      Cover     => [ qw( files     file ) ],
-      File      => [ qw( criteria  criterion ) ],
-      Criterion => [ qw( locations location ) ],
-      Location  => [ qw( data      datum ) ],
+      Cover     => [qw( files     file )],
+      File      => [qw( criteria  criterion )],
+      Criterion => [qw( locations location )],
+      Location  => [qw( data      datum )],
     };
     my $base = "Devel::Cover::DB::Base";
     while (my ($class, $functions) = each %$classes) {
@@ -745,6 +783,7 @@ sub _cover_file (
     $ff = $file unless -e $ff;
   }
   my $cf = $cover->{ $digests->{$digest} ||= $ff } ||= {};
+  $cf->{meta}{digest} = $digest;
 
   while (my ($criterion, $fc) = each %$f) {
     my $get = "get_$criterion";
@@ -791,7 +830,7 @@ sub cover ($self) {
     while (my ($file, $f) = each %$count) {
       $self->_cover_file(
         $file, $f, $r, $st, $cover,
-        $uncoverable, \%digests, \%files, \%warned
+        $uncoverable, \%digests, \%files, \%warned,
       );
     }
   }

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -67,8 +67,8 @@ sub new ($class, %o) {
     %o,
   };
 
-  $self->{all_criteria}         = [ $self->{criteria}->@*,       "total" ];
-  $self->{all_criteria_short}   = [ $self->{criteria_short}->@*, "total" ];
+  $self->{all_criteria}         = [$self->{criteria}->@*,       "total"];
+  $self->{all_criteria_short}   = [$self->{criteria_short}->@*, "total"];
   $self->{base}               ||= $self->{db};
   bless $self, $class;
 
@@ -308,6 +308,12 @@ sub dir_summary ($self, $dir, $criterion = undef) {
   $d->{$criterion}
 }
 
+sub slop_sub_lookup ($self, $file) {
+  my $slop = $self->summary($file, "slop") or return {};
+  my $subs = $slop->{subs}                 or return {};
+  +{ map { ("$_->{line}\0$_->{name}" => $_) } @$subs }
+}
+
 sub _sub_coverage ($file_obj, $start, $end) {
   my ($covered, $total) = (0, 0);
   for my $name (qw( statement branch condition )) {
@@ -348,8 +354,8 @@ sub _file_dir ($file) {
 }
 
 sub _file_cc_data ($file_obj, $cc_hash, $end_hash) {
-  my ($max,      $sum,      $count)      = (0, 0, 0);
-  my ($crap_max, $crap_sum, $crap_count) = (0, 0, 0);
+  my ($max, $sum, $count) = (0, 0, 0);
+  my ($crap_max, $crap_sum) = (0, 0);
   my @subs;
 
   for my $line (sort { $a <=> $b } keys %$cc_hash) {
@@ -367,7 +373,6 @@ sub _file_cc_data ($file_obj, $cc_hash, $end_hash) {
         my $crap = _crap($cc, $cov);
         $crap_max  = $crap if $crap > $crap_max;
         $crap_sum += $crap;
-        $crap_count++;
         push @subs, {
             name => $sub_name,
             line => $line + 0,
@@ -382,13 +387,12 @@ sub _file_cc_data ($file_obj, $cc_hash, $end_hash) {
 
   return unless $count;
   {
-    max        => $max,
-    sum        => $sum,
-    count      => $count,
-    crap_max   => $crap_max,
-    crap_sum   => $crap_sum,
-    crap_count => $crap_count,
-    subs       => \@subs,
+    max      => $max,
+    sum      => $sum,
+    count    => $count,
+    crap_max => $crap_max,
+    crap_sum => $crap_sum,
+    subs     => \@subs,
   }
 }
 
@@ -430,9 +434,9 @@ sub _summarise_dir_complexity ($self, $s, $dir_files, $dir_stats) {
 
 sub summarise_complexity ($self, $s, $files) {
   my $st = $self->{_structure} or return;
-  my ($total_sum, $total_count, $total_max)                = (0, 0, 0);
-  my ($crap_total_sum, $crap_total_count, $crap_total_max) = (0, 0, 0);
-  my ($fcrap_total_sum, $fcrap_total_count)                = (0, 0);
+  my ($total_sum, $total_count, $total_max) = (0, 0, 0);
+  my ($crap_total_sum, $crap_total_max)     = (0, 0);
+  my ($fcrap_total_sum, $fcrap_total_cnt)   = (0, 0);
   my $fslop_total_sum = 0;
   my %dir_stats;
   my %dir_files;
@@ -461,8 +465,8 @@ sub summarise_complexity ($self, $s, $files) {
     my $file_slop = _slop($file_crap);
     $s->{$file}{slop} = {
       max       => $d->{crap_max},
-      mean      => $d->{crap_sum} / $d->{crap_count},
-      count     => $d->{crap_count},
+      mean      => $d->{crap_sum} / $count,
+      count     => $count,
       subs      => $d->{subs},
       file_cc   => $file_cc,
       file_cov  => $file_cov,
@@ -476,13 +480,12 @@ sub summarise_complexity ($self, $s, $files) {
 
     $fcrap_total_sum += $file_crap;
     $fslop_total_sum += $file_slop;
-    $fcrap_total_count++;
-    $total_max         = $max if $max > $total_max;
-    $total_sum        += $sum;
-    $total_count      += $count;
-    $crap_total_max    = $d->{crap_max} if $d->{crap_max} > $crap_total_max;
-    $crap_total_sum   += $d->{crap_sum};
-    $crap_total_count += $d->{crap_count};
+    $fcrap_total_cnt++;
+    $total_max       = $max if $max > $total_max;
+    $total_sum      += $sum;
+    $total_count    += $count;
+    $crap_total_max  = $d->{crap_max} if $d->{crap_max} > $crap_total_max;
+    $crap_total_sum += $d->{crap_sum};
   }
   if ($total_count) {
     $s->{Total}{complexity} = {
@@ -491,19 +494,17 @@ sub summarise_complexity ($self, $s, $files) {
       count => $total_count,
     };
   }
-  if ($crap_total_count) {
+  if ($total_count) {
     my $module_cc   = $total_sum - $total_count + 1;
     my $module_cov  = _file_coverage($s->{Total});
     my $module_crap = _crap($module_cc, $module_cov);
     my $module_slop = _slop($module_crap);
     $s->{Total}{slop} = {
-      max       => $crap_total_max,
-      mean      => $crap_total_sum / $crap_total_count,
-      count     => $crap_total_count,
-      file_crap => $fcrap_total_count ? $fcrap_total_sum / $fcrap_total_count
-      : 0,
-      file_slop => $fcrap_total_count ? $fslop_total_sum / $fcrap_total_count
-      : 0,
+      max         => $crap_total_max,
+      mean        => $crap_total_sum / $total_count,
+      count       => $total_count,
+      file_crap   => $fcrap_total_cnt ? $fcrap_total_sum / $fcrap_total_cnt : 0,
+      file_slop   => $fcrap_total_cnt ? $fslop_total_sum / $fcrap_total_cnt : 0,
       module_cc   => $module_cc,
       module_cov  => $module_cov,
       module_crap => $module_crap,
@@ -659,9 +660,9 @@ sub add_branch ($self, $cc, $sc, $fc, $uc) {
       $a->[0][2] += $fc->[$i][2] if exists $fc->[$i][2];
       $a->[0][3] += $fc->[$i][3] if exists $fc->[$i][3];
     } else {
-      $cc->{$l}[$n] = [ $fc->[$i], $sc->[$i][1] ];
+      $cc->{$l}[$n] = [$fc->[$i], $sc->[$i][1]];
     }
-    $cc->{$l}[$n][2][ $_->[0] ] ||= $_->[1] for @{ $uc->{$l}[$n] };
+    $cc->{$l}[$n][2][$_->[0]] ||= $_->[1] for @{ $uc->{$l}[$n] };
   }
 }
 
@@ -684,7 +685,7 @@ sub add_subroutine ($self, $cc, $sc, $fc, $uc) {
       no warnings "uninitialized";
       $a->[0] += $fc->[$i];
     } else {
-      $cc->{$l}[$n] = [ $fc->[$i], $sc->[$i][1] ];
+      $cc->{$l}[$n] = [$fc->[$i], $sc->[$i][1]];
     }
     $cc->{$l}[$n][2] ||= $uc->{$l}[$n][0][1];
   }
@@ -717,7 +718,7 @@ sub uncoverable ($self) {
     while (<$f>) {
       chomp;
       my ($file, $crit, $line, $count, $type, $class, $note) = split " ", $_, 7;
-      push $u->{$file}{$crit}{$line}[$count]->@*, [ $type, $class, $note ];
+      push $u->{$file}{$crit}{$line}[$count]->@*, [$type, $class, $note];
     }
   }
 
@@ -832,7 +833,7 @@ sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
       for my $c (@counts) {
         # no warnings "uninitialized";
         # warn "pushing $criterion, $c - 1, $type, $class, $note";
-        push @waiting, [ $criterion, $c - 1, $type, $class, $note ];
+        push @waiting, [$criterion, $c - 1, $type, $class, $note];
       }
 
       next unless $code =~ /\S/;
@@ -842,7 +843,7 @@ sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
     while (my $w = shift @waiting) {
       my ($criterion, $count, $type, $class, $note) = @$w;
       push $uncoverable->{$digest}{$criterion}{$.}[$count]->@*,
-        [ $type, $class, $note ];
+        [$type, $class, $note];
     }
   }
   close $fh or warn "Devel::Cover: Can't close $file: $!\n";
@@ -1021,7 +1022,7 @@ sub cover ($self) {
       my $counts = Devel::Cover::Static::count_criteria($file);
       $self->{cover}{$file}
         = bless {
-          meta => { uncompiled => 1, ($counts ? (counts => $counts) : ()) }, },
+          meta => { uncompiled => 1, ($counts ? (counts => $counts) : ()) } },
         "Devel::Cover::DB::File";
     }
   }
@@ -1070,10 +1071,10 @@ Devel::Cover::DB - Code coverage metrics for Perl
 
 =head1 SYNOPSIS
 
- use Devel::Cover::DB;
+  use Devel::Cover::DB;
 
- my $db = Devel::Cover::DB->new(db => "my_coverage_db");
- $db->print_summary([$file1, $file2], ["statement", "pod"]);
+  my $db = Devel::Cover::DB->new(db => "my_coverage_db");
+  $db->print_summary([$file1, $file2], ["statement", "pod"]);
 
 =head1 DESCRIPTION
 
@@ -1094,19 +1095,19 @@ Constructs the DB from the specified database.
 Returns a Devel::Cover::DB::Cover object.  From here all the coverage
 data may be accessed.
 
- my $cover = $db->cover;
- for my $file ($cover->items) {
-     print "$file\n";
-     my $f = $cover->file($file);
-     for my $criterion ($f->items) {
-         print "  $criterion\n";
-         my $c = $f->criterion($criterion);
-         for my $location ($c->items) {
-             my $l = $c->location($location);
-             print "    $location @$l\n";
-         }
-     }
- }
+  my $cover = $db->cover;
+  for my $file ($cover->items) {
+    print "$file\n";
+    my $f = $cover->file($file);
+    for my $criterion ($f->items) {
+      print "  $criterion\n";
+      my $c = $f->criterion($criterion);
+      for my $location ($c->items) {
+        my $l = $c->location($location);
+        print "    $location @$l\n";
+      }
+    }
+  }
 
 Data for different criteria will be in different formats, so that will need
 special handling.  This is not yet documented so your best bet for now is to

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -124,7 +124,7 @@ sub set_subroutine ($self, $sub_name, $file, $line, $scount) {
       for $self->criteria;
   }
 
-  [ $file, $line, $sub_name, $scount ]
+  [$file, $line, $sub_name, $scount]
 }
 
 sub set_complexity ($self, $sub_id, $cc) {
@@ -132,11 +132,19 @@ sub set_complexity ($self, $sub_id, $cc) {
   $self->{f}{$file}{complexity}{$line}{$sub_name}[$scount] = $cc;
 }
 
-sub get_complexity ($self, $digest) {
+sub _file_by_digest ($self, $digest) {
+  if (my $files = $self->{digests}{$digest}) {
+    return $self->{f}{ $files->[0] };
+  }
   for my $fval (values $self->{f}->%*) {
-    return $fval->{complexity} if $fval->{digest} eq $digest;
+    return $fval if $fval->{digest} eq $digest;
   }
   return
+}
+
+sub get_complexity ($self, $digest) {
+  my $fval = $self->_file_by_digest($digest) or return;
+  $fval->{complexity}
 }
 
 sub set_end_line ($self, $sub_id, $end_line) {
@@ -145,10 +153,8 @@ sub set_end_line ($self, $sub_id, $end_line) {
 }
 
 sub get_end_lines ($self, $digest) {
-  for my $fval (values $self->{f}->%*) {
-    return $fval->{end_line} if $fval->{digest} eq $digest;
-  }
-  return
+  my $fval = $self->_file_by_digest($digest) or return;
+  $fval->{end_line}
 }
 
 sub store_counts ($self, $file) {
@@ -241,6 +247,7 @@ sub read ($self, $digest) {
     # structure database on disk.
   } elsif ($d eq $s->{digest}) {
     $self->{f}{ $s->{file} } = $s;
+    push $self->{digests}{$d}->@*, $s->{file};
   } else {
     print STDERR "Devel::Cover: Deleting old coverage ",
       "for changed file $s->{file}\n"

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -139,6 +139,18 @@ sub get_complexity ($self, $digest) {
   return
 }
 
+sub set_end_line ($self, $sub_id, $end_line) {
+  my ($file, $line, $sub_name, $scount) = @$sub_id;
+  $self->{f}{$file}{end_line}{$line}{$sub_name}[$scount] = $end_line;
+}
+
+sub get_end_lines ($self, $digest) {
+  for my $fval (values $self->{f}->%*) {
+    return $fval->{end_line} if $fval->{digest} eq $digest;
+  }
+  return
+}
+
 sub store_counts ($self, $file) {
   $self->{count}{$_}{$file} = $self->{f}{$file}{start}{-1}{__COVER__}[0]{$_}
     = $self->get_count($file, $_)

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -82,8 +82,7 @@ sub add_count ($self, $criterion) {
 }
 
 sub set_subroutine ($self, $sub_name, $file, $line, $scount) {
-  @$self{ qw( sub_name file line scount ) }
-    = ($sub_name, $file, $line, $scount);
+  @$self{qw( sub_name file line scount )} = ($sub_name, $file, $line, $scount);
 
   # When new code is added at runtime, via a string eval in some guise, we need
   # information about where structure information for the subroutine is.  This
@@ -124,6 +123,20 @@ sub set_subroutine ($self, $sub_name, $file, $line, $scount) {
       = $self->get_count($file, $_)
       for $self->criteria;
   }
+
+  [ $file, $line, $sub_name, $scount ]
+}
+
+sub set_complexity ($self, $sub_id, $cc) {
+  my ($file, $line, $sub_name, $scount) = @$sub_id;
+  $self->{f}{$file}{complexity}{$line}{$sub_name}[$scount] = $cc;
+}
+
+sub get_complexity ($self, $digest) {
+  for my $fval (values $self->{f}->%*) {
+    return $fval->{complexity} if $fval->{digest} eq $digest;
+  }
+  return
 }
 
 sub store_counts ($self, $file) {
@@ -340,6 +353,25 @@ disambiguates multiple subroutines with the same name on the same line
 Handles three cases: reusing existing structure, adding a new subroutine to a
 reused structure (e.g. a conditional C<< eval "use M" >>), and recording a
 subroutine in a new structure.
+
+Returns a sub_id arrayref C<[$file, $line, $sub_name, $scount]> suitable for
+passing to L</set_complexity>.
+
+=head2 set_complexity ($sub_id, $cc)
+
+ $struct->set_complexity($sub_id, 5);
+
+Store cyclomatic complexity C<$cc> for a subroutine identified by C<$sub_id>
+(as returned by L</set_subroutine>).  The value is stored at
+C<< $self-E<gt>{f}{$file}{complexity}{$line}{$sub_name}[$scount] >>.
+
+=head2 get_complexity ($digest)
+
+ my $complexity = $struct->get_complexity($digest);
+
+Return the complexity hash for the file matching C<$digest>, or C<undef> if no
+file matches.  The returned hash is keyed by line number, then subroutine name,
+with an arrayref of CC values indexed by C<$scount>.
 
 =head2 store_counts ($file)
 

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -84,15 +84,20 @@ sub untested_badge () {
   qq(<span class="untested-badge$tip"$data>untested</span>)
 }
 
-sub risk_tip ($f) {
-  <<HTML
-<table class="risk-tip">
-<tr><td>Branch errors</td><td>$f->{risk_branch}</td></tr>
-<tr><td>Condition errors</td><td>$f->{risk_cond}</td></tr>
-<tr><td>Coverage gap</td><td>$f->{risk_gap}%</td></tr>
-<tr class="risk-total"><td>Risk</td><td>$f->{risk}</td></tr>
+sub crap_tip ($f) {
+  my $o = <<HTML;
+<table class="crap-tip">
+<tr><td>File CC</td><td>$f->{file_cc}</td></tr>
+<tr><td>Combined cov</td><td>$f->{file_cov}%</td></tr>
+HTML
+  for ($f->{worst_subs}->@*) {
+    $o .= qq(<tr><td>$_->{name}</td><td>$_->{crap}</td></tr>\n);
+  }
+  $o .= <<HTML;
+<tr class="crap-total"><td>CRAP</td><td>$f->{file_crap}</td></tr>
 </table>
 HTML
+  $o
 }
 
 sub cov_bar ($pc, $uncompiled) {
@@ -132,26 +137,29 @@ HTML
   }
   $o .= cov_cell($f->{total}, $f->{uncompiled}, $f->{total_sort});
   $o .= <<HTML;
-<td data-value="$f->{risk}" class="risk-hover">
-$f->{risk} @{[ risk_tip($f) ]}</td>
+<td data-value="$f->{file_crap}" class="crap-hover">
+$f->{file_crap} @{[ crap_tip($f) ]}</td>
 </tr>
 HTML
   $o
 }
 
 sub render_worst_files ($worst) {
-  return "" unless @$worst && $worst->[0]{risk} > 0;
-  my $o = qq(<div class="worst-files">\n<h2>Highest risk</h2>\n)
+  return "" unless @$worst && $worst->[0]{file_crap} > 0;
+  my $o = qq(<div class="worst-files">\n<h2>Highest CRAP</h2>\n)
     . qq(<div class="worst-list">\n);
   for my $f (@$worst) {
-    next if $f->{risk} == 0;
+    next if $f->{file_crap} == 0;
     my $cls = $f->{uncompiled} ? "untested-worst" : $f->{total}{class};
     my $name
       = $f->{exists} ? qq(<a href="$f->{link}">$f->{short}</a>) : $f->{short};
     my $badge = $f->{uncompiled} ? untested_badge() . "\n" : "";
+    my $tip   = crap_tip($f);
+    my $crap  = $f->{file_crap};
+
     $o .= <<HTML;
 <div class="worst-item $cls">
-  $name $badge<strong class="risk-hover">$f->{risk} @{[ risk_tip($f) ]}</strong>
+  $name $badge<strong class="crap-hover">$crap $tip</strong>
 </div>
 HTML
   }
@@ -210,7 +218,7 @@ sub render_index ($file_data, $total, $dist) {
   my @groups = build_dir_groups($file_data);
   my @worst
     = @$file_data
-    ? (sort { $b->{risk} <=> $a->{risk} } @$file_data)
+    ? (sort { $b->{file_crap} <=> $a->{file_crap} } @$file_data)
     [ 0 .. ($#$file_data > 4 ? 4 : $#$file_data) ]
     : ();
 
@@ -248,9 +256,9 @@ Toggle "Hide 100% covered" to focus on incomplete files.</dd>
 <dt>Grouping</dt>
 <dd>Toggle "Group by directory" to organise files into
 collapsible groups. Click a directory row to collapse it.</dd>
-<dt>Risk</dt>
-<dd>Hover the risk column for a breakdown: branch errors +
-condition errors + coverage gap.</dd>
+<dt>CRAP</dt>
+<dd>File-level CRAP (Change Risk Anti-Patterns) score. Hover for
+a breakdown: file CC, combined coverage, and worst subs.</dd>
 <dt>Tooltips</dt>
 <dd>Hover any badge or coverage cell for covered/total counts.</dd>
 </dl>
@@ -286,7 +294,7 @@ HTML
 HTML
 
   my $ncrit  = $R{criteria}->@*;
-  my $ncols  = $ncrit + 2;       # criteria + total + risk
+  my $ncols  = $ncrit + 2;       # criteria + total + crap
   my $crit_w = 70 / $ncols;
   $o
     .= qq(<table class="file-table">\n<colgroup>\n)
@@ -300,7 +308,7 @@ HTML
   }
   $o .= <<HTML;
 <th data-sort="total">@{[ crit_name('total') ]}</th>
-<th data-sort="risk">risk</th>
+<th data-sort="crap">CRAP</th>
 </tr>
 </thead>
 <tbody>
@@ -327,16 +335,27 @@ HTML
   )
 }
 
+sub crap_class ($crap) {
+  return "" unless defined $crap;
+  $crap < 5 ? "c3" : $crap < 30 ? "c2" : $crap < 60 ? "c1" : "c0"
+}
+
 sub render_line_detail ($line) {
   my $o = qq(<tr class="line-detail"><td colspan="4">\n);
 
   if ($line->{subroutines}) {
     for my $s ($line->{subroutines}->@*) {
-      my $status = $s->{covered} ? "called" : "not called";
+      my $status  = $s->{covered} ? "called" : "not called";
+      my $cc_info = "";
+      if (defined $s->{cc}) {
+        my $cls  = crap_class($s->{crap});
+        my $crap = sprintf "%.1f", $s->{crap};
+        $cc_info = qq( <span class="$cls">CC=$s->{cc} CRAP=$crap</span>);
+      }
       $o .= <<HTML;
 <div class="detail">
 <span class="detail-heading">Subroutine</span>
-<span class="$s->{class}">$s->{name}: $status</span>
+<span class="$s->{class}">$s->{name}: $status$cc_info</span>
 </div>
 HTML
     }
@@ -383,7 +402,7 @@ HTML
       if ($tt->{legend} && $tt->{legend}->@*) {
         $o .= qq(<div class="tt-legend">\n);
         for my $item ($tt->{legend}->@*) {
-          $o .= qq(<div class="tt-legend-item">)
+          $o .= '<div class="tt-legend-item">'
             . qq(<strong>$item->{letter}</strong> = $item->{label}</div>\n);
         }
         $o .= "</div>\n";
@@ -499,7 +518,7 @@ HTML
     $o .= <<HTML;
 <span class="stat-badge untested-stat has-tip" data-tip="total: 0">
 @{[ crit_name("total") ]} 0.0%</span>
-<span class="stat-badge stat-risk has-tip" data-tip="risk: 0">risk 0</span>
+<span class="stat-badge stat-crap has-tip" data-tip="CRAP: 0">CRAP 0</span>
 HTML
   } else {
     my $tt = $total->{total};
@@ -511,8 +530,8 @@ HTML
 HTML
     }
     $o .= <<HTML;
-<span class="stat-badge stat-risk risk-hover has-tip" data-tip="risk score">
-risk $fd->{risk} @{[ risk_tip($fd) ]}</span>
+<span class="stat-badge stat-crap crap-hover has-tip" data-tip="CRAP score">
+CRAP $fd->{file_crap} @{[ crap_tip($fd) ]}</span>
 HTML
   }
 
@@ -538,7 +557,7 @@ condition, or subroutine detail.</dd>
 <dd>The strip on the right shows coverage at a glance. Click to
 jump to that line.</dd>
 <dt>Tooltips</dt>
-<dd>Hover badges for covered/total counts. Hover risk for a
+<dd>Hover badges for covered/total counts. Hover CRAP for a
 breakdown.</dd>
 <dt>Keyboard</dt>
 <dd><kbd>j</kbd> / <kbd>k</kbd> next/prev uncovered line
@@ -623,16 +642,23 @@ sub get_summary ($file, $criterion) {
   }
 }
 
-sub add_risk ($f, $risk_parts) {
-  my $pc   = $f->{total_pc};
-  my $gap  = 100 - ($pc eq "n/a" ? 0 : $pc);
-  my $berr = $risk_parts->{branch}    || 0;
-  my $cerr = $risk_parts->{condition} || 0;
-  $f->{risk}        = int($berr + $cerr + $gap);
-  $f->{risk_branch} = $berr;
-  $f->{risk_cond}   = $cerr;
-  $f->{risk_gap}    = sprintf "%.0f", $gap;
-  $f->{risk_gap_pc} = $pc;
+sub add_crap ($f, $file) {
+  my $crap_data = $R{db}->summary($file, "crap");
+  if ($crap_data && defined $crap_data->{file_crap}) {
+    $f->{file_crap} = sprintf "%.1f", $crap_data->{file_crap};
+    $f->{file_cc}   = $crap_data->{file_cc};
+    $f->{file_cov}  = sprintf "%.0f", $crap_data->{file_cov};
+    my @sorted = sort { $b->{crap} <=> $a->{crap} } grep defined $_->{crap},
+      @{ $crap_data->{subs} || [] };
+    $f->{worst_subs}
+      = [ map { { name => $_->{name}, crap => sprintf "%.1f", $_->{crap} } }
+        @sorted[ 0 .. ($#sorted > 2 ? 2 : $#sorted) ] ];
+  } else {
+    $f->{file_crap}  = 0;
+    $f->{file_cc}    = 0;
+    $f->{file_cov}   = 0;
+    $f->{worst_subs} = [];
+  }
 }
 
 sub build_one_file ($file) {
@@ -652,14 +678,11 @@ sub build_one_file ($file) {
     criteria   => {},
   );
 
-  my %risk_parts;
-
   for my $c ($R{showing}->@*) {
     my $s = get_summary($file, $c);
     $s->{class}      = "c0"  if $uncompiled && $s->{pc} eq "n/a";
     $s->{pc}         = "0.0" if $uncompiled && $s->{pc} eq "n/a";
     $f{criteria}{$c} = $s;
-    $risk_parts{$c}  = $s->{error} || 0 if $c =~ /^(?:branch|condition)$/;
   }
   my $total = get_summary($file, "total");
   if ($uncompiled && $total->{pc} eq "n/a") {
@@ -670,7 +693,7 @@ sub build_one_file ($file) {
   my $pc = $total->{pc} // "n/a";
   $f{total_pc}   = $pc;
   $f{total_sort} = $pc eq "n/a" ? -1 : $pc;
-  add_risk(\%f, \%risk_parts);
+  add_crap(\%f, $file);
   \%f
 }
 
@@ -680,7 +703,7 @@ sub build_file_data () {
     my $f = build_one_file($file);
     push @file_data, $f if $f;
   } sort {
-         ($b->{risk} || 0) <=> ($a->{risk} || 0)
+         ($b->{file_crap} || 0)   <=> ($a->{file_crap} || 0)
       || ($a->{total_sort} // -1) <=> ($b->{total_sort} // -1)
       || $a->{name} cmp $b->{name}
   } @file_data
@@ -714,10 +737,13 @@ sub line_subroutines ($f, $n) {
   my $subs = $f->subroutine or return;
   my $loc  = $subs->location($n);
   return unless $loc && @$loc;
+  my $cl = $R{crap_subs} || {};
   map { {
     name    => encode_entities($_->name),
     covered => $_->covered,
     class   => oclass($_, "subroutine"),
+    cc      => ($cl->{ "$n\0" . $_->name } // {})->{cc},
+    crap    => ($cl->{ "$n\0" . $_->name } // {})->{crap},
   } } @$loc
 }
 
@@ -939,11 +965,20 @@ sub generate_index ($outdir, $options, $file_data, $total, $dist) {
   write_file($html, render_index($file_data, $total, $dist));
 }
 
+sub _build_crap_subs ($file) {
+  my $crap_data = $R{db}->summary($file, "crap") or return {};
+  my $subs      = $crap_data->{subs}             or return {};
+  my %lookup;
+  $lookup{ $_->{line} . "\0" . $_->{name} } = $_ for @$subs;
+  \%lookup
+}
+
 sub generate_file_pages ($outdir, $file_data) {
   for my $idx (0 .. $#$file_data) {
     my $fd = $file_data->[$idx];
     next unless $fd->{exists};
     my $file = $fd->{name};
+    $R{crap_subs} = _build_crap_subs($file);
     my $lines
       = $fd->{uncompiled}
       ? build_untested_source_lines($file)
@@ -962,6 +997,7 @@ sub generate_file_pages ($outdir, $file_data) {
       "$outdir/$fd->{link}",
       render_file_page($fd, $lines, \%file_total, $prev, $next),
     );
+    delete $R{crap_subs};
   }
 }
 
@@ -1098,7 +1134,7 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   border-color: var(--border);
   color: var(--fg-muted);
 }
-.stat-risk {
+.stat-crap {
   background: var(--prefix-bg);
   border-color: var(--prefix-border);
   color: var(--fg);
@@ -1336,12 +1372,12 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
 .file-table .sort-asc::after { content: " \25b2"; }
 .file-table .sort-desc::after { content: " \25bc"; }
 
-.risk-hover {
+.crap-hover {
   position: relative;
   cursor: default;
 }
-.risk-hover:hover { z-index: 30; }
-.risk-tip {
+.crap-hover:hover { z-index: 30; }
+.crap-tip {
   display: none;
   position: absolute;
   bottom: 100%;
@@ -1358,14 +1394,14 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   border-collapse: collapse;
   pointer-events: none;
 }
-.risk-hover:hover .risk-tip { display: table; }
-.risk-tip td {
+.crap-hover:hover .crap-tip { display: table; }
+.crap-tip td {
   padding: 1px 6px;
   font-variant-numeric: tabular-nums;
 }
-.risk-tip td:first-child { text-align: left; }
-.risk-tip td:last-child { text-align: right; }
-.risk-tip .risk-total td {
+.crap-tip td:first-child { text-align: left; }
+.crap-tip td:last-child { text-align: right; }
+.crap-tip .crap-total td {
   border-top: 1px solid var(--tip-fg);
   font-weight: 600;
 }
@@ -1376,7 +1412,7 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   margin-top: 4px;
 }
 
-.header .risk-tip {
+.header .crap-tip {
   bottom: auto;
   top: 100%;
   margin-top: 4px;
@@ -1726,7 +1762,7 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
     var groupToggle = document.querySelector(".group-toggle");
 
     /* Read persisted state */
-    var sortCol = rget("sort-col", "risk");
+    var sortCol = rget("sort-col", "crap");
     var sortDir = rget("sort-dir", "desc");
 
     var defaultGrouped = fileCount > 30;

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -333,12 +333,10 @@ HTML
     $o .= qq(<tr class="dir-header" data-dir="$g->{dir}">\n)
       . "<td>$g->{dir}</td>\n";
     for my $c ($R{criteria}->@*) {
-      $o .= "<td></td>\n";
+      $o .= cov_cell($g->{criteria}{$c}, 0);
     }
-    $o
-      .= qq(<td class="$g->{class}">\n$g->{pc}\n)
-      . cov_bar($g->{pc} // "n/a", 0)
-      . "</td>\n<td></td>\n</tr>\n";
+    $o .= cov_cell($g->{total}, 0);
+    $o .= "<td></td>\n</tr>\n";
     $o .= file_row($_, $g->{dir}) for $g->{files}->@*;
   }
   $o .= "</tbody>\n</table>\n\n</div>\n";
@@ -739,6 +737,17 @@ sub build_file_data () {
   } @file_data
 }
 
+sub _dir_summary ($s) {
+  my $pc
+    = $s->{total} ? sprintf("%.1f", 100 * $s->{covered} / $s->{total}) : "n/a";
+  {
+    pc      => $pc,
+    covered => $s->{covered},
+    total   => $s->{total},
+    class   => class($pc, ($pc eq "n/a" || $pc < 100) ? 1 : 0, undef),
+  }
+}
+
 sub build_dir_groups ($file_data) {
   my (%dirs, %dir_stats);
   for my $f (@$file_data) {
@@ -748,17 +757,22 @@ sub build_dir_groups ($file_data) {
     my $t = $f->{total};
     $s->{covered} += $t->{covered} || 0;
     $s->{total}   += $t->{total}   || 0;
+    for my $c ($R{criteria}->@*) {
+      my $cs = $dir_stats{$d}{$c} ||= { covered => 0, total => 0 };
+      my $fc = $f->{criteria}{$c} // next;
+      $cs->{covered} += $fc->{covered} || 0;
+      $cs->{total}   += $fc->{total}   || 0;
+    }
   } map {
-    my $s = $dir_stats{$_};
-    my $pc
-      = $s->{total}
-      ? sprintf("%.1f", 100 * $s->{covered} / $s->{total})
-      : "n/a";
+    my $s  = $dir_stats{$_};
+    my $ts = _dir_summary($s);
     {
-      dir   => $_ || "(root)",
-      pc    => $pc,
-      class => class($pc, ($pc eq "n/a" || $pc < 100) ? 1 : 0, "total"),
-      files => $dirs{$_},
+      dir      => $_ || "(root)",
+      pc       => $ts->{pc},
+      class    => $ts->{class},
+      total    => $ts,
+      criteria => { map { $_ => _dir_summary($s->{$_}) } $R{criteria}->@* },
+      files    => $dirs{$_},
     }
   } sort keys %dirs
 }

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -626,7 +626,9 @@ sub oclass ($o, $criterion) {
 }
 
 sub fmt_pc ($pc) {
-  defined $pc ? (sprintf "%5.2f", $pc) =~ s/.\z//r =~ s/^\s+//r : "n/a"
+  defined $pc
+    ? (sprintf "%5.2f", $pc) =~ s/.\z//r =~ s/^\s+//r =~ s/^100\.0$/100/r
+    : "n/a"
 }
 
 sub get_summary ($file, $criterion) {

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -78,16 +78,19 @@ HTML
 }
 
 sub untested_badge () {
-  my $tip = $R{have_ppi} ? "" : " has-tip";
-  my $data
-    = $R{have_ppi} ? "" : ' data-tip="Install PPI for coverage estimates"';
-  qq(<span class="untested-badge$tip"$data>untested</span>)
+  my $cls = $R{have_ppi} ? "" : " tip-hover";
+  my $tip = $R{have_ppi} ? "" : glass_tip("Install PPI for coverage estimates");
+  qq(<span class="untested-badge$cls">untested $tip</span>)
+}
+
+sub glass_tip ($text) {
+  qq(<span class="glass-tip">$text</span>)
 }
 
 sub slop_tip ($f) {
   my $cov_cls = pc_class($f->{file_cov});
   my $o       = <<HTML;
-<div class="slop-tip">
+<div class="glass-tip slop-detail">
 <dl class="slop-tip-metrics">
 <dt>CC</dt><dd>$f->{file_cc}</dd>
 <dt>Cov</dt><dd class="$cov_cls">$f->{file_cov}%</dd>
@@ -124,9 +127,9 @@ sub cov_bar ($pc, $uncompiled) {
 sub cov_cell ($s, $uncompiled, $data_value = undef) {
   my $dv = $data_value // ($s->{pc} eq "n/a" ? -1 : $s->{pc});
   <<HTML
-<td class="$s->{class} has-tip"
-  data-value="$dv" data-tip="$s->{covered} / $s->{total}">
-$s->{pc} @{[ cov_bar($s->{pc}, $uncompiled) ]}</td>
+<td class="$s->{class} tip-hover" data-value="$dv">
+$s->{pc} @{[ cov_bar($s->{pc}, $uncompiled) ]}
+@{[ glass_tip("$s->{covered} / $s->{total}") ]}</td>
 HTML
 }
 
@@ -148,7 +151,7 @@ HTML
   }
   $o .= cov_cell($f->{total}, $f->{uncompiled}, $f->{total_sort});
   $o .= <<HTML;
-<td data-value="$f->{file_slop}" class="slop-hover">
+<td data-value="$f->{file_slop}" class="tip-hover">
 $f->{file_slop} @{[ slop_tip($f) ]}</td>
 </tr>
 HTML
@@ -170,7 +173,7 @@ sub render_worst_files ($worst) {
 
     $o .= <<HTML;
 <div class="worst-item $cls">
-  $name $badge<strong class="slop-hover">$slop $tip</strong>
+  $name $badge<strong class="tip-hover">$slop $tip</strong>
 </div>
 HTML
   }
@@ -193,8 +196,8 @@ sub render_dist_bar ($dist) {
     next unless $dist->{$key};
     my $w = $dist->{$key} / $dt * 100;
     $o .= <<HTML;
-<div class="dist-bar-seg has-tip" style="width:${w}%; background:var($var)"
-  data-tip="$tip"></div>
+<div class="dist-bar-seg tip-hover" style="width:${w}%; background:var($var)">
+@{[ glass_tip($tip) ]}</div>
 HTML
   }
   $o .= "</div>\n";
@@ -218,10 +221,10 @@ sub stat_badge ($c, $s) {
   my $pct = $s->{pc};
   my $suf = $pct ne "n/a" ? "%" : "";
   <<HTML
-<span class="stat-badge $s->{class} has-tip"
-  data-tip="$s->{covered} / $s->{total}">
+<span class="stat-badge $s->{class} tip-hover">
 <span class="badge-label">@{[ crit_name($c) ]} $pct$suf</span>
-@{[ cov_bar($pct, 0) ]}</span>
+@{[ cov_bar($pct, 0) ]}
+@{[ glass_tip("$s->{covered} / $s->{total}") ]}</span>
 HTML
 }
 
@@ -519,38 +522,37 @@ HTML
     my $s = $total->{$c};
     if ($fd->{uncompiled}) {
       $o .= <<HTML;
-<span class="stat-badge untested-stat has-tip"
-  data-tip="$c: 0" data-criterion="$c">
-@{[ crit_name($c) ]} 0.0%</span>
+<span class="stat-badge untested-stat tip-hover" data-criterion="$c">
+@{[ crit_name($c) ]} 0.0% @{[ glass_tip("$c: 0") ]}</span>
 HTML
     } else {
       my $cls = $s->{class} || "stat-na";
       my $pct = $s->{pc} . ($s->{pc} ne "n/a" ? "%" : "");
       $o .= <<HTML;
-<span class="stat-badge $cls has-tip" data-tip="$s->{covered} / $s->{total}"
-  data-criterion="$c">
-@{[ crit_name($c) ]} $pct</span>
+<span class="stat-badge $cls tip-hover" data-criterion="$c">
+@{[ crit_name($c) ]} $pct @{[ glass_tip("$s->{covered} / $s->{total}") ]}</span>
 HTML
     }
   }
 
   if ($fd->{uncompiled}) {
     $o .= <<HTML;
-<span class="stat-badge untested-stat has-tip" data-tip="total: 0">
-@{[ crit_name("total") ]} 0.0%</span>
-<span class="stat-badge stat-slop has-tip" data-tip="SLOP: 0">SLOP 0</span>
+<span class="stat-badge untested-stat tip-hover">
+@{[ crit_name("total") ]} 0.0% @{[ glass_tip("total: 0") ]}</span>
+<span class="stat-badge stat-slop tip-hover">
+SLOP 0 @{[ glass_tip("SLOP: 0") ]}</span>
 HTML
   } else {
     my $tt = $total->{total};
     if (($tt->{pc} // "n/a") ne "n/a") {
       $o .= <<HTML;
-<span class="stat-badge $tt->{class} has-tip"
-  data-tip="$tt->{covered} / $tt->{total}">
-@{[ crit_name("total") ]} $tt->{pc}%</span>
+<span class="stat-badge $tt->{class} tip-hover">
+@{[ crit_name("total") ]} $tt->{pc}%
+@{[ glass_tip("$tt->{covered} / $tt->{total}") ]}</span>
 HTML
     }
     $o .= <<HTML;
-<span class="stat-badge stat-slop slop-hover has-tip" data-tip="SLOP score">
+<span class="stat-badge stat-slop tip-hover">
 SLOP $fd->{file_slop} @{[ slop_tip($fd) ]}</span>
 HTML
   }
@@ -1401,41 +1403,21 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
 .file-table .sort-asc::after { content: " \25b2"; }
 .file-table .sort-desc::after { content: " \25bc"; }
 
-.slop-hover {
-  position: relative;
-  cursor: default;
-}
-.slop-hover:hover { z-index: 30; }
-.slop-tip {
-  display: none;
-  position: absolute;
-  bottom: 100%;
-  left: 50%;
-  transform: translateX(-50%);
+/* SLOP detail tooltip overrides */
+.glass-tip.slop-detail {
   padding: 8px 12px;
-  border-radius: 4px;
-  font-size: 13px;
   font-weight: normal;
-  white-space: nowrap;
-  background: var(--tip-glass-bg);
-  color: var(--tip-glass-fg);
-  border: 1px solid var(--tip-glass-border);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  z-index: 30;
-  pointer-events: none;
 }
-.slop-hover:hover .slop-tip { display: block; }
 
-.slop-tip dl {
+.slop-detail dl {
   display: grid;
   grid-template-columns: auto auto;
   gap: 1px 12px;
   margin: 0;
   font-variant-numeric: tabular-nums;
 }
-.slop-tip dt { text-align: left; }
-.slop-tip dd { text-align: right; margin: 0; }
+.slop-detail dt { text-align: left; }
+.slop-detail dd { text-align: right; margin: 0; }
 
 .slop-tip-subs {
   border-top: 1px solid var(--tip-glass-sep);
@@ -1454,22 +1436,17 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   font-variant-numeric: tabular-nums;
 }
 
-.slop-tip .c0,
-.slop-tip .c1,
-.slop-tip .c2,
-.slop-tip .c3 { background: transparent; }
-.slop-tip .c0 { color: var(--tip-c0); }
-.slop-tip .c1 { color: var(--tip-c1); }
-.slop-tip .c2 { color: var(--tip-c2); }
-.slop-tip .c3 { color: var(--tip-c3); }
+.slop-detail .c0,
+.slop-detail .c1,
+.slop-detail .c2,
+.slop-detail .c3 { background: transparent; }
+.slop-detail .c0 { color: var(--tip-c0); }
+.slop-detail .c1 { color: var(--tip-c1); }
+.slop-detail .c2 { color: var(--tip-c2); }
+.slop-detail .c3 { color: var(--tip-c3); }
 
-.header .has-tip::after {
-  bottom: auto;
-  top: 100%;
-  margin-top: 4px;
-}
-
-.header .slop-tip {
+/* Header: tooltips below */
+.header .glass-tip {
   bottom: auto;
   top: 100%;
   margin-top: 4px;
@@ -1501,9 +1478,11 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
 /* Untested files */
 
 tr.untested td { opacity: 0.7; }
-tr.untested td .has-tip::after { opacity: 0; }
+tr.untested td .glass-tip { display: none !important; }
 tr.untested td:hover { opacity: 1; }
-tr.untested td:hover .has-tip:hover::after { opacity: 1; }
+tr.untested td:hover .tip-hover:hover > .glass-tip {
+  display: block !important;
+}
 
 .cov-bar-untested {
   display: inline-block;

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -85,17 +85,28 @@ sub untested_badge () {
 }
 
 sub slop_tip ($f) {
-  my $o = <<HTML;
-<table class="slop-tip">
-<tr><td>File CC</td><td>$f->{file_cc}</td></tr>
-<tr><td>Combined cov</td><td>$f->{file_cov}%</td></tr>
+  my $cov_cls = pc_class($f->{file_cov});
+  my $o       = <<HTML;
+<div class="slop-tip">
+<dl class="slop-tip-metrics">
+<dt>CC</dt><dd>$f->{file_cc}</dd>
+<dt>Cov</dt><dd class="$cov_cls">$f->{file_cov}%</dd>
+</dl>
 HTML
-  for ($f->{worst_subs}->@*) {
-    $o .= qq(<tr><td>$_->{name}</td><td>$_->{crap}</td></tr>\n);
+  if ($f->{worst_subs}->@*) {
+    $o .= qq(<dl class="slop-tip-subs">\n);
+    for ($f->{worst_subs}->@*) {
+      my $cls = slop_class($_->{slop});
+      $o .= qq(<dt>$_->{name}</dt><dd class="$cls">$_->{crap}</dd>\n);
+    }
+    $o .= "</dl>\n";
   }
   $o .= <<HTML;
-<tr class="slop-total"><td>CRAP</td><td>$f->{file_crap}</td></tr>
-</table>
+<div class="slop-tip-total">
+<span class="slop-tip-label">CRAP</span>
+<span class="slop-tip-value">$f->{file_crap}</span>
+</div>
+</div>
 HTML
   $o
 }
@@ -339,6 +350,14 @@ HTML
 sub slop_class ($slop) {
   return "" unless defined $slop;
   $slop < 16 ? "c3" : $slop < 34 ? "c2" : $slop < 41 ? "c1" : "c0"
+}
+
+sub pc_class ($pc) {
+  !defined $pc                ? ""
+    : $pc >= 100              ? "c3"
+    : $pc >= $Threshold->{c1} ? "c2"
+    : $pc >= $Threshold->{c0} ? "c1"
+    : "c0"
 }
 
 sub render_line_detail ($line) {
@@ -654,9 +673,13 @@ sub add_slop ($f, $file) {
     $f->{file_cov}  = sprintf "%.0f", $slop_data->{file_cov};
     my @sorted = sort { $b->{crap} <=> $a->{crap} } grep defined $_->{crap},
       @{ $slop_data->{subs} || [] };
-    $f->{worst_subs}
-      = [ map { { name => $_->{name}, crap => sprintf "%.1f", $_->{crap} } }
-        @sorted[ 0 .. ($#sorted > 2 ? 2 : $#sorted) ] ];
+    $f->{worst_subs} = [
+      map { {
+        name => $_->{name},
+        crap => sprintf("%.1f", $_->{crap}),
+        slop => $_->{slop},
+      } } @sorted[ 0 .. ($#sorted > 2 ? 2 : $#sorted) ]
+    ];
   } else {
     $f->{file_crap}  = 0;
     $f->{file_slop}  = 0;
@@ -1389,28 +1412,56 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   bottom: 100%;
   left: 50%;
   transform: translateX(-50%);
-  padding: 6px 10px;
+  padding: 8px 12px;
   border-radius: 4px;
   font-size: 13px;
   font-weight: normal;
   white-space: nowrap;
-  background: var(--tip-bg);
-  color: var(--tip-fg);
+  background: var(--tip-glass-bg);
+  color: var(--tip-glass-fg);
+  border: 1px solid var(--tip-glass-border);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
   z-index: 30;
-  border-collapse: collapse;
   pointer-events: none;
 }
-.slop-hover:hover .slop-tip { display: table; }
-.slop-tip td {
-  padding: 1px 6px;
+.slop-hover:hover .slop-tip { display: block; }
+
+.slop-tip dl {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 1px 12px;
+  margin: 0;
   font-variant-numeric: tabular-nums;
 }
-.slop-tip td:first-child { text-align: left; }
-.slop-tip td:last-child { text-align: right; }
-.slop-tip .slop-total td {
-  border-top: 1px solid var(--tip-fg);
-  font-weight: 600;
+.slop-tip dt { text-align: left; }
+.slop-tip dd { text-align: right; margin: 0; }
+
+.slop-tip-subs {
+  border-top: 1px solid var(--tip-glass-sep);
+  margin-top: 4px !important;
+  padding-top: 4px;
 }
+
+.slop-tip-total {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  border-top: 1px solid var(--tip-glass-sep);
+  margin-top: 4px;
+  padding-top: 4px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.slop-tip .c0,
+.slop-tip .c1,
+.slop-tip .c2,
+.slop-tip .c3 { background: transparent; }
+.slop-tip .c0 { color: var(--tip-c0); }
+.slop-tip .c1 { color: var(--tip-c1); }
+.slop-tip .c2 { color: var(--tip-c2); }
+.slop-tip .c3 { color: var(--tip-c3); }
 
 .header .has-tip::after {
   bottom: auto;

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -336,7 +336,7 @@ HTML
   )
 }
 
-sub crap_class ($slop) {
+sub slop_class ($slop) {
   return "" unless defined $slop;
   $slop < 16 ? "c3" : $slop < 34 ? "c2" : $slop < 41 ? "c1" : "c0"
 }
@@ -349,7 +349,7 @@ sub render_line_detail ($line) {
       my $status  = $s->{covered} ? "called" : "not called";
       my $cc_info = "";
       if (defined $s->{cc}) {
-        my $cls  = crap_class($s->{slop});
+        my $cls  = slop_class($s->{slop});
         my $slop = sprintf "%.1f", $s->{slop} // 0;
         $cc_info = qq( <span class="$cls">CC=$s->{cc} SLOP=$slop</span>);
       }

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -84,9 +84,9 @@ sub untested_badge () {
   qq(<span class="untested-badge$tip"$data>untested</span>)
 }
 
-sub crap_tip ($f) {
+sub slop_tip ($f) {
   my $o = <<HTML;
-<table class="crap-tip">
+<table class="slop-tip">
 <tr><td>File CC</td><td>$f->{file_cc}</td></tr>
 <tr><td>Combined cov</td><td>$f->{file_cov}%</td></tr>
 HTML
@@ -94,7 +94,7 @@ HTML
     $o .= qq(<tr><td>$_->{name}</td><td>$_->{crap}</td></tr>\n);
   }
   $o .= <<HTML;
-<tr class="crap-total"><td>CRAP</td><td>$f->{file_crap}</td></tr>
+<tr class="slop-total"><td>CRAP</td><td>$f->{file_crap}</td></tr>
 </table>
 HTML
   $o
@@ -137,8 +137,8 @@ HTML
   }
   $o .= cov_cell($f->{total}, $f->{uncompiled}, $f->{total_sort});
   $o .= <<HTML;
-<td data-value="$f->{file_slop}" class="crap-hover">
-$f->{file_slop} @{[ crap_tip($f) ]}</td>
+<td data-value="$f->{file_slop}" class="slop-hover">
+$f->{file_slop} @{[ slop_tip($f) ]}</td>
 </tr>
 HTML
   $o
@@ -154,12 +154,12 @@ sub render_worst_files ($worst) {
     my $name
       = $f->{exists} ? qq(<a href="$f->{link}">$f->{short}</a>) : $f->{short};
     my $badge = $f->{uncompiled} ? untested_badge() . "\n" : "";
-    my $tip   = crap_tip($f);
+    my $tip   = slop_tip($f);
     my $slop  = $f->{file_slop};
 
     $o .= <<HTML;
 <div class="worst-item $cls">
-  $name $badge<strong class="crap-hover">$slop $tip</strong>
+  $name $badge<strong class="slop-hover">$slop $tip</strong>
 </div>
 HTML
   }
@@ -295,7 +295,7 @@ HTML
 HTML
 
   my $ncrit  = $R{criteria}->@*;
-  my $ncols  = $ncrit + 2;       # criteria + total + crap
+  my $ncols  = $ncrit + 2;       # criteria + total + slop
   my $crit_w = 70 / $ncols;
   $o
     .= qq(<table class="file-table">\n<colgroup>\n)
@@ -519,7 +519,7 @@ HTML
     $o .= <<HTML;
 <span class="stat-badge untested-stat has-tip" data-tip="total: 0">
 @{[ crit_name("total") ]} 0.0%</span>
-<span class="stat-badge stat-crap has-tip" data-tip="SLOP: 0">SLOP 0</span>
+<span class="stat-badge stat-slop has-tip" data-tip="SLOP: 0">SLOP 0</span>
 HTML
   } else {
     my $tt = $total->{total};
@@ -531,8 +531,8 @@ HTML
 HTML
     }
     $o .= <<HTML;
-<span class="stat-badge stat-crap crap-hover has-tip" data-tip="SLOP score">
-SLOP $fd->{file_slop} @{[ crap_tip($fd) ]}</span>
+<span class="stat-badge stat-slop slop-hover has-tip" data-tip="SLOP score">
+SLOP $fd->{file_slop} @{[ slop_tip($fd) ]}</span>
 HTML
   }
 
@@ -645,15 +645,15 @@ sub get_summary ($file, $criterion) {
   }
 }
 
-sub add_crap ($f, $file) {
-  my $crap_data = $R{db}->summary($file, "crap");
-  if ($crap_data && defined $crap_data->{file_crap}) {
-    $f->{file_crap} = sprintf "%.1f", $crap_data->{file_crap};
-    $f->{file_slop} = sprintf "%.1f", $crap_data->{file_slop} // 0;
-    $f->{file_cc}   = $crap_data->{file_cc};
-    $f->{file_cov}  = sprintf "%.0f", $crap_data->{file_cov};
+sub add_slop ($f, $file) {
+  my $slop_data = $R{db}->summary($file, "slop");
+  if ($slop_data && defined $slop_data->{file_crap}) {
+    $f->{file_crap} = sprintf "%.1f", $slop_data->{file_crap};
+    $f->{file_slop} = sprintf "%.1f", $slop_data->{file_slop} // 0;
+    $f->{file_cc}   = $slop_data->{file_cc};
+    $f->{file_cov}  = sprintf "%.0f", $slop_data->{file_cov};
     my @sorted = sort { $b->{crap} <=> $a->{crap} } grep defined $_->{crap},
-      @{ $crap_data->{subs} || [] };
+      @{ $slop_data->{subs} || [] };
     $f->{worst_subs}
       = [ map { { name => $_->{name}, crap => sprintf "%.1f", $_->{crap} } }
         @sorted[ 0 .. ($#sorted > 2 ? 2 : $#sorted) ] ];
@@ -698,7 +698,7 @@ sub build_one_file ($file) {
   my $pc = $total->{pc} // "n/a";
   $f{total_pc}   = $pc;
   $f{total_sort} = $pc eq "n/a" ? -1 : $pc;
-  add_crap(\%f, $file);
+  add_slop(\%f, $file);
   \%f
 }
 
@@ -742,7 +742,7 @@ sub line_subroutines ($f, $n) {
   my $subs = $f->subroutine or return;
   my $loc  = $subs->location($n);
   return unless $loc && @$loc;
-  my $cl = $R{crap_subs} || {};
+  my $cl = $R{slop_subs} || {};
   map { {
     name    => encode_entities($_->name),
     covered => $_->covered,
@@ -971,9 +971,9 @@ sub generate_index ($outdir, $options, $file_data, $total, $dist) {
   write_file($html, render_index($file_data, $total, $dist));
 }
 
-sub _build_crap_subs ($file) {
-  my $crap_data = $R{db}->summary($file, "crap") or return {};
-  my $subs      = $crap_data->{subs}             or return {};
+sub _build_slop_subs ($file) {
+  my $slop_data = $R{db}->summary($file, "slop") or return {};
+  my $subs      = $slop_data->{subs}             or return {};
   my %lookup;
   $lookup{ $_->{line} . "\0" . $_->{name} } = $_ for @$subs;
   \%lookup
@@ -984,7 +984,7 @@ sub generate_file_pages ($outdir, $file_data) {
     my $fd = $file_data->[$idx];
     next unless $fd->{exists};
     my $file = $fd->{name};
-    $R{crap_subs} = _build_crap_subs($file);
+    $R{slop_subs} = _build_slop_subs($file);
     my $lines
       = $fd->{uncompiled}
       ? build_untested_source_lines($file)
@@ -1003,7 +1003,7 @@ sub generate_file_pages ($outdir, $file_data) {
       "$outdir/$fd->{link}",
       render_file_page($fd, $lines, \%file_total, $prev, $next),
     );
-    delete $R{crap_subs};
+    delete $R{slop_subs};
   }
 }
 
@@ -1140,7 +1140,7 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   border-color: var(--border);
   color: var(--fg-muted);
 }
-.stat-crap {
+.stat-slop {
   background: var(--prefix-bg);
   border-color: var(--prefix-border);
   color: var(--fg);
@@ -1378,12 +1378,12 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
 .file-table .sort-asc::after { content: " \25b2"; }
 .file-table .sort-desc::after { content: " \25bc"; }
 
-.crap-hover {
+.slop-hover {
   position: relative;
   cursor: default;
 }
-.crap-hover:hover { z-index: 30; }
-.crap-tip {
+.slop-hover:hover { z-index: 30; }
+.slop-tip {
   display: none;
   position: absolute;
   bottom: 100%;
@@ -1400,14 +1400,14 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   border-collapse: collapse;
   pointer-events: none;
 }
-.crap-hover:hover .crap-tip { display: table; }
-.crap-tip td {
+.slop-hover:hover .slop-tip { display: table; }
+.slop-tip td {
   padding: 1px 6px;
   font-variant-numeric: tabular-nums;
 }
-.crap-tip td:first-child { text-align: left; }
-.crap-tip td:last-child { text-align: right; }
-.crap-tip .crap-total td {
+.slop-tip td:first-child { text-align: left; }
+.slop-tip td:last-child { text-align: right; }
+.slop-tip .slop-total td {
   border-top: 1px solid var(--tip-fg);
   font-weight: 600;
 }
@@ -1418,7 +1418,7 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   margin-top: 4px;
 }
 
-.header .crap-tip {
+.header .slop-tip {
   bottom: auto;
   top: 100%;
   margin-top: 4px;

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1471,8 +1471,13 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   user-select: none;
 }
 
-.dir-header td:first-child {
+.dir-header td {
+  background: var(--bg-alt);
+  border-top: 6px solid var(--bg);
   font-weight: 600;
+}
+
+.dir-header td:first-child {
   color: var(--fg-muted);
 }
 

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -256,7 +256,7 @@ HTML
     my $tip = sprintf "CC %d &middot; cov %.0f%% &middot; CRAP %.1f",
       $ms->{module_cc}, $ms->{module_cov}, $ms->{module_crap};
     $o .= <<HTML;
-<span class="stat-badge tip-hover">
+<span class="stat-badge stat-slop tip-hover">
 <span class="badge-label">slop $sv</span>
 @{[ glass_tip($tip) ]}</span>
 HTML
@@ -1189,6 +1189,7 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   .name-full  { display: none !important; }
   .name-short { display: inline !important; }
   .stat-badge { width: 140px; }
+  .stat-slop  { width: auto; }
 }
 
 /* Narrow: stack pills vertically */
@@ -1210,6 +1211,7 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   background: var(--prefix-bg);
   border-color: var(--prefix-border);
   color: var(--fg);
+  width: auto;
 }
 .stat-badge[data-criterion] {
   cursor: pointer;

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -160,8 +160,7 @@ HTML
 
 sub render_worst_files ($worst) {
   return "" unless @$worst && $worst->[0]{file_slop} > 0;
-  my $o = qq(<div class="worst-files">\n<h2>Highest SLOP</h2>\n)
-    . qq(<div class="worst-list">\n);
+  my $o = qq(<div class="worst-files">\n<h2>Top SLOP</h2>\n);
   for my $f (@$worst) {
     next if $f->{file_slop} == 0;
     my $cls = $f->{uncompiled} ? "untested-worst" : $f->{total}{class};
@@ -177,7 +176,7 @@ sub render_worst_files ($worst) {
 </div>
 HTML
   }
-  $o .= "</div>\n</div>\n";
+  $o .= "</div>\n";
   $o
 }
 
@@ -186,11 +185,11 @@ sub render_dist_bar ($dist) {
   return "" unless $dt > 0;
   my $o = qq(<div class="dist-bar">\n);
   for my $seg (
-    [ c0       => "--cov-none-border", $dist->{tip_c0} ],
-    [ c1       => "--cov-low-border",  $dist->{tip_c1} ],
-    [ c2       => "--cov-good-border", $dist->{tip_c2} ],
-    [ c3       => "--cov-full-border", $dist->{tip_c3} ],
-    [ untested => "--untested-bar",    $dist->{tip_untested} ],
+    [c0       => "--cov-none-border", $dist->{tip_c0}],
+    [c1       => "--cov-low-border",  $dist->{tip_c1}],
+    [c2       => "--cov-good-border", $dist->{tip_c2}],
+    [c3       => "--cov-full-border", $dist->{tip_c3}],
+    [untested => "--untested-bar",    $dist->{tip_untested}],
   ) {
     my ($key, $var, $tip) = @$seg;
     next unless $dist->{$key};
@@ -233,7 +232,7 @@ sub render_index ($file_data, $total, $dist) {
   my @worst
     = @$file_data
     ? (sort { $b->{file_slop} <=> $a->{file_slop} } @$file_data)
-    [ 0 .. ($#$file_data > 4 ? 4 : $#$file_data) ]
+    [0 .. ($#$file_data > 4 ? 4 : $#$file_data)]
     : ();
 
   my $o = <<HTML;
@@ -694,7 +693,7 @@ sub add_slop ($f, $file) {
         name => $_->{name},
         crap => sprintf("%.1f", $_->{crap}),
         slop => $_->{slop},
-      } } @sorted[ 0 .. ($#sorted > 2 ? 2 : $#sorted) ]
+      } } @sorted[0 .. ($#sorted > 2 ? 2 : $#sorted)]
     ];
   } else {
     $f->{file_crap}  = 0;
@@ -864,7 +863,7 @@ sub line_truth_tables ($f, $n) {
       headers    => \@headers,
       legend     => [
         map { {
-          letter => $headers[$_], label => encode_entities($labels[$_]), } }
+          letter => $headers[$_], label => encode_entities($labels[$_]) } }
           0 .. $#labels
       ],
     }
@@ -1062,8 +1061,8 @@ sub generate_file_pages ($outdir, $file_data) {
       )
       : totals_for($file);
 
-    my $prev = $idx > 0            ? $file_data->[ $idx - 1 ] : undef;
-    my $next = $idx < $#$file_data ? $file_data->[ $idx + 1 ] : undef;
+    my $prev = $idx > 0            ? $file_data->[$idx - 1] : undef;
+    my $next = $idx < $#$file_data ? $file_data->[$idx + 1] : undef;
 
     write_file(
       "$outdir/$fd->{link}",
@@ -1085,10 +1084,9 @@ sub report ($pkg, $db, $options) {
     os       => $^O,
     options  => $options,
     version  => $VERSION,
-    showing  => [ grep $options->{show}{$_}, $db->criteria ],
-    criteria =>
-      [ grep $_ ne "time", grep $options->{show}{$_}, $db->criteria ],
-    headers => [
+    showing  => [grep $options->{show}{$_}, $db->criteria],
+    criteria => [grep $_ ne "time", grep $options->{show}{$_}, $db->criteria],
+    headers  => [
       map  { ($db->criteria_short)[$_] }
       grep { $options->{show}{ ($db->criteria)[$_] } }
         (0 .. $db->criteria - 1)
@@ -1330,6 +1328,11 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
 /* Worst files */
 
 .worst-files {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  overflow: hidden;
   margin-bottom: 24px;
 }
 
@@ -1338,15 +1341,8 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  margin: 0 0 8px 0;
+  margin: 0;
   color: var(--fg-muted);
-}
-
-.worst-list {
-  display: flex;
-  gap: 8px;
-  flex-wrap: nowrap;
-  overflow: hidden;
 }
 
 .worst-item {

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -250,6 +250,23 @@ HTML
   my $tt = $total->{total};
   $o .= stat_badge("total", $tt) if ($tt->{pc} // "n/a") ne "n/a";
 
+  my $ms = $R{db}->summary("Total", "slop");
+  if ($ms && defined $ms->{module_slop}) {
+    my $sv  = sprintf "%.1f", $ms->{module_slop};
+    my $sc  = slop_class($ms->{module_slop});
+    my $bar = 100 - $sv;
+    $bar = 0   if $bar < 0;
+    $bar = 100 if $bar > 100;
+    my $tip = sprintf "CC %d &middot; cov %.0f%% &middot; CRAP %.1f",
+      $ms->{module_cc}, $ms->{module_cov}, $ms->{module_crap};
+    $o .= <<HTML;
+<span class="stat-badge $sc tip-hover">
+<span class="badge-label">slop $sv</span>
+@{[ cov_bar($bar, 0) ]}
+@{[ glass_tip($tip) ]}</span>
+HTML
+  }
+
   $o .= <<HTML;
 <button class="help-toggle" aria-label="Help">?</button>
 <button class="theme-toggle" aria-label="Toggle dark mode">&#x263e;</button>

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -88,7 +88,7 @@ sub glass_tip ($text) {
 }
 
 sub slop_tip ($f) {
-  my $cov_cls = pc_class($f->{file_cov});
+  my $cov_cls = class($f->{file_cov}, $f->{file_cov} < 100, "total");
   my $o       = <<HTML;
 <div class="glass-tip slop-detail">
 <dl class="slop-tip-metrics">
@@ -366,14 +366,6 @@ HTML
 sub slop_class ($slop) {
   return "" unless defined $slop;
   $slop < 16 ? "c3" : $slop < 34 ? "c2" : $slop < 41 ? "c1" : "c0"
-}
-
-sub pc_class ($pc) {
-  !defined $pc                ? ""
-    : $pc >= 100              ? "c3"
-    : $pc >= $Threshold->{c1} ? "c2"
-    : $pc >= $Threshold->{c0} ? "c1"
-    : "c0"
 }
 
 sub render_line_detail ($line) {
@@ -665,10 +657,9 @@ sub fmt_pc ($pc) {
     : "n/a"
 }
 
-sub get_summary ($file, $criterion) {
-  my $part = $R{db}->summary($file);
+sub _format_criterion ($part, $criterion) {
   return { pc => "n/a", class => "na", covered => 0, total => 0, error => 0 }
-    unless exists $part->{$criterion};
+    unless $part && exists $part->{$criterion};
   my $c = $part->{$criterion};
   {
     pc      => fmt_pc($c->{percentage}),
@@ -679,8 +670,11 @@ sub get_summary ($file, $criterion) {
   }
 }
 
-sub add_slop ($f, $file) {
-  my $slop_data = $R{db}->summary($file, "slop");
+sub get_summary ($file, $criterion) {
+  _format_criterion($R{db}->summary($file), $criterion)
+}
+
+sub _apply_slop ($f, $slop_data) {
   if ($slop_data && defined $slop_data->{file_crap}) {
     $f->{file_crap} = sprintf "%.1f", $slop_data->{file_crap};
     $f->{file_slop} = sprintf "%.1f", $slop_data->{file_slop} // 0;
@@ -736,7 +730,7 @@ sub build_one_file ($file) {
   my $pc = $total->{pc} // "n/a";
   $f{total_pc}   = $pc;
   $f{total_sort} = $pc eq "n/a" ? -1 : $pc;
-  add_slop(\%f, $file);
+  _apply_slop(\%f, $R{db}->summary($file, "slop"));
   \%f
 }
 
@@ -753,34 +747,7 @@ sub build_file_data () {
 }
 
 sub get_dir_summary ($dir, $criterion) {
-  my $part = $R{db}->dir_summary($dir);
-  return { pc => "n/a", class => "na", covered => 0, total => 0, error => 0 }
-    unless $part && exists $part->{$criterion};
-  my $c = $part->{$criterion};
-  {
-    pc      => fmt_pc($c->{percentage}),
-    class   => class($c->{percentage}, $c->{error}, $criterion),
-    covered => $c->{covered} || 0,
-    total   => $c->{total}   || 0,
-    error   => $c->{error}   || 0,
-  }
-}
-
-sub add_dir_slop ($f, $dir) {
-  my $slop_data = $R{db}->dir_summary($dir, "slop");
-  if ($slop_data && defined $slop_data->{file_crap}) {
-    $f->{file_crap}  = sprintf "%.1f", $slop_data->{file_crap};
-    $f->{file_slop}  = sprintf "%.1f", $slop_data->{file_slop} // 0;
-    $f->{file_cc}    = $slop_data->{file_cc};
-    $f->{file_cov}   = sprintf "%.0f", $slop_data->{file_cov};
-    $f->{worst_subs} = [];
-  } else {
-    $f->{file_crap}  = 0;
-    $f->{file_slop}  = 0;
-    $f->{file_cc}    = 0;
-    $f->{file_cov}   = 0;
-    $f->{worst_subs} = [];
-  }
+  _format_criterion($R{db}->dir_summary($dir), $criterion)
 }
 
 sub build_dir_groups ($file_data) {
@@ -798,7 +765,7 @@ sub build_dir_groups ($file_data) {
     };
     $g->{pc}    = $g->{total}{pc};
     $g->{class} = $g->{total}{class};
-    add_dir_slop($g, $dir);
+    _apply_slop($g, $R{db}->dir_summary($dir, "slop"));
     $g;
   } sort keys %dirs
 }
@@ -1036,20 +1003,12 @@ sub generate_index ($outdir, $options, $file_data, $total, $dist) {
   write_file($html, render_index($file_data, $total, $dist));
 }
 
-sub _build_slop_subs ($file) {
-  my $slop_data = $R{db}->summary($file, "slop") or return {};
-  my $subs      = $slop_data->{subs}             or return {};
-  my %lookup;
-  $lookup{ $_->{line} . "\0" . $_->{name} } = $_ for @$subs;
-  \%lookup
-}
-
 sub generate_file_pages ($outdir, $file_data) {
   for my $idx (0 .. $#$file_data) {
     my $fd = $file_data->[$idx];
     next unless $fd->{exists};
     my $file = $fd->{name};
-    $R{slop_subs} = _build_slop_subs($file);
+    $R{slop_subs} = $R{db}->slop_sub_lookup($file);
     my $lines
       = $fd->{uncompiled}
       ? build_untested_source_lines($file)

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -336,7 +336,11 @@ HTML
       $o .= cov_cell($g->{criteria}{$c}, 0);
     }
     $o .= cov_cell($g->{total}, 0);
-    $o .= "<td></td>\n</tr>\n";
+    $o .= <<HTML;
+<td data-value="$g->{file_slop}" class="tip-hover">
+$g->{file_slop} @{[ slop_tip($g) ]}</td>
+</tr>
+HTML
     $o .= file_row($_, $g->{dir}) for $g->{files}->@*;
   }
   $o .= "</tbody>\n</table>\n\n</div>\n";
@@ -737,43 +741,54 @@ sub build_file_data () {
   } @file_data
 }
 
-sub _dir_summary ($s) {
-  my $pc
-    = $s->{total} ? sprintf("%.1f", 100 * $s->{covered} / $s->{total}) : "n/a";
+sub get_dir_summary ($dir, $criterion) {
+  my $part = $R{db}->dir_summary($dir);
+  return { pc => "n/a", class => "na", covered => 0, total => 0, error => 0 }
+    unless $part && exists $part->{$criterion};
+  my $c = $part->{$criterion};
   {
-    pc      => $pc,
-    covered => $s->{covered},
-    total   => $s->{total},
-    class   => class($pc, ($pc eq "n/a" || $pc < 100) ? 1 : 0, undef),
+    pc      => fmt_pc($c->{percentage}),
+    class   => class($c->{percentage}, $c->{error}, $criterion),
+    covered => $c->{covered} || 0,
+    total   => $c->{total}   || 0,
+    error   => $c->{error}   || 0,
+  }
+}
+
+sub add_dir_slop ($f, $dir) {
+  my $slop_data = $R{db}->dir_summary($dir, "slop");
+  if ($slop_data && defined $slop_data->{file_crap}) {
+    $f->{file_crap}  = sprintf "%.1f", $slop_data->{file_crap};
+    $f->{file_slop}  = sprintf "%.1f", $slop_data->{file_slop} // 0;
+    $f->{file_cc}    = $slop_data->{file_cc};
+    $f->{file_cov}   = sprintf "%.0f", $slop_data->{file_cov};
+    $f->{worst_subs} = [];
+  } else {
+    $f->{file_crap}  = 0;
+    $f->{file_slop}  = 0;
+    $f->{file_cc}    = 0;
+    $f->{file_cov}   = 0;
+    $f->{worst_subs} = [];
   }
 }
 
 sub build_dir_groups ($file_data) {
-  my (%dirs, %dir_stats);
-  for my $f (@$file_data) {
-    my $d = $f->{dir};
-    push $dirs{$d}->@*, $f;
-    my $s = $dir_stats{$d} ||= { covered => 0, total => 0 };
-    my $t = $f->{total};
-    $s->{covered} += $t->{covered} || 0;
-    $s->{total}   += $t->{total}   || 0;
-    for my $c ($R{criteria}->@*) {
-      my $cs = $dir_stats{$d}{$c} ||= { covered => 0, total => 0 };
-      my $fc = $f->{criteria}{$c} // next;
-      $cs->{covered} += $fc->{covered} || 0;
-      $cs->{total}   += $fc->{total}   || 0;
-    }
-  } map {
-    my $s  = $dir_stats{$_};
-    my $ts = _dir_summary($s);
-    {
-      dir      => $_ || "(root)",
-      pc       => $ts->{pc},
-      class    => $ts->{class},
-      total    => $ts,
-      criteria => { map { $_ => _dir_summary($s->{$_}) } $R{criteria}->@* },
-      files    => $dirs{$_},
-    }
+  my %dirs;
+  push $dirs{ $_->{dir} }->@*, $_ for @$file_data;
+  map {
+    my $dir = $_;
+    my $g   = {
+      dir      => $dir || "(root)",
+      dir_key  => $dir,
+      total    => get_dir_summary($dir, "total"),
+      criteria =>
+        { map { $_ => get_dir_summary($dir, $_) } $R{criteria}->@* },
+      files => $dirs{$dir},
+    };
+    $g->{pc}    = $g->{total}{pc};
+    $g->{class} = $g->{total}{class};
+    add_dir_slop($g, $dir);
+    $g;
   } sort keys %dirs
 }
 

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -253,16 +253,11 @@ HTML
   my $ms = $R{db}->summary("Total", "slop");
   if ($ms && defined $ms->{module_slop}) {
     my $sv  = sprintf "%.1f", $ms->{module_slop};
-    my $sc  = slop_class($ms->{module_slop});
-    my $bar = 100 - $sv;
-    $bar = 0   if $bar < 0;
-    $bar = 100 if $bar > 100;
     my $tip = sprintf "CC %d &middot; cov %.0f%% &middot; CRAP %.1f",
       $ms->{module_cc}, $ms->{module_cov}, $ms->{module_crap};
     $o .= <<HTML;
-<span class="stat-badge $sc tip-hover">
+<span class="stat-badge tip-hover">
 <span class="badge-label">slop $sv</span>
-@{[ cov_bar($bar, 0) ]}
 @{[ glass_tip($tip) ]}</span>
 HTML
   }

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -137,29 +137,29 @@ HTML
   }
   $o .= cov_cell($f->{total}, $f->{uncompiled}, $f->{total_sort});
   $o .= <<HTML;
-<td data-value="$f->{file_crap}" class="crap-hover">
-$f->{file_crap} @{[ crap_tip($f) ]}</td>
+<td data-value="$f->{file_slop}" class="crap-hover">
+$f->{file_slop} @{[ crap_tip($f) ]}</td>
 </tr>
 HTML
   $o
 }
 
 sub render_worst_files ($worst) {
-  return "" unless @$worst && $worst->[0]{file_crap} > 0;
-  my $o = qq(<div class="worst-files">\n<h2>Highest CRAP</h2>\n)
+  return "" unless @$worst && $worst->[0]{file_slop} > 0;
+  my $o = qq(<div class="worst-files">\n<h2>Highest SLOP</h2>\n)
     . qq(<div class="worst-list">\n);
   for my $f (@$worst) {
-    next if $f->{file_crap} == 0;
+    next if $f->{file_slop} == 0;
     my $cls = $f->{uncompiled} ? "untested-worst" : $f->{total}{class};
     my $name
       = $f->{exists} ? qq(<a href="$f->{link}">$f->{short}</a>) : $f->{short};
     my $badge = $f->{uncompiled} ? untested_badge() . "\n" : "";
     my $tip   = crap_tip($f);
-    my $crap  = $f->{file_crap};
+    my $slop  = $f->{file_slop};
 
     $o .= <<HTML;
 <div class="worst-item $cls">
-  $name $badge<strong class="crap-hover">$crap $tip</strong>
+  $name $badge<strong class="crap-hover">$slop $tip</strong>
 </div>
 HTML
   }
@@ -218,7 +218,7 @@ sub render_index ($file_data, $total, $dist) {
   my @groups = build_dir_groups($file_data);
   my @worst
     = @$file_data
-    ? (sort { $b->{file_crap} <=> $a->{file_crap} } @$file_data)
+    ? (sort { $b->{file_slop} <=> $a->{file_slop} } @$file_data)
     [ 0 .. ($#$file_data > 4 ? 4 : $#$file_data) ]
     : ();
 
@@ -256,9 +256,10 @@ Toggle "Hide 100% covered" to focus on incomplete files.</dd>
 <dt>Grouping</dt>
 <dd>Toggle "Group by directory" to organise files into
 collapsible groups. Click a directory row to collapse it.</dd>
-<dt>CRAP</dt>
-<dd>File-level CRAP (Change Risk Anti-Patterns) score. Hover for
-a breakdown: file CC, combined coverage, and worst subs.</dd>
+<dt>SLOP</dt>
+<dd>Scaled Likelihood Of Problems - a log-scaled CRAP score
+compressed to a 0-100 range. Hover for a breakdown: file CC,
+combined coverage, worst subs, and the raw CRAP score.</dd>
 <dt>Tooltips</dt>
 <dd>Hover any badge or coverage cell for covered/total counts.</dd>
 </dl>
@@ -308,7 +309,7 @@ HTML
   }
   $o .= <<HTML;
 <th data-sort="total">@{[ crit_name('total') ]}</th>
-<th data-sort="crap">CRAP</th>
+<th data-sort="slop">SLOP</th>
 </tr>
 </thead>
 <tbody>
@@ -335,9 +336,9 @@ HTML
   )
 }
 
-sub crap_class ($crap) {
-  return "" unless defined $crap;
-  $crap < 5 ? "c3" : $crap < 30 ? "c2" : $crap < 60 ? "c1" : "c0"
+sub crap_class ($slop) {
+  return "" unless defined $slop;
+  $slop < 16 ? "c3" : $slop < 34 ? "c2" : $slop < 41 ? "c1" : "c0"
 }
 
 sub render_line_detail ($line) {
@@ -348,9 +349,9 @@ sub render_line_detail ($line) {
       my $status  = $s->{covered} ? "called" : "not called";
       my $cc_info = "";
       if (defined $s->{cc}) {
-        my $cls  = crap_class($s->{crap});
-        my $crap = sprintf "%.1f", $s->{crap};
-        $cc_info = qq( <span class="$cls">CC=$s->{cc} CRAP=$crap</span>);
+        my $cls  = crap_class($s->{slop});
+        my $slop = sprintf "%.1f", $s->{slop} // 0;
+        $cc_info = qq( <span class="$cls">CC=$s->{cc} SLOP=$slop</span>);
       }
       $o .= <<HTML;
 <div class="detail">
@@ -518,7 +519,7 @@ HTML
     $o .= <<HTML;
 <span class="stat-badge untested-stat has-tip" data-tip="total: 0">
 @{[ crit_name("total") ]} 0.0%</span>
-<span class="stat-badge stat-crap has-tip" data-tip="CRAP: 0">CRAP 0</span>
+<span class="stat-badge stat-crap has-tip" data-tip="SLOP: 0">SLOP 0</span>
 HTML
   } else {
     my $tt = $total->{total};
@@ -530,8 +531,8 @@ HTML
 HTML
     }
     $o .= <<HTML;
-<span class="stat-badge stat-crap crap-hover has-tip" data-tip="CRAP score">
-CRAP $fd->{file_crap} @{[ crap_tip($fd) ]}</span>
+<span class="stat-badge stat-crap crap-hover has-tip" data-tip="SLOP score">
+SLOP $fd->{file_slop} @{[ crap_tip($fd) ]}</span>
 HTML
   }
 
@@ -557,7 +558,7 @@ condition, or subroutine detail.</dd>
 <dd>The strip on the right shows coverage at a glance. Click to
 jump to that line.</dd>
 <dt>Tooltips</dt>
-<dd>Hover badges for covered/total counts. Hover CRAP for a
+<dd>Hover badges for covered/total counts. Hover SLOP for a
 breakdown.</dd>
 <dt>Keyboard</dt>
 <dd><kbd>j</kbd> / <kbd>k</kbd> next/prev uncovered line
@@ -646,6 +647,7 @@ sub add_crap ($f, $file) {
   my $crap_data = $R{db}->summary($file, "crap");
   if ($crap_data && defined $crap_data->{file_crap}) {
     $f->{file_crap} = sprintf "%.1f", $crap_data->{file_crap};
+    $f->{file_slop} = sprintf "%.1f", $crap_data->{file_slop} // 0;
     $f->{file_cc}   = $crap_data->{file_cc};
     $f->{file_cov}  = sprintf "%.0f", $crap_data->{file_cov};
     my @sorted = sort { $b->{crap} <=> $a->{crap} } grep defined $_->{crap},
@@ -655,6 +657,7 @@ sub add_crap ($f, $file) {
         @sorted[ 0 .. ($#sorted > 2 ? 2 : $#sorted) ] ];
   } else {
     $f->{file_crap}  = 0;
+    $f->{file_slop}  = 0;
     $f->{file_cc}    = 0;
     $f->{file_cov}   = 0;
     $f->{worst_subs} = [];
@@ -703,7 +706,7 @@ sub build_file_data () {
     my $f = build_one_file($file);
     push @file_data, $f if $f;
   } sort {
-         ($b->{file_crap} || 0)   <=> ($a->{file_crap} || 0)
+         ($b->{file_slop} || 0)   <=> ($a->{file_slop} || 0)
       || ($a->{total_sort} // -1) <=> ($b->{total_sort} // -1)
       || $a->{name} cmp $b->{name}
   } @file_data
@@ -744,6 +747,7 @@ sub line_subroutines ($f, $n) {
     class   => oclass($_, "subroutine"),
     cc      => ($cl->{ "$n\0" . $_->name } // {})->{cc},
     crap    => ($cl->{ "$n\0" . $_->name } // {})->{crap},
+    slop    => ($cl->{ "$n\0" . $_->name } // {})->{slop},
   } } @$loc
 }
 
@@ -1762,7 +1766,8 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
     var groupToggle = document.querySelector(".group-toggle");
 
     /* Read persisted state */
-    var sortCol = rget("sort-col", "crap");
+    var sortCol = rget("sort-col", "slop");
+    if (sortCol === "crap") { sortCol = "slop"; rset("sort-col", "slop"); }
     var sortDir = rget("sort-dir", "desc");
 
     var defaultGrouped = fileCount > 30;

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -197,9 +197,17 @@ sub print_conditions ($db, $file, $) {
   say "";
 }
 
-sub _gather_subs ($dfile, $pods, $display_name) {
+sub _crap_lookup ($db, $file) {
+  my $crap = $db->{summary}{$file}{crap} or return {};
+  my $subs = $crap->{subs}               or return {};
+  my %lookup;
+  $lookup{ $_->{line} . "\0" . $_->{name} } = $_ for @$subs;
+  \%lookup
+}
+
+sub _gather_subs ($dfile, $pods, $display_name, $crap_lookup) {
   my $subs = $dfile->subroutine or return;
-  my %maxw = (h => 8, c => 5, p => 3, s => 10);
+  my %maxw = (h => 8, c => 5, p => 3, s => 10, cc => 3, cr => 5);
   my %by_type;
 
   for my $location ($subs->items) {
@@ -212,13 +220,19 @@ sub _gather_subs ($dfile, $pods, $display_name) {
       my $p = $e ? ($e->uncoverable ? "-" : "") . $e->covered : "";
       my $s = $sub->name;
 
-      $maxw{h} = length $h if length $h > $maxw{h};
-      $maxw{c} = length $c if length $c > $maxw{c};
-      $maxw{p} = length $p if $p && length $p > $maxw{p};
-      $maxw{s} = length $s if length $s > $maxw{s};
+      my $info = $crap_lookup->{"$location\0$s"};
+      my $cc   = defined $info ? $info->{cc}                    : "";
+      my $cr   = defined $info ? sprintf("%.1f", $info->{crap}) : "";
+
+      $maxw{h}  = length $h  if length $h > $maxw{h};
+      $maxw{c}  = length $c  if length $c > $maxw{c};
+      $maxw{p}  = length $p  if $p && length $p > $maxw{p};
+      $maxw{s}  = length $s  if length $s > $maxw{s};
+      $maxw{cc} = length $cc if length $cc > $maxw{cc};
+      $maxw{cr} = length $cr if length $cr > $maxw{cr};
 
       my $type = $sub->covered ? "covered" : "uncovered";
-      push $by_type{$type}{$s}->@*, [ $c, $pods ? $p : (), $h ];
+      push $by_type{$type}{$s}->@*, [ $c, $pods ? $p : (), $cc, $cr, $h ];
     }
   }
 
@@ -228,24 +242,38 @@ sub _gather_subs ($dfile, $pods, $display_name) {
 sub print_subroutines ($db, $file, $options, $short) {
   my $dfile = $db->cover->file($file);
   my $pods  = $options->{show}{pod} && $dfile->pod;
+  my $cl    = _crap_lookup($db, $file);
 
-  my ($by_type, $maxw) = _gather_subs($dfile, $pods, $short->{$file});
+  my ($by_type, $maxw) = _gather_subs($dfile, $pods, $short->{$file}, $cl);
   return unless $by_type;
 
-  my $tpl = "%-$maxw->{s}s %$maxw->{c}s ";
-  $tpl .= "%$maxw->{p}s " if $pods;
+  my $has_crap = %$cl;
+  my $tpl      = "%-$maxw->{s}s %$maxw->{c}s ";
+  $tpl .= "%$maxw->{p}s "  if $pods;
+  $tpl .= "%$maxw->{cc}s " if $has_crap;
+  $tpl .= "%$maxw->{cr}s " if $has_crap;
   $tpl .= "%-$maxw->{h}s\n";
 
   for my $type (sort keys %$by_type) {
     say ucfirst($type),            " Subroutines";
     say "-" x (12 + length $type), "\n";
-    printf $tpl, "Subroutine", "Count", $pods ? "Pod" : (), "Location";
+    printf $tpl, "Subroutine", "Count", $pods ? "Pod" : (),
+      $has_crap ? ("CC", "CRAP") : (), "Location";
     printf $tpl, "-" x $maxw->{s}, "-" x $maxw->{c},
-      $pods ? "-" x $maxw->{p} : (), "-" x $maxw->{h};
+      $pods ? "-" x $maxw->{p} : (),
+      $has_crap ? ("-" x $maxw->{cc}, "-" x $maxw->{cr}) : (), "-" x $maxw->{h};
 
     for my $s (sort keys $by_type->{$type}->%*) {
-      printf $tpl, $s, @$_
-        for sort { $a->[-1] cmp $b->[-1] } $by_type->{$type}{$s}->@*;
+      for (sort { $a->[-1] cmp $b->[-1] } $by_type->{$type}{$s}->@*) {
+        my @row = @$_;
+        unless ($has_crap) {
+          # Remove the CC and CRAP slots (after count/pod, before location)
+          my $loc = pop @row;
+          splice @row, -2;
+          push @row, $loc;
+        }
+        printf $tpl, $s, @row;
+      }
     }
     say "";
   }
@@ -360,10 +388,17 @@ Print one or more output lines for source line C<$n> with text C<$l>. Multiple
 output lines are produced when a single source line has several coverage points
 (e.g. chained conditions).
 
-=head2 _gather_subs ($dfile, $pods, $display_name)
+=head2 _crap_lookup ($db, $file)
+
+Build a lookup hash mapping C<"$line\0$name"> to CRAP sub detail from the
+summary data for C<$file>.  Returns an empty hashref when no CRAP data exists.
+
+=head2 _gather_subs ($dfile, $pods, $display_name, $crap_lookup)
 
 Walk the subroutine and pod coverage data for a file, returning a hashref of
 covered/uncovered sub entries and a hashref of column widths for formatting.
+When C<$crap_lookup> is non-empty, CC and CRAP values are included in each
+entry.
 
 =head1 SEE ALSO
 

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -222,7 +222,7 @@ sub _gather_subs ($dfile, $pods, $display_name, $crap_lookup) {
 
       my $info = $crap_lookup->{"$location\0$s"};
       my $cc   = defined $info ? $info->{cc}                    : "";
-      my $cr   = defined $info ? sprintf("%.1f", $info->{crap}) : "";
+      my $cr   = defined $info ? sprintf("%.1f", $info->{slop}) : "";
 
       $maxw{h}  = length $h  if length $h > $maxw{h};
       $maxw{c}  = length $c  if length $c > $maxw{c};
@@ -258,7 +258,7 @@ sub print_subroutines ($db, $file, $options, $short) {
     say ucfirst($type),            " Subroutines";
     say "-" x (12 + length $type), "\n";
     printf $tpl, "Subroutine", "Count", $pods ? "Pod" : (),
-      $has_crap ? ("CC", "CRAP") : (), "Location";
+      $has_crap ? ("CC", "SLOP") : (), "Location";
     printf $tpl, "-" x $maxw->{s}, "-" x $maxw->{c},
       $pods ? "-" x $maxw->{p} : (),
       $has_crap ? ("-" x $maxw->{cc}, "-" x $maxw->{cr}) : (), "-" x $maxw->{h};
@@ -397,7 +397,7 @@ summary data for C<$file>.  Returns an empty hashref when no CRAP data exists.
 
 Walk the subroutine and pod coverage data for a file, returning a hashref of
 covered/uncovered sub entries and a hashref of column widths for formatting.
-When C<$crap_lookup> is non-empty, CC and CRAP values are included in each
+When C<$crap_lookup> is non-empty, CC and SLOP values are included in each
 entry.
 
 =head1 SEE ALSO

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -165,7 +165,7 @@ sub print_conditions ($db, $file, $) {
   for my $location (sort { $a <=> $b } $conditions->items) {
     my %seen;
     for my $c ($conditions->location($location)->@*) {
-      push $r{ $c->type }->@*, [ $c, $seen{ $c->type }++ ? "" : $location ];
+      push $r{ $c->type }->@*, [$c, $seen{ $c->type }++ ? "" : $location];
     }
   }
 
@@ -197,18 +197,17 @@ sub print_conditions ($db, $file, $) {
   say "";
 }
 
-sub _slop_lookup ($db, $file) {
-  my $slop = $db->{summary}{$file}{slop} or return {};
-  my $subs = $slop->{subs}               or return {};
-  my %lookup;
-  $lookup{ $_->{line} . "\0" . $_->{name} } = $_ for @$subs;
-  \%lookup
+sub _update_maxw ($maxw, %vals) {
+  for my $k (keys %vals) {
+    $maxw->{$k} = length $vals{$k} if length $vals{$k} > $maxw->{$k};
+  }
 }
 
 sub _gather_subs ($dfile, $pods, $display_name, $slop_lookup) {
   my $subs = $dfile->subroutine or return;
   my %maxw = (h => 8, c => 5, p => 3, s => 10, cc => 3, cr => 5);
   my %by_type;
+  my $has_slop = %$slop_lookup;
 
   for my $location ($subs->items) {
     my $l = $subs->location($location);
@@ -224,15 +223,12 @@ sub _gather_subs ($dfile, $pods, $display_name, $slop_lookup) {
       my $cc   = defined $info ? $info->{cc}                    : "";
       my $cr   = defined $info ? sprintf("%.1f", $info->{slop}) : "";
 
-      $maxw{h}  = length $h  if length $h > $maxw{h};
-      $maxw{c}  = length $c  if length $c > $maxw{c};
-      $maxw{p}  = length $p  if $p && length $p > $maxw{p};
-      $maxw{s}  = length $s  if length $s > $maxw{s};
-      $maxw{cc} = length $cc if length $cc > $maxw{cc};
-      $maxw{cr} = length $cr if length $cr > $maxw{cr};
+      _update_maxw(\%maxw, h => $h, c => $c, s => $s, cc => $cc, cr => $cr);
+      $maxw{p} = length $p if $p && length $p > $maxw{p};
 
       my $type = $sub->covered ? "covered" : "uncovered";
-      push $by_type{$type}{$s}->@*, [ $c, $pods ? $p : (), $cc, $cr, $h ];
+      push $by_type{$type}{$s}->@*,
+        [$c, $pods ? $p : (), $has_slop ? ($cc, $cr) : (), $h];
     }
   }
 
@@ -242,7 +238,7 @@ sub _gather_subs ($dfile, $pods, $display_name, $slop_lookup) {
 sub print_subroutines ($db, $file, $options, $short) {
   my $dfile = $db->cover->file($file);
   my $pods  = $options->{show}{pod} && $dfile->pod;
-  my $cl    = _slop_lookup($db, $file);
+  my $cl    = $db->slop_sub_lookup($file);
 
   my ($by_type, $maxw) = _gather_subs($dfile, $pods, $short->{$file}, $cl);
   return unless $by_type;
@@ -264,16 +260,8 @@ sub print_subroutines ($db, $file, $options, $short) {
       $has_slop ? ("-" x $maxw->{cc}, "-" x $maxw->{cr}) : (), "-" x $maxw->{h};
 
     for my $s (sort keys $by_type->{$type}->%*) {
-      for (sort { $a->[-1] cmp $b->[-1] } $by_type->{$type}{$s}->@*) {
-        my @row = @$_;
-        unless ($has_slop) {
-          # Remove the CC and SLOP slots (after count/pod, before location)
-          my $loc = pop @row;
-          splice @row, -2;
-          push @row, $loc;
-        }
-        printf $tpl, $s, @row;
-      }
+      printf $tpl, $s, @$_
+        for sort { $a->[-1] cmp $b->[-1] } $by_type->{$type}{$s}->@*;
     }
     say "";
   }
@@ -388,10 +376,10 @@ Print one or more output lines for source line C<$n> with text C<$l>. Multiple
 output lines are produced when a single source line has several coverage points
 (e.g. chained conditions).
 
-=head2 _slop_lookup ($db, $file)
+=head2 _update_maxw ($maxw, %vals)
 
-Build a lookup hash mapping C<"$line\0$name"> to SLOP sub detail from the
-summary data for C<$file>.  Returns an empty hashref when no SLOP data exists.
+Update column-width hash C<$maxw> in place: for each key in C<%vals>, set
+C<< $maxw->{$k} >> to the value's length if it exceeds the current maximum.
 
 =head2 _gather_subs ($dfile, $pods, $display_name, $slop_lookup)
 

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -197,15 +197,15 @@ sub print_conditions ($db, $file, $) {
   say "";
 }
 
-sub _crap_lookup ($db, $file) {
-  my $crap = $db->{summary}{$file}{crap} or return {};
-  my $subs = $crap->{subs}               or return {};
+sub _slop_lookup ($db, $file) {
+  my $slop = $db->{summary}{$file}{slop} or return {};
+  my $subs = $slop->{subs}               or return {};
   my %lookup;
   $lookup{ $_->{line} . "\0" . $_->{name} } = $_ for @$subs;
   \%lookup
 }
 
-sub _gather_subs ($dfile, $pods, $display_name, $crap_lookup) {
+sub _gather_subs ($dfile, $pods, $display_name, $slop_lookup) {
   my $subs = $dfile->subroutine or return;
   my %maxw = (h => 8, c => 5, p => 3, s => 10, cc => 3, cr => 5);
   my %by_type;
@@ -220,7 +220,7 @@ sub _gather_subs ($dfile, $pods, $display_name, $crap_lookup) {
       my $p = $e ? ($e->uncoverable ? "-" : "") . $e->covered : "";
       my $s = $sub->name;
 
-      my $info = $crap_lookup->{"$location\0$s"};
+      my $info = $slop_lookup->{"$location\0$s"};
       my $cc   = defined $info ? $info->{cc}                    : "";
       my $cr   = defined $info ? sprintf("%.1f", $info->{slop}) : "";
 
@@ -242,32 +242,32 @@ sub _gather_subs ($dfile, $pods, $display_name, $crap_lookup) {
 sub print_subroutines ($db, $file, $options, $short) {
   my $dfile = $db->cover->file($file);
   my $pods  = $options->{show}{pod} && $dfile->pod;
-  my $cl    = _crap_lookup($db, $file);
+  my $cl    = _slop_lookup($db, $file);
 
   my ($by_type, $maxw) = _gather_subs($dfile, $pods, $short->{$file}, $cl);
   return unless $by_type;
 
-  my $has_crap = %$cl;
+  my $has_slop = %$cl;
   my $tpl      = "%-$maxw->{s}s %$maxw->{c}s ";
   $tpl .= "%$maxw->{p}s "  if $pods;
-  $tpl .= "%$maxw->{cc}s " if $has_crap;
-  $tpl .= "%$maxw->{cr}s " if $has_crap;
+  $tpl .= "%$maxw->{cc}s " if $has_slop;
+  $tpl .= "%$maxw->{cr}s " if $has_slop;
   $tpl .= "%-$maxw->{h}s\n";
 
   for my $type (sort keys %$by_type) {
     say ucfirst($type),            " Subroutines";
     say "-" x (12 + length $type), "\n";
     printf $tpl, "Subroutine", "Count", $pods ? "Pod" : (),
-      $has_crap ? ("CC", "SLOP") : (), "Location";
+      $has_slop ? ("CC", "SLOP") : (), "Location";
     printf $tpl, "-" x $maxw->{s}, "-" x $maxw->{c},
       $pods ? "-" x $maxw->{p} : (),
-      $has_crap ? ("-" x $maxw->{cc}, "-" x $maxw->{cr}) : (), "-" x $maxw->{h};
+      $has_slop ? ("-" x $maxw->{cc}, "-" x $maxw->{cr}) : (), "-" x $maxw->{h};
 
     for my $s (sort keys $by_type->{$type}->%*) {
       for (sort { $a->[-1] cmp $b->[-1] } $by_type->{$type}{$s}->@*) {
         my @row = @$_;
-        unless ($has_crap) {
-          # Remove the CC and CRAP slots (after count/pod, before location)
+        unless ($has_slop) {
+          # Remove the CC and SLOP slots (after count/pod, before location)
           my $loc = pop @row;
           splice @row, -2;
           push @row, $loc;
@@ -388,16 +388,16 @@ Print one or more output lines for source line C<$n> with text C<$l>. Multiple
 output lines are produced when a single source line has several coverage points
 (e.g. chained conditions).
 
-=head2 _crap_lookup ($db, $file)
+=head2 _slop_lookup ($db, $file)
 
-Build a lookup hash mapping C<"$line\0$name"> to CRAP sub detail from the
-summary data for C<$file>.  Returns an empty hashref when no CRAP data exists.
+Build a lookup hash mapping C<"$line\0$name"> to SLOP sub detail from the
+summary data for C<$file>.  Returns an empty hashref when no SLOP data exists.
 
-=head2 _gather_subs ($dfile, $pods, $display_name, $crap_lookup)
+=head2 _gather_subs ($dfile, $pods, $display_name, $slop_lookup)
 
 Walk the subroutine and pod coverage data for a file, returning a hashref of
 covered/uncovered sub entries and a hashref of column widths for formatting.
-When C<$crap_lookup> is non-empty, CC and SLOP values are included in each
+When C<$slop_lookup> is non-empty, CC and SLOP values are included in each
 entry.
 
 =head1 SEE ALSO

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -250,6 +250,14 @@ our $Crisp_base_css = <<'CSS';
 
   --tip-bg: #1a1a1a;
   --tip-fg: #ffffff;
+  --tip-glass-bg: rgba(255, 255, 255, 0.92);
+  --tip-glass-fg: #1a1a1a;
+  --tip-glass-border: rgba(0, 0, 0, 0.12);
+  --tip-glass-sep: rgba(0, 0, 0, 0.2);
+  --tip-c0: #dd0000;
+  --tip-c1: #c08820;
+  --tip-c2: #2080a8;
+  --tip-c3: #008800;
 
   --bg: #ffffff;
   --bg-alt: #e8ecf0;
@@ -297,6 +305,14 @@ our $Crisp_base_css = <<'CSS';
 
     --tip-bg: #bbb;
     --tip-fg: #1a1a1a;
+    --tip-glass-bg: rgba(20, 20, 20, 0.92);
+    --tip-glass-fg: #e0e0e0;
+    --tip-glass-border: rgba(255, 255, 255, 0.12);
+    --tip-glass-sep: rgba(255, 255, 255, 0.2);
+    --tip-c0: #ff4444;
+    --tip-c1: #e0a830;
+    --tip-c2: #48c0e0;
+    --tip-c3: #44dd44;
 
     --bg: #1a1a1a;
     --bg-alt: #242424;
@@ -336,6 +352,14 @@ html[data-theme="dark"] {
 
   --tip-bg: #e0e0e0;
   --tip-fg: #1a1a1a;
+  --tip-glass-bg: rgba(20, 20, 20, 0.92);
+  --tip-glass-fg: #e0e0e0;
+  --tip-glass-border: rgba(255, 255, 255, 0.12);
+  --tip-glass-sep: rgba(255, 255, 255, 0.2);
+  --tip-c0: #ff4444;
+  --tip-c1: #e0a830;
+  --tip-c2: #48c0e0;
+  --tip-c3: #44dd44;
 
   --bg: #1a1a1a;
   --bg-alt: #242424;
@@ -374,6 +398,14 @@ html[data-theme="light"] {
 
   --tip-bg: #1a1a1a;
   --tip-fg: #ffffff;
+  --tip-glass-bg: rgba(255, 255, 255, 0.92);
+  --tip-glass-fg: #1a1a1a;
+  --tip-glass-border: rgba(0, 0, 0, 0.12);
+  --tip-glass-sep: rgba(0, 0, 0, 0.2);
+  --tip-c0: #dd0000;
+  --tip-c1: #c08820;
+  --tip-c2: #2080a8;
+  --tip-c3: #008800;
 
   --bg: #ffffff;
   --bg-alt: #e8ecf0;

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -248,8 +248,6 @@ our $Crisp_base_css = <<'CSS';
   --untested-worst-bg: #e8e8e8;
   --untested-worst-fg: #666;
 
-  --tip-bg: #1a1a1a;
-  --tip-fg: #ffffff;
   --tip-glass-bg: rgba(255, 255, 255, 0.92);
   --tip-glass-fg: #1a1a1a;
   --tip-glass-border: rgba(0, 0, 0, 0.12);
@@ -303,8 +301,6 @@ our $Crisp_base_css = <<'CSS';
     --untested-worst-bg: #333;
     --untested-worst-fg: #bbb;
 
-    --tip-bg: #bbb;
-    --tip-fg: #1a1a1a;
     --tip-glass-bg: rgba(20, 20, 20, 0.92);
     --tip-glass-fg: #e0e0e0;
     --tip-glass-border: rgba(255, 255, 255, 0.12);
@@ -350,8 +346,6 @@ html[data-theme="dark"] {
   --untested-worst-bg: #333;
   --untested-worst-fg: #bbb;
 
-  --tip-bg: #e0e0e0;
-  --tip-fg: #1a1a1a;
   --tip-glass-bg: rgba(20, 20, 20, 0.92);
   --tip-glass-fg: #e0e0e0;
   --tip-glass-border: rgba(255, 255, 255, 0.12);
@@ -396,8 +390,6 @@ html[data-theme="light"] {
   --untested-worst-bg: #e8e8e8;
   --untested-worst-fg: #666;
 
-  --tip-bg: #1a1a1a;
-  --tip-fg: #ffffff;
   --tip-glass-bg: rgba(255, 255, 255, 0.92);
   --tip-glass-fg: #1a1a1a;
   --tip-glass-border: rgba(0, 0, 0, 0.12);
@@ -550,15 +542,16 @@ a:visited { color: var(--link-visited); }
   margin-top: 24px;
 }
 
-/* Cell tooltips */
+/* Glass tooltips */
 
-.has-tip {
+.tip-hover {
   position: relative;
   cursor: default;
 }
+.tip-hover:hover { z-index: 30; }
 
-.has-tip::after {
-  content: attr(data-tip);
+.glass-tip {
+  display: none;
   position: absolute;
   bottom: 100%;
   left: 50%;
@@ -568,15 +561,16 @@ a:visited { color: var(--link-visited); }
   font-size: 13px;
   font-weight: 600;
   white-space: nowrap;
-  background: var(--tip-bg);
-  color: var(--tip-fg);
+  background: var(--tip-glass-bg);
+  color: var(--tip-glass-fg);
+  border: 1px solid var(--tip-glass-border);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 30;
   pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-  z-index: 20;
 }
 
-.has-tip:hover::after { opacity: 1; }
+.tip-hover:hover > .glass-tip { display: block; }
 
 /* Coverage bar */
 

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -298,19 +298,17 @@ sub test_slop_scoring () {
   is $uc->{cc},   1, "slop: uncalled CC = 1";
   is $uc->{cov},  0, "slop: uncalled cov = 0";
   is $uc->{crap}, 2, "slop: uncalled CRAP = 2";
-  ok abs($uc->{slop} - log(2) * 10) < 0.01,
-    "slop: uncalled SLOP = ln(2)*10";
+  ok abs($uc->{slop} - log(2) * 10) < 0.01, "slop: uncalled SLOP = ln(2)*10";
 
   # partial_branch: CC=2, partial coverage.
   # Bounds: cov=100% => CRAP=2, cov=0% => CRAP=6.
   my $pb = $by_name{partial_branch};
   ok defined $pb, "slop: partial_branch present";
   is $pb->{cc}, 2, "slop: partial_branch CC = 2";
-  ok $pb->{crap} > 2, "slop: partial_branch CRAP > CC";
-  ok $pb->{crap} < 6, "slop: partial_branch CRAP < CC^2+CC";
-  ok $pb->{slop} > 0, "slop: partial_branch SLOP > 0";
-  ok $pb->{slop} > $uc->{slop},
-    "slop: partial_branch SLOP > uncalled SLOP";
+  ok $pb->{crap} > 2,           "slop: partial_branch CRAP > CC";
+  ok $pb->{crap} < 6,           "slop: partial_branch CRAP < CC^2+CC";
+  ok $pb->{slop} > 0,           "slop: partial_branch SLOP > 0";
+  ok $pb->{slop} > $uc->{slop}, "slop: partial_branch SLOP > uncalled SLOP";
 
   # Total aggregation
   my $ts = $db->{summary}{Total}{slop};
@@ -406,24 +404,74 @@ sub test_file_level_slop () {
 
   # file_crap: CRAP formula applied to file-level inputs
   ok exists $slop->{file_crap}, "fileslop: has file_crap";
-  my $cc  = $slop->{file_cc};
-  my $cov = $slop->{file_cov};
+  my $cc            = $slop->{file_cc};
+  my $cov           = $slop->{file_cov};
   my $expected_crap = $cc**2 * (1 - $cov / 100)**3 + $cc;
   is $slop->{file_crap}, $expected_crap,
     "fileslop: file_crap matches CRAP formula";
 
   # file_slop: ln(file_crap) * 10
   ok exists $slop->{file_slop}, "fileslop: has file_slop";
-  my $expected_slop
-    = $slop->{file_crap} > 1 ? log($slop->{file_crap}) * 10 : 0;
+  my $expected_slop = $slop->{file_crap} > 1 ? log($slop->{file_crap}) * 10 : 0;
   ok abs($slop->{file_slop} - $expected_slop) < 0.01,
     "fileslop: file_slop = log(file_crap) * 10";
 
   # Total aggregation
   my $ts = $db->{summary}{Total}{slop};
-  ok defined $ts, "fileslop: Total has slop entry";
+  ok defined $ts,             "fileslop: Total has slop entry";
   ok exists $ts->{file_crap}, "fileslop: Total has file_crap";
   ok exists $ts->{file_slop}, "fileslop: Total has file_slop";
+}
+
+sub test_dir_level_slop () {
+  my ($db_path, $script) = run_cover("cc_dirslop", $Crap_script);
+
+  my $st = Devel::Cover::DB::Structure->new(base => $db_path);
+  $st->read_all;
+
+  my $db = Devel::Cover::DB->new(db => $db_path)->merge_runs;
+  $db->set_structure($st);
+  $db->calculate_summary(
+    statement  => 1,
+    branch     => 1,
+    condition  => 1,
+    subroutine => 1,
+  );
+
+  # Directory summary should exist for the script's parent dir
+  my ($file) = grep /cc_dirslop\.pl$/, keys $db->{summary}->%*;
+  ok defined $file, "dirslop: file found in summary";
+  (my $dir = $file) =~ s|/[^/]+$||;
+  my $ds = $db->dir_summary($dir);
+  ok defined $ds, "dirslop: dir summary exists";
+
+  # Per-criterion aggregation
+  for my $c (qw( statement branch condition total )) {
+    ok exists $ds->{$c},           "dirslop: has $c";
+    ok defined $ds->{$c}{covered}, "dirslop: $c has covered";
+    ok defined $ds->{$c}{total},   "dirslop: $c has total";
+  }
+
+  # SLOP entry
+  my $slop = $ds->{slop};
+  ok defined $slop,             "dirslop: has slop entry";
+  ok exists $slop->{file_cc},   "dirslop: has file_cc";
+  ok exists $slop->{file_cov},  "dirslop: has file_cov";
+  ok exists $slop->{file_crap}, "dirslop: has file_crap";
+  ok exists $slop->{file_slop}, "dirslop: has file_slop";
+
+  # dir_cc should equal the single file's file_cc (one file
+  # in the directory)
+  my $file_slop = $db->{summary}{$file}{slop};
+  is $slop->{file_cc}, $file_slop->{file_cc},
+    "dirslop: dir cc matches single file cc";
+
+  # CRAP formula
+  my $cc            = $slop->{file_cc};
+  my $cov           = $slop->{file_cov};
+  my $expected_crap = $cc**2 * (1 - $cov / 100)**3 + $cc;
+  is $slop->{file_crap}, $expected_crap,
+    "dirslop: dir crap matches CRAP formula";
 }
 
 sub main () {
@@ -434,6 +482,7 @@ sub main () {
   test_slop_scoring;
   test_text_report_slop;
   test_file_level_slop;
+  test_dir_level_slop;
 }
 
 main;

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -56,10 +56,8 @@ sub run_cover ($label, $script_content) {
 # script's file digest.
 sub cover_complexity ($label, $script_content) {
   my ($db, $script) = run_cover($label, $script_content);
-
   my $st = Devel::Cover::DB::Structure->new(base => $db);
   $st->read_all;
-
   $st->get_complexity(md5_file($script))
 }
 
@@ -76,7 +74,7 @@ sub cover_complexity ($label, $script_content) {
 # Line 8: sub ternary      - one cond_expr (?:)
 # Line 9: sub with_foreach - one foreach loop (iter)
 
-my $Cc = cover_complexity("cc_basic", <<'PERL');
+my $Cc_script = <<'PERL';
 use strict;
 use warnings;
 
@@ -95,36 +93,23 @@ ternary(1);
 with_foreach("a", "b");
 PERL
 
-ok defined $Cc, "complexity data present in structure";
+sub test_cc_counting () {
+  my $cc = cover_complexity("cc_basic", $Cc_script);
 
-is $Cc->{4}{linear}[0],       1, "linear: CC = 1";
-is $Cc->{5}{one_if}[0],       2, "one if: CC = 2";
-is $Cc->{6}{elsif_two}[0],    3, "if/elsif: CC = 3";
-is $Cc->{7}{with_and}[0],     2, "&&: CC = 2";
-is $Cc->{8}{ternary}[0],      2, "ternary: CC = 2";
-is $Cc->{9}{with_foreach}[0], 2, "foreach: CC = 2";
+  ok defined $cc, "complexity data present in structure";
+
+  is $cc->{4}{linear}[0],       1, "linear: CC = 1";
+  is $cc->{5}{one_if}[0],       2, "one if: CC = 2";
+  is $cc->{6}{elsif_two}[0],    3, "if/elsif: CC = 3";
+  is $cc->{7}{with_and}[0],     2, "&&: CC = 2";
+  is $cc->{8}{ternary}[0],      2, "ternary: CC = 2";
+  is $cc->{9}{with_foreach}[0], 2, "foreach: CC = 2";
+}
 
 # Summary aggregation tests
 # Reuse the same test script layout (6 subs: CC = 1, 2, 3, 2, 2, 2).
-{
-  my ($db_path, $script) = run_cover("cc_summary", <<'PERL');
-use strict;
-use warnings;
-
-sub linear       { 42 }
-sub one_if       { if ($_[0]) { return 1 } return 0 }
-sub elsif_two    { if ($_[0] > 0) { 1 } elsif ($_[0] < 0) { -1 } else { 0 } }
-sub with_and     { $_[0] && $_[1] }
-sub ternary      { $_[0] ? 1 : 0 }
-sub with_foreach { my $s; foreach my $x (@_) { $s .= $x } $s }
-
-linear();
-one_if(1);
-elsif_two(1);
-with_and(1, 1);
-ternary(1);
-with_foreach("a", "b");
-PERL
+sub test_summary_aggregation () {
+  my ($db_path, $script) = run_cover("cc_summary", $Cc_script);
 
   my $st = Devel::Cover::DB::Structure->new(base => $db_path);
   $st->read_all;
@@ -169,7 +154,7 @@ PERL
 # 10: (blank)
 # 11: oneliner();
 # 12: multiline();
-{
+sub test_end_lines () {
   my ($db_path, $script) = run_cover("cc_endline", <<'PERL');
 use strict;
 use warnings;
@@ -196,4 +181,11 @@ PERL
     "multi-line sub: end_line = last statement line";
 }
 
+sub main () {
+  test_cc_counting;
+  test_summary_aggregation;
+  test_end_lines;
+}
+
+main;
 done_testing;

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -119,6 +119,36 @@ with_default();
 with_default_cond();
 PERL
 
+# CRAP scoring test script.
+# Line layout:
+# 1: use strict;
+# 2: use warnings;
+# 3: (blank)
+# 4: sub fully_covered     - CC=1, all stmts executed
+# 5: sub uncalled           - CC=1, no stmts executed
+# 6: sub partial_branch {   - CC=2, only true branch taken
+# 7:     if ($_[0]) { return 1 }
+# 8:     return 0;
+# 9: }
+# 10: (blank)
+# 11: fully_covered();
+# 12: partial_branch(1);
+
+my $Crap_script = <<'PERL';
+use strict;
+use warnings;
+
+sub fully_covered { 42 }
+sub uncalled      { 42 }
+sub partial_branch {
+    if ($_[0]) { return 1 }
+    return 0;
+}
+
+fully_covered();
+partial_branch(1);
+PERL
+
 sub test_cc_counting () {
   my $cc = cover_complexity("cc_basic", $Cc_script);
 
@@ -221,11 +251,74 @@ sub test_signature_cc () {
     "signature default with ||: CC = 3 (1 argdefelem + 1 logop)";
 }
 
+# CRAP (Change Risk Anti-Patterns) scoring tests.
+# Verifies that summarise_complexity computes per-sub combined
+# coverage and CRAP scores alongside existing complexity aggregation.
+sub test_crap_scoring () {
+  my ($db_path, $script) = run_cover("cc_crap", $Crap_script);
+
+  my $st = Devel::Cover::DB::Structure->new(base => $db_path);
+  $st->read_all;
+
+  my $db = Devel::Cover::DB->new(db => $db_path)->merge_runs;
+  $db->set_structure($st);
+  $db->calculate_summary(
+    statement  => 1,
+    branch     => 1,
+    condition  => 1,
+    subroutine => 1,
+  );
+
+  my ($file) = grep /cc_crap\.pl$/, keys $db->{summary}->%*;
+  ok defined $file, "crap: summary contains cover file";
+
+  my $crap = $db->{summary}{$file}{crap};
+  ok defined $crap, "crap: file summary has crap entry";
+
+  ok exists $crap->{max},   "crap: has max";
+  ok exists $crap->{mean},  "crap: has mean";
+  ok exists $crap->{count}, "crap: has count";
+  ok exists $crap->{subs},  "crap: has subs";
+
+  # Build lookup by sub name for easier assertions.
+  my %by_name = map { $_->{name} => $_ } $crap->{subs}->@*;
+
+  # fully_covered: CC=1, cov=100%, CRAP = 1^2*(1-1)^3 + 1 = 1
+  my $fc = $by_name{fully_covered};
+  ok defined $fc, "crap: fully_covered present";
+  is $fc->{cc},   1,   "crap: fully_covered CC = 1";
+  is $fc->{cov},  100, "crap: fully_covered cov = 100";
+  is $fc->{crap}, 1,   "crap: fully_covered CRAP = 1";
+
+  # uncalled: CC=1, cov=0%, CRAP = 1^2*(1-0)^3 + 1 = 2
+  my $uc = $by_name{uncalled};
+  ok defined $uc, "crap: uncalled present";
+  is $uc->{cc},   1, "crap: uncalled CC = 1";
+  is $uc->{cov},  0, "crap: uncalled cov = 0";
+  is $uc->{crap}, 2, "crap: uncalled CRAP = 2";
+
+  # partial_branch: CC=2, partial coverage.
+  # Bounds: cov=100% => CRAP=2, cov=0% => CRAP=6.
+  my $pb = $by_name{partial_branch};
+  ok defined $pb, "crap: partial_branch present";
+  is $pb->{cc}, 2, "crap: partial_branch CC = 2";
+  ok $pb->{crap} > 2, "crap: partial_branch CRAP > CC";
+  ok $pb->{crap} < 6, "crap: partial_branch CRAP < CC^2+CC";
+
+  # Total aggregation
+  my $ts = $db->{summary}{Total}{crap};
+  ok defined $ts,         "crap: Total has crap entry";
+  ok exists $ts->{max},   "crap: Total has max";
+  ok exists $ts->{mean},  "crap: Total has mean";
+  ok exists $ts->{count}, "crap: Total has count";
+}
+
 sub main () {
   test_cc_counting;
   test_summary_aggregation;
   test_end_lines;
   test_signature_cc;
+  test_crap_scoring;
 }
 
 main;

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -93,6 +93,32 @@ ternary(1);
 with_foreach("a", "b");
 PERL
 
+# Signature script for testing argdefelem CC counting.
+# Line numbers:
+# 1: use 5.20.0;
+# 2: use warnings;
+# 3: use feature "signatures";
+# 4: no warnings "experimental::signatures";
+# 5: (blank)
+# 6: sub with_default         - CC=2: 1 argdefelem
+# 7: sub with_default_cond    - CC=3: 1 argdefelem + 1 logop (||)
+# 8: (blank)
+# 9: with_default();
+# 10: with_default_cond();
+
+my $Sig_script = <<'PERL';
+use 5.20.0;
+use warnings;
+use feature "signatures";
+no warnings "experimental::signatures";
+
+sub with_default ($x = 42) { $x }
+sub with_default_cond ($x = $ENV{X} || 1) { $x }
+
+with_default();
+with_default_cond();
+PERL
+
 sub test_cc_counting () {
   my $cc = cover_complexity("cc_basic", $Cc_script);
 
@@ -182,10 +208,24 @@ PERL
     "multi-line sub: end_line = last statement line";
 }
 
+# Signature default CC tests.
+# Verifies argdefelem ops count as CC decision points, and that
+# conditions inside defaults (logops, cond_exprs) stack correctly.
+sub test_signature_cc () {
+  my $cc = cover_complexity("cc_sig", $Sig_script);
+
+  ok defined $cc, "signature: complexity data present";
+
+  is $cc->{6}{with_default}[0], 2, "signature default: CC = 2 (1 argdefelem)";
+  is $cc->{7}{with_default_cond}[0], 3,
+    "signature default with ||: CC = 3 (1 argdefelem + 1 logop)";
+}
+
 sub main () {
   test_cc_counting;
   test_summary_aggregation;
   test_end_lines;
+  test_signature_cc;
 }
 
 main;

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -20,12 +20,13 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 use Digest::MD5 ();
 use File::Spec  ();
 use File::Temp  qw( tempdir );
-use Test::More import => [qw( done_testing is ok )];
+use Test::More import => [qw( done_testing is like ok )];
 
 my $Root = Cwd::cwd();
 
 use Devel::Cover::DB            ();
 use Devel::Cover::DB::Structure ();
+use Devel::Cover::Report::Text  ();
 
 my $Tmpdir = tempdir(CLEANUP => 1);
 
@@ -313,12 +314,112 @@ sub test_crap_scoring () {
   ok exists $ts->{count}, "crap: Total has count";
 }
 
+# Text report CC/CRAP column tests.
+# Verifies that print_subroutines includes CC and CRAP columns
+# when CRAP summary data is available.
+sub test_text_report_crap () {
+  my ($db_path, $script) = run_cover("cc_text", $Crap_script);
+
+  my $st = Devel::Cover::DB::Structure->new(base => $db_path);
+  $st->read_all;
+
+  my $db = Devel::Cover::DB->new(db => $db_path)->merge_runs;
+  $db->set_structure($st);
+  $db->calculate_summary(
+    statement  => 1,
+    branch     => 1,
+    condition  => 1,
+    subroutine => 1,
+  );
+
+  my @files = $db->cover->items;
+  my $options
+    = { show => { subroutine => 1 }, file => \@files, annotations => [] };
+
+  # Capture the report output.
+  my $output;
+  {
+    open my $fh, ">", \$output or die "Cannot open scalar ref: $!";
+    local *STDOUT = $fh;
+    Devel::Cover::Report::Text->report($db, $options);
+    close $fh or die "Cannot close scalar ref: $!";
+  }
+
+  # Header should contain CC and CRAP columns.
+  like $output, qr/^\s*Subroutine\b.*\bCC\b.*\bCRAP\b/m,
+    "text: header contains CC and CRAP columns";
+
+  # fully_covered: CC=1, CRAP=1.0
+  like $output, qr/fully_covered\s+\d+\s+1\s+1\.0\b/,
+    "text: fully_covered has CC=1 CRAP=1.0";
+
+  # uncalled: CC=1, CRAP=2.0
+  like $output, qr/uncalled\s+\d+\s+1\s+2\.0\b/,
+    "text: uncalled has CC=1 CRAP=2.0";
+
+  # partial_branch: CC=2, CRAP between 2 and 6
+  like $output, qr/partial_branch\s+\d+\s+2\s+\d+\.\d/,
+    "text: partial_branch has CC=2 and a CRAP score";
+}
+
+# File-level CRAP tests.
+# Verifies that summarise_complexity computes file_cc, file_cov,
+# and file_crap by treating the entire file as one sub body.
+sub test_file_level_crap () {
+  my ($db_path, $script) = run_cover("cc_filecrap", $Crap_script);
+
+  my $st = Devel::Cover::DB::Structure->new(base => $db_path);
+  $st->read_all;
+
+  my $db = Devel::Cover::DB->new(db => $db_path)->merge_runs;
+  $db->set_structure($st);
+  $db->calculate_summary(
+    statement  => 1,
+    branch     => 1,
+    condition  => 1,
+    subroutine => 1,
+  );
+
+  my ($file) = grep /cc_filecrap\.pl$/, keys $db->{summary}->%*;
+  ok defined $file, "filecrap: summary contains cover file";
+
+  my $crap = $db->{summary}{$file}{crap};
+  ok defined $crap, "filecrap: file summary has crap entry";
+
+  # file_cc = sum of per-sub CCs - count + 1
+  ok exists $crap->{file_cc}, "filecrap: has file_cc";
+  my $expected_cc_sum = 0;
+  $expected_cc_sum += $_->{cc} for $crap->{subs}->@*;
+  is $crap->{file_cc}, $expected_cc_sum - $crap->{count} + 1,
+    "filecrap: file_cc = sum(cc) - count + 1";
+
+  # file_cov: combined stmt+branch+condition coverage
+  ok exists $crap->{file_cov}, "filecrap: has file_cov";
+  ok $crap->{file_cov} >= 0 && $crap->{file_cov} <= 100,
+    "filecrap: file_cov is 0..100";
+
+  # file_crap: CRAP formula applied to file-level inputs
+  ok exists $crap->{file_crap}, "filecrap: has file_crap";
+  my $cc  = $crap->{file_cc};
+  my $cov = $crap->{file_cov};
+  my $expected_crap = $cc**2 * (1 - $cov / 100)**3 + $cc;
+  is $crap->{file_crap}, $expected_crap,
+    "filecrap: file_crap matches CRAP formula";
+
+  # Total aggregation
+  my $ts = $db->{summary}{Total}{crap};
+  ok defined $ts, "filecrap: Total has crap entry";
+  ok exists $ts->{file_crap}, "filecrap: Total has file_crap";
+}
+
 sub main () {
   test_cc_counting;
   test_summary_aggregation;
   test_end_lines;
   test_signature_cc;
   test_crap_scoring;
+  test_text_report_crap;
+  test_file_level_crap;
 }
 
 main;

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -1,0 +1,99 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Cwd     ();
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Digest::MD5 ();
+use File::Spec  ();
+use File::Temp  qw( tempdir );
+use Test::More import => [qw( done_testing is ok )];
+
+my $Root = Cwd::cwd();
+
+use Devel::Cover::DB::Structure ();
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+
+sub md5_file ($path) {
+  open my $fh, "<", $path or die "Cannot open $path: $!";
+  binmode $fh;
+  Digest::MD5->new->addfile($fh)->hexdigest
+}
+
+# Run a script under Devel::Cover and return the complexity hash for that
+# script's file digest.
+sub cover_complexity ($label, $script_content) {
+  my $script = File::Spec->catfile($Tmpdir, "$label.pl");
+  my $db     = File::Spec->catdir($Tmpdir, "${label}_db");
+
+  open my $fh, ">", $script or die "Cannot write $script: $!";
+  print $fh $script_content;
+  close $fh or die "Cannot close $script: $!";
+
+  my @inc = map { "-I$_" } "$Root/blib/arch", "$Root/blib/lib", "$Root/lib";
+
+  system($^X, @inc, "-MDevel::Cover=-db,$db,-silent,1", $script) == 0
+    or die "Failed to run $label under Devel::Cover: $?";
+
+  my $st = Devel::Cover::DB::Structure->new(base => $db);
+  $st->read_all;
+
+  $st->get_complexity(md5_file($script))
+}
+
+# Line numbers matter - they are the hash keys for complexity lookup.
+# If you change the layout, update the assertions below.
+#
+# Line 1: use strict;
+# Line 2: use warnings;
+# Line 3: (blank)
+# Line 4: sub linear       - no decisions
+# Line 5: sub one_if       - one cond_expr (if)
+# Line 6: sub elsif_two    - two cond_exprs (if + elsif)
+# Line 7: sub with_and     - one logop (&&)
+# Line 8: sub ternary      - one cond_expr (?:)
+# Line 9: sub with_foreach - one foreach loop (iter)
+
+my $Cc = cover_complexity("cc_basic", <<'PERL');
+use strict;
+use warnings;
+
+sub linear       { 42 }
+sub one_if       { if ($_[0]) { return 1 } return 0 }
+sub elsif_two    { if ($_[0] > 0) { 1 } elsif ($_[0] < 0) { -1 } else { 0 } }
+sub with_and     { $_[0] && $_[1] }
+sub ternary      { $_[0] ? 1 : 0 }
+sub with_foreach { my $s; foreach my $x (@_) { $s .= $x } $s }
+
+linear();
+one_if(1);
+elsif_two(1);
+with_and(1, 1);
+ternary(1);
+with_foreach("a", "b");
+PERL
+
+ok defined $Cc, "complexity data present in structure";
+
+is $Cc->{4}{linear}[0],       1, "linear: CC = 1";
+is $Cc->{5}{one_if}[0],       2, "one if: CC = 2";
+is $Cc->{6}{elsif_two}[0],    3, "if/elsif: CC = 3";
+is $Cc->{7}{with_and}[0],     2, "&&: CC = 2";
+is $Cc->{8}{ternary}[0],      2, "ternary: CC = 2";
+is $Cc->{9}{with_foreach}[0], 2, "foreach: CC = 2";
+
+done_testing;

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -141,15 +141,16 @@ sub test_summary_aggregation () {
 
 # Sub end line tests
 # Uses a multi-line sub to verify end_line > start_line.
+# Subs are keyed by first statement line (not the sub declaration).
 # Line layout:
 # 1: use strict;
 # 2: use warnings;
 # 3: (blank)
-# 4: sub oneliner { 42 }
+# 4: sub oneliner { 42 }         - first stmt on line 4
 # 5: sub multiline {
-# 6:   my $x = 1;
+# 6:   my $x = 1;                - first stmt on line 6
 # 7:   my $y = 2;
-# 8:   $x + $y;
+# 8:   $x + $y;                  - last stmt on line 8
 # 9: }
 # 10: (blank)
 # 11: oneliner();
@@ -177,7 +178,7 @@ PERL
   ok defined $ends, "end_lines data present in structure";
 
   is $ends->{4}{oneliner}[0], 4, "single-line sub: end_line = start_line";
-  is $ends->{5}{multiline}[0], 8,
+  is $ends->{6}{multiline}[0], 8,
     "multi-line sub: end_line = last statement line";
 }
 

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -255,7 +255,7 @@ sub test_signature_cc () {
 # CRAP (Change Risk Anti-Patterns) scoring tests.
 # Verifies that summarise_complexity computes per-sub combined
 # coverage and CRAP scores alongside existing complexity aggregation.
-sub test_crap_scoring () {
+sub test_slop_scoring () {
   my ($db_path, $script) = run_cover("cc_crap", $Crap_script);
 
   my $st = Devel::Cover::DB::Structure->new(base => $db_path);
@@ -271,59 +271,59 @@ sub test_crap_scoring () {
   );
 
   my ($file) = grep /cc_crap\.pl$/, keys $db->{summary}->%*;
-  ok defined $file, "crap: summary contains cover file";
+  ok defined $file, "slop: summary contains cover file";
 
-  my $crap = $db->{summary}{$file}{crap};
-  ok defined $crap, "crap: file summary has crap entry";
+  my $slop = $db->{summary}{$file}{slop};
+  ok defined $slop, "slop: file summary has slop entry";
 
-  ok exists $crap->{max},   "crap: has max";
-  ok exists $crap->{mean},  "crap: has mean";
-  ok exists $crap->{count}, "crap: has count";
-  ok exists $crap->{subs},  "crap: has subs";
+  ok exists $slop->{max},   "slop: has max";
+  ok exists $slop->{mean},  "slop: has mean";
+  ok exists $slop->{count}, "slop: has count";
+  ok exists $slop->{subs},  "slop: has subs";
 
   # Build lookup by sub name for easier assertions.
-  my %by_name = map { $_->{name} => $_ } $crap->{subs}->@*;
+  my %by_name = map { $_->{name} => $_ } $slop->{subs}->@*;
 
   # fully_covered: CC=1, cov=100%, CRAP = 1^2*(1-1)^3 + 1 = 1
   my $fc = $by_name{fully_covered};
-  ok defined $fc, "crap: fully_covered present";
-  is $fc->{cc},   1,   "crap: fully_covered CC = 1";
-  is $fc->{cov},  100, "crap: fully_covered cov = 100";
-  is $fc->{crap}, 1,   "crap: fully_covered CRAP = 1";
+  ok defined $fc, "slop: fully_covered present";
+  is $fc->{cc},   1,   "slop: fully_covered CC = 1";
+  is $fc->{cov},  100, "slop: fully_covered cov = 100";
+  is $fc->{crap}, 1,   "slop: fully_covered CRAP = 1";
   is $fc->{slop}, 0,   "slop: fully_covered SLOP = 0";
 
   # uncalled: CC=1, cov=0%, CRAP = 1^2*(1-0)^3 + 1 = 2
   my $uc = $by_name{uncalled};
-  ok defined $uc, "crap: uncalled present";
-  is $uc->{cc},   1, "crap: uncalled CC = 1";
-  is $uc->{cov},  0, "crap: uncalled cov = 0";
-  is $uc->{crap}, 2, "crap: uncalled CRAP = 2";
+  ok defined $uc, "slop: uncalled present";
+  is $uc->{cc},   1, "slop: uncalled CC = 1";
+  is $uc->{cov},  0, "slop: uncalled cov = 0";
+  is $uc->{crap}, 2, "slop: uncalled CRAP = 2";
   ok abs($uc->{slop} - log(2) * 10) < 0.01,
     "slop: uncalled SLOP = ln(2)*10";
 
   # partial_branch: CC=2, partial coverage.
   # Bounds: cov=100% => CRAP=2, cov=0% => CRAP=6.
   my $pb = $by_name{partial_branch};
-  ok defined $pb, "crap: partial_branch present";
-  is $pb->{cc}, 2, "crap: partial_branch CC = 2";
-  ok $pb->{crap} > 2, "crap: partial_branch CRAP > CC";
-  ok $pb->{crap} < 6, "crap: partial_branch CRAP < CC^2+CC";
+  ok defined $pb, "slop: partial_branch present";
+  is $pb->{cc}, 2, "slop: partial_branch CC = 2";
+  ok $pb->{crap} > 2, "slop: partial_branch CRAP > CC";
+  ok $pb->{crap} < 6, "slop: partial_branch CRAP < CC^2+CC";
   ok $pb->{slop} > 0, "slop: partial_branch SLOP > 0";
   ok $pb->{slop} > $uc->{slop},
     "slop: partial_branch SLOP > uncalled SLOP";
 
   # Total aggregation
-  my $ts = $db->{summary}{Total}{crap};
-  ok defined $ts,         "crap: Total has crap entry";
-  ok exists $ts->{max},   "crap: Total has max";
-  ok exists $ts->{mean},  "crap: Total has mean";
-  ok exists $ts->{count}, "crap: Total has count";
+  my $ts = $db->{summary}{Total}{slop};
+  ok defined $ts,         "slop: Total has slop entry";
+  ok exists $ts->{max},   "slop: Total has max";
+  ok exists $ts->{mean},  "slop: Total has mean";
+  ok exists $ts->{count}, "slop: Total has count";
 }
 
 # Text report CC/SLOP column tests.
 # Verifies that print_subroutines includes CC and SLOP columns
 # when CRAP summary data is available.
-sub test_text_report_crap () {
+sub test_text_report_slop () {
   my ($db_path, $script) = run_cover("cc_text", $Crap_script);
 
   my $st = Devel::Cover::DB::Structure->new(base => $db_path);
@@ -371,7 +371,7 @@ sub test_text_report_crap () {
 # File-level CRAP tests.
 # Verifies that summarise_complexity computes file_cc, file_cov,
 # and file_crap by treating the entire file as one sub body.
-sub test_file_level_crap () {
+sub test_file_level_slop () {
   my ($db_path, $script) = run_cover("cc_filecrap", $Crap_script);
 
   my $st = Devel::Cover::DB::Structure->new(base => $db_path);
@@ -387,43 +387,43 @@ sub test_file_level_crap () {
   );
 
   my ($file) = grep /cc_filecrap\.pl$/, keys $db->{summary}->%*;
-  ok defined $file, "filecrap: summary contains cover file";
+  ok defined $file, "fileslop: summary contains cover file";
 
-  my $crap = $db->{summary}{$file}{crap};
-  ok defined $crap, "filecrap: file summary has crap entry";
+  my $slop = $db->{summary}{$file}{slop};
+  ok defined $slop, "fileslop: file summary has slop entry";
 
   # file_cc = sum of per-sub CCs - count + 1
-  ok exists $crap->{file_cc}, "filecrap: has file_cc";
+  ok exists $slop->{file_cc}, "fileslop: has file_cc";
   my $expected_cc_sum = 0;
-  $expected_cc_sum += $_->{cc} for $crap->{subs}->@*;
-  is $crap->{file_cc}, $expected_cc_sum - $crap->{count} + 1,
-    "filecrap: file_cc = sum(cc) - count + 1";
+  $expected_cc_sum += $_->{cc} for $slop->{subs}->@*;
+  is $slop->{file_cc}, $expected_cc_sum - $slop->{count} + 1,
+    "fileslop: file_cc = sum(cc) - count + 1";
 
   # file_cov: combined stmt+branch+condition coverage
-  ok exists $crap->{file_cov}, "filecrap: has file_cov";
-  ok $crap->{file_cov} >= 0 && $crap->{file_cov} <= 100,
-    "filecrap: file_cov is 0..100";
+  ok exists $slop->{file_cov}, "fileslop: has file_cov";
+  ok $slop->{file_cov} >= 0 && $slop->{file_cov} <= 100,
+    "fileslop: file_cov is 0..100";
 
   # file_crap: CRAP formula applied to file-level inputs
-  ok exists $crap->{file_crap}, "filecrap: has file_crap";
-  my $cc  = $crap->{file_cc};
-  my $cov = $crap->{file_cov};
+  ok exists $slop->{file_crap}, "fileslop: has file_crap";
+  my $cc  = $slop->{file_cc};
+  my $cov = $slop->{file_cov};
   my $expected_crap = $cc**2 * (1 - $cov / 100)**3 + $cc;
-  is $crap->{file_crap}, $expected_crap,
-    "filecrap: file_crap matches CRAP formula";
+  is $slop->{file_crap}, $expected_crap,
+    "fileslop: file_crap matches CRAP formula";
 
   # file_slop: ln(file_crap) * 10
-  ok exists $crap->{file_slop}, "filecrap: has file_slop";
+  ok exists $slop->{file_slop}, "fileslop: has file_slop";
   my $expected_slop
-    = $crap->{file_crap} > 1 ? log($crap->{file_crap}) * 10 : 0;
-  ok abs($crap->{file_slop} - $expected_slop) < 0.01,
-    "filecrap: file_slop = log(file_crap) * 10";
+    = $slop->{file_crap} > 1 ? log($slop->{file_crap}) * 10 : 0;
+  ok abs($slop->{file_slop} - $expected_slop) < 0.01,
+    "fileslop: file_slop = log(file_crap) * 10";
 
   # Total aggregation
-  my $ts = $db->{summary}{Total}{crap};
-  ok defined $ts, "filecrap: Total has crap entry";
-  ok exists $ts->{file_crap}, "filecrap: Total has file_crap";
-  ok exists $ts->{file_slop}, "filecrap: Total has file_slop";
+  my $ts = $db->{summary}{Total}{slop};
+  ok defined $ts, "fileslop: Total has slop entry";
+  ok exists $ts->{file_crap}, "fileslop: Total has file_crap";
+  ok exists $ts->{file_slop}, "fileslop: Total has file_slop";
 }
 
 sub main () {
@@ -431,9 +431,9 @@ sub main () {
   test_summary_aggregation;
   test_end_lines;
   test_signature_cc;
-  test_crap_scoring;
-  test_text_report_crap;
-  test_file_level_crap;
+  test_slop_scoring;
+  test_text_report_slop;
+  test_file_level_slop;
 }
 
 main;

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -154,4 +154,46 @@ PERL
   is $ts->{count}, 8,    "Total complexity count = 8";
 }
 
+# Sub end line tests
+# Uses a multi-line sub to verify end_line > start_line.
+# Line layout:
+# 1: use strict;
+# 2: use warnings;
+# 3: (blank)
+# 4: sub oneliner { 42 }
+# 5: sub multiline {
+# 6:   my $x = 1;
+# 7:   my $y = 2;
+# 8:   $x + $y;
+# 9: }
+# 10: (blank)
+# 11: oneliner();
+# 12: multiline();
+{
+  my ($db_path, $script) = run_cover("cc_endline", <<'PERL');
+use strict;
+use warnings;
+
+sub oneliner { 42 }
+sub multiline {
+  my $x = 1;
+  my $y = 2;
+  $x + $y;
+}
+
+oneliner();
+multiline();
+PERL
+
+  my $st = Devel::Cover::DB::Structure->new(base => $db_path);
+  $st->read_all;
+
+  my $ends = $st->get_end_lines(md5_file($script));
+  ok defined $ends, "end_lines data present in structure";
+
+  is $ends->{4}{oneliner}[0], 4, "single-line sub: end_line = start_line";
+  is $ends->{5}{multiline}[0], 8,
+    "multi-line sub: end_line = last statement line";
+}
+
 done_testing;

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -290,6 +290,7 @@ sub test_crap_scoring () {
   is $fc->{cc},   1,   "crap: fully_covered CC = 1";
   is $fc->{cov},  100, "crap: fully_covered cov = 100";
   is $fc->{crap}, 1,   "crap: fully_covered CRAP = 1";
+  is $fc->{slop}, 0,   "slop: fully_covered SLOP = 0";
 
   # uncalled: CC=1, cov=0%, CRAP = 1^2*(1-0)^3 + 1 = 2
   my $uc = $by_name{uncalled};
@@ -297,6 +298,8 @@ sub test_crap_scoring () {
   is $uc->{cc},   1, "crap: uncalled CC = 1";
   is $uc->{cov},  0, "crap: uncalled cov = 0";
   is $uc->{crap}, 2, "crap: uncalled CRAP = 2";
+  ok abs($uc->{slop} - log(2) * 10) < 0.01,
+    "slop: uncalled SLOP = ln(2)*10";
 
   # partial_branch: CC=2, partial coverage.
   # Bounds: cov=100% => CRAP=2, cov=0% => CRAP=6.
@@ -305,6 +308,9 @@ sub test_crap_scoring () {
   is $pb->{cc}, 2, "crap: partial_branch CC = 2";
   ok $pb->{crap} > 2, "crap: partial_branch CRAP > CC";
   ok $pb->{crap} < 6, "crap: partial_branch CRAP < CC^2+CC";
+  ok $pb->{slop} > 0, "slop: partial_branch SLOP > 0";
+  ok $pb->{slop} > $uc->{slop},
+    "slop: partial_branch SLOP > uncalled SLOP";
 
   # Total aggregation
   my $ts = $db->{summary}{Total}{crap};
@@ -314,8 +320,8 @@ sub test_crap_scoring () {
   ok exists $ts->{count}, "crap: Total has count";
 }
 
-# Text report CC/CRAP column tests.
-# Verifies that print_subroutines includes CC and CRAP columns
+# Text report CC/SLOP column tests.
+# Verifies that print_subroutines includes CC and SLOP columns
 # when CRAP summary data is available.
 sub test_text_report_crap () {
   my ($db_path, $script) = run_cover("cc_text", $Crap_script);
@@ -345,21 +351,21 @@ sub test_text_report_crap () {
     close $fh or die "Cannot close scalar ref: $!";
   }
 
-  # Header should contain CC and CRAP columns.
-  like $output, qr/^\s*Subroutine\b.*\bCC\b.*\bCRAP\b/m,
-    "text: header contains CC and CRAP columns";
+  # Header should contain CC and SLOP columns.
+  like $output, qr/^\s*Subroutine\b.*\bCC\b.*\bSLOP\b/m,
+    "text: header contains CC and SLOP columns";
 
-  # fully_covered: CC=1, CRAP=1.0
-  like $output, qr/fully_covered\s+\d+\s+1\s+1\.0\b/,
-    "text: fully_covered has CC=1 CRAP=1.0";
+  # fully_covered: CC=1, SLOP=0.0 (CRAP=1, ln(1)*10=0)
+  like $output, qr/fully_covered\s+\d+\s+1\s+0\.0\b/,
+    "text: fully_covered has CC=1 SLOP=0.0";
 
-  # uncalled: CC=1, CRAP=2.0
-  like $output, qr/uncalled\s+\d+\s+1\s+2\.0\b/,
-    "text: uncalled has CC=1 CRAP=2.0";
+  # uncalled: CC=1, SLOP=6.9 (CRAP=2, ln(2)*10=6.93)
+  like $output, qr/uncalled\s+\d+\s+1\s+6\.9\b/,
+    "text: uncalled has CC=1 SLOP=6.9";
 
-  # partial_branch: CC=2, CRAP between 2 and 6
+  # partial_branch: CC=2, SLOP > 6.9
   like $output, qr/partial_branch\s+\d+\s+2\s+\d+\.\d/,
-    "text: partial_branch has CC=2 and a CRAP score";
+    "text: partial_branch has CC=2 and a SLOP score";
 }
 
 # File-level CRAP tests.
@@ -406,10 +412,18 @@ sub test_file_level_crap () {
   is $crap->{file_crap}, $expected_crap,
     "filecrap: file_crap matches CRAP formula";
 
+  # file_slop: ln(file_crap) * 10
+  ok exists $crap->{file_slop}, "filecrap: has file_slop";
+  my $expected_slop
+    = $crap->{file_crap} > 1 ? log($crap->{file_crap}) * 10 : 0;
+  ok abs($crap->{file_slop} - $expected_slop) < 0.01,
+    "filecrap: file_slop = log(file_crap) * 10";
+
   # Total aggregation
   my $ts = $db->{summary}{Total}{crap};
   ok defined $ts, "filecrap: Total has crap entry";
   ok exists $ts->{file_crap}, "filecrap: Total has file_crap";
+  ok exists $ts->{file_slop}, "filecrap: Total has file_slop";
 }
 
 sub main () {

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -24,6 +24,7 @@ use Test::More import => [qw( done_testing is ok )];
 
 my $Root = Cwd::cwd();
 
+use Devel::Cover::DB            ();
 use Devel::Cover::DB::Structure ();
 
 my $Tmpdir = tempdir(CLEANUP => 1);
@@ -34,9 +35,8 @@ sub md5_file ($path) {
   Digest::MD5->new->addfile($fh)->hexdigest
 }
 
-# Run a script under Devel::Cover and return the complexity hash for that
-# script's file digest.
-sub cover_complexity ($label, $script_content) {
+# Run a script under Devel::Cover and return ($db_path, $script_path).
+sub run_cover ($label, $script_content) {
   my $script = File::Spec->catfile($Tmpdir, "$label.pl");
   my $db     = File::Spec->catdir($Tmpdir, "${label}_db");
 
@@ -48,6 +48,14 @@ sub cover_complexity ($label, $script_content) {
 
   system($^X, @inc, "-MDevel::Cover=-db,$db,-silent,1", $script) == 0
     or die "Failed to run $label under Devel::Cover: $?";
+
+  ($db, $script)
+}
+
+# Run a script under Devel::Cover and return the complexity hash for that
+# script's file digest.
+sub cover_complexity ($label, $script_content) {
+  my ($db, $script) = run_cover($label, $script_content);
 
   my $st = Devel::Cover::DB::Structure->new(base => $db);
   $st->read_all;
@@ -95,5 +103,55 @@ is $Cc->{6}{elsif_two}[0],    3, "if/elsif: CC = 3";
 is $Cc->{7}{with_and}[0],     2, "&&: CC = 2";
 is $Cc->{8}{ternary}[0],      2, "ternary: CC = 2";
 is $Cc->{9}{with_foreach}[0], 2, "foreach: CC = 2";
+
+# Summary aggregation tests
+# Reuse the same test script layout (6 subs: CC = 1, 2, 3, 2, 2, 2).
+{
+  my ($db_path, $script) = run_cover("cc_summary", <<'PERL');
+use strict;
+use warnings;
+
+sub linear       { 42 }
+sub one_if       { if ($_[0]) { return 1 } return 0 }
+sub elsif_two    { if ($_[0] > 0) { 1 } elsif ($_[0] < 0) { -1 } else { 0 } }
+sub with_and     { $_[0] && $_[1] }
+sub ternary      { $_[0] ? 1 : 0 }
+sub with_foreach { my $s; foreach my $x (@_) { $s .= $x } $s }
+
+linear();
+one_if(1);
+elsif_two(1);
+with_and(1, 1);
+ternary(1);
+with_foreach("a", "b");
+PERL
+
+  my $st = Devel::Cover::DB::Structure->new(base => $db_path);
+  $st->read_all;
+
+  my $db = Devel::Cover::DB->new(db => $db_path)->merge_runs;
+  $db->set_structure($st);
+  $db->calculate_summary(statement => 1, subroutine => 1);
+
+  # Find the cover file key for our script
+  my ($file) = grep /cc_summary\.pl$/, keys $db->{summary}->%*;
+  ok defined $file, "summary contains cover file for test script";
+
+  my $cs = $db->{summary}{$file}{complexity};
+  ok defined $cs, "file summary has complexity entry";
+
+  # 8 subs: 6 named + 2 BEGIN blocks from use strict/warnings.
+  # CC values: 1,1 (BEGINs), 1,2,3,2,2,2 (named) = sum 14, mean 1.75
+  is $cs->{max},   3,    "file complexity max = 3 (elsif_two)";
+  is $cs->{mean},  1.75, "file complexity mean = 1.75";
+  is $cs->{count}, 8,    "file complexity count = 8 subs";
+
+  my $ts = $db->{summary}{Total}{complexity};
+  ok defined $ts, "Total summary has complexity entry";
+
+  is $ts->{max},   3,    "Total complexity max = 3";
+  is $ts->{mean},  1.75, "Total complexity mean = 1.75";
+  is $ts->{count}, 8,    "Total complexity count = 8";
+}
 
 done_testing;

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -421,6 +421,22 @@ sub test_file_level_slop () {
   ok defined $ts,             "fileslop: Total has slop entry";
   ok exists $ts->{file_crap}, "fileslop: Total has file_crap";
   ok exists $ts->{file_slop}, "fileslop: Total has file_slop";
+
+  # Module-level SLOP (whole-codebase CRAP)
+  ok exists $ts->{module_cc},   "fileslop: Total has module_cc";
+  ok exists $ts->{module_cov},  "fileslop: Total has module_cov";
+  ok exists $ts->{module_crap}, "fileslop: Total has module_crap";
+  ok exists $ts->{module_slop}, "fileslop: Total has module_slop";
+  ok $ts->{module_cc} > 0,      "fileslop: module_cc > 0";
+  my $mcc = $ts->{module_cc};
+  my $mcv = $ts->{module_cov};
+  my $expected_mcrap = $mcc**2 * (1 - $mcv / 100)**3 + $mcc;
+  is $ts->{module_crap}, $expected_mcrap,
+    "fileslop: module_crap matches CRAP formula";
+  my $expected_mslop
+    = $ts->{module_crap} > 1 ? log($ts->{module_crap}) * 10 : 0;
+  ok abs($ts->{module_slop} - $expected_mslop) < 0.01,
+    "fileslop: module_slop = log(module_crap) * 10";
 }
 
 sub test_dir_level_slop () {

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -17,10 +17,14 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
 use File::Spec ();
-use Test::More import => [ qw( done_testing is like ok plan unlike ) ];
+use Test::More import => [qw( done_testing is like ok plan unlike )];
 use Devel::Cover::Report::Html_crisp ();
-use Devel::Cover::Test::Showcase
-  qw( create_cover_db run_cover setup_lib_dir slurp );
+use Devel::Cover::Test::Showcase     qw(
+  create_cover_db
+  run_cover
+  setup_lib_dir
+  slurp
+);
 
 eval "require HTML::Entities; 1" or do {
   plan skip_all => "HTML::Entities not available";
@@ -114,23 +118,23 @@ sub test_render_index () {
 
   # Structural checks on the golden TT output - these will be
   # re-run against _render_index output once it replaces TT.
-  like $got, qr/<!DOCTYPE html>/,         "has doctype";
-  like $got, qr/<title>Coverage Summary/, "has summary title";
-  like $got, qr/class="file-table"/,      "has file table";
-  like $got, qr/class="worst-files"/,     "has worst files";
-  like $got, qr/class="dist-bar"/,        "has distribution bar";
-  like $got, qr/class="filter-bar"/,      "has filter bar";
-  like $got, qr/data-sort="slop"/,        "has SLOP column";
-  unlike $got, qr/data-sort="risk"/,      "no risk column";
-  like $got, qr/Highest SLOP/,            "worst files heading";
-  like $got, qr/Covered\/Calc\.pm/,       "Covered/Calc.pm present";
-  like $got, qr/Covered\/Full\.pm/,       "Covered/Full.pm present";
-  like $got, qr/Uncovered\/Calc\.pm/,     "Uncovered/Calc.pm present";
-  like $got, qr/Uncovered\/Full\.pm/,     "Uncovered/Full.pm present";
-  like $got, qr/untested-badge/,          "has untested badge";
-  like $got, qr/class="help-overlay"/,    "has help overlay";
-  like $got, qr/class="footer"/,          "has footer";
-  like $got, qr/Devel::Cover/,            "footer mentions Devel::Cover";
+  like $got,   qr/<!DOCTYPE html>/,         "has doctype";
+  like $got,   qr/<title>Coverage Summary/, "has summary title";
+  like $got,   qr/class="file-table"/,      "has file table";
+  like $got,   qr/class="worst-files"/,     "has worst files";
+  like $got,   qr/class="dist-bar"/,        "has distribution bar";
+  like $got,   qr/class="filter-bar"/,      "has filter bar";
+  like $got,   qr/data-sort="slop"/,        "has SLOP column";
+  unlike $got, qr/data-sort="risk"/,        "no risk column";
+  like $got,   qr/Highest SLOP/,            "worst files heading";
+  like $got,   qr/Covered\/Calc\.pm/,       "Covered/Calc.pm present";
+  like $got,   qr/Covered\/Full\.pm/,       "Covered/Full.pm present";
+  like $got,   qr/Uncovered\/Calc\.pm/,     "Uncovered/Calc.pm present";
+  like $got,   qr/Uncovered\/Full\.pm/,     "Uncovered/Full.pm present";
+  like $got,   qr/untested-badge/,          "has untested badge";
+  like $got,   qr/class="help-overlay"/,    "has help overlay";
+  like $got,   qr/class="footer"/,          "has footer";
+  like $got,   qr/Devel::Cover/,            "footer mentions Devel::Cover";
 }
 
 sub test_render_file_page () {

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -126,7 +126,7 @@ sub test_render_index () {
   like $got,   qr/class="filter-bar"/,      "has filter bar";
   like $got,   qr/data-sort="slop"/,        "has SLOP column";
   unlike $got, qr/data-sort="risk"/,        "no risk column";
-  like $got,   qr/Highest SLOP/,            "worst files heading";
+  like $got,   qr/Top SLOP/,                "worst files heading";
   like $got,   qr/Covered\/Calc\.pm/,       "Covered/Calc.pm present";
   like $got,   qr/Covered\/Full\.pm/,       "Covered/Full.pm present";
   like $got,   qr/Uncovered\/Calc\.pm/,     "Uncovered/Calc.pm present";

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -17,7 +17,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
 use File::Spec ();
-use Test::More import => [ qw( done_testing is like ok plan ) ];
+use Test::More import => [ qw( done_testing is like ok plan unlike ) ];
 use Devel::Cover::Report::Html_crisp ();
 use Devel::Cover::Test::Showcase
   qw( create_cover_db run_cover setup_lib_dir slurp );
@@ -120,7 +120,9 @@ sub test_render_index () {
   like $got, qr/class="worst-files"/,     "has worst files";
   like $got, qr/class="dist-bar"/,        "has distribution bar";
   like $got, qr/class="filter-bar"/,      "has filter bar";
-  like $got, qr/data-sort="risk"/,        "has risk column";
+  like $got, qr/data-sort="crap"/,        "has CRAP column";
+  unlike $got, qr/data-sort="risk"/,      "no risk column";
+  like $got, qr/Highest CRAP/,            "worst files heading";
   like $got, qr/Covered\/Calc\.pm/,       "Covered/Calc.pm present";
   like $got, qr/Covered\/Full\.pm/,       "Covered/Full.pm present";
   like $got, qr/Uncovered\/Calc\.pm/,     "Uncovered/Calc.pm present";

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -195,6 +195,14 @@ sub test_dir_row_slop () {
     "dir row: has SLOP tooltip";
 }
 
+sub test_module_slop_badge () {
+  my $got = $Golden{"coverage.html"};
+  like $got, qr/stat-badge.*?slop\b/s,
+    "header: has SLOP stat badge";
+  like $got, qr/slop.*?help-toggle/s,
+    "header: SLOP badge before help button";
+}
+
 sub test_render_untested_page () {
   my ($untested) = grep /Uncovered-Calc/, keys %Golden;
   ok defined $untested, "golden untested file page exists";
@@ -214,6 +222,7 @@ sub main () {
   test_tooltip_structure;
   test_glass_tooltips;
   test_dir_row_slop;
+  test_module_slop_badge;
   test_render_untested_page;
   done_testing;
 }

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -152,6 +152,22 @@ sub test_render_file_page () {
   like $got, qr/class="src/,           "file: has source column";
 }
 
+sub test_tooltip_structure () {
+  my $got = $Golden{"coverage.html"};
+
+  # New dl-based tooltip structure
+  like $got, qr/class="slop-tip"/,         "tooltip: has slop-tip";
+  like $got, qr/class="slop-tip-metrics"/, "tooltip: has metrics section";
+  like $got, qr/class="slop-tip-subs"/,    "tooltip: has subs section";
+  like $got, qr/class="slop-tip-total"/,   "tooltip: has total section";
+
+  # Colour coding inside tooltips
+  like $got, qr/slop-tip-metrics.*?class="c[0-3]"/s,
+    "tooltip: coverage value has colour class";
+  like $got, qr/slop-tip-subs.*?class="c[0-3]"/s,
+    "tooltip: sub entry has colour class";
+}
+
 sub test_render_untested_page () {
   my ($untested) = grep /Uncovered-Calc/, keys %Golden;
   ok defined $untested, "golden untested file page exists";
@@ -168,6 +184,7 @@ sub main () {
   test_render_layout;
   test_render_index;
   test_render_file_page;
+  test_tooltip_structure;
   test_render_untested_page;
   done_testing;
 }

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -120,9 +120,9 @@ sub test_render_index () {
   like $got, qr/class="worst-files"/,     "has worst files";
   like $got, qr/class="dist-bar"/,        "has distribution bar";
   like $got, qr/class="filter-bar"/,      "has filter bar";
-  like $got, qr/data-sort="crap"/,        "has CRAP column";
+  like $got, qr/data-sort="slop"/,        "has SLOP column";
   unlike $got, qr/data-sort="risk"/,      "no risk column";
-  like $got, qr/Highest CRAP/,            "worst files heading";
+  like $got, qr/Highest SLOP/,            "worst files heading";
   like $got, qr/Covered\/Calc\.pm/,       "Covered/Calc.pm present";
   like $got, qr/Covered\/Full\.pm/,       "Covered/Full.pm present";
   like $got, qr/Uncovered\/Calc\.pm/,     "Uncovered/Calc.pm present";

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -159,8 +159,9 @@ sub test_render_file_page () {
 sub test_tooltip_structure () {
   my $got = $Golden{"coverage.html"};
 
-  # New dl-based tooltip structure
-  like $got, qr/class="slop-tip"/,         "tooltip: has slop-tip";
+  # Unified glass tooltip system
+  like $got, qr/class="glass-tip slop-detail"/,
+    "tooltip: has glass-tip slop-detail";
   like $got, qr/class="slop-tip-metrics"/, "tooltip: has metrics section";
   like $got, qr/class="slop-tip-subs"/,    "tooltip: has subs section";
   like $got, qr/class="slop-tip-total"/,   "tooltip: has total section";
@@ -170,6 +171,22 @@ sub test_tooltip_structure () {
     "tooltip: coverage value has colour class";
   like $got, qr/slop-tip-subs.*?class="c[0-3]"/s,
     "tooltip: sub entry has colour class";
+}
+
+sub test_glass_tooltips () {
+  my $index = $Golden{"coverage.html"};
+
+  # Single tooltip mechanism: tip-hover + glass-tip child
+  like $index,   qr/class="[^"]*tip-hover/, "glass: has tip-hover class";
+  like $index,   qr/class="glass-tip"/,     "glass: has glass-tip child";
+  unlike $index, qr/class="[^"]*has-tip/,   "glass: no has-tip class";
+  unlike $index, qr/data-tip="/,            "glass: no data-tip attributes";
+
+  # File page SLOP badge uses tip-hover
+  my ($covered) = grep /Covered-Calc/, keys %Golden;
+  my $file_page = $Golden{$covered};
+  like $file_page,   qr/stat-slop tip-hover/, "glass: SLOP badge has tip-hover";
+  unlike $file_page, qr/slop-hover/,          "glass: no slop-hover class";
 }
 
 sub test_render_untested_page () {
@@ -189,6 +206,7 @@ sub main () {
   test_render_index;
   test_render_file_page;
   test_tooltip_structure;
+  test_glass_tooltips;
   test_render_untested_page;
   done_testing;
 }

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -189,6 +189,12 @@ sub test_glass_tooltips () {
   unlike $file_page, qr/slop-hover/,          "glass: no slop-hover class";
 }
 
+sub test_dir_row_slop () {
+  my $got = $Golden{"coverage.html"};
+  like $got, qr/dir-header.*?tip-hover.*?slop-detail/s,
+    "dir row: has SLOP tooltip";
+}
+
 sub test_render_untested_page () {
   my ($untested) = grep /Uncovered-Calc/, keys %Golden;
   ok defined $untested, "golden untested file page exists";
@@ -207,6 +213,7 @@ sub main () {
   test_render_file_page;
   test_tooltip_structure;
   test_glass_tooltips;
+  test_dir_row_slop;
   test_render_untested_page;
   done_testing;
 }

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -713,6 +713,48 @@ sub test_get_complexity () {
   ok !defined $miss, "get_complexity: returns undef for unknown digest";
 }
 
+sub test_set_end_line () {
+  my $file = write_source("setend.pm", "package SetEnd;\nsub f {}\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+
+  my $sub_id = [ $file, 10, "f", 0 ];
+  $st->set_end_line($sub_id, 25);
+
+  is $st->{f}{$file}{end_line}{10}{f}[0], 25,
+    "set_end_line: stores end line at correct key";
+}
+
+sub test_get_end_lines () {
+  my $file   = write_source("getend.pm", "package GetEnd;\nsub g {}\n1\n");
+  my $digest = md5_file($file);
+  my $st     = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->set_end_line([ $file, 8, "g", 0 ], 20);
+
+  my $got = $st->get_end_lines($digest);
+  is_deeply $got, { 8 => { g => [20] } }, "get_end_lines: retrieves by digest";
+
+  my $miss = $st->get_end_lines("nonexistent_digest");
+  ok !defined $miss, "get_end_lines: returns undef for unknown digest";
+}
+
+sub test_end_line_write_read () {
+  my $base = fresh_base("end_write_read");
+  my $file = write_source("endwr.pm", "package EndWR;\nsub f {}\n1\n");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->set_file($file);
+  $st->set_end_line([ $file, 5, "f", 0 ], 15);
+  $st->write($base);
+
+  my $st2 = Devel::Cover::DB::Structure->new(base => $base);
+  $st2->read_all;
+
+  is $st2->{f}{$file}{end_line}{5}{f}[0], 15,
+    "end_line write/read: survives round-trip";
+}
+
 sub test_set_subroutine_returns_sub_id () {
   my $file = write_source("subid.pm", "package SubId;\nsub h {}\n1\n");
   my $st   = Devel::Cover::DB::Structure->new;
@@ -778,6 +820,9 @@ sub main () {
   test_set_complexity_multiple_subs;
   test_complexity_write_read;
   test_get_complexity;
+  test_set_end_line;
+  test_get_end_lines;
+  test_end_line_write_read;
   test_set_subroutine_returns_sub_id;
   done_testing;
 }

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -824,7 +824,7 @@ sub main () {
   test_get_end_lines;
   test_end_line_write_read;
   test_set_subroutine_returns_sub_id;
-  done_testing;
 }
 
 main;
+done_testing;

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -20,7 +20,7 @@ use Digest::MD5 ();
 use File::Path  qw( make_path );
 use File::Spec  ();
 use File::Temp  qw( tempdir );
-use Test::More import => [ qw( done_testing is is_deeply like ok pass ) ];
+use Test::More import => [qw( done_testing is is_deeply like ok pass )];
 
 use Devel::Cover::DB::Structure ();
 
@@ -42,6 +42,7 @@ sub md5_file ($path) {
 
 {
   no feature "signatures";
+
   sub capture_stderr (&) {
     my ($code) = @_;
     my $stderr = "";
@@ -113,7 +114,7 @@ sub test_criteria () {
   my $st = Devel::Cover::DB::Structure->new;
   $st->add_criteria("statement", "branch");
   my @c = sort $st->criteria;
-  is_deeply \@c, [ qw( branch statement ) ], "criteria: round-trip";
+  is_deeply \@c, [qw( branch statement )], "criteria: round-trip";
 }
 
 sub test_delete_file () {
@@ -655,6 +656,78 @@ sub test_digest_dash_e () {
   is $stderr, "", "digest -e: suppresses warning for -e";
 }
 
+sub test_set_complexity () {
+  my $file = write_source("setcc.pm", "package SetCC;\nsub mysub {}\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+
+  my $sub_id = [ $file, 10, "mysub", 0 ];
+  $st->set_complexity($sub_id, 5);
+
+  is $st->{f}{$file}{complexity}{10}{mysub}[0], 5,
+    "set_complexity: stores CC at correct key";
+}
+
+sub test_set_complexity_multiple_subs () {
+  my $file
+    = write_source("setcc2.pm", "package SetCC2;\nsub a {}\nsub b {}\n1\n");
+  my $st = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+
+  $st->set_complexity([ $file, 10, "sub_a", 0 ], 3);
+  $st->set_complexity([ $file, 20, "sub_b", 0 ], 7);
+
+  is $st->{f}{$file}{complexity}{10}{sub_a}[0], 3,
+    "set_complexity multi: first sub has correct CC";
+  is $st->{f}{$file}{complexity}{20}{sub_b}[0], 7,
+    "set_complexity multi: second sub has correct CC";
+}
+
+sub test_complexity_write_read () {
+  my $base = fresh_base("cc_write_read");
+  my $file = write_source("ccwr.pm", "package CCWR;\nsub f {}\n1\n");
+
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->set_file($file);
+  $st->set_complexity([ $file, 5, "f", 0 ], 4);
+  $st->write($base);
+
+  my $st2 = Devel::Cover::DB::Structure->new(base => $base);
+  $st2->read_all;
+
+  is $st2->{f}{$file}{complexity}{5}{f}[0], 4,
+    "complexity write/read: survives round-trip";
+}
+
+sub test_get_complexity () {
+  my $file   = write_source("getcc.pm", "package GetCC;\nsub g {}\n1\n");
+  my $digest = md5_file($file);
+  my $st     = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->set_complexity([ $file, 8, "g", 0 ], 6);
+
+  my $got = $st->get_complexity($digest);
+  is_deeply $got, { 8 => { g => [6] } }, "get_complexity: retrieves by digest";
+
+  my $miss = $st->get_complexity("nonexistent_digest");
+  ok !defined $miss, "get_complexity: returns undef for unknown digest";
+}
+
+sub test_set_subroutine_returns_sub_id () {
+  my $file = write_source("subid.pm", "package SubId;\nsub h {}\n1\n");
+  my $st   = Devel::Cover::DB::Structure->new;
+  $st->set_file($file);
+  $st->add_criteria("statement");
+  $st->add_count("statement");
+
+  my $sub_id = $st->set_subroutine("h", $file, 15, 0);
+  is_deeply $sub_id, [ $file, 15, "h", 0 ], "set_subroutine: returns sub_id";
+
+  $st->set_complexity($sub_id, 9);
+  is $st->{f}{$file}{complexity}{15}{h}[0], 9,
+    "set_subroutine + set_complexity: end-to-end via sub_id";
+}
+
 sub main () {
   test_new;
   test_digest;
@@ -701,6 +774,11 @@ sub main () {
   test_write_no_digest_self_cover_no_match;
   test_autoload_no_criterion;
   test_digest_dash_e;
+  test_set_complexity;
+  test_set_complexity_multiple_subs;
+  test_complexity_write_read;
+  test_get_complexity;
+  test_set_subroutine_returns_sub_id;
   done_testing;
 }
 

--- a/test_output/cover/accessor.5.020000
+++ b/test_output/cover/accessor.5.020000
@@ -38,11 +38,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location           
----------- ----- -------------------
-BEGIN          1 Accessor_maker.pm:4
-__ANON__       4 Accessor_maker.pm:5
-import         1 Accessor_maker.pm:5
+Subroutine Count  CC  CRAP Location           
+---------- ----- --- ----- -------------------
+BEGIN          1   1   1.0 Accessor_maker.pm:4
+__ANON__       4   1   1.0 Accessor_maker.pm:5
+import         1   1   1.0 Accessor_maker.pm:5
 
 
 accessor
@@ -90,11 +90,11 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location   
----------- ----- -----------
-BEGIN          1 accessor:4 
-BEGIN          1 accessor:7 
-new            2 accessor:2 
-test           2 accessor:13
+Subroutine Count  CC  CRAP Location   
+---------- ----- --- ----- -----------
+BEGIN          1   1   1.0 accessor:4 
+BEGIN          1   1   1.0 accessor:7 
+new            2   1   1.0 accessor:2 
+test           2   3   3.0 accessor:13
 
 

--- a/test_output/cover/accessor.5.020000
+++ b/test_output/cover/accessor.5.020000
@@ -38,11 +38,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location           
+Subroutine Count  CC  SLOP Location           
 ---------- ----- --- ----- -------------------
-BEGIN          1   1   1.0 Accessor_maker.pm:4
-__ANON__       4   1   1.0 Accessor_maker.pm:5
-import         1   1   1.0 Accessor_maker.pm:5
+BEGIN          1   1   0.0 Accessor_maker.pm:4
+__ANON__       4   1   0.0 Accessor_maker.pm:5
+import         1   1   0.0 Accessor_maker.pm:5
 
 
 accessor
@@ -90,11 +90,11 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location   
+Subroutine Count  CC  SLOP Location   
 ---------- ----- --- ----- -----------
-BEGIN          1   1   1.0 accessor:4 
-BEGIN          1   1   1.0 accessor:7 
-new            2   1   1.0 accessor:2 
-test           2   3   3.0 accessor:13
+BEGIN          1   1   0.0 accessor:4 
+BEGIN          1   1   0.0 accessor:7 
+new            2   1   0.0 accessor:2 
+test           2   3  11.0 accessor:13
 
 

--- a/test_output/cover/alias.5.020000
+++ b/test_output/cover/alias.5.020000
@@ -56,8 +56,8 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location      
+Subroutine Count  CC  SLOP Location      
 ---------- ----- --- ----- --------------
-is_3digits     2   2   2.0 tests/alias:13
+is_3digits     2   2   6.9 tests/alias:13
 
 

--- a/test_output/cover/alias.5.020000
+++ b/test_output/cover/alias.5.020000
@@ -56,8 +56,8 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location      
----------- ----- --------------
-is_3digits     2 tests/alias:13
+Subroutine Count  CC  CRAP Location      
+---------- ----- --- ----- --------------
+is_3digits     2   2   2.0 tests/alias:13
 
 

--- a/test_output/cover/alias1.5.020000
+++ b/test_output/cover/alias1.5.020000
@@ -66,12 +66,12 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location    
----------- ----- ------------
-BEGIN          1 Alias1.pm:10
-BEGIN          1 Alias1.pm:11
-BEGIN          1 Alias1.pm:13
-is_3digits     2 Alias1.pm:19
+Subroutine Count  CC  CRAP Location    
+---------- ----- --- ----- ------------
+BEGIN          1   1   1.0 Alias1.pm:10
+BEGIN          1   1   1.0 Alias1.pm:11
+BEGIN          1   1   1.0 Alias1.pm:13
+is_3digits     2   2   2.0 Alias1.pm:19
 
 
 alias1
@@ -109,11 +109,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location 
----------- ----- ---------
-BEGIN          1 alias1:10
-BEGIN          1 alias1:11
-BEGIN          1 alias1:12
-BEGIN          1 alias1:14
+Subroutine Count  CC  CRAP Location 
+---------- ----- --- ----- ---------
+BEGIN          1   1   1.0 alias1:10
+BEGIN          1   1   1.0 alias1:11
+BEGIN          1   1   1.0 alias1:12
+BEGIN          1   1   1.0 alias1:14
 
 

--- a/test_output/cover/alias1.5.020000
+++ b/test_output/cover/alias1.5.020000
@@ -66,12 +66,12 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location    
+Subroutine Count  CC  SLOP Location    
 ---------- ----- --- ----- ------------
-BEGIN          1   1   1.0 Alias1.pm:10
-BEGIN          1   1   1.0 Alias1.pm:11
-BEGIN          1   1   1.0 Alias1.pm:13
-is_3digits     2   2   2.0 Alias1.pm:19
+BEGIN          1   1   0.0 Alias1.pm:10
+BEGIN          1   1   0.0 Alias1.pm:11
+BEGIN          1   1   0.0 Alias1.pm:13
+is_3digits     2   2   6.9 Alias1.pm:19
 
 
 alias1
@@ -109,11 +109,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location 
+Subroutine Count  CC  SLOP Location 
 ---------- ----- --- ----- ---------
-BEGIN          1   1   1.0 alias1:10
-BEGIN          1   1   1.0 alias1:11
-BEGIN          1   1   1.0 alias1:12
-BEGIN          1   1   1.0 alias1:14
+BEGIN          1   1   0.0 alias1:10
+BEGIN          1   1   0.0 alias1:11
+BEGIN          1   1   0.0 alias1:12
+BEGIN          1   1   0.0 alias1:14
 
 

--- a/test_output/cover/any_all.5.042000
+++ b/test_output/cover/any_all.5.042000
@@ -69,13 +69,13 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-BEGIN          1 tests/any_all:13
-BEGIN          1 tests/any_all:14
-BEGIN          1 tests/any_all:15
-BEGIN          1 tests/any_all:16
-BEGIN          1 tests/any_all:17
-main           1 tests/any_all:20
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+BEGIN          1   1   1.0 tests/any_all:13
+BEGIN          1   1   1.0 tests/any_all:14
+BEGIN          1   1   1.0 tests/any_all:15
+BEGIN          1   1   1.0 tests/any_all:16
+BEGIN          1   1   1.0 tests/any_all:17
+main           1   3   3.1 tests/any_all:20
 
 

--- a/test_output/cover/any_all.5.042000
+++ b/test_output/cover/any_all.5.042000
@@ -69,13 +69,13 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-BEGIN          1   1   1.0 tests/any_all:13
-BEGIN          1   1   1.0 tests/any_all:14
-BEGIN          1   1   1.0 tests/any_all:15
-BEGIN          1   1   1.0 tests/any_all:16
-BEGIN          1   1   1.0 tests/any_all:17
-main           1   3   3.1 tests/any_all:20
+BEGIN          1   1   0.0 tests/any_all:13
+BEGIN          1   1   0.0 tests/any_all:14
+BEGIN          1   1   0.0 tests/any_all:15
+BEGIN          1   1   0.0 tests/any_all:16
+BEGIN          1   1   0.0 tests/any_all:17
+main           1   3  11.3 tests/any_all:20
 
 

--- a/test_output/cover/bigint.5.032000
+++ b/test_output/cover/bigint.5.032000
@@ -56,10 +56,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location       
+Subroutine Count  CC  SLOP Location       
 ---------- ----- --- ----- ---------------
-BEGIN          1   1   1.0 tests/bigint:13
-BEGIN          1   1   1.0 tests/bigint:14
-BEGIN          1   1   1.0 tests/bigint:16
+BEGIN          1   1   0.0 tests/bigint:13
+BEGIN          1   1   0.0 tests/bigint:14
+BEGIN          1   1   0.0 tests/bigint:16
 
 

--- a/test_output/cover/bigint.5.032000
+++ b/test_output/cover/bigint.5.032000
@@ -56,10 +56,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location       
----------- ----- ---------------
-BEGIN          1 tests/bigint:13
-BEGIN          1 tests/bigint:14
-BEGIN          1 tests/bigint:16
+Subroutine Count  CC  CRAP Location       
+---------- ----- --- ----- ---------------
+BEGIN          1   1   1.0 tests/bigint:13
+BEGIN          1   1   1.0 tests/bigint:14
+BEGIN          1   1   1.0 tests/bigint:16
 
 

--- a/test_output/cover/branch_return_sub.5.020000
+++ b/test_output/cover/branch_return_sub.5.020000
@@ -70,10 +70,10 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location                  
----------- ----- --------------------------
-BEGIN          1 tests/branch_return_sub:10
-BEGIN          1 tests/branch_return_sub:11
-my_sqrt        3 tests/branch_return_sub:14
+Subroutine Count  CC  CRAP Location                  
+---------- ----- --- ----- --------------------------
+BEGIN          1   1   1.0 tests/branch_return_sub:10
+BEGIN          1   1   1.0 tests/branch_return_sub:11
+my_sqrt        3   3   3.0 tests/branch_return_sub:14
 
 

--- a/test_output/cover/branch_return_sub.5.020000
+++ b/test_output/cover/branch_return_sub.5.020000
@@ -70,10 +70,10 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location                  
+Subroutine Count  CC  SLOP Location                  
 ---------- ----- --- ----- --------------------------
-BEGIN          1   1   1.0 tests/branch_return_sub:10
-BEGIN          1   1   1.0 tests/branch_return_sub:11
-my_sqrt        3   3   3.0 tests/branch_return_sub:14
+BEGIN          1   1   0.0 tests/branch_return_sub:10
+BEGIN          1   1   0.0 tests/branch_return_sub:11
+my_sqrt        3   3  11.0 tests/branch_return_sub:14
 
 

--- a/test_output/cover/change.5.020000
+++ b/test_output/cover/change.5.020000
@@ -45,8 +45,8 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location       
----------- ----- ---------------
-new_sub        1 tests/change:12
+Subroutine Count  CC  CRAP Location       
+---------- ----- --- ----- ---------------
+new_sub        1   1   1.0 tests/change:12
 
 

--- a/test_output/cover/change.5.020000
+++ b/test_output/cover/change.5.020000
@@ -45,8 +45,8 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location       
+Subroutine Count  CC  SLOP Location       
 ---------- ----- --- ----- ---------------
-new_sub        1   1   1.0 tests/change:12
+new_sub        1   1   0.0 tests/change:12
 
 

--- a/test_output/cover/circular_ref.5.020000
+++ b/test_output/cover/circular_ref.5.020000
@@ -42,16 +42,16 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location            
+Subroutine Count  CC  SLOP Location            
 ---------- ----- --- ----- --------------------
-BEGIN          1   1   1.0 tests/circular_ref:4
-BEGIN          1   1   1.0 tests/circular_ref:5
+BEGIN          1   1   0.0 tests/circular_ref:4
+BEGIN          1   1   0.0 tests/circular_ref:5
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location            
+Subroutine Count  CC  SLOP Location            
 ---------- ----- --- ----- --------------------
-f              0   2   6.0 tests/circular_ref:8
+f              0   2  17.9 tests/circular_ref:8
 
 

--- a/test_output/cover/circular_ref.5.020000
+++ b/test_output/cover/circular_ref.5.020000
@@ -42,16 +42,16 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location            
----------- ----- --------------------
-BEGIN          1 tests/circular_ref:4
-BEGIN          1 tests/circular_ref:5
+Subroutine Count  CC  CRAP Location            
+---------- ----- --- ----- --------------------
+BEGIN          1   1   1.0 tests/circular_ref:4
+BEGIN          1   1   1.0 tests/circular_ref:5
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location            
----------- ----- --------------------
-f              0 tests/circular_ref:8
+Subroutine Count  CC  CRAP Location            
+---------- ----- --- ----- --------------------
+f              0   2   6.0 tests/circular_ref:8
 
 

--- a/test_output/cover/class38.5.038000
+++ b/test_output/cover/class38.5.038000
@@ -104,27 +104,27 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-BEGIN          1   1   1.0 tests/class38:13
-BEGIN          1   1   1.0 tests/class38:14
-BEGIN          1   1   1.0 tests/class38:15
-__ANON__       2   1   1.0 tests/class38:23
-__ANON__       1   1   1.0 tests/class38:35
-get_anon       1   1   1.0 tests/class38:35
-greet          2   2   2.0 tests/class38:29
-is_loud        1   2   2.1 tests/class38:33
-main           1   9  11.1 tests/class38:44
-name           2   1   1.0 tests/class38:25
-speak          2   1   1.0 tests/class38:26
-speak          1   1   1.0 tests/class38:39
+BEGIN          1   1   0.0 tests/class38:13
+BEGIN          1   1   0.0 tests/class38:14
+BEGIN          1   1   0.0 tests/class38:15
+__ANON__       2   1   0.0 tests/class38:23
+__ANON__       1   1   0.0 tests/class38:35
+get_anon       1   1   0.0 tests/class38:35
+greet          2   2   6.9 tests/class38:29
+is_loud        1   2   7.6 tests/class38:33
+main           1   9  24.1 tests/class38:44
+name           2   1   0.0 tests/class38:25
+speak          2   1   0.0 tests/class38:26
+speak          1   1   0.0 tests/class38:39
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-unused         0   1   2.0 tests/class38:27
-unused_dog     0   1   2.0 tests/class38:40
+unused         0   1   6.9 tests/class38:27
+unused_dog     0   1   6.9 tests/class38:40
 
 

--- a/test_output/cover/class38.5.038000
+++ b/test_output/cover/class38.5.038000
@@ -104,27 +104,27 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-BEGIN          1 tests/class38:13
-BEGIN          1 tests/class38:14
-BEGIN          1 tests/class38:15
-__ANON__       2 tests/class38:23
-__ANON__       1 tests/class38:35
-get_anon       1 tests/class38:35
-greet          2 tests/class38:29
-is_loud        1 tests/class38:33
-main           1 tests/class38:44
-name           2 tests/class38:25
-speak          2 tests/class38:26
-speak          1 tests/class38:39
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+BEGIN          1   1   1.0 tests/class38:13
+BEGIN          1   1   1.0 tests/class38:14
+BEGIN          1   1   1.0 tests/class38:15
+__ANON__       2   1   1.0 tests/class38:23
+__ANON__       1   1   1.0 tests/class38:35
+get_anon       1   1   1.0 tests/class38:35
+greet          2   2   2.0 tests/class38:29
+is_loud        1   2   2.1 tests/class38:33
+main           1   9  11.1 tests/class38:44
+name           2   1   1.0 tests/class38:25
+speak          2   1   1.0 tests/class38:26
+speak          1   1   1.0 tests/class38:39
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-unused         0 tests/class38:27
-unused_dog     0 tests/class38:40
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+unused         0   1   2.0 tests/class38:27
+unused_dog     0   1   2.0 tests/class38:40
 
 

--- a/test_output/cover/class40.5.040000
+++ b/test_output/cover/class40.5.040000
@@ -108,27 +108,27 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-BEGIN          1   1   1.0 tests/class40:13
-BEGIN          1   1   1.0 tests/class40:14
-BEGIN          1   1   1.0 tests/class40:15
-__ANON__       2   1   1.0 tests/class40:23
-__ANON__       1   1   1.0 tests/class40:35
-get_anon       1   1   1.0 tests/class40:35
-greet          2   2   2.0 tests/class40:29
-is_loud        1   2   2.1 tests/class40:33
-main           1  11  14.4 tests/class40:44
-name           2   1   1.0 tests/class40:25
-speak          2   1   1.0 tests/class40:26
-speak          1   1   1.0 tests/class40:39
+BEGIN          1   1   0.0 tests/class40:13
+BEGIN          1   1   0.0 tests/class40:14
+BEGIN          1   1   0.0 tests/class40:15
+__ANON__       2   1   0.0 tests/class40:23
+__ANON__       1   1   0.0 tests/class40:35
+get_anon       1   1   0.0 tests/class40:35
+greet          2   2   6.9 tests/class40:29
+is_loud        1   2   7.6 tests/class40:33
+main           1  11  26.6 tests/class40:44
+name           2   1   0.0 tests/class40:25
+speak          2   1   0.0 tests/class40:26
+speak          1   1   0.0 tests/class40:39
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-unused         0   1   2.0 tests/class40:27
-unused_dog     0   1   2.0 tests/class40:40
+unused         0   1   6.9 tests/class40:27
+unused_dog     0   1   6.9 tests/class40:40
 
 

--- a/test_output/cover/class40.5.040000
+++ b/test_output/cover/class40.5.040000
@@ -108,27 +108,27 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-BEGIN          1 tests/class40:13
-BEGIN          1 tests/class40:14
-BEGIN          1 tests/class40:15
-__ANON__       2 tests/class40:23
-__ANON__       1 tests/class40:35
-get_anon       1 tests/class40:35
-greet          2 tests/class40:29
-is_loud        1 tests/class40:33
-main           1 tests/class40:44
-name           2 tests/class40:25
-speak          2 tests/class40:26
-speak          1 tests/class40:39
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+BEGIN          1   1   1.0 tests/class40:13
+BEGIN          1   1   1.0 tests/class40:14
+BEGIN          1   1   1.0 tests/class40:15
+__ANON__       2   1   1.0 tests/class40:23
+__ANON__       1   1   1.0 tests/class40:35
+get_anon       1   1   1.0 tests/class40:35
+greet          2   2   2.0 tests/class40:29
+is_loud        1   2   2.1 tests/class40:33
+main           1  11  14.4 tests/class40:44
+name           2   1   1.0 tests/class40:25
+speak          2   1   1.0 tests/class40:26
+speak          1   1   1.0 tests/class40:39
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-unused         0 tests/class40:27
-unused_dog     0 tests/class40:40
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+unused         0   1   2.0 tests/class40:27
+unused_dog     0   1   2.0 tests/class40:40
 
 

--- a/test_output/cover/class42.5.042000
+++ b/test_output/cover/class42.5.042000
@@ -118,29 +118,29 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  CRAP Location        
+Subroutine   Count  CC  SLOP Location        
 ------------ ----- --- ----- ----------------
-BEGIN            1   1   1.0 tests/class42:13
-BEGIN            1   1   1.0 tests/class42:14
-BEGIN            1   1   1.0 tests/class42:15
-__ANON__         2   1   1.0 tests/class42:23
-__ANON__         1   1   1.0 tests/class42:40
-_private         1   1   1.0 tests/class42:35
-call_private     1   1   1.0 tests/class42:38
-get_anon         1   1   1.0 tests/class42:40
-greet            2   2   2.0 tests/class42:29
-is_loud          1   2   2.1 tests/class42:33
-main             1  13  17.6 tests/class42:49
-name             2   1   1.0 tests/class42:25
-speak            2   1   1.0 tests/class42:26
-speak            1   1   1.0 tests/class42:44
+BEGIN            1   1   0.0 tests/class42:13
+BEGIN            1   1   0.0 tests/class42:14
+BEGIN            1   1   0.0 tests/class42:15
+__ANON__         2   1   0.0 tests/class42:23
+__ANON__         1   1   0.0 tests/class42:40
+_private         1   1   0.0 tests/class42:35
+call_private     1   1   0.0 tests/class42:38
+get_anon         1   1   0.0 tests/class42:40
+greet            2   2   6.9 tests/class42:29
+is_loud          1   2   7.6 tests/class42:33
+main             1  13  28.7 tests/class42:49
+name             2   1   0.0 tests/class42:25
+speak            2   1   0.0 tests/class42:26
+speak            1   1   0.0 tests/class42:44
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine   Count  CC  CRAP Location        
+Subroutine   Count  CC  SLOP Location        
 ------------ ----- --- ----- ----------------
-unused           0   1   2.0 tests/class42:27
-unused_dog       0   1   2.0 tests/class42:45
+unused           0   1   6.9 tests/class42:27
+unused_dog       0   1   6.9 tests/class42:45
 
 

--- a/test_output/cover/class42.5.042000
+++ b/test_output/cover/class42.5.042000
@@ -118,29 +118,29 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine   Count Location        
------------- ----- ----------------
-BEGIN            1 tests/class42:13
-BEGIN            1 tests/class42:14
-BEGIN            1 tests/class42:15
-__ANON__         2 tests/class42:23
-__ANON__         1 tests/class42:40
-_private         1 tests/class42:35
-call_private     1 tests/class42:38
-get_anon         1 tests/class42:40
-greet            2 tests/class42:29
-is_loud          1 tests/class42:33
-main             1 tests/class42:49
-name             2 tests/class42:25
-speak            2 tests/class42:26
-speak            1 tests/class42:44
+Subroutine   Count  CC  CRAP Location        
+------------ ----- --- ----- ----------------
+BEGIN            1   1   1.0 tests/class42:13
+BEGIN            1   1   1.0 tests/class42:14
+BEGIN            1   1   1.0 tests/class42:15
+__ANON__         2   1   1.0 tests/class42:23
+__ANON__         1   1   1.0 tests/class42:40
+_private         1   1   1.0 tests/class42:35
+call_private     1   1   1.0 tests/class42:38
+get_anon         1   1   1.0 tests/class42:40
+greet            2   2   2.0 tests/class42:29
+is_loud          1   2   2.1 tests/class42:33
+main             1  13  17.6 tests/class42:49
+name             2   1   1.0 tests/class42:25
+speak            2   1   1.0 tests/class42:26
+speak            1   1   1.0 tests/class42:44
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine   Count Location        
------------- ----- ----------------
-unused           0 tests/class42:27
-unused_dog       0 tests/class42:45
+Subroutine   Count  CC  CRAP Location        
+------------ ----- --- ----- ----------------
+unused           0   1   2.0 tests/class42:27
+unused_dog       0   1   2.0 tests/class42:45
 
 

--- a/test_output/cover/cond_and.5.020000
+++ b/test_output/cover/cond_and.5.020000
@@ -106,10 +106,10 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location         
----------- ----- -----------------
-BEGIN          1 tests/cond_and:10
-BEGIN          1 tests/cond_and:11
-pas           11 tests/cond_and:50
+Subroutine Count  CC  CRAP Location         
+---------- ----- --- ----- -----------------
+BEGIN          1   1   1.0 tests/cond_and:10
+BEGIN          1   1   1.0 tests/cond_and:11
+pas           11   2   2.1 tests/cond_and:50
 
 

--- a/test_output/cover/cond_and.5.020000
+++ b/test_output/cover/cond_and.5.020000
@@ -106,10 +106,10 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location         
+Subroutine Count  CC  SLOP Location         
 ---------- ----- --- ----- -----------------
-BEGIN          1   1   1.0 tests/cond_and:10
-BEGIN          1   1   1.0 tests/cond_and:11
-pas           11   2   2.1 tests/cond_and:50
+BEGIN          1   1   0.0 tests/cond_and:10
+BEGIN          1   1   0.0 tests/cond_and:11
+pas           11   2   7.6 tests/cond_and:50
 
 

--- a/test_output/cover/cond_and.5.043008
+++ b/test_output/cover/cond_and.5.043008
@@ -106,10 +106,10 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location         
----------- ----- -----------------
-BEGIN          1 tests/cond_and:10
-BEGIN          1 tests/cond_and:11
-pas           11 tests/cond_and:50
+Subroutine Count  CC  CRAP Location         
+---------- ----- --- ----- -----------------
+BEGIN          1   1   1.0 tests/cond_and:10
+BEGIN          1   1   1.0 tests/cond_and:11
+pas           11   2   2.1 tests/cond_and:50
 
 

--- a/test_output/cover/cond_and.5.043008
+++ b/test_output/cover/cond_and.5.043008
@@ -106,10 +106,10 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location         
+Subroutine Count  CC  SLOP Location         
 ---------- ----- --- ----- -----------------
-BEGIN          1   1   1.0 tests/cond_and:10
-BEGIN          1   1   1.0 tests/cond_and:11
-pas           11   2   2.1 tests/cond_and:50
+BEGIN          1   1   0.0 tests/cond_and:10
+BEGIN          1   1   0.0 tests/cond_and:11
+pas           11   2   7.6 tests/cond_and:50
 
 

--- a/test_output/cover/cond_branch.5.020000
+++ b/test_output/cover/cond_branch.5.020000
@@ -471,28 +471,28 @@ line  err      %   l&&r  l&&!r  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location             
----------- ----- ---------------------
-BEGIN          1 tests/cond_branch:10 
-BEGIN          1 tests/cond_branch:11 
-BEGIN          1 tests/cond_branch:112
-BEGIN          1 tests/cond_branch:118
-BEGIN          1 tests/cond_branch:149
-BEGIN          1 tests/cond_branch:156
-BEGIN          1 tests/cond_branch:202
-BEGIN          1 tests/cond_branch:211
-BEGIN          1 tests/cond_branch:229
-BEGIN          1 tests/cond_branch:79 
-BEGIN          1 tests/cond_branch:85 
-__ANON__       4 tests/cond_branch:219
-__ANON__       4 tests/cond_branch:224
-__ANON__       4 tests/cond_branch:230
-__ANON__       4 tests/cond_branch:235
-__ANON__       4 tests/cond_branch:240
-__ANON__       4 tests/cond_branch:245
-__ANON__       4 tests/cond_branch:253
-__ANON__       4 tests/cond_branch:261
-__ANON__       4 tests/cond_branch:269
-__ANON__       4 tests/cond_branch:278
+Subroutine Count  CC  CRAP Location             
+---------- ----- --- ----- ---------------------
+BEGIN          1   1   1.0 tests/cond_branch:10 
+BEGIN          1   1   1.0 tests/cond_branch:11 
+BEGIN          1   1   1.0 tests/cond_branch:112
+BEGIN          1   1   1.0 tests/cond_branch:118
+BEGIN          1   1   1.0 tests/cond_branch:149
+BEGIN          1   1   1.0 tests/cond_branch:156
+BEGIN          1   1   1.0 tests/cond_branch:202
+BEGIN          1   1   1.0 tests/cond_branch:211
+BEGIN          1   1   1.0 tests/cond_branch:229
+BEGIN          1   1   1.0 tests/cond_branch:79 
+BEGIN          1   1   1.0 tests/cond_branch:85 
+__ANON__       4   2   2.0 tests/cond_branch:219
+__ANON__       4   2   2.0 tests/cond_branch:224
+__ANON__       4   2   4.3 tests/cond_branch:230
+__ANON__       4   2   2.0 tests/cond_branch:235
+__ANON__       4   2   2.0 tests/cond_branch:240
+__ANON__       4   3   3.0 tests/cond_branch:245
+__ANON__       4   3   3.0 tests/cond_branch:253
+__ANON__       4   3   3.0 tests/cond_branch:261
+__ANON__       4   3   3.0 tests/cond_branch:269
+__ANON__       4   3   3.0 tests/cond_branch:278
 
 

--- a/test_output/cover/cond_branch.5.020000
+++ b/test_output/cover/cond_branch.5.020000
@@ -471,28 +471,28 @@ line  err      %   l&&r  l&&!r  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location             
+Subroutine Count  CC  SLOP Location             
 ---------- ----- --- ----- ---------------------
-BEGIN          1   1   1.0 tests/cond_branch:10 
-BEGIN          1   1   1.0 tests/cond_branch:11 
-BEGIN          1   1   1.0 tests/cond_branch:112
-BEGIN          1   1   1.0 tests/cond_branch:118
-BEGIN          1   1   1.0 tests/cond_branch:149
-BEGIN          1   1   1.0 tests/cond_branch:156
-BEGIN          1   1   1.0 tests/cond_branch:202
-BEGIN          1   1   1.0 tests/cond_branch:211
-BEGIN          1   1   1.0 tests/cond_branch:229
-BEGIN          1   1   1.0 tests/cond_branch:79 
-BEGIN          1   1   1.0 tests/cond_branch:85 
-__ANON__       4   2   2.0 tests/cond_branch:219
-__ANON__       4   2   2.0 tests/cond_branch:224
-__ANON__       4   2   4.3 tests/cond_branch:230
-__ANON__       4   2   2.0 tests/cond_branch:235
-__ANON__       4   2   2.0 tests/cond_branch:240
-__ANON__       4   3   3.0 tests/cond_branch:245
-__ANON__       4   3   3.0 tests/cond_branch:253
-__ANON__       4   3   3.0 tests/cond_branch:261
-__ANON__       4   3   3.0 tests/cond_branch:269
-__ANON__       4   3   3.0 tests/cond_branch:278
+BEGIN          1   1   0.0 tests/cond_branch:10 
+BEGIN          1   1   0.0 tests/cond_branch:11 
+BEGIN          1   1   0.0 tests/cond_branch:112
+BEGIN          1   1   0.0 tests/cond_branch:118
+BEGIN          1   1   0.0 tests/cond_branch:149
+BEGIN          1   1   0.0 tests/cond_branch:156
+BEGIN          1   1   0.0 tests/cond_branch:202
+BEGIN          1   1   0.0 tests/cond_branch:211
+BEGIN          1   1   0.0 tests/cond_branch:229
+BEGIN          1   1   0.0 tests/cond_branch:79 
+BEGIN          1   1   0.0 tests/cond_branch:85 
+__ANON__       4   2   6.9 tests/cond_branch:219
+__ANON__       4   2   6.9 tests/cond_branch:224
+__ANON__       4   2  14.6 tests/cond_branch:230
+__ANON__       4   2   6.9 tests/cond_branch:235
+__ANON__       4   2   6.9 tests/cond_branch:240
+__ANON__       4   3  11.0 tests/cond_branch:245
+__ANON__       4   3  11.0 tests/cond_branch:253
+__ANON__       4   3  11.0 tests/cond_branch:261
+__ANON__       4   3  11.0 tests/cond_branch:269
+__ANON__       4   3  11.0 tests/cond_branch:278
 
 

--- a/test_output/cover/cond_branch.5.043008
+++ b/test_output/cover/cond_branch.5.043008
@@ -471,28 +471,28 @@ line  err      %   l&&r  l&&!r  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location             
----------- ----- ---------------------
-BEGIN          1 tests/cond_branch:10 
-BEGIN          1 tests/cond_branch:11 
-BEGIN          1 tests/cond_branch:112
-BEGIN          1 tests/cond_branch:118
-BEGIN          1 tests/cond_branch:149
-BEGIN          1 tests/cond_branch:156
-BEGIN          1 tests/cond_branch:202
-BEGIN          1 tests/cond_branch:211
-BEGIN          1 tests/cond_branch:229
-BEGIN          1 tests/cond_branch:79 
-BEGIN          1 tests/cond_branch:85 
-__ANON__       4 tests/cond_branch:219
-__ANON__       4 tests/cond_branch:224
-__ANON__       4 tests/cond_branch:230
-__ANON__       4 tests/cond_branch:235
-__ANON__       4 tests/cond_branch:240
-__ANON__       4 tests/cond_branch:245
-__ANON__       4 tests/cond_branch:253
-__ANON__       4 tests/cond_branch:261
-__ANON__       4 tests/cond_branch:269
-__ANON__       4 tests/cond_branch:278
+Subroutine Count  CC  CRAP Location             
+---------- ----- --- ----- ---------------------
+BEGIN          1   1   1.0 tests/cond_branch:10 
+BEGIN          1   1   1.0 tests/cond_branch:11 
+BEGIN          1   1   1.0 tests/cond_branch:112
+BEGIN          1   1   1.0 tests/cond_branch:118
+BEGIN          1   1   1.0 tests/cond_branch:149
+BEGIN          1   1   1.0 tests/cond_branch:156
+BEGIN          1   1   1.0 tests/cond_branch:202
+BEGIN          1   1   1.0 tests/cond_branch:211
+BEGIN          1   1   1.0 tests/cond_branch:229
+BEGIN          1   1   1.0 tests/cond_branch:79 
+BEGIN          1   1   1.0 tests/cond_branch:85 
+__ANON__       4   2   2.0 tests/cond_branch:219
+__ANON__       4   2   2.0 tests/cond_branch:224
+__ANON__       4   2   4.3 tests/cond_branch:230
+__ANON__       4   2   2.0 tests/cond_branch:235
+__ANON__       4   2   2.0 tests/cond_branch:240
+__ANON__       4   3   3.0 tests/cond_branch:245
+__ANON__       4   3   3.0 tests/cond_branch:253
+__ANON__       4   3   3.0 tests/cond_branch:261
+__ANON__       4   3   3.0 tests/cond_branch:269
+__ANON__       4   3   3.0 tests/cond_branch:278
 
 

--- a/test_output/cover/cond_branch.5.043008
+++ b/test_output/cover/cond_branch.5.043008
@@ -471,28 +471,28 @@ line  err      %   l&&r  l&&!r  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location             
+Subroutine Count  CC  SLOP Location             
 ---------- ----- --- ----- ---------------------
-BEGIN          1   1   1.0 tests/cond_branch:10 
-BEGIN          1   1   1.0 tests/cond_branch:11 
-BEGIN          1   1   1.0 tests/cond_branch:112
-BEGIN          1   1   1.0 tests/cond_branch:118
-BEGIN          1   1   1.0 tests/cond_branch:149
-BEGIN          1   1   1.0 tests/cond_branch:156
-BEGIN          1   1   1.0 tests/cond_branch:202
-BEGIN          1   1   1.0 tests/cond_branch:211
-BEGIN          1   1   1.0 tests/cond_branch:229
-BEGIN          1   1   1.0 tests/cond_branch:79 
-BEGIN          1   1   1.0 tests/cond_branch:85 
-__ANON__       4   2   2.0 tests/cond_branch:219
-__ANON__       4   2   2.0 tests/cond_branch:224
-__ANON__       4   2   4.3 tests/cond_branch:230
-__ANON__       4   2   2.0 tests/cond_branch:235
-__ANON__       4   2   2.0 tests/cond_branch:240
-__ANON__       4   3   3.0 tests/cond_branch:245
-__ANON__       4   3   3.0 tests/cond_branch:253
-__ANON__       4   3   3.0 tests/cond_branch:261
-__ANON__       4   3   3.0 tests/cond_branch:269
-__ANON__       4   3   3.0 tests/cond_branch:278
+BEGIN          1   1   0.0 tests/cond_branch:10 
+BEGIN          1   1   0.0 tests/cond_branch:11 
+BEGIN          1   1   0.0 tests/cond_branch:112
+BEGIN          1   1   0.0 tests/cond_branch:118
+BEGIN          1   1   0.0 tests/cond_branch:149
+BEGIN          1   1   0.0 tests/cond_branch:156
+BEGIN          1   1   0.0 tests/cond_branch:202
+BEGIN          1   1   0.0 tests/cond_branch:211
+BEGIN          1   1   0.0 tests/cond_branch:229
+BEGIN          1   1   0.0 tests/cond_branch:79 
+BEGIN          1   1   0.0 tests/cond_branch:85 
+__ANON__       4   2   6.9 tests/cond_branch:219
+__ANON__       4   2   6.9 tests/cond_branch:224
+__ANON__       4   2  14.6 tests/cond_branch:230
+__ANON__       4   2   6.9 tests/cond_branch:235
+__ANON__       4   2   6.9 tests/cond_branch:240
+__ANON__       4   3  11.0 tests/cond_branch:245
+__ANON__       4   3  11.0 tests/cond_branch:253
+__ANON__       4   3  11.0 tests/cond_branch:261
+__ANON__       4   3  11.0 tests/cond_branch:269
+__ANON__       4   3  11.0 tests/cond_branch:278
 
 

--- a/test_output/cover/cond_chained.5.020000
+++ b/test_output/cover/cond_chained.5.020000
@@ -72,10 +72,10 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location             
----------- ----- ---------------------
-t1             1 tests/cond_chained:4 
-t2             1 tests/cond_chained:10
-t3             1 tests/cond_chained:16
+Subroutine Count  CC  CRAP Location             
+---------- ----- --- ----- ---------------------
+t1             1   4   4.0 tests/cond_chained:4 
+t2             1   4   4.0 tests/cond_chained:10
+t3             1   6   6.4 tests/cond_chained:16
 
 

--- a/test_output/cover/cond_chained.5.020000
+++ b/test_output/cover/cond_chained.5.020000
@@ -72,10 +72,10 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location             
+Subroutine Count  CC  SLOP Location             
 ---------- ----- --- ----- ---------------------
-t1             1   4   4.0 tests/cond_chained:4 
-t2             1   4   4.0 tests/cond_chained:10
-t3             1   6   6.4 tests/cond_chained:16
+t1             1   4  13.9 tests/cond_chained:4 
+t2             1   4  13.9 tests/cond_chained:10
+t3             1   6  18.6 tests/cond_chained:16
 
 

--- a/test_output/cover/cond_or.5.020000
+++ b/test_output/cover/cond_or.5.020000
@@ -179,19 +179,19 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-BEGIN          1   1   1.0 cond_or:13
-BEGIN          1   1   1.0 cond_or:14
-BEGIN          1   1   1.0 cond_or:24
+BEGIN          1   1   0.0 cond_or:13
+BEGIN          1   1   0.0 cond_or:14
+BEGIN          1   1   0.0 cond_or:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-__ANON__       0   1   1.0 cond_or:71
-__ANON__       0   2   3.7 cond_or:81
+__ANON__       0   1   0.2 cond_or:71
+__ANON__       0   2  13.0 cond_or:81
 
 
 cond_or.pl
@@ -276,10 +276,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-BEGIN          1   1   1.0 cond_or.pl:10
-BEGIN          1   1   1.0 cond_or.pl:11
-cond_dor      11  21  30.5 cond_or.pl:14
+BEGIN          1   1   0.0 cond_or.pl:10
+BEGIN          1   1   0.0 cond_or.pl:11
+cond_dor      11  21  34.2 cond_or.pl:14
 
 

--- a/test_output/cover/cond_or.5.020000
+++ b/test_output/cover/cond_or.5.020000
@@ -179,19 +179,19 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location  
----------- ----- ----------
-BEGIN          1 cond_or:13
-BEGIN          1 cond_or:14
-BEGIN          1 cond_or:24
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+BEGIN          1   1   1.0 cond_or:13
+BEGIN          1   1   1.0 cond_or:14
+BEGIN          1   1   1.0 cond_or:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location  
----------- ----- ----------
-__ANON__       0 cond_or:71
-__ANON__       0 cond_or:81
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+__ANON__       0   1   1.0 cond_or:71
+__ANON__       0   2   3.7 cond_or:81
 
 
 cond_or.pl
@@ -276,10 +276,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location     
----------- ----- -------------
-BEGIN          1 cond_or.pl:10
-BEGIN          1 cond_or.pl:11
-cond_dor      11 cond_or.pl:14
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+BEGIN          1   1   1.0 cond_or.pl:10
+BEGIN          1   1   1.0 cond_or.pl:11
+cond_dor      11  21  30.5 cond_or.pl:14
 
 

--- a/test_output/cover/cond_or.5.022000
+++ b/test_output/cover/cond_or.5.022000
@@ -179,19 +179,19 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-BEGIN          1   1   1.0 cond_or:13
-BEGIN          1   1   1.0 cond_or:14
-BEGIN          1   1   1.0 cond_or:24
+BEGIN          1   1   0.0 cond_or:13
+BEGIN          1   1   0.0 cond_or:14
+BEGIN          1   1   0.0 cond_or:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-__ANON__       0   1   1.0 cond_or:71
-__ANON__       0   2   3.7 cond_or:81
+__ANON__       0   1   0.2 cond_or:71
+__ANON__       0   2  13.0 cond_or:81
 
 
 cond_or.pl
@@ -276,10 +276,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-BEGIN          1   1   1.0 cond_or.pl:10
-BEGIN          1   1   1.0 cond_or.pl:11
-cond_dor      11  21  30.5 cond_or.pl:14
+BEGIN          1   1   0.0 cond_or.pl:10
+BEGIN          1   1   0.0 cond_or.pl:11
+cond_dor      11  21  34.2 cond_or.pl:14
 
 

--- a/test_output/cover/cond_or.5.022000
+++ b/test_output/cover/cond_or.5.022000
@@ -179,19 +179,19 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location  
----------- ----- ----------
-BEGIN          1 cond_or:13
-BEGIN          1 cond_or:14
-BEGIN          1 cond_or:24
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+BEGIN          1   1   1.0 cond_or:13
+BEGIN          1   1   1.0 cond_or:14
+BEGIN          1   1   1.0 cond_or:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location  
----------- ----- ----------
-__ANON__       0 cond_or:71
-__ANON__       0 cond_or:81
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+__ANON__       0   1   1.0 cond_or:71
+__ANON__       0   2   3.7 cond_or:81
 
 
 cond_or.pl
@@ -276,10 +276,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location     
----------- ----- -------------
-BEGIN          1 cond_or.pl:10
-BEGIN          1 cond_or.pl:11
-cond_dor      11 cond_or.pl:14
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+BEGIN          1   1   1.0 cond_or.pl:10
+BEGIN          1   1   1.0 cond_or.pl:11
+cond_dor      11  21  30.5 cond_or.pl:14
 
 

--- a/test_output/cover/cond_or.5.026000
+++ b/test_output/cover/cond_or.5.026000
@@ -177,19 +177,19 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location  
----------- ----- ----------
-BEGIN          1 cond_or:13
-BEGIN          1 cond_or:14
-BEGIN          1 cond_or:24
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+BEGIN          1   1   1.0 cond_or:13
+BEGIN          1   1   1.0 cond_or:14
+BEGIN          1   1   1.0 cond_or:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location  
----------- ----- ----------
-__ANON__       0 cond_or:71
-__ANON__       0 cond_or:81
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+__ANON__       0   1   1.0 cond_or:71
+__ANON__       0   2   3.7 cond_or:81
 
 
 cond_or.pl
@@ -274,10 +274,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location     
----------- ----- -------------
-BEGIN          1 cond_or.pl:10
-BEGIN          1 cond_or.pl:11
-cond_dor      11 cond_or.pl:14
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+BEGIN          1   1   1.0 cond_or.pl:10
+BEGIN          1   1   1.0 cond_or.pl:11
+cond_dor      11  21  30.5 cond_or.pl:14
 
 

--- a/test_output/cover/cond_or.5.026000
+++ b/test_output/cover/cond_or.5.026000
@@ -177,19 +177,19 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-BEGIN          1   1   1.0 cond_or:13
-BEGIN          1   1   1.0 cond_or:14
-BEGIN          1   1   1.0 cond_or:24
+BEGIN          1   1   0.0 cond_or:13
+BEGIN          1   1   0.0 cond_or:14
+BEGIN          1   1   0.0 cond_or:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-__ANON__       0   1   1.0 cond_or:71
-__ANON__       0   2   3.7 cond_or:81
+__ANON__       0   1   0.2 cond_or:71
+__ANON__       0   2  13.0 cond_or:81
 
 
 cond_or.pl
@@ -274,10 +274,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-BEGIN          1   1   1.0 cond_or.pl:10
-BEGIN          1   1   1.0 cond_or.pl:11
-cond_dor      11  21  30.5 cond_or.pl:14
+BEGIN          1   1   0.0 cond_or.pl:10
+BEGIN          1   1   0.0 cond_or.pl:11
+cond_dor      11  21  34.2 cond_or.pl:14
 
 

--- a/test_output/cover/cond_or.5.038000
+++ b/test_output/cover/cond_or.5.038000
@@ -177,19 +177,19 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location  
----------- ----- ----------
-BEGIN          1 cond_or:13
-BEGIN          1 cond_or:14
-BEGIN          1 cond_or:24
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+BEGIN          1   1   1.0 cond_or:13
+BEGIN          1   1   1.0 cond_or:14
+BEGIN          1   1   1.0 cond_or:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location  
----------- ----- ----------
-__ANON__       0 cond_or:71
-__ANON__       0 cond_or:81
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+__ANON__       0   1   1.1 cond_or:71
+__ANON__       0   2   3.7 cond_or:81
 
 
 cond_or.pl
@@ -274,10 +274,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location     
----------- ----- -------------
-BEGIN          1 cond_or.pl:10
-BEGIN          1 cond_or.pl:11
-cond_dor      11 cond_or.pl:14
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+BEGIN          1   1   1.0 cond_or.pl:10
+BEGIN          1   1   1.0 cond_or.pl:11
+cond_dor      11  21  30.5 cond_or.pl:14
 
 

--- a/test_output/cover/cond_or.5.038000
+++ b/test_output/cover/cond_or.5.038000
@@ -177,19 +177,19 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-BEGIN          1   1   1.0 cond_or:13
-BEGIN          1   1   1.0 cond_or:14
-BEGIN          1   1   1.0 cond_or:24
+BEGIN          1   1   0.0 cond_or:13
+BEGIN          1   1   0.0 cond_or:14
+BEGIN          1   1   0.0 cond_or:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-__ANON__       0   1   1.1 cond_or:71
-__ANON__       0   2   3.7 cond_or:81
+__ANON__       0   1   0.6 cond_or:71
+__ANON__       0   2  13.0 cond_or:81
 
 
 cond_or.pl
@@ -274,10 +274,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-BEGIN          1   1   1.0 cond_or.pl:10
-BEGIN          1   1   1.0 cond_or.pl:11
-cond_dor      11  21  30.5 cond_or.pl:14
+BEGIN          1   1   0.0 cond_or.pl:10
+BEGIN          1   1   0.0 cond_or.pl:11
+cond_dor      11  21  34.2 cond_or.pl:14
 
 

--- a/test_output/cover/cond_or.5.043008
+++ b/test_output/cover/cond_or.5.043008
@@ -177,19 +177,19 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location  
----------- ----- ----------
-BEGIN          1 cond_or:13
-BEGIN          1 cond_or:14
-BEGIN          1 cond_or:24
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+BEGIN          1   1   1.0 cond_or:13
+BEGIN          1   1   1.0 cond_or:14
+BEGIN          1   1   1.0 cond_or:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location  
----------- ----- ----------
-__ANON__       0 cond_or:71
-__ANON__       0 cond_or:81
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+__ANON__       0   1   1.1 cond_or:71
+__ANON__       0   2   3.7 cond_or:81
 
 
 cond_or.pl
@@ -274,10 +274,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location     
----------- ----- -------------
-BEGIN          1 cond_or.pl:10
-BEGIN          1 cond_or.pl:11
-cond_dor      11 cond_or.pl:14
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+BEGIN          1   1   1.0 cond_or.pl:10
+BEGIN          1   1   1.0 cond_or.pl:11
+cond_dor      11  21  30.5 cond_or.pl:14
 
 

--- a/test_output/cover/cond_or.5.043008
+++ b/test_output/cover/cond_or.5.043008
@@ -177,19 +177,19 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-BEGIN          1   1   1.0 cond_or:13
-BEGIN          1   1   1.0 cond_or:14
-BEGIN          1   1   1.0 cond_or:24
+BEGIN          1   1   0.0 cond_or:13
+BEGIN          1   1   0.0 cond_or:14
+BEGIN          1   1   0.0 cond_or:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-__ANON__       0   1   1.1 cond_or:71
-__ANON__       0   2   3.7 cond_or:81
+__ANON__       0   1   0.6 cond_or:71
+__ANON__       0   2  13.0 cond_or:81
 
 
 cond_or.pl
@@ -274,10 +274,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-BEGIN          1   1   1.0 cond_or.pl:10
-BEGIN          1   1   1.0 cond_or.pl:11
-cond_dor      11  21  30.5 cond_or.pl:14
+BEGIN          1   1   0.0 cond_or.pl:10
+BEGIN          1   1   0.0 cond_or.pl:11
+cond_dor      11  21  34.2 cond_or.pl:14
 
 

--- a/test_output/cover/cond_or_interp.5.020000
+++ b/test_output/cover/cond_or_interp.5.020000
@@ -161,9 +161,9 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location               
+Subroutine Count  CC  SLOP Location               
 ---------- ----- --- ----- -----------------------
-BEGIN          1   1   1.0 tests/cond_or_interp:26
-BEGIN          1   1   1.0 tests/cond_or_interp:27
+BEGIN          1   1   0.0 tests/cond_or_interp:26
+BEGIN          1   1   0.0 tests/cond_or_interp:27
 
 

--- a/test_output/cover/cond_or_interp.5.020000
+++ b/test_output/cover/cond_or_interp.5.020000
@@ -161,9 +161,9 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location               
----------- ----- -----------------------
-BEGIN          1 tests/cond_or_interp:26
-BEGIN          1 tests/cond_or_interp:27
+Subroutine Count  CC  CRAP Location               
+---------- ----- --- ----- -----------------------
+BEGIN          1   1   1.0 tests/cond_or_interp:26
+BEGIN          1   1   1.0 tests/cond_or_interp:27
 
 

--- a/test_output/cover/cond_or_interp.5.028000
+++ b/test_output/cover/cond_or_interp.5.028000
@@ -161,9 +161,9 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location               
+Subroutine Count  CC  SLOP Location               
 ---------- ----- --- ----- -----------------------
-BEGIN          1   1   1.0 tests/cond_or_interp:26
-BEGIN          1   1   1.0 tests/cond_or_interp:27
+BEGIN          1   1   0.0 tests/cond_or_interp:26
+BEGIN          1   1   0.0 tests/cond_or_interp:27
 
 

--- a/test_output/cover/cond_or_interp.5.028000
+++ b/test_output/cover/cond_or_interp.5.028000
@@ -161,9 +161,9 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location               
----------- ----- -----------------------
-BEGIN          1 tests/cond_or_interp:26
-BEGIN          1 tests/cond_or_interp:27
+Subroutine Count  CC  CRAP Location               
+---------- ----- --- ----- -----------------------
+BEGIN          1   1   1.0 tests/cond_or_interp:26
+BEGIN          1   1   1.0 tests/cond_or_interp:27
 
 

--- a/test_output/cover/cond_xor.5.020000
+++ b/test_output/cover/cond_xor.5.020000
@@ -64,9 +64,9 @@ line  err      %   l&&r  l&&!r  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location         
----------- ----- -----------------
-BEGIN          1 tests/cond_xor:10
-BEGIN          1 tests/cond_xor:11
+Subroutine Count  CC  CRAP Location         
+---------- ----- --- ----- -----------------
+BEGIN          1   1   1.0 tests/cond_xor:10
+BEGIN          1   1   1.0 tests/cond_xor:11
 
 

--- a/test_output/cover/cond_xor.5.020000
+++ b/test_output/cover/cond_xor.5.020000
@@ -64,9 +64,9 @@ line  err      %   l&&r  l&&!r  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location         
+Subroutine Count  CC  SLOP Location         
 ---------- ----- --- ----- -----------------
-BEGIN          1   1   1.0 tests/cond_xor:10
-BEGIN          1   1   1.0 tests/cond_xor:11
+BEGIN          1   1   0.0 tests/cond_xor:10
+BEGIN          1   1   0.0 tests/cond_xor:11
 
 

--- a/test_output/cover/cond_xor.5.040000
+++ b/test_output/cover/cond_xor.5.040000
@@ -64,9 +64,9 @@ line  err      %   l&&r  l&&!r  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location         
----------- ----- -----------------
-BEGIN          1 tests/cond_xor:10
-BEGIN          1 tests/cond_xor:11
+Subroutine Count  CC  CRAP Location         
+---------- ----- --- ----- -----------------
+BEGIN          1   1   1.0 tests/cond_xor:10
+BEGIN          1   1   1.0 tests/cond_xor:11
 
 

--- a/test_output/cover/cond_xor.5.040000
+++ b/test_output/cover/cond_xor.5.040000
@@ -64,9 +64,9 @@ line  err      %   l&&r  l&&!r  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location         
+Subroutine Count  CC  SLOP Location         
 ---------- ----- --- ----- -----------------
-BEGIN          1   1   1.0 tests/cond_xor:10
-BEGIN          1   1   1.0 tests/cond_xor:11
+BEGIN          1   1   0.0 tests/cond_xor:10
+BEGIN          1   1   0.0 tests/cond_xor:11
 
 

--- a/test_output/cover/cond_xor_hp.5.040000
+++ b/test_output/cover/cond_xor_hp.5.040000
@@ -70,10 +70,10 @@ line  err      %   l&&r  l&&!r  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location            
+Subroutine Count  CC  SLOP Location            
 ---------- ----- --- ----- --------------------
-BEGIN          1   1   1.0 tests/cond_xor_hp:13
-BEGIN          1   1   1.0 tests/cond_xor_hp:14
-main           1   6   6.3 tests/cond_xor_hp:17
+BEGIN          1   1   0.0 tests/cond_xor_hp:13
+BEGIN          1   1   0.0 tests/cond_xor_hp:14
+main           1   6  18.4 tests/cond_xor_hp:17
 
 

--- a/test_output/cover/cond_xor_hp.5.040000
+++ b/test_output/cover/cond_xor_hp.5.040000
@@ -70,10 +70,10 @@ line  err      %   l&&r  l&&!r  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location            
----------- ----- --------------------
-BEGIN          1 tests/cond_xor_hp:13
-BEGIN          1 tests/cond_xor_hp:14
-main           1 tests/cond_xor_hp:17
+Subroutine Count  CC  CRAP Location            
+---------- ----- --- ----- --------------------
+BEGIN          1   1   1.0 tests/cond_xor_hp:13
+BEGIN          1   1   1.0 tests/cond_xor_hp:14
+main           1   6   6.3 tests/cond_xor_hp:17
 
 

--- a/test_output/cover/cop.5.020000
+++ b/test_output/cover/cop.5.020000
@@ -46,17 +46,17 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location    
+Subroutine Count  CC  SLOP Location    
 ---------- ----- --- ----- ------------
-BEGIN          1   1   1.0 tests/cop:10
-BEGIN          1   1   1.0 tests/cop:11
-BEGIN          1   1   1.0 tests/cop:13
+BEGIN          1   1   0.0 tests/cop:10
+BEGIN          1   1   0.0 tests/cop:11
+BEGIN          1   1   0.0 tests/cop:13
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location    
+Subroutine Count  CC  SLOP Location    
 ---------- ----- --- ----- ------------
-__ANON__       0   1   1.1 tests/cop:15
+__ANON__       0   1   1.2 tests/cop:15
 
 

--- a/test_output/cover/cop.5.020000
+++ b/test_output/cover/cop.5.020000
@@ -46,17 +46,17 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location    
----------- ----- ------------
-BEGIN          1 tests/cop:10
-BEGIN          1 tests/cop:11
-BEGIN          1 tests/cop:13
+Subroutine Count  CC  CRAP Location    
+---------- ----- --- ----- ------------
+BEGIN          1   1   1.0 tests/cop:10
+BEGIN          1   1   1.0 tests/cop:11
+BEGIN          1   1   1.0 tests/cop:13
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location    
----------- ----- ------------
-__ANON__       0 tests/cop:15
+Subroutine Count  CC  CRAP Location    
+---------- ----- --- ----- ------------
+__ANON__       0   1   1.1 tests/cop:15
 
 

--- a/test_output/cover/dbm_cond.5.020000
+++ b/test_output/cover/dbm_cond.5.020000
@@ -93,13 +93,13 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location         
----------- ----- -----------------
-BEGIN          1 tests/dbm_cond:13
-BEGIN          1 tests/dbm_cond:14
-BEGIN          1 tests/dbm_cond:16
-BEGIN          1 tests/dbm_cond:18
-testdbm        2 tests/dbm_cond:26
-testh          2 tests/dbm_cond:36
+Subroutine Count  CC  CRAP Location         
+---------- ----- --- ----- -----------------
+BEGIN          1   1   1.0 tests/dbm_cond:13
+BEGIN          1   1   1.0 tests/dbm_cond:14
+BEGIN          1   1   1.0 tests/dbm_cond:16
+BEGIN          1   1   1.0 tests/dbm_cond:18
+testdbm        2   2   2.0 tests/dbm_cond:26
+testh          2   2   2.0 tests/dbm_cond:36
 
 

--- a/test_output/cover/dbm_cond.5.020000
+++ b/test_output/cover/dbm_cond.5.020000
@@ -93,13 +93,13 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location         
+Subroutine Count  CC  SLOP Location         
 ---------- ----- --- ----- -----------------
-BEGIN          1   1   1.0 tests/dbm_cond:13
-BEGIN          1   1   1.0 tests/dbm_cond:14
-BEGIN          1   1   1.0 tests/dbm_cond:16
-BEGIN          1   1   1.0 tests/dbm_cond:18
-testdbm        2   2   2.0 tests/dbm_cond:26
-testh          2   2   2.0 tests/dbm_cond:36
+BEGIN          1   1   0.0 tests/dbm_cond:13
+BEGIN          1   1   0.0 tests/dbm_cond:14
+BEGIN          1   1   0.0 tests/dbm_cond:16
+BEGIN          1   1   0.0 tests/dbm_cond:18
+testdbm        2   2   6.9 tests/dbm_cond:26
+testh          2   2   6.9 tests/dbm_cond:36
 
 

--- a/test_output/cover/dbm_cond.5.022000
+++ b/test_output/cover/dbm_cond.5.022000
@@ -93,13 +93,13 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location         
----------- ----- -----------------
-BEGIN          1 tests/dbm_cond:13
-BEGIN          1 tests/dbm_cond:14
-BEGIN          1 tests/dbm_cond:16
-BEGIN          1 tests/dbm_cond:18
-testdbm        2 tests/dbm_cond:26
-testh          2 tests/dbm_cond:36
+Subroutine Count  CC  CRAP Location         
+---------- ----- --- ----- -----------------
+BEGIN          1   1   1.0 tests/dbm_cond:13
+BEGIN          1   1   1.0 tests/dbm_cond:14
+BEGIN          1   1   1.0 tests/dbm_cond:16
+BEGIN          1   1   1.0 tests/dbm_cond:18
+testdbm        2   2   2.0 tests/dbm_cond:26
+testh          2   2   2.0 tests/dbm_cond:36
 
 

--- a/test_output/cover/dbm_cond.5.022000
+++ b/test_output/cover/dbm_cond.5.022000
@@ -93,13 +93,13 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location         
+Subroutine Count  CC  SLOP Location         
 ---------- ----- --- ----- -----------------
-BEGIN          1   1   1.0 tests/dbm_cond:13
-BEGIN          1   1   1.0 tests/dbm_cond:14
-BEGIN          1   1   1.0 tests/dbm_cond:16
-BEGIN          1   1   1.0 tests/dbm_cond:18
-testdbm        2   2   2.0 tests/dbm_cond:26
-testh          2   2   2.0 tests/dbm_cond:36
+BEGIN          1   1   0.0 tests/dbm_cond:13
+BEGIN          1   1   0.0 tests/dbm_cond:14
+BEGIN          1   1   0.0 tests/dbm_cond:16
+BEGIN          1   1   0.0 tests/dbm_cond:18
+testdbm        2   2   6.9 tests/dbm_cond:26
+testh          2   2   6.9 tests/dbm_cond:36
 
 

--- a/test_output/cover/default_param.5.020000
+++ b/test_output/cover/default_param.5.020000
@@ -58,10 +58,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location              
+Subroutine Count  CC  SLOP Location              
 ---------- ----- --- ----- ----------------------
-BEGIN          1   1   1.0 tests/default_param:10
-BEGIN          1   1   1.0 tests/default_param:11
-p              2   4   4.0 tests/default_param:14
+BEGIN          1   1   0.0 tests/default_param:10
+BEGIN          1   1   0.0 tests/default_param:11
+p              2   4  13.9 tests/default_param:14
 
 

--- a/test_output/cover/default_param.5.020000
+++ b/test_output/cover/default_param.5.020000
@@ -58,10 +58,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location              
----------- ----- ----------------------
-BEGIN          1 tests/default_param:10
-BEGIN          1 tests/default_param:11
-p              2 tests/default_param:14
+Subroutine Count  CC  CRAP Location              
+---------- ----- --- ----- ----------------------
+BEGIN          1   1   1.0 tests/default_param:10
+BEGIN          1   1   1.0 tests/default_param:11
+p              2   4   4.0 tests/default_param:14
 
 

--- a/test_output/cover/deparse.5.020000
+++ b/test_output/cover/deparse.5.020000
@@ -48,17 +48,17 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-BEGIN          1 tests/deparse:10
-BEGIN          1 tests/deparse:11
-BEGIN          1 tests/deparse:13
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+BEGIN          1   1   1.0 tests/deparse:10
+BEGIN          1   1   1.0 tests/deparse:11
+BEGIN          1   1   1.0 tests/deparse:13
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-__ANON__       0 tests/deparse:16
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+__ANON__       0   1   2.0 tests/deparse:16
 
 

--- a/test_output/cover/deparse.5.020000
+++ b/test_output/cover/deparse.5.020000
@@ -48,17 +48,17 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-BEGIN          1   1   1.0 tests/deparse:10
-BEGIN          1   1   1.0 tests/deparse:11
-BEGIN          1   1   1.0 tests/deparse:13
+BEGIN          1   1   0.0 tests/deparse:10
+BEGIN          1   1   0.0 tests/deparse:11
+BEGIN          1   1   0.0 tests/deparse:13
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-__ANON__       0   1   2.0 tests/deparse:16
+__ANON__       0   1   6.9 tests/deparse:16
 
 

--- a/test_output/cover/destroy.5.020000
+++ b/test_output/cover/destroy.5.020000
@@ -46,9 +46,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-DESTROY        1   1   1.0 tests/destroy:17
-new            1   1   1.0 tests/destroy:12
+DESTROY        1   1   0.0 tests/destroy:17
+new            1   1   0.0 tests/destroy:12
 
 

--- a/test_output/cover/destroy.5.020000
+++ b/test_output/cover/destroy.5.020000
@@ -46,9 +46,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-DESTROY        1 tests/destroy:17
-new            1 tests/destroy:12
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+DESTROY        1   1   1.0 tests/destroy:17
+new            1   1   1.0 tests/destroy:12
 
 

--- a/test_output/cover/dynamic_subs.5.020000
+++ b/test_output/cover/dynamic_subs.5.020000
@@ -96,23 +96,23 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location             
----------- ----- ---------------------
-AUTOLOAD       3 tests/dynamic_subs:41
-BEGIN          1 tests/dynamic_subs:31
-BEGIN          1 tests/dynamic_subs:43
-__ANON__       5 tests/dynamic_subs:16
-__ANON__       2 tests/dynamic_subs:33
-__ANON__       3 tests/dynamic_subs:46
-__ANON__       2 tests/dynamic_subs:50
-gen            4 tests/dynamic_subs:14
+Subroutine Count  CC  CRAP Location             
+---------- ----- --- ----- ---------------------
+AUTOLOAD       3   2   2.0 tests/dynamic_subs:41
+BEGIN          1   1   1.0 tests/dynamic_subs:31
+BEGIN          1   1   1.0 tests/dynamic_subs:43
+__ANON__       5   2   2.1 tests/dynamic_subs:16
+__ANON__       2   1   1.0 tests/dynamic_subs:33
+__ANON__       3   1   1.0 tests/dynamic_subs:46
+__ANON__       2   1   1.0 tests/dynamic_subs:50
+gen            4   1   1.0 tests/dynamic_subs:14
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location             
----------- ----- ---------------------
-empty          0 tests/dynamic_subs:11
-unused         0 tests/dynamic_subs:10
+Subroutine Count  CC  CRAP Location             
+---------- ----- --- ----- ---------------------
+empty          0   1   1.0 tests/dynamic_subs:11
+unused         0   1   2.0 tests/dynamic_subs:10
 
 

--- a/test_output/cover/dynamic_subs.5.020000
+++ b/test_output/cover/dynamic_subs.5.020000
@@ -96,23 +96,23 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location             
+Subroutine Count  CC  SLOP Location             
 ---------- ----- --- ----- ---------------------
-AUTOLOAD       3   2   2.0 tests/dynamic_subs:41
-BEGIN          1   1   1.0 tests/dynamic_subs:31
-BEGIN          1   1   1.0 tests/dynamic_subs:43
-__ANON__       5   2   2.1 tests/dynamic_subs:16
-__ANON__       2   1   1.0 tests/dynamic_subs:33
-__ANON__       3   1   1.0 tests/dynamic_subs:46
-__ANON__       2   1   1.0 tests/dynamic_subs:50
-gen            4   1   1.0 tests/dynamic_subs:14
+AUTOLOAD       3   2   6.9 tests/dynamic_subs:41
+BEGIN          1   1   0.0 tests/dynamic_subs:31
+BEGIN          1   1   0.0 tests/dynamic_subs:43
+__ANON__       5   2   7.2 tests/dynamic_subs:16
+__ANON__       2   1   0.0 tests/dynamic_subs:33
+__ANON__       3   1   0.0 tests/dynamic_subs:46
+__ANON__       2   1   0.0 tests/dynamic_subs:50
+gen            4   1   0.0 tests/dynamic_subs:14
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location             
+Subroutine Count  CC  SLOP Location             
 ---------- ----- --- ----- ---------------------
-empty          0   1   1.0 tests/dynamic_subs:11
-unused         0   1   2.0 tests/dynamic_subs:10
+empty          0   1   0.0 tests/dynamic_subs:11
+unused         0   1   6.9 tests/dynamic_subs:10
 
 

--- a/test_output/cover/empty_else.5.020000
+++ b/test_output/cover/empty_else.5.020000
@@ -65,10 +65,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location           
+Subroutine Count  CC  SLOP Location           
 ---------- ----- --- ----- -------------------
-BEGIN          1   1   1.0 tests/empty_else:13
-BEGIN          1   1   1.0 tests/empty_else:14
-test_sub       1   2   2.1 tests/empty_else:23
+BEGIN          1   1   0.0 tests/empty_else:13
+BEGIN          1   1   0.0 tests/empty_else:14
+test_sub       1   2   7.2 tests/empty_else:23
 
 

--- a/test_output/cover/empty_else.5.020000
+++ b/test_output/cover/empty_else.5.020000
@@ -65,10 +65,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location           
----------- ----- -------------------
-BEGIN          1 tests/empty_else:13
-BEGIN          1 tests/empty_else:14
-test_sub       1 tests/empty_else:23
+Subroutine Count  CC  CRAP Location           
+---------- ----- --- ----- -------------------
+BEGIN          1   1   1.0 tests/empty_else:13
+BEGIN          1   1   1.0 tests/empty_else:14
+test_sub       1   2   2.1 tests/empty_else:23
 
 

--- a/test_output/cover/eval1.5.020000
+++ b/test_output/cover/eval1.5.020000
@@ -89,20 +89,20 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location      
----------- ----- --------------
-BEGIN          1 tests/eval1:10
-BEGIN          1 tests/eval1:11
-BEGIN          1 tests/eval1:13
-e              3 tests/eval1:17
-f              2 tests/eval1:24
-h              3 tests/eval1:24
+Subroutine Count  CC  CRAP Location      
+---------- ----- --- ----- --------------
+BEGIN          1   1   1.0 tests/eval1:10
+BEGIN          1   1   1.0 tests/eval1:11
+BEGIN          1   2   2.0 tests/eval1:13
+e              3   1   1.0 tests/eval1:17
+f              2   1   1.0 tests/eval1:24
+h              3   1   1.0 tests/eval1:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location      
----------- ----- --------------
-g              0 tests/eval1:24
+Subroutine Count  CC  CRAP Location      
+---------- ----- --- ----- --------------
+g              0   1   1.0 tests/eval1:24
 
 

--- a/test_output/cover/eval1.5.020000
+++ b/test_output/cover/eval1.5.020000
@@ -89,20 +89,20 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location      
+Subroutine Count  CC  SLOP Location      
 ---------- ----- --- ----- --------------
-BEGIN          1   1   1.0 tests/eval1:10
-BEGIN          1   1   1.0 tests/eval1:11
-BEGIN          1   2   2.0 tests/eval1:13
-e              3   1   1.0 tests/eval1:17
-f              2   1   1.0 tests/eval1:24
-h              3   1   1.0 tests/eval1:24
+BEGIN          1   1   0.0 tests/eval1:10
+BEGIN          1   1   0.0 tests/eval1:11
+BEGIN          1   2   7.1 tests/eval1:13
+e              3   1   0.0 tests/eval1:17
+f              2   1   0.1 tests/eval1:24
+h              3   1   0.1 tests/eval1:24
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location      
+Subroutine Count  CC  SLOP Location      
 ---------- ----- --- ----- --------------
-g              0   1   1.0 tests/eval1:24
+g              0   1   0.1 tests/eval1:24
 
 

--- a/test_output/cover/eval2.5.020000
+++ b/test_output/cover/eval2.5.020000
@@ -42,9 +42,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E3             0   1   2.0 E3.pm:12
+E3             0   1   6.9 E3.pm:12
 
 
 E4.pm
@@ -69,9 +69,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E4             0   1   2.0 E4.pm:12
+E4             0   1   6.9 E4.pm:12
 
 
 eval2
@@ -132,10 +132,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-BEGIN          1   1   1.0 eval2:10
-BEGIN          1   1   1.0 eval2:16
-BEGIN          1   1   1.0 eval2:18
+BEGIN          1   1   0.0 eval2:10
+BEGIN          1   1   0.0 eval2:16
+BEGIN          1   1   0.0 eval2:18
 
 

--- a/test_output/cover/eval2.5.020000
+++ b/test_output/cover/eval2.5.020000
@@ -42,9 +42,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location
----------- ----- --------
-E3             0 E3.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E3             0   1   2.0 E3.pm:12
 
 
 E4.pm
@@ -69,9 +69,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location
----------- ----- --------
-E4             0 E4.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E4             0   1   2.0 E4.pm:12
 
 
 eval2
@@ -132,10 +132,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-BEGIN          1 eval2:10
-BEGIN          1 eval2:16
-BEGIN          1 eval2:18
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+BEGIN          1   1   1.0 eval2:10
+BEGIN          1   1   1.0 eval2:16
+BEGIN          1   1   1.0 eval2:18
 
 

--- a/test_output/cover/eval3.5.020000
+++ b/test_output/cover/eval3.5.020000
@@ -72,10 +72,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location      
----------- ----- --------------
-BEGIN          1 tests/eval3:10
-s2             1 tests/eval3:16
-s3             1 tests/eval3:18
+Subroutine Count  CC  CRAP Location      
+---------- ----- --- ----- --------------
+BEGIN          1   1   1.0 tests/eval3:10
+s2             1   1   1.0 tests/eval3:16
+s3             1   1   1.0 tests/eval3:18
 
 

--- a/test_output/cover/eval3.5.020000
+++ b/test_output/cover/eval3.5.020000
@@ -72,10 +72,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location      
+Subroutine Count  CC  SLOP Location      
 ---------- ----- --- ----- --------------
-BEGIN          1   1   1.0 tests/eval3:10
-s2             1   1   1.0 tests/eval3:16
-s3             1   1   1.0 tests/eval3:18
+BEGIN          1   1   0.0 tests/eval3:10
+s2             1   1   0.0 tests/eval3:16
+s3             1   1   0.0 tests/eval3:18
 
 

--- a/test_output/cover/eval_merge.5.020000
+++ b/test_output/cover/eval_merge.5.020000
@@ -42,9 +42,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E2             1 E2.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E2             1   1   1.0 E2.pm:12
 
 
 E3.pm
@@ -69,9 +69,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E3             1 E3.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E3             1   1   1.0 E3.pm:12
 
 
 eval_merge
@@ -133,10 +133,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location     
----------- ----- -------------
-BEGIN          1 eval_merge:10
-BEGIN          1 eval_merge:15
-BEGIN          1 eval_merge:15
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+BEGIN          1   1   1.0 eval_merge:10
+BEGIN          1   1   1.0 eval_merge:15
+BEGIN          1   1   1.0 eval_merge:15
 
 

--- a/test_output/cover/eval_merge.5.020000
+++ b/test_output/cover/eval_merge.5.020000
@@ -42,9 +42,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E2             1   1   1.0 E2.pm:12
+E2             1   1   0.0 E2.pm:12
 
 
 E3.pm
@@ -69,9 +69,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E3             1   1   1.0 E3.pm:12
+E3             1   1   0.0 E3.pm:12
 
 
 eval_merge
@@ -133,10 +133,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-BEGIN          1   1   1.0 eval_merge:10
-BEGIN          1   1   1.0 eval_merge:15
-BEGIN          1   1   1.0 eval_merge:15
+BEGIN          1   1   0.0 eval_merge:10
+BEGIN          1   1   0.0 eval_merge:15
+BEGIN          1   1   0.0 eval_merge:15
 
 

--- a/test_output/cover/eval_merge.t.5.020000
+++ b/test_output/cover/eval_merge.t.5.020000
@@ -49,9 +49,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E2             1   1   1.0 E2.pm:12
+E2             1   1   0.0 E2.pm:12
 
 
 E3.pm
@@ -76,9 +76,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E3             2   1   1.0 E3.pm:12
+E3             2   1   0.0 E3.pm:12
 
 
 E4.pm
@@ -103,9 +103,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E4             1   1   1.0 E4.pm:12
+E4             1   1   0.0 E4.pm:12
 
 
 eval_merge
@@ -173,12 +173,12 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-BEGIN          2   1   1.0 eval_merge:10
-BEGIN          1   1   1.0 eval_merge:15
-BEGIN          1   1   1.0 eval_merge:15
-BEGIN          1   1   1.0 eval_merge:18
-BEGIN          1   1   1.0 eval_merge:18
+BEGIN          2   1   0.0 eval_merge:10
+BEGIN          1   1   0.0 eval_merge:15
+BEGIN          1   1   0.0 eval_merge:15
+BEGIN          1   1   0.0 eval_merge:18
+BEGIN          1   1   0.0 eval_merge:18
 
 

--- a/test_output/cover/eval_merge.t.5.020000
+++ b/test_output/cover/eval_merge.t.5.020000
@@ -49,9 +49,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E2             1 E2.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E2             1   1   1.0 E2.pm:12
 
 
 E3.pm
@@ -76,9 +76,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E3             2 E3.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E3             2   1   1.0 E3.pm:12
 
 
 E4.pm
@@ -103,9 +103,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E4             1 E4.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E4             1   1   1.0 E4.pm:12
 
 
 eval_merge
@@ -173,12 +173,12 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location     
----------- ----- -------------
-BEGIN          2 eval_merge:10
-BEGIN          1 eval_merge:15
-BEGIN          1 eval_merge:15
-BEGIN          1 eval_merge:18
-BEGIN          1 eval_merge:18
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+BEGIN          2   1   1.0 eval_merge:10
+BEGIN          1   1   1.0 eval_merge:15
+BEGIN          1   1   1.0 eval_merge:15
+BEGIN          1   1   1.0 eval_merge:18
+BEGIN          1   1   1.0 eval_merge:18
 
 

--- a/test_output/cover/eval_merge_0.5.020000
+++ b/test_output/cover/eval_merge_0.5.020000
@@ -42,9 +42,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E2             1 E2.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E2             1   1   1.0 E2.pm:12
 
 
 E3.pm
@@ -69,9 +69,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E3             1 E3.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E3             1   1   1.0 E3.pm:12
 
 
 eval_merge_0
@@ -104,10 +104,10 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location       
----------- ----- ---------------
-BEGIN          1 eval_merge_0:10
-BEGIN          1 eval_merge_0:12
-BEGIN          1 eval_merge_0:13
+Subroutine Count  CC  CRAP Location       
+---------- ----- --- ----- ---------------
+BEGIN          1   1   1.0 eval_merge_0:10
+BEGIN          1   1   1.0 eval_merge_0:12
+BEGIN          1   1   1.0 eval_merge_0:13
 
 

--- a/test_output/cover/eval_merge_0.5.020000
+++ b/test_output/cover/eval_merge_0.5.020000
@@ -42,9 +42,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E2             1   1   1.0 E2.pm:12
+E2             1   1   0.0 E2.pm:12
 
 
 E3.pm
@@ -69,9 +69,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E3             1   1   1.0 E3.pm:12
+E3             1   1   0.0 E3.pm:12
 
 
 eval_merge_0
@@ -104,10 +104,10 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location       
+Subroutine Count  CC  SLOP Location       
 ---------- ----- --- ----- ---------------
-BEGIN          1   1   1.0 eval_merge_0:10
-BEGIN          1   1   1.0 eval_merge_0:12
-BEGIN          1   1   1.0 eval_merge_0:13
+BEGIN          1   1   0.0 eval_merge_0:10
+BEGIN          1   1   0.0 eval_merge_0:12
+BEGIN          1   1   0.0 eval_merge_0:13
 
 

--- a/test_output/cover/eval_merge_1.5.020000
+++ b/test_output/cover/eval_merge_1.5.020000
@@ -42,9 +42,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E3             1 E3.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E3             1   1   1.0 E3.pm:12
 
 
 E4.pm
@@ -69,9 +69,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E4             1 E4.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E4             1   1   1.0 E4.pm:12
 
 
 eval_merge_1
@@ -104,10 +104,10 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location       
----------- ----- ---------------
-BEGIN          1 eval_merge_1:10
-BEGIN          1 eval_merge_1:12
-BEGIN          1 eval_merge_1:13
+Subroutine Count  CC  CRAP Location       
+---------- ----- --- ----- ---------------
+BEGIN          1   1   1.0 eval_merge_1:10
+BEGIN          1   1   1.0 eval_merge_1:12
+BEGIN          1   1   1.0 eval_merge_1:13
 
 

--- a/test_output/cover/eval_merge_1.5.020000
+++ b/test_output/cover/eval_merge_1.5.020000
@@ -42,9 +42,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E3             1   1   1.0 E3.pm:12
+E3             1   1   0.0 E3.pm:12
 
 
 E4.pm
@@ -69,9 +69,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E4             1   1   1.0 E4.pm:12
+E4             1   1   0.0 E4.pm:12
 
 
 eval_merge_1
@@ -104,10 +104,10 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location       
+Subroutine Count  CC  SLOP Location       
 ---------- ----- --- ----- ---------------
-BEGIN          1   1   1.0 eval_merge_1:10
-BEGIN          1   1   1.0 eval_merge_1:12
-BEGIN          1   1   1.0 eval_merge_1:13
+BEGIN          1   1   0.0 eval_merge_1:10
+BEGIN          1   1   0.0 eval_merge_1:12
+BEGIN          1   1   0.0 eval_merge_1:13
 
 

--- a/test_output/cover/eval_merge_sep.t.5.020000
+++ b/test_output/cover/eval_merge_sep.t.5.020000
@@ -50,9 +50,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E2             1 E2.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E2             1   1   1.0 E2.pm:12
 
 
 E3.pm
@@ -77,9 +77,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E3             2 E3.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E3             2   1   1.0 E3.pm:12
 
 
 E4.pm
@@ -104,9 +104,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-E4             1 E4.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E4             1   1   1.0 E4.pm:12
 
 
 eval_merge_0
@@ -139,11 +139,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location       
----------- ----- ---------------
-BEGIN          1 eval_merge_0:10
-BEGIN          1 eval_merge_0:12
-BEGIN          1 eval_merge_0:13
+Subroutine Count  CC  CRAP Location       
+---------- ----- --- ----- ---------------
+BEGIN          1   1   1.0 eval_merge_0:10
+BEGIN          1   1   1.0 eval_merge_0:12
+BEGIN          1   1   1.0 eval_merge_0:13
 
 
 eval_merge_1
@@ -176,10 +176,10 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location       
----------- ----- ---------------
-BEGIN          1 eval_merge_1:10
-BEGIN          1 eval_merge_1:12
-BEGIN          1 eval_merge_1:13
+Subroutine Count  CC  CRAP Location       
+---------- ----- --- ----- ---------------
+BEGIN          1   1   1.0 eval_merge_1:10
+BEGIN          1   1   1.0 eval_merge_1:12
+BEGIN          1   1   1.0 eval_merge_1:13
 
 

--- a/test_output/cover/eval_merge_sep.t.5.020000
+++ b/test_output/cover/eval_merge_sep.t.5.020000
@@ -50,9 +50,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E2             1   1   1.0 E2.pm:12
+E2             1   1   0.0 E2.pm:12
 
 
 E3.pm
@@ -77,9 +77,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E3             2   1   1.0 E3.pm:12
+E3             2   1   0.0 E3.pm:12
 
 
 E4.pm
@@ -104,9 +104,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E4             1   1   1.0 E4.pm:12
+E4             1   1   0.0 E4.pm:12
 
 
 eval_merge_0
@@ -139,11 +139,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location       
+Subroutine Count  CC  SLOP Location       
 ---------- ----- --- ----- ---------------
-BEGIN          1   1   1.0 eval_merge_0:10
-BEGIN          1   1   1.0 eval_merge_0:12
-BEGIN          1   1   1.0 eval_merge_0:13
+BEGIN          1   1   0.0 eval_merge_0:10
+BEGIN          1   1   0.0 eval_merge_0:12
+BEGIN          1   1   0.0 eval_merge_0:13
 
 
 eval_merge_1
@@ -176,10 +176,10 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location       
+Subroutine Count  CC  SLOP Location       
 ---------- ----- --- ----- ---------------
-BEGIN          1   1   1.0 eval_merge_1:10
-BEGIN          1   1   1.0 eval_merge_1:12
-BEGIN          1   1   1.0 eval_merge_1:13
+BEGIN          1   1   0.0 eval_merge_1:10
+BEGIN          1   1   0.0 eval_merge_1:12
+BEGIN          1   1   0.0 eval_merge_1:13
 
 

--- a/test_output/cover/eval_nested.5.020000
+++ b/test_output/cover/eval_nested.5.020000
@@ -55,10 +55,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location            
----------- ----- --------------------
-BEGIN          1 tests/eval_nested:10
-BEGIN          1 tests/eval_nested:11
-config         2 tests/eval_nested:13
+Subroutine Count  CC  CRAP Location            
+---------- ----- --- ----- --------------------
+BEGIN          1   1   1.0 tests/eval_nested:10
+BEGIN          1   1   1.0 tests/eval_nested:11
+config         2   1   1.0 tests/eval_nested:13
 
 

--- a/test_output/cover/eval_nested.5.020000
+++ b/test_output/cover/eval_nested.5.020000
@@ -55,10 +55,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location            
+Subroutine Count  CC  SLOP Location            
 ---------- ----- --- ----- --------------------
-BEGIN          1   1   1.0 tests/eval_nested:10
-BEGIN          1   1   1.0 tests/eval_nested:11
-config         2   1   1.0 tests/eval_nested:13
+BEGIN          1   1   0.0 tests/eval_nested:10
+BEGIN          1   1   0.0 tests/eval_nested:11
+config         2   1   0.0 tests/eval_nested:13
 
 

--- a/test_output/cover/eval_string.5.020000
+++ b/test_output/cover/eval_string.5.020000
@@ -84,10 +84,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location            
+Subroutine Count  CC  SLOP Location            
 ---------- ----- --- ----- --------------------
-BEGIN          1   1   1.0 tests/eval_string:2 
-BEGIN          1   1   1.0 tests/eval_string:3 
-ev             1   2   2.1 tests/eval_string:30
+BEGIN          1   1   0.0 tests/eval_string:2 
+BEGIN          1   1   0.0 tests/eval_string:3 
+ev             1   2   7.4 tests/eval_string:30
 
 

--- a/test_output/cover/eval_string.5.020000
+++ b/test_output/cover/eval_string.5.020000
@@ -84,10 +84,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location            
----------- ----- --------------------
-BEGIN          1 tests/eval_string:2 
-BEGIN          1 tests/eval_string:3 
-ev             1 tests/eval_string:30
+Subroutine Count  CC  CRAP Location            
+---------- ----- --- ----- --------------------
+BEGIN          1   1   1.0 tests/eval_string:2 
+BEGIN          1   1   1.0 tests/eval_string:3 
+ev             1   2   2.1 tests/eval_string:30
 
 

--- a/test_output/cover/eval_sub.t.5.020000
+++ b/test_output/cover/eval_sub.t.5.020000
@@ -90,10 +90,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location      
+Subroutine Count  CC  SLOP Location      
 ---------- ----- --- ----- --------------
-BEGIN          4   1   1.0 tests/eval3:10
-s1             3   1   1.0 tests/eval3:14
-s3             4   1   1.0 tests/eval3:18
+BEGIN          4   1   0.0 tests/eval3:10
+s1             3   1   0.0 tests/eval3:14
+s3             4   1   0.0 tests/eval3:18
 
 

--- a/test_output/cover/eval_sub.t.5.020000
+++ b/test_output/cover/eval_sub.t.5.020000
@@ -90,10 +90,10 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location      
----------- ----- --------------
-BEGIN          4 tests/eval3:10
-s1             3 tests/eval3:14
-s3             4 tests/eval3:18
+Subroutine Count  CC  CRAP Location      
+---------- ----- --- ----- --------------
+BEGIN          4   1   1.0 tests/eval3:10
+s1             3   1   1.0 tests/eval3:14
+s3             4   1   1.0 tests/eval3:18
 
 

--- a/test_output/cover/eval_use.t.5.020000
+++ b/test_output/cover/eval_use.t.5.020000
@@ -61,9 +61,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E2             0   1   2.0 E2.pm:12
+E2             0   1   6.9 E2.pm:12
 
 
 E3.pm
@@ -88,9 +88,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E3             0   1   2.0 E3.pm:12
+E3             0   1   6.9 E3.pm:12
 
 
 E4.pm
@@ -115,9 +115,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E4             0   1   2.0 E4.pm:12
+E4             0   1   6.9 E4.pm:12
 
 
 eval2
@@ -181,11 +181,11 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-BEGIN          4   1   1.0 eval2:10
-BEGIN          2   1   1.0 eval2:14
-BEGIN          2   1   1.0 eval2:16
-BEGIN          3   1   1.0 eval2:18
+BEGIN          4   1   0.0 eval2:10
+BEGIN          2   1   0.0 eval2:14
+BEGIN          2   1   0.0 eval2:16
+BEGIN          3   1   0.0 eval2:18
 
 

--- a/test_output/cover/eval_use.t.5.020000
+++ b/test_output/cover/eval_use.t.5.020000
@@ -61,9 +61,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location
----------- ----- --------
-E2             0 E2.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E2             0   1   2.0 E2.pm:12
 
 
 E3.pm
@@ -88,9 +88,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location
----------- ----- --------
-E3             0 E3.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E3             0   1   2.0 E3.pm:12
 
 
 E4.pm
@@ -115,9 +115,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location
----------- ----- --------
-E4             0 E4.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E4             0   1   2.0 E4.pm:12
 
 
 eval2
@@ -181,11 +181,11 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-BEGIN          4 eval2:10
-BEGIN          2 eval2:14
-BEGIN          2 eval2:16
-BEGIN          3 eval2:18
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+BEGIN          4   1   1.0 eval2:10
+BEGIN          2   1   1.0 eval2:14
+BEGIN          2   1   1.0 eval2:16
+BEGIN          3   1   1.0 eval2:18
 
 

--- a/test_output/cover/exec_die.5.020000
+++ b/test_output/cover/exec_die.5.020000
@@ -53,8 +53,8 @@ line  err      %   true  false   branch
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location         
+Subroutine Count  CC  SLOP Location         
 ---------- ----- --- ----- -----------------
-__ANON__       0   1   2.0 tests/exec_die:18
+__ANON__       0   1   6.9 tests/exec_die:18
 
 

--- a/test_output/cover/exec_die.5.020000
+++ b/test_output/cover/exec_die.5.020000
@@ -53,8 +53,8 @@ line  err      %   true  false   branch
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location         
----------- ----- -----------------
-__ANON__       0 tests/exec_die:18
+Subroutine Count  CC  CRAP Location         
+---------- ----- --- ----- -----------------
+__ANON__       0   1   2.0 tests/exec_die:18
 
 

--- a/test_output/cover/if.5.020000
+++ b/test_output/cover/if.5.020000
@@ -78,9 +78,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location   
----------- ----- -----------
-BEGIN          1 tests/if:10
-BEGIN          1 tests/if:11
+Subroutine Count  CC  CRAP Location   
+---------- ----- --- ----- -----------
+BEGIN          1   1   1.0 tests/if:10
+BEGIN          1   1   1.0 tests/if:11
 
 

--- a/test_output/cover/if.5.020000
+++ b/test_output/cover/if.5.020000
@@ -78,9 +78,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location   
+Subroutine Count  CC  SLOP Location   
 ---------- ----- --- ----- -----------
-BEGIN          1   1   1.0 tests/if:10
-BEGIN          1   1   1.0 tests/if:11
+BEGIN          1   1   0.0 tests/if:10
+BEGIN          1   1   0.0 tests/if:11
 
 

--- a/test_output/cover/loop_condition.5.020000
+++ b/test_output/cover/loop_condition.5.020000
@@ -121,9 +121,9 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location               
----------- ----- -----------------------
-BEGIN          1 tests/loop_condition:13
-BEGIN          1 tests/loop_condition:14
+Subroutine Count  CC  CRAP Location               
+---------- ----- --- ----- -----------------------
+BEGIN          1   1   1.0 tests/loop_condition:13
+BEGIN          1   1   1.0 tests/loop_condition:14
 
 

--- a/test_output/cover/loop_condition.5.020000
+++ b/test_output/cover/loop_condition.5.020000
@@ -121,9 +121,9 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location               
+Subroutine Count  CC  SLOP Location               
 ---------- ----- --- ----- -----------------------
-BEGIN          1   1   1.0 tests/loop_condition:13
-BEGIN          1   1   1.0 tests/loop_condition:14
+BEGIN          1   1   0.0 tests/loop_condition:13
+BEGIN          1   1   0.0 tests/loop_condition:14
 
 

--- a/test_output/cover/module1.5.020000
+++ b/test_output/cover/module1.5.020000
@@ -62,18 +62,18 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-zz            11   1   1.0 Module1.pm:29
+zz            11   1   0.0 Module1.pm:29
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-_aa            0   1   2.0 Module1.pm:14
-xx             0   1   2.0 Module1.pm:20
-yy             0   1   2.0 Module1.pm:25
+_aa            0   1   6.9 Module1.pm:14
+xx             0   1   6.9 Module1.pm:20
+yy             0   1   6.9 Module1.pm:25
 
 
 module1
@@ -132,12 +132,12 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-BEGIN          1   1   1.0 module1:12
-BEGIN          1   1   1.0 module1:13
-BEGIN          1   1   1.0 module1:15
-BEGIN          1   1   1.0 module1:17
-xx            11   1   1.0 module1:22
+BEGIN          1   1   0.0 module1:12
+BEGIN          1   1   0.0 module1:13
+BEGIN          1   1   0.0 module1:15
+BEGIN          1   1   0.0 module1:17
+xx            11   1   0.0 module1:22
 
 

--- a/test_output/cover/module1.5.020000
+++ b/test_output/cover/module1.5.020000
@@ -62,18 +62,18 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location     
----------- ----- -------------
-zz            11 Module1.pm:29
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+zz            11   1   1.0 Module1.pm:29
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location     
----------- ----- -------------
-_aa            0 Module1.pm:14
-xx             0 Module1.pm:20
-yy             0 Module1.pm:25
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+_aa            0   1   2.0 Module1.pm:14
+xx             0   1   2.0 Module1.pm:20
+yy             0   1   2.0 Module1.pm:25
 
 
 module1
@@ -132,12 +132,12 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location  
----------- ----- ----------
-BEGIN          1 module1:12
-BEGIN          1 module1:13
-BEGIN          1 module1:15
-BEGIN          1 module1:17
-xx            11 module1:22
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+BEGIN          1   1   1.0 module1:12
+BEGIN          1   1   1.0 module1:13
+BEGIN          1   1   1.0 module1:15
+BEGIN          1   1   1.0 module1:17
+xx            11   1   1.0 module1:22
 
 

--- a/test_output/cover/module2.5.020000
+++ b/test_output/cover/module2.5.020000
@@ -62,18 +62,18 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-zz            11   1   1.0 Module2.pm:29
+zz            11   1   0.0 Module2.pm:29
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-_aa            0   1   2.0 Module2.pm:14
-_xx            0   1   2.0 Module2.pm:20
-yy             0   1   2.0 Module2.pm:25
+_aa            0   1   6.9 Module2.pm:14
+_xx            0   1   6.9 Module2.pm:20
+yy             0   1   6.9 Module2.pm:25
 
 
 module2
@@ -132,12 +132,12 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-BEGIN          1   1   1.0 module2:12
-BEGIN          1   1   1.0 module2:13
-BEGIN          1   1   1.0 module2:15
-BEGIN          1   1   1.0 module2:17
-xx            11   1   1.0 module2:22
+BEGIN          1   1   0.0 module2:12
+BEGIN          1   1   0.0 module2:13
+BEGIN          1   1   0.0 module2:15
+BEGIN          1   1   0.0 module2:17
+xx            11   1   0.0 module2:22
 
 

--- a/test_output/cover/module2.5.020000
+++ b/test_output/cover/module2.5.020000
@@ -62,18 +62,18 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location     
----------- ----- -------------
-zz            11 Module2.pm:29
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+zz            11   1   1.0 Module2.pm:29
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location     
----------- ----- -------------
-_aa            0 Module2.pm:14
-_xx            0 Module2.pm:20
-yy             0 Module2.pm:25
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+_aa            0   1   2.0 Module2.pm:14
+_xx            0   1   2.0 Module2.pm:20
+yy             0   1   2.0 Module2.pm:25
 
 
 module2
@@ -132,12 +132,12 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location  
----------- ----- ----------
-BEGIN          1 module2:12
-BEGIN          1 module2:13
-BEGIN          1 module2:15
-BEGIN          1 module2:17
-xx            11 module2:22
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+BEGIN          1   1   1.0 module2:12
+BEGIN          1   1   1.0 module2:13
+BEGIN          1   1   1.0 module2:15
+BEGIN          1   1   1.0 module2:17
+xx            11   1   1.0 module2:22
 
 

--- a/test_output/cover/module_ignore.5.020000
+++ b/test_output/cover/module_ignore.5.020000
@@ -66,11 +66,11 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location              
+Subroutine Count  CC  SLOP Location              
 ---------- ----- --- ----- ----------------------
-BEGIN          1   1   1.0 tests/module_ignore:12
-BEGIN          1   1   1.0 tests/module_ignore:13
-BEGIN          1   1   1.0 tests/module_ignore:15
-BEGIN          1   1   1.0 tests/module_ignore:17
+BEGIN          1   1   0.0 tests/module_ignore:12
+BEGIN          1   1   0.0 tests/module_ignore:13
+BEGIN          1   1   0.0 tests/module_ignore:15
+BEGIN          1   1   0.0 tests/module_ignore:17
 
 

--- a/test_output/cover/module_ignore.5.020000
+++ b/test_output/cover/module_ignore.5.020000
@@ -66,11 +66,11 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location              
----------- ----- ----------------------
-BEGIN          1 tests/module_ignore:12
-BEGIN          1 tests/module_ignore:13
-BEGIN          1 tests/module_ignore:15
-BEGIN          1 tests/module_ignore:17
+Subroutine Count  CC  CRAP Location              
+---------- ----- --- ----- ----------------------
+BEGIN          1   1   1.0 tests/module_ignore:12
+BEGIN          1   1   1.0 tests/module_ignore:13
+BEGIN          1   1   1.0 tests/module_ignore:15
+BEGIN          1   1   1.0 tests/module_ignore:17
 
 

--- a/test_output/cover/module_import.5.020000
+++ b/test_output/cover/module_import.5.020000
@@ -41,9 +41,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location           
----------- ----- -------------------
-import         1 Module_import.pm:11
+Subroutine Count  CC  CRAP Location           
+---------- ----- --- ----- -------------------
+import         1   1   1.0 Module_import.pm:11
 
 
 module_import
@@ -68,9 +68,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-BEGIN          1 module_import:10
-BEGIN          1 module_import:12
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+BEGIN          1   1   1.0 module_import:10
+BEGIN          1   1   1.0 module_import:12
 
 

--- a/test_output/cover/module_import.5.020000
+++ b/test_output/cover/module_import.5.020000
@@ -41,9 +41,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location           
+Subroutine Count  CC  SLOP Location           
 ---------- ----- --- ----- -------------------
-import         1   1   1.0 Module_import.pm:11
+import         1   1   0.0 Module_import.pm:11
 
 
 module_import
@@ -68,9 +68,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-BEGIN          1   1   1.0 module_import:10
-BEGIN          1   1   1.0 module_import:12
+BEGIN          1   1   0.0 module_import:10
+BEGIN          1   1   0.0 module_import:12
 
 

--- a/test_output/cover/module_relative.5.020000
+++ b/test_output/cover/module_relative.5.020000
@@ -41,9 +41,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location           
----------- ----- -------------------
-import         1 Module_import.pm:11
+Subroutine Count  CC  CRAP Location           
+---------- ----- --- ----- -------------------
+import         1   1   1.0 Module_import.pm:11
 
 
 module_relative
@@ -76,11 +76,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location          
----------- ----- ------------------
-BEGIN          1 module_relative:13
-BEGIN          1 module_relative:14
-BEGIN          1 module_relative:15
-BEGIN          1 module_relative:16
+Subroutine Count  CC  CRAP Location          
+---------- ----- --- ----- ------------------
+BEGIN          1   1   1.0 module_relative:13
+BEGIN          1   1   1.0 module_relative:14
+BEGIN          1   1   1.0 module_relative:15
+BEGIN          1   1   1.0 module_relative:16
 
 

--- a/test_output/cover/module_relative.5.020000
+++ b/test_output/cover/module_relative.5.020000
@@ -41,9 +41,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location           
+Subroutine Count  CC  SLOP Location           
 ---------- ----- --- ----- -------------------
-import         1   1   1.0 Module_import.pm:11
+import         1   1   0.0 Module_import.pm:11
 
 
 module_relative
@@ -76,11 +76,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location          
+Subroutine Count  CC  SLOP Location          
 ---------- ----- --- ----- ------------------
-BEGIN          1   1   1.0 module_relative:13
-BEGIN          1   1   1.0 module_relative:14
-BEGIN          1   1   1.0 module_relative:15
-BEGIN          1   1   1.0 module_relative:16
+BEGIN          1   1   0.0 module_relative:13
+BEGIN          1   1   0.0 module_relative:14
+BEGIN          1   1   0.0 module_relative:15
+BEGIN          1   1   0.0 module_relative:16
 
 

--- a/test_output/cover/module_statements.5.020000
+++ b/test_output/cover/module_statements.5.020000
@@ -100,22 +100,22 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location                  
+Subroutine Count  CC  SLOP Location                  
 ---------- ----- --- ----- --------------------------
-BEGIN          1   1   1.0 tests/module_statements:12
-BEGIN          1   1   1.0 tests/module_statements:13
-BEGIN          1   1   1.0 tests/module_statements:15
-BEGIN          1   1   1.0 tests/module_statements:17
-xx            11   1   1.0 tests/module_statements:22
-zz            11   1   1.0 tests/module_statements:55
+BEGIN          1   1   0.0 tests/module_statements:12
+BEGIN          1   1   0.0 tests/module_statements:13
+BEGIN          1   1   0.0 tests/module_statements:15
+BEGIN          1   1   0.0 tests/module_statements:17
+xx            11   1   0.0 tests/module_statements:22
+zz            11   1   0.0 tests/module_statements:55
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location                  
+Subroutine Count  CC  SLOP Location                  
 ---------- ----- --- ----- --------------------------
-_aa            0   1   2.0 tests/module_statements:40
-xx             0   1   2.0 tests/module_statements:46
-yy             0   1   2.0 tests/module_statements:51
+_aa            0   1   6.9 tests/module_statements:40
+xx             0   1   6.9 tests/module_statements:46
+yy             0   1   6.9 tests/module_statements:51
 
 

--- a/test_output/cover/module_statements.5.020000
+++ b/test_output/cover/module_statements.5.020000
@@ -100,22 +100,22 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location                  
----------- ----- --------------------------
-BEGIN          1 tests/module_statements:12
-BEGIN          1 tests/module_statements:13
-BEGIN          1 tests/module_statements:15
-BEGIN          1 tests/module_statements:17
-xx            11 tests/module_statements:22
-zz            11 tests/module_statements:55
+Subroutine Count  CC  CRAP Location                  
+---------- ----- --- ----- --------------------------
+BEGIN          1   1   1.0 tests/module_statements:12
+BEGIN          1   1   1.0 tests/module_statements:13
+BEGIN          1   1   1.0 tests/module_statements:15
+BEGIN          1   1   1.0 tests/module_statements:17
+xx            11   1   1.0 tests/module_statements:22
+zz            11   1   1.0 tests/module_statements:55
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location                  
----------- ----- --------------------------
-_aa            0 tests/module_statements:40
-xx             0 tests/module_statements:46
-yy             0 tests/module_statements:51
+Subroutine Count  CC  CRAP Location                  
+---------- ----- --- ----- --------------------------
+_aa            0   1   2.0 tests/module_statements:40
+xx             0   1   2.0 tests/module_statements:46
+yy             0   1   2.0 tests/module_statements:51
 
 

--- a/test_output/cover/moo_cond.5.020000
+++ b/test_output/cover/moo_cond.5.020000
@@ -67,11 +67,11 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location         
----------- ----- -----------------
-BEGIN          1 tests/moo_cond:13
-BEGIN          1 tests/moo_cond:14
-BEGIN          1 tests/moo_cond:18
-trigger        2 tests/moo_cond:27
+Subroutine Count  CC  CRAP Location         
+---------- ----- --- ----- -----------------
+BEGIN          1   1   1.0 tests/moo_cond:13
+BEGIN          1   1   1.0 tests/moo_cond:14
+BEGIN          1   1   1.0 tests/moo_cond:18
+trigger        2   3   3.0 tests/moo_cond:27
 
 

--- a/test_output/cover/moo_cond.5.020000
+++ b/test_output/cover/moo_cond.5.020000
@@ -67,11 +67,11 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location         
+Subroutine Count  CC  SLOP Location         
 ---------- ----- --- ----- -----------------
-BEGIN          1   1   1.0 tests/moo_cond:13
-BEGIN          1   1   1.0 tests/moo_cond:14
-BEGIN          1   1   1.0 tests/moo_cond:18
-trigger        2   3   3.0 tests/moo_cond:27
+BEGIN          1   1   0.0 tests/moo_cond:13
+BEGIN          1   1   0.0 tests/moo_cond:14
+BEGIN          1   1   0.0 tests/moo_cond:18
+trigger        2   3  11.0 tests/moo_cond:27
 
 

--- a/test_output/cover/moose_basic.5.020000
+++ b/test_output/cover/moose_basic.5.020000
@@ -40,8 +40,8 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location            
+Subroutine Count  CC  SLOP Location            
 ---------- ----- --- ----- --------------------
-BEGIN          1   1   1.0 tests/moose_basic:14
+BEGIN          1   1   0.0 tests/moose_basic:14
 
 

--- a/test_output/cover/moose_basic.5.020000
+++ b/test_output/cover/moose_basic.5.020000
@@ -40,8 +40,8 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location            
----------- ----- --------------------
-BEGIN          1 tests/moose_basic:14
+Subroutine Count  CC  CRAP Location            
+---------- ----- --- ----- --------------------
+BEGIN          1   1   1.0 tests/moose_basic:14
 
 

--- a/test_output/cover/moose_cond.5.020000
+++ b/test_output/cover/moose_cond.5.020000
@@ -74,11 +74,11 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location           
----------- ----- -------------------
-BEGIN          1 tests/moose_cond:13
-BEGIN          1 tests/moose_cond:14
-BEGIN          1 tests/moose_cond:18
-wagh           2 tests/moose_cond:30
+Subroutine Count  CC  CRAP Location           
+---------- ----- --- ----- -------------------
+BEGIN          1   1   1.0 tests/moose_cond:13
+BEGIN          1   1   1.0 tests/moose_cond:14
+BEGIN          1   1   1.0 tests/moose_cond:18
+wagh           2   3   3.0 tests/moose_cond:30
 
 

--- a/test_output/cover/moose_cond.5.020000
+++ b/test_output/cover/moose_cond.5.020000
@@ -74,11 +74,11 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location           
+Subroutine Count  CC  SLOP Location           
 ---------- ----- --- ----- -------------------
-BEGIN          1   1   1.0 tests/moose_cond:13
-BEGIN          1   1   1.0 tests/moose_cond:14
-BEGIN          1   1   1.0 tests/moose_cond:18
-wagh           2   3   3.0 tests/moose_cond:30
+BEGIN          1   1   0.0 tests/moose_cond:13
+BEGIN          1   1   0.0 tests/moose_cond:14
+BEGIN          1   1   0.0 tests/moose_cond:18
+wagh           2   3  11.1 tests/moose_cond:30
 
 

--- a/test_output/cover/moose_constraint.5.020000
+++ b/test_output/cover/moose_constraint.5.020000
@@ -54,9 +54,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location                 
----------- ----- -------------------------
-BEGIN          1 tests/moose_constraint:13
-BEGIN          1 tests/moose_constraint:17
+Subroutine Count  CC  CRAP Location                 
+---------- ----- --- ----- -------------------------
+BEGIN          1   1   1.0 tests/moose_constraint:13
+BEGIN          1   1   1.0 tests/moose_constraint:17
 
 

--- a/test_output/cover/moose_constraint.5.020000
+++ b/test_output/cover/moose_constraint.5.020000
@@ -54,9 +54,9 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location                 
+Subroutine Count  CC  SLOP Location                 
 ---------- ----- --- ----- -------------------------
-BEGIN          1   1   1.0 tests/moose_constraint:13
-BEGIN          1   1   1.0 tests/moose_constraint:17
+BEGIN          1   1   0.0 tests/moose_constraint:13
+BEGIN          1   1   0.0 tests/moose_constraint:17
 
 

--- a/test_output/cover/overload_bool.5.020000
+++ b/test_output/cover/overload_bool.5.020000
@@ -73,17 +73,17 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location              
+Subroutine Count  CC  SLOP Location              
 ---------- ----- --- ----- ----------------------
-BEGIN          1   1   1.1 tests/overload_bool:13
+BEGIN          1   1   0.6 tests/overload_bool:13
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location              
+Subroutine Count  CC  SLOP Location              
 ---------- ----- --- ----- ----------------------
-__ANON__       0   1   2.0 tests/overload_bool:12
-__ANON__       0   1   1.1 tests/overload_bool:13
-render         0   1   2.0 tests/overload_bool:16
+__ANON__       0   1   6.9 tests/overload_bool:12
+__ANON__       0   1   0.6 tests/overload_bool:13
+render         0   1   6.9 tests/overload_bool:16
 
 

--- a/test_output/cover/overload_bool.5.020000
+++ b/test_output/cover/overload_bool.5.020000
@@ -73,17 +73,17 @@ line  err      %      l     !l   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location              
----------- ----- ----------------------
-BEGIN          1 tests/overload_bool:13
+Subroutine Count  CC  CRAP Location              
+---------- ----- --- ----- ----------------------
+BEGIN          1   1   1.1 tests/overload_bool:13
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location              
----------- ----- ----------------------
-__ANON__       0 tests/overload_bool:12
-__ANON__       0 tests/overload_bool:13
-render         0 tests/overload_bool:16
+Subroutine Count  CC  CRAP Location              
+---------- ----- --- ----- ----------------------
+__ANON__       0   1   2.0 tests/overload_bool:12
+__ANON__       0   1   1.1 tests/overload_bool:13
+render         0   1   2.0 tests/overload_bool:16
 
 

--- a/test_output/cover/overload_bool2.5.020000
+++ b/test_output/cover/overload_bool2.5.020000
@@ -53,11 +53,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location               
----------- ----- -----------------------
-BEGIN          1 tests/overload_bool2:10
-BEGIN          1 tests/overload_bool2:11
-BEGIN          1 tests/overload_bool2:16
-meh            3 tests/overload_bool2:18
+Subroutine Count  CC  CRAP Location               
+---------- ----- --- ----- -----------------------
+BEGIN          1   1   1.0 tests/overload_bool2:10
+BEGIN          1   1   1.0 tests/overload_bool2:11
+BEGIN          1   1   1.0 tests/overload_bool2:16
+meh            3   1   1.0 tests/overload_bool2:18
 
 

--- a/test_output/cover/overload_bool2.5.020000
+++ b/test_output/cover/overload_bool2.5.020000
@@ -53,11 +53,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location               
+Subroutine Count  CC  SLOP Location               
 ---------- ----- --- ----- -----------------------
-BEGIN          1   1   1.0 tests/overload_bool2:10
-BEGIN          1   1   1.0 tests/overload_bool2:11
-BEGIN          1   1   1.0 tests/overload_bool2:16
-meh            3   1   1.0 tests/overload_bool2:18
+BEGIN          1   1   0.0 tests/overload_bool2:10
+BEGIN          1   1   0.0 tests/overload_bool2:11
+BEGIN          1   1   0.0 tests/overload_bool2:16
+meh            3   1   0.0 tests/overload_bool2:18
 
 

--- a/test_output/cover/overload_bool2.5.022000
+++ b/test_output/cover/overload_bool2.5.022000
@@ -54,11 +54,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location               
+Subroutine Count  CC  SLOP Location               
 ---------- ----- --- ----- -----------------------
-BEGIN          1   1   1.0 tests/overload_bool2:10
-BEGIN          1   1   1.0 tests/overload_bool2:11
-BEGIN          1   1   1.0 tests/overload_bool2:16
-meh            3   1   1.0 tests/overload_bool2:18
+BEGIN          1   1   0.0 tests/overload_bool2:10
+BEGIN          1   1   0.0 tests/overload_bool2:11
+BEGIN          1   1   0.0 tests/overload_bool2:16
+meh            3   1   0.0 tests/overload_bool2:18
 
 

--- a/test_output/cover/overload_bool2.5.022000
+++ b/test_output/cover/overload_bool2.5.022000
@@ -54,11 +54,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location               
----------- ----- -----------------------
-BEGIN          1 tests/overload_bool2:10
-BEGIN          1 tests/overload_bool2:11
-BEGIN          1 tests/overload_bool2:16
-meh            3 tests/overload_bool2:18
+Subroutine Count  CC  CRAP Location               
+---------- ----- --- ----- -----------------------
+BEGIN          1   1   1.0 tests/overload_bool2:10
+BEGIN          1   1   1.0 tests/overload_bool2:11
+BEGIN          1   1   1.0 tests/overload_bool2:16
+meh            3   1   1.0 tests/overload_bool2:18
 
 

--- a/test_output/cover/overload_bool2.5.038000
+++ b/test_output/cover/overload_bool2.5.038000
@@ -54,11 +54,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location               
----------- ----- -----------------------
-BEGIN          1 tests/overload_bool2:10
-BEGIN          1 tests/overload_bool2:11
-BEGIN          1 tests/overload_bool2:16
-meh            2 tests/overload_bool2:18
+Subroutine Count  CC  CRAP Location               
+---------- ----- --- ----- -----------------------
+BEGIN          1   1   1.0 tests/overload_bool2:10
+BEGIN          1   1   1.0 tests/overload_bool2:11
+BEGIN          1   1   1.0 tests/overload_bool2:16
+meh            2   1   1.0 tests/overload_bool2:18
 
 

--- a/test_output/cover/overload_bool2.5.038000
+++ b/test_output/cover/overload_bool2.5.038000
@@ -54,11 +54,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location               
+Subroutine Count  CC  SLOP Location               
 ---------- ----- --- ----- -----------------------
-BEGIN          1   1   1.0 tests/overload_bool2:10
-BEGIN          1   1   1.0 tests/overload_bool2:11
-BEGIN          1   1   1.0 tests/overload_bool2:16
-meh            2   1   1.0 tests/overload_bool2:18
+BEGIN          1   1   0.0 tests/overload_bool2:10
+BEGIN          1   1   0.0 tests/overload_bool2:11
+BEGIN          1   1   0.0 tests/overload_bool2:16
+meh            2   1   0.0 tests/overload_bool2:18
 
 

--- a/test_output/cover/overloaded.5.020000
+++ b/test_output/cover/overloaded.5.020000
@@ -60,11 +60,11 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location           
+Subroutine Count  CC  SLOP Location           
 ---------- ----- --- ----- -------------------
-BEGIN          1   1   1.0 tests/overloaded:18
-new            1   1   1.0 tests/overloaded:17
-num            2   1   1.0 tests/overloaded:19
-str            2   1   1.0 tests/overloaded:20
+BEGIN          1   1   0.0 tests/overloaded:18
+new            1   1   0.0 tests/overloaded:17
+num            2   1   0.0 tests/overloaded:19
+str            2   1   0.0 tests/overloaded:20
 
 

--- a/test_output/cover/overloaded.5.020000
+++ b/test_output/cover/overloaded.5.020000
@@ -60,11 +60,11 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location           
----------- ----- -------------------
-BEGIN          1 tests/overloaded:18
-new            1 tests/overloaded:17
-num            2 tests/overloaded:19
-str            2 tests/overloaded:20
+Subroutine Count  CC  CRAP Location           
+---------- ----- --- ----- -------------------
+BEGIN          1   1   1.0 tests/overloaded:18
+new            1   1   1.0 tests/overloaded:17
+num            2   1   1.0 tests/overloaded:19
+str            2   1   1.0 tests/overloaded:20
 
 

--- a/test_output/cover/padrange2.5.020000
+++ b/test_output/cover/padrange2.5.020000
@@ -49,9 +49,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location         
----------- ----- -----------------
-BEGIN          1 tests/padrange2:3
-BEGIN          1 tests/padrange2:4
+Subroutine Count  CC  CRAP Location         
+---------- ----- --- ----- -----------------
+BEGIN          1   1   1.0 tests/padrange2:3
+BEGIN          1   1   1.0 tests/padrange2:4
 
 

--- a/test_output/cover/padrange2.5.020000
+++ b/test_output/cover/padrange2.5.020000
@@ -49,9 +49,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location         
+Subroutine Count  CC  SLOP Location         
 ---------- ----- --- ----- -----------------
-BEGIN          1   1   1.0 tests/padrange2:3
-BEGIN          1   1   1.0 tests/padrange2:4
+BEGIN          1   1   0.0 tests/padrange2:3
+BEGIN          1   1   0.0 tests/padrange2:4
 
 

--- a/test_output/cover/padrange2.5.022000
+++ b/test_output/cover/padrange2.5.022000
@@ -49,9 +49,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location         
----------- ----- -----------------
-BEGIN          1 tests/padrange2:3
-BEGIN          1 tests/padrange2:4
+Subroutine Count  CC  CRAP Location         
+---------- ----- --- ----- -----------------
+BEGIN          1   1   1.0 tests/padrange2:3
+BEGIN          1   1   1.0 tests/padrange2:4
 
 

--- a/test_output/cover/padrange2.5.022000
+++ b/test_output/cover/padrange2.5.022000
@@ -49,9 +49,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location         
+Subroutine Count  CC  SLOP Location         
 ---------- ----- --- ----- -----------------
-BEGIN          1   1   1.0 tests/padrange2:3
-BEGIN          1   1   1.0 tests/padrange2:4
+BEGIN          1   1   0.0 tests/padrange2:3
+BEGIN          1   1   0.0 tests/padrange2:4
 
 

--- a/test_output/cover/pod.5.020000
+++ b/test_output/cover/pod.5.020000
@@ -23,46 +23,46 @@ Finish: ...
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod Location     
----------- ----- --- -------------
-_aa            0     Module1.pm:14
-xx             0     Module1.pm:20
-yy             0   1 Module1.pm:25
-zz             0   0 Module1.pm:29
+Subroutine Count Pod  CC  CRAP Location     
+---------- ----- --- --- ----- -------------
+_aa            0       1   2.0 Module1.pm:14
+xx             0       1   2.0 Module1.pm:20
+yy             0   1   1   2.0 Module1.pm:25
+zz             0   0   1   2.0 Module1.pm:29
 
 
 Covered Subroutines
 -------------------
 
-Subroutine Count Pod Location    
----------- ----- --- ------------
-BEGIN          1     PodMod.pm:10
+Subroutine Count Pod  CC  CRAP Location    
+---------- ----- --- --- ----- ------------
+BEGIN          1       1   1.0 PodMod.pm:10
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod Location    
----------- ----- --- ------------
-vv             0   1 PodMod.pm:12
-ww             0   0 PodMod.pm:13
-yy             0   1 PodMod.pm:14
+Subroutine Count Pod  CC  CRAP Location    
+---------- ----- --- --- ----- ------------
+vv             0   1   1   2.0 PodMod.pm:12
+ww             0   0   1   2.0 PodMod.pm:13
+yy             0   1   1   2.0 PodMod.pm:14
 
 
 Covered Subroutines
 -------------------
 
-Subroutine Count Location
----------- ----- --------
-BEGIN          1 pod:14  
-BEGIN          1 pod:15  
-BEGIN          1 pod:17  
-BEGIN          1 pod:19  
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+BEGIN          1   1   1.0 pod:14  
+BEGIN          1   1   1.0 pod:15  
+BEGIN          1   1   1.0 pod:17  
+BEGIN          1   1   1.0 pod:19  
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location
----------- ----- --------
-xx             0 pod:24  
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+xx             0   1   2.0 pod:24  
 
 

--- a/test_output/cover/pod.5.020000
+++ b/test_output/cover/pod.5.020000
@@ -23,46 +23,46 @@ Finish: ...
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod  CC  CRAP Location     
+Subroutine Count Pod  CC  SLOP Location     
 ---------- ----- --- --- ----- -------------
-_aa            0       1   2.0 Module1.pm:14
-xx             0       1   2.0 Module1.pm:20
-yy             0   1   1   2.0 Module1.pm:25
-zz             0   0   1   2.0 Module1.pm:29
+_aa            0       1   6.9 Module1.pm:14
+xx             0       1   6.9 Module1.pm:20
+yy             0   1   1   6.9 Module1.pm:25
+zz             0   0   1   6.9 Module1.pm:29
 
 
 Covered Subroutines
 -------------------
 
-Subroutine Count Pod  CC  CRAP Location    
+Subroutine Count Pod  CC  SLOP Location    
 ---------- ----- --- --- ----- ------------
-BEGIN          1       1   1.0 PodMod.pm:10
+BEGIN          1       1   0.0 PodMod.pm:10
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod  CC  CRAP Location    
+Subroutine Count Pod  CC  SLOP Location    
 ---------- ----- --- --- ----- ------------
-vv             0   1   1   2.0 PodMod.pm:12
-ww             0   0   1   2.0 PodMod.pm:13
-yy             0   1   1   2.0 PodMod.pm:14
+vv             0   1   1   6.9 PodMod.pm:12
+ww             0   0   1   6.9 PodMod.pm:13
+yy             0   1   1   6.9 PodMod.pm:14
 
 
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-BEGIN          1   1   1.0 pod:14  
-BEGIN          1   1   1.0 pod:15  
-BEGIN          1   1   1.0 pod:17  
-BEGIN          1   1   1.0 pod:19  
+BEGIN          1   1   0.0 pod:14  
+BEGIN          1   1   0.0 pod:15  
+BEGIN          1   1   0.0 pod:17  
+BEGIN          1   1   0.0 pod:19  
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-xx             0   1   2.0 pod:24  
+xx             0   1   6.9 pod:24  
 
 

--- a/test_output/cover/pod_nocp.5.020000
+++ b/test_output/cover/pod_nocp.5.020000
@@ -23,46 +23,46 @@ Finish: ...
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod  CC  CRAP Location     
+Subroutine Count Pod  CC  SLOP Location     
 ---------- ----- --- --- ----- -------------
-_aa            0       1   2.0 Module1.pm:14
-xx             0       1   2.0 Module1.pm:20
-yy             0   1   1   2.0 Module1.pm:25
-zz             0   0   1   2.0 Module1.pm:29
+_aa            0       1   6.9 Module1.pm:14
+xx             0       1   6.9 Module1.pm:20
+yy             0   1   1   6.9 Module1.pm:25
+zz             0   0   1   6.9 Module1.pm:29
 
 
 Covered Subroutines
 -------------------
 
-Subroutine Count Pod  CC  CRAP Location    
+Subroutine Count Pod  CC  SLOP Location    
 ---------- ----- --- --- ----- ------------
-BEGIN          1       1   1.0 PodMod.pm:10
+BEGIN          1       1   0.0 PodMod.pm:10
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod  CC  CRAP Location    
+Subroutine Count Pod  CC  SLOP Location    
 ---------- ----- --- --- ----- ------------
-vv             0   1   1   2.0 PodMod.pm:12
-ww             0   0   1   2.0 PodMod.pm:13
-yy             0   0   1   2.0 PodMod.pm:14
+vv             0   1   1   6.9 PodMod.pm:12
+ww             0   0   1   6.9 PodMod.pm:13
+yy             0   0   1   6.9 PodMod.pm:14
 
 
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location   
+Subroutine Count  CC  SLOP Location   
 ---------- ----- --- ----- -----------
-BEGIN          1   1   1.0 pod_nocp:14
-BEGIN          1   1   1.0 pod_nocp:15
-BEGIN          1   1   1.0 pod_nocp:17
-BEGIN          1   1   1.0 pod_nocp:19
+BEGIN          1   1   0.0 pod_nocp:14
+BEGIN          1   1   0.0 pod_nocp:15
+BEGIN          1   1   0.0 pod_nocp:17
+BEGIN          1   1   0.0 pod_nocp:19
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location   
+Subroutine Count  CC  SLOP Location   
 ---------- ----- --- ----- -----------
-xx             0   1   2.0 pod_nocp:24
+xx             0   1   6.9 pod_nocp:24
 
 

--- a/test_output/cover/pod_nocp.5.020000
+++ b/test_output/cover/pod_nocp.5.020000
@@ -23,46 +23,46 @@ Finish: ...
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod Location     
----------- ----- --- -------------
-_aa            0     Module1.pm:14
-xx             0     Module1.pm:20
-yy             0   1 Module1.pm:25
-zz             0   0 Module1.pm:29
+Subroutine Count Pod  CC  CRAP Location     
+---------- ----- --- --- ----- -------------
+_aa            0       1   2.0 Module1.pm:14
+xx             0       1   2.0 Module1.pm:20
+yy             0   1   1   2.0 Module1.pm:25
+zz             0   0   1   2.0 Module1.pm:29
 
 
 Covered Subroutines
 -------------------
 
-Subroutine Count Pod Location    
----------- ----- --- ------------
-BEGIN          1     PodMod.pm:10
+Subroutine Count Pod  CC  CRAP Location    
+---------- ----- --- --- ----- ------------
+BEGIN          1       1   1.0 PodMod.pm:10
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod Location    
----------- ----- --- ------------
-vv             0   1 PodMod.pm:12
-ww             0   0 PodMod.pm:13
-yy             0   0 PodMod.pm:14
+Subroutine Count Pod  CC  CRAP Location    
+---------- ----- --- --- ----- ------------
+vv             0   1   1   2.0 PodMod.pm:12
+ww             0   0   1   2.0 PodMod.pm:13
+yy             0   0   1   2.0 PodMod.pm:14
 
 
 Covered Subroutines
 -------------------
 
-Subroutine Count Location   
----------- ----- -----------
-BEGIN          1 pod_nocp:14
-BEGIN          1 pod_nocp:15
-BEGIN          1 pod_nocp:17
-BEGIN          1 pod_nocp:19
+Subroutine Count  CC  CRAP Location   
+---------- ----- --- ----- -----------
+BEGIN          1   1   1.0 pod_nocp:14
+BEGIN          1   1   1.0 pod_nocp:15
+BEGIN          1   1   1.0 pod_nocp:17
+BEGIN          1   1   1.0 pod_nocp:19
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location   
----------- ----- -----------
-xx             0 pod_nocp:24
+Subroutine Count  CC  CRAP Location   
+---------- ----- --- ----- -----------
+xx             0   1   2.0 pod_nocp:24
 
 

--- a/test_output/cover/readonly.5.020000
+++ b/test_output/cover/readonly.5.020000
@@ -82,12 +82,12 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine             Count  CC  CRAP Location         
+Subroutine             Count  CC  SLOP Location         
 ---------------------- ----- --- ----- -----------------
-BEGIN                      1   1   1.0 tests/readonly:13
-BEGIN                      1   1   1.0 tests/readonly:14
-BEGIN                      1   1   1.0 tests/readonly:16
-test_posix_regexp          1   3   3.0 tests/readonly:34
-test_readonly_coverage     1   3   3.0 tests/readonly:23
+BEGIN                      1   1   0.0 tests/readonly:13
+BEGIN                      1   1   0.0 tests/readonly:14
+BEGIN                      1   1   0.0 tests/readonly:16
+test_posix_regexp          1   3  11.0 tests/readonly:34
+test_readonly_coverage     1   3  11.0 tests/readonly:23
 
 

--- a/test_output/cover/readonly.5.020000
+++ b/test_output/cover/readonly.5.020000
@@ -82,12 +82,12 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine             Count Location         
----------------------- ----- -----------------
-BEGIN                      1 tests/readonly:13
-BEGIN                      1 tests/readonly:14
-BEGIN                      1 tests/readonly:16
-test_posix_regexp          1 tests/readonly:34
-test_readonly_coverage     1 tests/readonly:23
+Subroutine             Count  CC  CRAP Location         
+---------------------- ----- --- ----- -----------------
+BEGIN                      1   1   1.0 tests/readonly:13
+BEGIN                      1   1   1.0 tests/readonly:14
+BEGIN                      1   1   1.0 tests/readonly:16
+test_posix_regexp          1   3   3.0 tests/readonly:34
+test_readonly_coverage     1   3   3.0 tests/readonly:23
 
 

--- a/test_output/cover/recursive_sub.5.020000
+++ b/test_output/cover/recursive_sub.5.020000
@@ -52,9 +52,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine     Count  CC  CRAP Location              
+Subroutine     Count  CC  SLOP Location              
 -------------- ----- --- ----- ----------------------
-BEGIN              1   1   1.0 tests/recursive_sub:10
-recursive_func     4   2   2.0 tests/recursive_sub:14
+BEGIN              1   1   0.0 tests/recursive_sub:10
+recursive_func     4   2   6.9 tests/recursive_sub:14
 
 

--- a/test_output/cover/recursive_sub.5.020000
+++ b/test_output/cover/recursive_sub.5.020000
@@ -52,9 +52,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine     Count Location              
--------------- ----- ----------------------
-BEGIN              1 tests/recursive_sub:10
-recursive_func     4 tests/recursive_sub:14
+Subroutine     Count  CC  CRAP Location              
+-------------- ----- --- ----- ----------------------
+BEGIN              1   1   1.0 tests/recursive_sub:10
+recursive_func     4   2   2.0 tests/recursive_sub:14
 
 

--- a/test_output/cover/redefine_sub.5.020000
+++ b/test_output/cover/redefine_sub.5.020000
@@ -51,9 +51,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location             
----------- ----- ---------------------
-__ANON__       2 tests/redefine_sub:15
-s1             2 tests/redefine_sub:4 
+Subroutine Count  CC  CRAP Location             
+---------- ----- --- ----- ---------------------
+__ANON__       2   1   1.0 tests/redefine_sub:15
+s1             2   2   2.0 tests/redefine_sub:4 
 
 

--- a/test_output/cover/redefine_sub.5.020000
+++ b/test_output/cover/redefine_sub.5.020000
@@ -51,9 +51,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location             
+Subroutine Count  CC  SLOP Location             
 ---------- ----- --- ----- ---------------------
-__ANON__       2   1   1.0 tests/redefine_sub:15
-s1             2   2   2.0 tests/redefine_sub:4 
+__ANON__       2   1   0.0 tests/redefine_sub:15
+s1             2   2   6.9 tests/redefine_sub:4 
 
 

--- a/test_output/cover/require.5.020000
+++ b/test_output/cover/require.5.020000
@@ -41,9 +41,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location
+Subroutine Count  CC  SLOP Location
 ---------- ----- --- ----- --------
-E2             0   1   2.0 E2.pm:12
+E2             0   1   6.9 E2.pm:12
 
 
 require
@@ -78,9 +78,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location  
+Subroutine Count  CC  SLOP Location  
 ---------- ----- --- ----- ----------
-BEGIN          1   2   2.0 require:10
-BEGIN          1   1   1.0 require:11
+BEGIN          1   2   7.1 require:10
+BEGIN          1   1   0.0 require:11
 
 

--- a/test_output/cover/require.5.020000
+++ b/test_output/cover/require.5.020000
@@ -41,9 +41,9 @@ line  err   stmt   bran   cond    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location
----------- ----- --------
-E2             0 E2.pm:12
+Subroutine Count  CC  CRAP Location
+---------- ----- --- ----- --------
+E2             0   1   2.0 E2.pm:12
 
 
 require
@@ -78,9 +78,9 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location  
----------- ----- ----------
-BEGIN          1 require:10
-BEGIN          1 require:11
+Subroutine Count  CC  CRAP Location  
+---------- ----- --- ----- ----------
+BEGIN          1   2   2.0 require:10
+BEGIN          1   1   1.0 require:11
 
 

--- a/test_output/cover/signature.5.032000
+++ b/test_output/cover/signature.5.032000
@@ -58,11 +58,11 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location          
----------- ----- ------------------
-BEGIN          1 tests/signature:13
-BEGIN          1 tests/signature:14
-BEGIN          1 tests/signature:15
-xx             1 tests/signature:17
+Subroutine Count  CC  CRAP Location          
+---------- ----- --- ----- ------------------
+BEGIN          1   1   1.0 tests/signature:13
+BEGIN          1   1   1.0 tests/signature:14
+BEGIN          1   1   1.0 tests/signature:15
+xx             1   2   2.0 tests/signature:17
 
 

--- a/test_output/cover/signature.5.032000
+++ b/test_output/cover/signature.5.032000
@@ -58,11 +58,11 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location          
+Subroutine Count  CC  SLOP Location          
 ---------- ----- --- ----- ------------------
-BEGIN          1   1   1.0 tests/signature:13
-BEGIN          1   1   1.0 tests/signature:14
-BEGIN          1   1   1.0 tests/signature:15
-xx             1   2   2.0 tests/signature:17
+BEGIN          1   1   0.0 tests/signature:13
+BEGIN          1   1   0.0 tests/signature:14
+BEGIN          1   1   0.0 tests/signature:15
+xx             1   2   6.9 tests/signature:17
 
 

--- a/test_output/cover/skip.5.020000
+++ b/test_output/cover/skip.5.020000
@@ -51,8 +51,8 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location     
+Subroutine Count  CC  SLOP Location     
 ---------- ----- --- ----- -------------
-main           1   3   3.3 tests/skip:11
+main           1   3  12.0 tests/skip:11
 
 

--- a/test_output/cover/skip.5.020000
+++ b/test_output/cover/skip.5.020000
@@ -51,8 +51,8 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location     
----------- ----- -------------
-main           1 tests/skip:11
+Subroutine Count  CC  CRAP Location     
+---------- ----- --- ----- -------------
+main           1   3   3.3 tests/skip:11
 
 

--- a/test_output/cover/sort.5.020000
+++ b/test_output/cover/sort.5.020000
@@ -80,20 +80,20 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine   Count Location     
------------- ----- -------------
-BEGIN            1 tests/sort:3 
-BEGIN            1 tests/sort:30
-GetAlgorithm     1 tests/sort:19
-backwards        6 tests/sort:11
-fail             1 tests/sort:37
-xyz              8 tests/sort:42
+Subroutine   Count  CC  CRAP Location     
+------------ ----- --- ----- -------------
+BEGIN            1   1   1.0 tests/sort:3 
+BEGIN            1   1   1.0 tests/sort:30
+GetAlgorithm     1   1   1.0 tests/sort:19
+backwards        6   1   1.0 tests/sort:11
+fail             1   1   1.0 tests/sort:37
+xyz              8   1   1.0 tests/sort:42
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine   Count Location     
------------- ----- -------------
-forwards         0 tests/sort:15
+Subroutine   Count  CC  CRAP Location     
+------------ ----- --- ----- -------------
+forwards         0   1   2.0 tests/sort:15
 
 

--- a/test_output/cover/sort.5.020000
+++ b/test_output/cover/sort.5.020000
@@ -80,20 +80,20 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  CRAP Location     
+Subroutine   Count  CC  SLOP Location     
 ------------ ----- --- ----- -------------
-BEGIN            1   1   1.0 tests/sort:3 
-BEGIN            1   1   1.0 tests/sort:30
-GetAlgorithm     1   1   1.0 tests/sort:19
-backwards        6   1   1.0 tests/sort:11
-fail             1   1   1.0 tests/sort:37
-xyz              8   1   1.0 tests/sort:42
+BEGIN            1   1   0.0 tests/sort:3 
+BEGIN            1   1   0.0 tests/sort:30
+GetAlgorithm     1   1   0.0 tests/sort:19
+backwards        6   1   0.0 tests/sort:11
+fail             1   1   0.0 tests/sort:37
+xyz              8   1   0.0 tests/sort:42
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine   Count  CC  CRAP Location     
+Subroutine   Count  CC  SLOP Location     
 ------------ ----- --- ----- -------------
-forwards         0   1   2.0 tests/sort:15
+forwards         0   1   6.9 tests/sort:15
 
 

--- a/test_output/cover/sort_or.5.020000
+++ b/test_output/cover/sort_or.5.020000
@@ -110,10 +110,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-BEGIN          1 tests/sort_or:10
-BEGIN          1 tests/sort_or:11
-boom           1 tests/sort_or:50
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+BEGIN          1   1   1.0 tests/sort_or:10
+BEGIN          1   1   1.0 tests/sort_or:11
+boom           1   1   1.0 tests/sort_or:50
 
 

--- a/test_output/cover/sort_or.5.020000
+++ b/test_output/cover/sort_or.5.020000
@@ -110,10 +110,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-BEGIN          1   1   1.0 tests/sort_or:10
-BEGIN          1   1   1.0 tests/sort_or:11
-boom           1   1   1.0 tests/sort_or:50
+BEGIN          1   1   0.0 tests/sort_or:10
+BEGIN          1   1   0.0 tests/sort_or:11
+boom           1   1   0.0 tests/sort_or:50
 
 

--- a/test_output/cover/sort_or.5.022000
+++ b/test_output/cover/sort_or.5.022000
@@ -112,10 +112,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-BEGIN          1 tests/sort_or:10
-BEGIN          1 tests/sort_or:11
-boom           1 tests/sort_or:50
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+BEGIN          1   1   1.0 tests/sort_or:10
+BEGIN          1   1   1.0 tests/sort_or:11
+boom           1   1   1.0 tests/sort_or:50
 
 

--- a/test_output/cover/sort_or.5.022000
+++ b/test_output/cover/sort_or.5.022000
@@ -112,10 +112,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-BEGIN          1   1   1.0 tests/sort_or:10
-BEGIN          1   1   1.0 tests/sort_or:11
-boom           1   1   1.0 tests/sort_or:50
+BEGIN          1   1   0.0 tests/sort_or:10
+BEGIN          1   1   0.0 tests/sort_or:11
+boom           1   1   0.0 tests/sort_or:50
 
 

--- a/test_output/cover/sort_or.5.026000
+++ b/test_output/cover/sort_or.5.026000
@@ -112,10 +112,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-BEGIN          1 tests/sort_or:10
-BEGIN          1 tests/sort_or:11
-boom           1 tests/sort_or:50
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+BEGIN          1   1   1.0 tests/sort_or:10
+BEGIN          1   1   1.0 tests/sort_or:11
+boom           1   1   1.0 tests/sort_or:50
 
 

--- a/test_output/cover/sort_or.5.026000
+++ b/test_output/cover/sort_or.5.026000
@@ -112,10 +112,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-BEGIN          1   1   1.0 tests/sort_or:10
-BEGIN          1   1   1.0 tests/sort_or:11
-boom           1   1   1.0 tests/sort_or:50
+BEGIN          1   1   0.0 tests/sort_or:10
+BEGIN          1   1   0.0 tests/sort_or:11
+boom           1   1   0.0 tests/sort_or:50
 
 

--- a/test_output/cover/sort_or.5.043008
+++ b/test_output/cover/sort_or.5.043008
@@ -112,10 +112,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location        
----------- ----- ----------------
-BEGIN          1 tests/sort_or:10
-BEGIN          1 tests/sort_or:11
-boom           1 tests/sort_or:50
+Subroutine Count  CC  CRAP Location        
+---------- ----- --- ----- ----------------
+BEGIN          1   1   1.0 tests/sort_or:10
+BEGIN          1   1   1.0 tests/sort_or:11
+boom           1   1   1.0 tests/sort_or:50
 
 

--- a/test_output/cover/sort_or.5.043008
+++ b/test_output/cover/sort_or.5.043008
@@ -112,10 +112,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location        
+Subroutine Count  CC  SLOP Location        
 ---------- ----- --- ----- ----------------
-BEGIN          1   1   1.0 tests/sort_or:10
-BEGIN          1   1   1.0 tests/sort_or:11
-boom           1   1   1.0 tests/sort_or:50
+BEGIN          1   1   0.0 tests/sort_or:10
+BEGIN          1   1   0.0 tests/sort_or:11
+boom           1   1   0.0 tests/sort_or:50
 
 

--- a/test_output/cover/special_blocks.5.020000
+++ b/test_output/cover/special_blocks.5.020000
@@ -58,13 +58,13 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location               
+Subroutine Count  CC  SLOP Location               
 ---------- ----- --- ----- -----------------------
-BEGIN          1   1   1.0 tests/special_blocks:10
-BEGIN          1   1   1.0 tests/special_blocks:11
-BEGIN          1   1   1.0 tests/special_blocks:16
-CHECK          1   1   1.0 tests/special_blocks:20
-END            1   1   1.0 tests/special_blocks:28
-INIT           1   1   1.0 tests/special_blocks:24
+BEGIN          1   1   0.0 tests/special_blocks:10
+BEGIN          1   1   0.0 tests/special_blocks:11
+BEGIN          1   1   0.0 tests/special_blocks:16
+CHECK          1   1   0.0 tests/special_blocks:20
+END            1   1   0.0 tests/special_blocks:28
+INIT           1   1   0.0 tests/special_blocks:24
 
 

--- a/test_output/cover/special_blocks.5.020000
+++ b/test_output/cover/special_blocks.5.020000
@@ -58,13 +58,13 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location               
----------- ----- -----------------------
-BEGIN          1 tests/special_blocks:10
-BEGIN          1 tests/special_blocks:11
-BEGIN          1 tests/special_blocks:16
-CHECK          1 tests/special_blocks:20
-END            1 tests/special_blocks:28
-INIT           1 tests/special_blocks:24
+Subroutine Count  CC  CRAP Location               
+---------- ----- --- ----- -----------------------
+BEGIN          1   1   1.0 tests/special_blocks:10
+BEGIN          1   1   1.0 tests/special_blocks:11
+BEGIN          1   1   1.0 tests/special_blocks:16
+CHECK          1   1   1.0 tests/special_blocks:20
+END            1   1   1.0 tests/special_blocks:28
+INIT           1   1   1.0 tests/special_blocks:24
 
 

--- a/test_output/cover/subs_only.5.020000
+++ b/test_output/cover/subs_only.5.020000
@@ -52,8 +52,8 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location          
+Subroutine Count  CC  SLOP Location          
 ---------- ----- --- ----- ------------------
-xx            11   1   1.0 tests/subs_only:20
+xx            11   1   0.0 tests/subs_only:20
 
 

--- a/test_output/cover/subs_only.5.020000
+++ b/test_output/cover/subs_only.5.020000
@@ -52,8 +52,8 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location          
----------- ----- ------------------
-xx            11 tests/subs_only:20
+Subroutine Count  CC  CRAP Location          
+---------- ----- --- ----- ------------------
+xx            11   1   1.0 tests/subs_only:20
 
 

--- a/test_output/cover/t0.5.020000
+++ b/test_output/cover/t0.5.020000
@@ -87,9 +87,9 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location   
----------- ----- -----------
-BEGIN          1 tests/t0:10
-BEGIN          1 tests/t0:11
+Subroutine Count  CC  CRAP Location   
+---------- ----- --- ----- -----------
+BEGIN          1   1   1.0 tests/t0:10
+BEGIN          1   1   1.0 tests/t0:11
 
 

--- a/test_output/cover/t0.5.020000
+++ b/test_output/cover/t0.5.020000
@@ -87,9 +87,9 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location   
+Subroutine Count  CC  SLOP Location   
 ---------- ----- --- ----- -----------
-BEGIN          1   1   1.0 tests/t0:10
-BEGIN          1   1   1.0 tests/t0:11
+BEGIN          1   1   0.0 tests/t0:10
+BEGIN          1   1   0.0 tests/t0:11
 
 

--- a/test_output/cover/t0.5.043008
+++ b/test_output/cover/t0.5.043008
@@ -87,9 +87,9 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location   
----------- ----- -----------
-BEGIN          1 tests/t0:10
-BEGIN          1 tests/t0:11
+Subroutine Count  CC  CRAP Location   
+---------- ----- --- ----- -----------
+BEGIN          1   1   1.0 tests/t0:10
+BEGIN          1   1   1.0 tests/t0:11
 
 

--- a/test_output/cover/t0.5.043008
+++ b/test_output/cover/t0.5.043008
@@ -87,9 +87,9 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location   
+Subroutine Count  CC  SLOP Location   
 ---------- ----- --- ----- -----------
-BEGIN          1   1   1.0 tests/t0:10
-BEGIN          1   1   1.0 tests/t0:11
+BEGIN          1   1   0.0 tests/t0:10
+BEGIN          1   1   0.0 tests/t0:11
 
 

--- a/test_output/cover/t1.5.020000
+++ b/test_output/cover/t1.5.020000
@@ -46,10 +46,10 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location   
+Subroutine Count  CC  SLOP Location   
 ---------- ----- --- ----- -----------
-BEGIN          1   1   1.0 tests/t1:10
-BEGIN          1   1   1.0 tests/t1:11
-xx             1   1   1.0 tests/t1:16
+BEGIN          1   1   0.0 tests/t1:10
+BEGIN          1   1   0.0 tests/t1:11
+xx             1   1   0.0 tests/t1:16
 
 

--- a/test_output/cover/t1.5.020000
+++ b/test_output/cover/t1.5.020000
@@ -46,10 +46,10 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location   
----------- ----- -----------
-BEGIN          1 tests/t1:10
-BEGIN          1 tests/t1:11
-xx             1 tests/t1:16
+Subroutine Count  CC  CRAP Location   
+---------- ----- --- ----- -----------
+BEGIN          1   1   1.0 tests/t1:10
+BEGIN          1   1   1.0 tests/t1:11
+xx             1   1   1.0 tests/t1:16
 
 

--- a/test_output/cover/t2.5.020000
+++ b/test_output/cover/t2.5.020000
@@ -72,10 +72,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location   
+Subroutine Count  CC  SLOP Location   
 ---------- ----- --- ----- -----------
-BEGIN          1   1   1.0 tests/t2:10
-BEGIN          1   1   1.0 tests/t2:11
-xx            11   1   1.0 tests/t2:16
+BEGIN          1   1   0.0 tests/t2:10
+BEGIN          1   1   0.0 tests/t2:11
+xx            11   1   0.0 tests/t2:16
 
 

--- a/test_output/cover/t2.5.020000
+++ b/test_output/cover/t2.5.020000
@@ -72,10 +72,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location   
----------- ----- -----------
-BEGIN          1 tests/t2:10
-BEGIN          1 tests/t2:11
-xx            11 tests/t2:16
+Subroutine Count  CC  CRAP Location   
+---------- ----- --- ----- -----------
+BEGIN          1   1   1.0 tests/t2:10
+BEGIN          1   1   1.0 tests/t2:11
+xx            11   1   1.0 tests/t2:16
 
 

--- a/test_output/cover/t2.5.043008
+++ b/test_output/cover/t2.5.043008
@@ -72,10 +72,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location   
+Subroutine Count  CC  SLOP Location   
 ---------- ----- --- ----- -----------
-BEGIN          1   1   1.0 tests/t2:10
-BEGIN          1   1   1.0 tests/t2:11
-xx            11   1   1.0 tests/t2:16
+BEGIN          1   1   0.0 tests/t2:10
+BEGIN          1   1   0.0 tests/t2:11
+xx            11   1   0.0 tests/t2:16
 
 

--- a/test_output/cover/t2.5.043008
+++ b/test_output/cover/t2.5.043008
@@ -72,10 +72,10 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count Location   
----------- ----- -----------
-BEGIN          1 tests/t2:10
-BEGIN          1 tests/t2:11
-xx            11 tests/t2:16
+Subroutine Count  CC  CRAP Location   
+---------- ----- --- ----- -----------
+BEGIN          1   1   1.0 tests/t2:10
+BEGIN          1   1   1.0 tests/t2:11
+xx            11   1   1.0 tests/t2:16
 
 

--- a/test_output/cover/taint.5.020000
+++ b/test_output/cover/taint.5.020000
@@ -47,11 +47,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location      
+Subroutine Count  CC  SLOP Location      
 ---------- ----- --- ----- --------------
-BEGIN          1   1   1.0 tests/taint:10
-BEGIN          1   1   1.0 tests/taint:11
-BEGIN          1   1   1.0 tests/taint:12
-BEGIN          1   1   1.0 tests/taint:14
+BEGIN          1   1   0.0 tests/taint:10
+BEGIN          1   1   0.0 tests/taint:11
+BEGIN          1   1   0.0 tests/taint:12
+BEGIN          1   1   0.0 tests/taint:14
 
 

--- a/test_output/cover/taint.5.020000
+++ b/test_output/cover/taint.5.020000
@@ -47,11 +47,11 @@ line  err   stmt   bran   cond    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count Location      
----------- ----- --------------
-BEGIN          1 tests/taint:10
-BEGIN          1 tests/taint:11
-BEGIN          1 tests/taint:12
-BEGIN          1 tests/taint:14
+Subroutine Count  CC  CRAP Location      
+---------- ----- --- ----- --------------
+BEGIN          1   1   1.0 tests/taint:10
+BEGIN          1   1   1.0 tests/taint:11
+BEGIN          1   1   1.0 tests/taint:12
+BEGIN          1   1   1.0 tests/taint:14
 
 

--- a/test_output/cover/uncoverable.5.020000
+++ b/test_output/cover/uncoverable.5.020000
@@ -129,8 +129,8 @@ line  err      %     !l  l&&!r   l&&r   expr
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  CRAP Location            
+Subroutine Count  CC  SLOP Location            
 ---------- ----- --- ----- --------------------
-z             -0   1   1.0 tests/uncoverable:44
+z             -0   1   0.0 tests/uncoverable:44
 
 

--- a/test_output/cover/uncoverable.5.020000
+++ b/test_output/cover/uncoverable.5.020000
@@ -129,8 +129,8 @@ line  err      %     !l  l&&!r   l&&r   expr
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Location            
----------- ----- --------------------
-z             -0 tests/uncoverable:44
+Subroutine Count  CC  CRAP Location            
+---------- ----- --- ----- --------------------
+z             -0   1   1.0 tests/uncoverable:44
 
 

--- a/test_output/cover/uncoverable_error.5.020000
+++ b/test_output/cover/uncoverable_error.5.020000
@@ -101,9 +101,9 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location                  
+Subroutine Count  CC  SLOP Location                  
 ---------- ----- --- ----- --------------------------
-main           1   8   8.7 tests/uncoverable_error:17
-usub          -1   1   1.0 tests/uncoverable_error:13
+main           1   8  21.7 tests/uncoverable_error:17
+usub          -1   1   0.0 tests/uncoverable_error:13
 
 

--- a/test_output/cover/uncoverable_error.5.020000
+++ b/test_output/cover/uncoverable_error.5.020000
@@ -101,9 +101,9 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location                  
----------- ----- --------------------------
-main           1 tests/uncoverable_error:17
-usub          -1 tests/uncoverable_error:13
+Subroutine Count  CC  CRAP Location                  
+---------- ----- --- ----- --------------------------
+main           1   8   8.7 tests/uncoverable_error:17
+usub          -1   1   1.0 tests/uncoverable_error:13
 
 

--- a/test_output/cover/uncoverable_error_ignore.5.020000
+++ b/test_output/cover/uncoverable_error_ignore.5.020000
@@ -101,9 +101,9 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  CRAP Location                         
+Subroutine Count  CC  SLOP Location                         
 ---------- ----- --- ----- ---------------------------------
-main           1   8   8.7 tests/uncoverable_error_ignore:19
-usub          -1   1   1.0 tests/uncoverable_error_ignore:15
+main           1   8  21.7 tests/uncoverable_error_ignore:19
+usub          -1   1   0.0 tests/uncoverable_error_ignore:15
 
 

--- a/test_output/cover/uncoverable_error_ignore.5.020000
+++ b/test_output/cover/uncoverable_error_ignore.5.020000
@@ -101,9 +101,9 @@ line  err      %     !l  l&&!r   l&&r   expr
 Covered Subroutines
 -------------------
 
-Subroutine Count Location                         
----------- ----- ---------------------------------
-main           1 tests/uncoverable_error_ignore:19
-usub          -1 tests/uncoverable_error_ignore:15
+Subroutine Count  CC  CRAP Location                         
+---------- ----- --- ----- ---------------------------------
+main           1   8   8.7 tests/uncoverable_error_ignore:19
+usub          -1   1   1.0 tests/uncoverable_error_ignore:15
 
 


### PR DESCRIPTION
Fixes #448

## Summary

Replaces the CRAP (Change Risk Anti-Patterns) metric with SLOP (Scaled Likelihood Of Problems), a new risk scoring formula that combines cyclomatic complexity with coverage data to highlight code most likely to harbour defects.

Key changes:

- Cyclomatic complexity (CC) computation during the optree walk, including signature defaults as decision points
- Sub end line tracking in the XS walker
- SLOP scoring at subroutine, file, and directory levels
- CC and SLOP columns in the Text report
- SLOP display in Html_crisp with tooltips, badges, and a "Top SLOP" index
- Technical design document in `docs/technical/slop.md`
- Regenerated golden files for all affected tests

## Test plan

- New `t/internal/complexity.t` covering CC counting, SLOP computation, and file-level aggregation
- Extended `t/internal/html_crisp_render.t` and `t/internal/structure.t`
- All golden files regenerated