### PR TITLE
GH-454 Centralise output via Log module

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -20,6 +20,7 @@ BEGIN {
 
 use Devel::Cover::DB  ();
 use Devel::Cover::Inc ();
+use Devel::Cover::Log qw( dcerror dcinfo );
 
 BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
 
@@ -67,13 +68,13 @@ sub check_self_coverage () {
     && $INC{"Devel/Cover.pm"}
     && !Devel::Cover::has_select()
   ) {
-    my $err = "$0 shouldn't be run with coverage turned on.\n";
+    my $err = "$0 shouldn't be run with coverage turned on.";
     eval {
       require POSIX;
-      print STDERR $err;
+      dcerror $err;
       POSIX::_exit(1);
     };
-    die $err;
+    die "$err\n";
   }
 }
 
@@ -181,7 +182,7 @@ sub check_options () {
       my $format = "Devel::Cover::Report::\u$report";
       eval "use $format";
       if ($@) {
-        print "Error: $report is not a recognised output format\n$@\n\n";
+        dcerror "$report is not a recognised output format\n$@";
         ()
       } else {
         $report
@@ -199,7 +200,7 @@ sub check_options () {
     my $annotation = "Devel::Cover::Annotation::\u$a";
     eval "use $annotation";
     if ($@) {
-      print "Error: $a is not a recognised annotation\n\n$@";
+      dcerror "$a is not a recognised annotation\n$@";
       exit 1;
     }
     my $ann = $annotation->new;
@@ -229,11 +230,10 @@ sub delete_db (@dbs) {
   for my $del (@dbs) {
     my $db = Devel::Cover::DB->new(db => $del);
     unless ($db->is_valid) {
-      print "Devel::Cover: $del is an invalid database - ignoring\n"
-        unless $Options->{silent};
+      dcinfo "$del is an invalid database - ignoring";
       next;
     }
-    print "Deleting database $del\n" if $db->exists && !$Options->{silent};
+    dcinfo "Deleting database $del" if $db->exists;
     $db->delete;
     rmtree($del);
   }
@@ -320,7 +320,7 @@ sub do_test ($dbname) {
     File::Find::find({ wanted => $xs, no_chdir => 0 }, ".");
   }
   # print STDERR "$_: $ENV{$_}\n" for qw(PERL5OPT HARNESS_PERL_SWITCHES);
-  print STDERR "cover: running $test\n";
+  dcinfo "running $test";
   my $test_result = system $test;
   $test_result >>= 8;
 }
@@ -343,7 +343,7 @@ sub do_gcov ($dbname) {
     $gcov_flags .= "r" if $Options->{relative_only};
     my @args = $Options->{gcov_chdir} ? () : ("-o", $File::Find::dir);
     my @c    = ("gcov", $gcov_flags, @args, $name);
-    print STDERR "cover: running @c\n";
+    dcinfo "running @c";
     system @c;
   };
   File::Find::find({ wanted => $gc, no_chdir => !$Options->{gcov_chdir} }, ".");
@@ -368,7 +368,8 @@ sub do_gcov ($dbname) {
 
     # print STDERR "cover: test [$o]\n";
     my @c = ($^X, @opts, $gcov2perl, "-db", $dbname, @gc);
-    print STDERR "cover: running @c\n";
+    push @c, "-silent" if $Options->{silent};
+    dcinfo "running @c";
     system @c;
   }
 }
@@ -385,7 +386,7 @@ sub scan_select_dirs ($db) {
 
   for my $dir ($Options->{select_dir}->@*) {
     unless (-d $dir) {
-      warn "cover: --select_dir directory does not exist: $dir\n";
+      dcerror "--select_dir directory does not exist: $dir";
       next;
     }
     File::Find::find({ wanted => $wanted, no_chdir => 1 }, $dir);
@@ -393,19 +394,17 @@ sub scan_select_dirs ($db) {
 
   $db->{files} = [sort @files];
   $db->write($db->{db});
-  print "Added ", scalar @files, " file(s) from --select_dir\n"
-    unless $Options->{silent};
+  dcinfo "Added " . (scalar @files) . " file(s) from --select_dir";
   unless (eval { require PPI; 1 }) {
-    print "PPI is not installed. Coverage estimates for untested"
+    dcinfo "PPI is not installed. Coverage estimates for untested"
       . " files are unavailable.\n"
-      . "Install PPI from CPAN for per-criteria counts.\n"
-      unless $Options->{silent};
+      . "Install PPI from CPAN for per-criteria counts.";
   }
 }
 
 sub manage_dbs ($dbname, $test_result) {
 
-  print "Reading database from $dbname\n" unless $Options->{silent};
+  dcinfo "Reading database from $dbname";
   my $db = Devel::Cover::DB->new(
     db               => $dbname,
     prefer_lib       => $Options->{prefer_lib},
@@ -433,7 +432,7 @@ sub manage_dbs ($dbname, $test_result) {
 
   for my $merge (@ARGV) {
     $read_structure->();
-    print "Merging database from $merge\n" unless $Options->{silent};
+    dcinfo "Merging database from $merge";
     my $mdb = Devel::Cover::DB->new(db => $merge);
     $mdb = $mdb->merge_runs;
     $db->merge($mdb);
@@ -461,7 +460,7 @@ sub manage_dbs ($dbname, $test_result) {
 
   if (exists $Options->{write}) {
     $dbname = $Options->{write} if length $Options->{write};
-    print "Writing database to $dbname\n" unless $Options->{silent};
+    dcinfo "Writing database to $dbname";
     $db->write($dbname);
     $read_structure->();
     $structure->write($dbname);
@@ -478,8 +477,6 @@ sub manage_dbs ($dbname, $test_result) {
   $read_structure->();
   $db->set_structure($structure);
   $db->calculate_summary(map { $_ => 1 } $Options->{coverage}->@*);
-
-  print "\n\n" unless $Options->{silent};
 
   $db
 }
@@ -523,8 +520,7 @@ sub run_reports ($db, $argv) {
       if ($format->can("launch")) {
         $format->launch($options);
       } else {
-        print STDERR "The launch option is not available for the ",
-          "$report report.\n"
+        dcerror "The launch option is not available for the $report report.";
       }
     }
   }

--- a/bin/gcov2perl
+++ b/bin/gcov2perl
@@ -15,12 +15,15 @@ no warnings qw( experimental::signatures experimental::postderef );
 
 # VERSION
 
-use Devel::Cover::DB ();
+use Devel::Cover::DB  ();
+use Devel::Cover::Log qw( dcerror dcinfo );
 
 use File::Path   qw( mkpath );
 use File::Spec   ();
 use Getopt::Long qw( GetOptions );
 use Pod::Usage   qw( pod2usage );
+
+$Devel::Cover::Log::Prefix = "gcov2perl";
 
 my $Options = { db => "cover_db" };
 
@@ -28,8 +31,9 @@ sub get_options () {
   die "Bad option"
     unless GetOptions(
       $Options,  # Store the options in the Options hash
-      qw( db=s help|h! info|i! version|v! )
+      qw( db=s help|h! info|i! silent! version|v! )
     );
+  $Devel::Cover::Silent = 1 if $Options->{silent};
   print "$0 version " . __PACKAGE__->VERSION . "\n" and exit 0
     if $Options->{version};
   pod2usage(-exitval => 0, -verbose => 0) if $Options->{help};
@@ -66,7 +70,7 @@ sub add_cover ($file) {
     }
     unless (defined $run{digests}{$f}) {
       unless (-f $f) {
-        warn "no source $f found for $file\n";
+        dcerror "no source $f found for $file";
         close $fh or die "Can't close $file: $!\n";
         return;
       }
@@ -105,8 +109,9 @@ sub add_cover ($file) {
         $structure->add_branch($f, [ $line, { text => $text } ]);
         push $run{count}{$f}{branch}->@*, \@branches;
       } else {
-        warn "gcov2perl: Warning: ignoring branch with ", scalar @branches,
-          " targets at $f:$line $text\n";
+        dcinfo "Warning: ignoring branch with "
+          . scalar @branches
+          . " targets at $f:$line $text";
       }
       redo gcov_line;  # process the line after the branch data
     }
@@ -127,7 +132,7 @@ sub add_cover ($file) {
 
   $cover->{db} = $db;
 
-  print STDOUT "gcov2perl: Writing coverage database to $db\n";
+  dcinfo "Writing coverage database to $db";
   $cover->write;
 }
 

--- a/bin/gcov2perl
+++ b/bin/gcov2perl
@@ -31,7 +31,7 @@ sub get_options () {
   die "Bad option"
     unless GetOptions(
       $Options,  # Store the options in the Options hash
-      qw( db=s help|h! info|i! silent! version|v! )
+      qw( db=s help|h! info|i! silent! version|v! ),
     );
   $Devel::Cover::Silent = 1 if $Options->{silent};
   print "$0 version " . __PACKAGE__->VERSION . "\n" and exit 0
@@ -106,7 +106,7 @@ sub add_cover ($file) {
       # print "branches on $f:$line are: @branches\n";
 
       if (@branches == 2) {
-        $structure->add_branch($f, [ $line, { text => $text } ]);
+        $structure->add_branch($f, [$line, { text => $text }]);
         push $run{count}{$f}{branch}->@*, \@branches;
       } else {
         dcinfo "Warning: ignoring branch with "
@@ -123,7 +123,7 @@ sub add_cover ($file) {
   my $cover = Devel::Cover::DB->new(
     base      => $db,
     runs      => { $run => \%run },
-    structure => $structure
+    structure => $structure,
   );
 
   $db .= "/runs";
@@ -153,7 +153,7 @@ gcov2perl - convert gcov files to Devel::Cover databases
 
 =head1 SYNOPSIS
 
- gcov2perl -h -i -v -db database gcov_files
+  gcov2perl -h -i -v -db database gcov_files
 
 =head1 DESCRIPTION
 
@@ -163,11 +163,12 @@ Convert gcov files to Devel::Cover databases.
 
 The following command line options are supported:
 
- -db database    - specify the database to use
+  -db database    - specify the database to use
+  -silent         - suppress informational messages (default off)
 
- -h -help        - show help
- -i -info        - show documentation
- -v -version     - show version
+  -h -help        - show help
+  -i -info        - show documentation
+  -v -version     - show version
 
 =head1 DETAILS
 
@@ -175,9 +176,9 @@ To obtain coverage of XS files they must first be compiled with the appropriate
 options.  In a standard Makefile environment, such as that created by
 ExtUtils::MakeMaker, this can be accomplished with the command:
 
- HARNESS_PERL_SWITCHES=-MDevel::Cover make test \
-   CCFLAGS=-O0\ -fprofile-arcs\ -ftest-coverage \
-   OTHERLDFLAGS=-fprofile-arcs\ -ftest-coverage
+  HARNESS_PERL_SWITCHES=-MDevel::Cover make test \
+    CCFLAGS=-O0\ -fprofile-arcs\ -ftest-coverage \
+    OTHERLDFLAGS=-fprofile-arcs\ -ftest-coverage
 
 If you have already built your object files it may be necessary to run make
 clean first, or to find some other way to ensure that they get rebuilt with the
@@ -185,31 +186,31 @@ options gcov requires.
 
 Now the code coverage data has been collected C<gcov> needs to be run:
 
- gcov Mylib.xs
+  gcov Mylib.xs
 
 This will create one or more gcov files on which you can run C<gcov2perl>:
 
- gcov2perl Mylib.xs.gcov
+  gcov2perl Mylib.xs.gcov
 
 Finally, C<cover> should be run as usual with any options required:
 
- cover
+  cover
 
 If you are running everything with standard options, you can do all this with
 one command:
 
- cover -test
+  cover -test
 
 =head1 EXIT STATUS
 
 The following exit values are returned:
 
- 0   All files converted successfully
- >0  An error occurred.
+  0   All files converted successfully
+  >0  An error occurred.
 
 =head1 SEE ALSO
 
- Devel::Cover
+  Devel::Cover
 
 =head1 LICENCE
 

--- a/lib/Devel/Cover/Base/Editor.pm
+++ b/lib/Devel/Cover/Base/Editor.pm
@@ -14,13 +14,14 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
+use Devel::Cover::Log qw( dcinfo );
 use Template 2.00 ();
 
 sub report ($pkg, $db, $options) {
   my $template = Template->new({
     LOAD_TEMPLATES => [
       Devel::Cover::Base::Editor::Template::Provider->new({
-        editor_class => $pkg, })
+        editor_class => $pkg })
     ],
   });
 
@@ -44,15 +45,15 @@ sub report ($pkg, $db, $options) {
     },
     version => $pkg->VERSION,
     files   =>
-      [ grep !$db->cover->file($_)->{meta}{uncompiled}, $options->{file}->@* ],
+      [grep !$db->cover->file($_)->{meta}{uncompiled}, $options->{file}->@*],
     cover => $db->cover,
-    types => [ grep $_ ne "time", keys $options->{show}->%* ],
+    types => [grep $_ ne "time", keys $options->{show}->%*],
   };
 
   my $out = "$options->{outputdir}/$options->{outputfile}";
   $template->process($pkg->template_name, $vars, $out) or die $template->error;
 
-  print $pkg->output_message($out) . "\n" unless $options->{silent};
+  dcinfo $pkg->output_message($out);
 }
 
 sub template_name  { die "Subclass must implement template_name" }

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -17,6 +17,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 use Devel::Cover::Criterion ();
 use Devel::Cover::DB::File  ();
 use Devel::Cover::DB::IO    ();
+use Devel::Cover::Log       qw( dcinfo );
 
 use Carp         qw( carp croak );
 use File::Find   qw( find );
@@ -181,8 +182,7 @@ sub validate_db ($self) {
   # die if the db is invalid.
 
   # just warn for now
-  print STDERR "Devel::Cover: $self->{db} is an invalid database\n"
-    unless $self->is_valid;
+  dcinfo "$self->{db} is an invalid database" unless $self->is_valid;
 
   $self
 }
@@ -221,9 +221,7 @@ sub merge ($self, $from) {
           && $run->{digests}{$file} ne $digest
         ) {
           # File has changed.  Delete old coverage instead of merging.
-          print STDOUT "Devel::Cover: Deleting old coverage for ",
-            "changed file $file\n"
-            unless $Devel::Cover::Silent;
+          dcinfo "Deleting old coverage for changed file $file";
           delete $run->{digests}{$file};
           delete $run->{count}{$file};
           delete $run->{vec}{$file};
@@ -780,8 +778,7 @@ sub uncoverable ($self) {
 
   for my $file ($self->uncoverable_files) {
     open my $f, "<", $file or next;
-    print STDOUT "Reading uncoverable information from $file\n"
-      unless $Devel::Cover::Silent;
+    dcinfo "Reading uncoverable information from $file";
     while (<$f>) {
       chomp;
       my ($file, $crit, $line, $count, $type, $class, $note) = split " ", $_, 7;
@@ -1002,9 +999,8 @@ sub _file_digest ($r, $file) {
   no warnings "once";
   my $digest = $r->{digests}{$file};
   return $digest if $digest;
-  print STDERR "Devel::Cover: Can't find digest for $file\n"
-    unless $Devel::Cover::Silent
-    || $file =~ $Devel::Cover::DB::Ignore_filenames
+  dcinfo "Can't find digest for $file"
+    unless $file =~ $Devel::Cover::DB::Ignore_filenames
     || ($Devel::Cover::Self_cover && $file =~ "/Devel/Cover[./]");
   undef
 }
@@ -1015,8 +1011,7 @@ sub _cover_file (
 ) {
   my $digest = _file_digest($r, $file) or return;
 
-  print STDERR "Devel::Cover: merging data for $file ",
-    "into $digests->{$digest}\n"
+  dcinfo "merging data for $file into $digests->{$digest}"
     if !$files->{$file}++ && $digests->{$digest};
 
   $self->uncoverable_comments($uncoverable, $file, $digest)
@@ -1033,8 +1028,7 @@ sub _cover_file (
   while (my ($criterion, $fc) = each %$f) {
     my $get = "get_$criterion";
     my $sc  = $st->$get($digest) or do {
-      print STDERR "Devel::Cover: Warning: can't locate ",
-        "structure for $criterion in $file\n"
+      dcinfo "Warning: can't locate structure for $criterion in $file"
         unless $warned->{$file}{$criterion}++;
       next;
     };

--- a/lib/Devel/Cover/DB/Digests.pm
+++ b/lib/Devel/Cover/DB/Digests.pm
@@ -13,6 +13,7 @@ use warnings;
 # VERSION
 
 use Devel::Cover::DB::IO;
+use Devel::Cover::Log qw( dcinfo );
 
 my $File = "digests";
 
@@ -65,8 +66,7 @@ sub canonical_file {
   if ($digest) {
     my $dfile = $self->get($digest);
     if ($dfile && $dfile ne $file) {
-      print STDERR "Devel::Cover: Adding coverage for $file to $dfile\n"
-        unless $Devel::Cover::Silent;
+      dcinfo "Adding coverage for $file to $dfile";
       $cfile = $dfile;
     } else {
       $self->set($file, $digest);

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -18,6 +18,7 @@ use List::Util  qw( any );
 
 use Devel::Cover::DB     ();
 use Devel::Cover::DB::IO ();
+use Devel::Cover::Log    qw( dcinfo );
 
 # VERSION
 our $AUTOLOAD;
@@ -169,11 +170,8 @@ sub digest ($self, $file) {
     binmode $fh;
     $digest = Digest::MD5->new->addfile($fh)->hexdigest;
   } else {
-    print STDERR "Devel::Cover: Warning: can't open $file "
-      . "for MD5 digest: $!\n"
-      unless lc $file eq "-e"
-      or $Devel::Cover::Silent
-      or $file =~ $Devel::Cover::DB::Ignore_filenames;
+    dcinfo "Warning: can't open $file for MD5 digest: $!"
+      unless lc $file eq "-e" or $file =~ $Devel::Cover::DB::Ignore_filenames;
   }
   $digest
 }
@@ -203,9 +201,8 @@ sub write ($self, $dir) {
     my $digest = $self->{f}{$file}{digest};
     $digest = $1 if defined $digest && $digest =~ /(.*)/;  # ie tainting
     unless ($digest) {
-      print STDERR "Can't find digest for $file"
-        unless $Devel::Cover::Silent
-        || $file =~ $Devel::Cover::DB::Ignore_filenames
+      dcinfo "Can't find digest for $file"
+        unless $file =~ $Devel::Cover::DB::Ignore_filenames
         || ($Devel::Cover::Self_cover && $file =~ "/Devel/Cover[./]");
       next;
     }
@@ -215,17 +212,13 @@ sub write ($self, $dir) {
     my $io = Devel::Cover::DB::IO->new;
     $io->write($self->{f}{$file}, $df_temp);               # unless -e $df;
     unless (rename $df_temp, $df_final) {
-      unless ($Devel::Cover::Silent) {
-        if (-e $df_final) {
-          print STDERR "Can't rename $df_temp to $df_final "
-            . "(which exists): $!";
-        } else {
-          print STDERR "Can't rename $df_temp to $df_final: $!";
-        }
+      if (-e $df_final) {
+        dcinfo "Can't rename $df_temp to $df_final (which exists): $!";
+      } else {
+        dcinfo "Can't rename $df_temp to $df_final: $!";
       }
       unless (unlink $df_temp) {
-        print STDERR "Can't remove $df_temp after failed rename: $!"
-          unless $Devel::Cover::Silent;
+        dcinfo "Can't remove $df_temp after failed rename: $!";
       }
     }
   }
@@ -249,12 +242,9 @@ sub read ($self, $digest) {
     $self->{f}{ $s->{file} } = $s;
     push $self->{digests}{$d}->@*, $s->{file};
   } else {
-    print STDERR "Devel::Cover: Deleting old coverage ",
-      "for changed file $s->{file}\n"
-      unless $Devel::Cover::Silent;
+    dcinfo "Deleting old coverage for changed file $s->{file}";
     unless (unlink $file) {
-      print STDERR "Devel::Cover: can't delete $file: $!\n"
-        unless $Devel::Cover::Silent;
+      dcinfo "can't delete $file: $!";
     }
   }
   $self

--- a/lib/Devel/Cover/Log.pm
+++ b/lib/Devel/Cover/Log.pm
@@ -1,0 +1,104 @@
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+package Devel::Cover::Log;
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+our $VERSION;
+
+use Devel::Cover::Inc ();
+use Exporter          qw( import );
+
+BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
+
+our @EXPORT_OK = qw( dcinfo dcerror dcprogress );
+our $Prefix    = "cover";
+
+sub dcinfo ($msg) {
+  return if $Devel::Cover::Silent;
+  print STDERR "$Prefix: $msg\n";
+}
+
+sub dcerror ($msg) {
+  print STDERR "$Prefix: $msg\n";
+}
+
+sub dcprogress ($msg) {
+  return if $Devel::Cover::Silent;
+  print STDERR "$Prefix: $msg\n";
+}
+
+1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+Devel::Cover::Log - Centralised diagnostic output for Devel::Cover
+
+=head1 SYNOPSIS
+
+ use Devel::Cover::Log qw( dcinfo dcerror dcprogress );
+
+ dcinfo "Reading database from $dbname";
+ dcerror "Unrecognised output format: $fmt";
+ dcprogress "Rendering $n of $total";
+
+ # Tools other than C<cover> can override the prefix:
+ local $Devel::Cover::Log::Prefix = "gcov2perl";
+ dcinfo "Writing coverage database to $db";
+
+=head1 DESCRIPTION
+
+All diagnostic output goes to STDERR with a consistent C<"$Prefix: "> prefix
+(default C<cover>).  STDOUT is reserved for requested output such as the
+summary table, the C<--dump_db> dump, and report content for text-based
+reporters.
+
+Functions are exported on request; import only those you need.
+
+=head2 Functions
+
+=over 4
+
+=item dcinfo($msg)
+
+Informational/progress/status message.  Silenced when
+C<$Devel::Cover::Silent> is true.
+
+=item dcerror($msg)
+
+Error message.  Never silenced: errors are always reported.
+
+=item dcprogress($msg)
+
+Reserved for progress reporting.  Currently behaves like C<dcinfo>; future
+versions may add tty-aware line-overwrite behaviour.  Silenced when
+C<$Devel::Cover::Silent> is true.
+
+=back
+
+=head1 SEE ALSO
+
+L<Devel::Cover>
+
+=head1 LICENCE
+
+Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+This software is free.  It is licensed under the same terms as Perl itself.
+
+The latest version of this software should be available from my homepage:
+https://pjcj.net
+
+=cut

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -21,6 +21,7 @@ BEGIN {
 use Devel::Cover::Html_Common  ## no perlimports
   qw( launch highlight $Have_highlighter );
 use Devel::Cover::Inc ();
+use Devel::Cover::Log qw( dcinfo );
 use Devel::Cover::Web qw( write_file );
 
 BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
@@ -367,7 +368,7 @@ sub report ($pkg, $db, $options) {
   }
 
   my $html = print_summary;
-  print "HTML output written to $html\n" unless $options->{silent};
+  dcinfo "HTML output written to $html";
 }
 
 1;

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -24,6 +24,7 @@ use Devel::Cover::Html_Common     qw( $Have_highlighter highlight launch );
 use Devel::Cover::Web             qw( $Cov $Crisp_base_css $Crisp_theme_js );
 use Devel::Cover::Condition_table ();
 use Devel::Cover::Inc             ();
+use Devel::Cover::Log             qw( dcinfo );
 use Devel::Cover::Path            qw( common_prefix );
 
 use File::Path     qw( mkpath );
@@ -1108,7 +1109,7 @@ sub report ($pkg, $db, $options) {
   generate_file_pages($outdir, \@file_data);
 
   my $html = "$outdir/$options->{option}{outputfile}";
-  print "HTML output written to $html\n" unless $options->{silent};
+  dcinfo "HTML output written to $html";
 }
 
 $Assets{css} = $Crisp_base_css . <<'CSS';

--- a/lib/Devel/Cover/Report/Html_minimal.pm
+++ b/lib/Devel/Cover/Report/Html_minimal.pm
@@ -8,6 +8,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 use HTML::Entities            qw( encode_entities );
 use Getopt::Long              qw( GetOptions );
 use Devel::Cover::Html_Common qw( launch );          ## no perlimports
+use Devel::Cover::Log         qw( dcinfo );
 use Devel::Cover::Truth_Table ();
 
 our $VERSION;
@@ -607,7 +608,7 @@ END_HTML
   print $fh "</table>\n</body>\n</html>\n";
   close $fh or warn "Unable to close '$outfile' [$!]";
 
-  print "HTML output written to $outfile\n" unless $options->{silent};
+  dcinfo "HTML output written to $outfile";
 }
 
 sub get_options ($self, $opt) {
@@ -646,8 +647,6 @@ sub report ($pkg, $db, $opt) {
     }
   }
   print_summary_report($db, $opt);
-
-  print "done.\n" unless $opt->{silent};
 }
 
 ## no critic (Documentation::RequirePodAtEnd)

--- a/lib/Devel/Cover/Report/Html_subtle.pm
+++ b/lib/Devel/Cover/Report/Html_subtle.pm
@@ -7,6 +7,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 # VERSION
 
 use Devel::Cover::Html_Common qw( launch );  ## no perlimports
+use Devel::Cover::Log         qw( dcinfo );
 use Devel::Cover::Truth_Table;               ## no perlimports
 
 use Getopt::Long   qw( GetOptions );
@@ -328,7 +329,7 @@ sub print_summary ($db, $options) {
   my $html = "$options->{outputdir}/$options->{option}{outputfile}";
   $Template->process("summary", $vars, $html) or die $Template->error;
 
-  print "HTML output written to $html\n" unless $options->{silent};
+  dcinfo "HTML output written to $html";
 }
 
 # Entry point for printing HTML reports

--- a/lib/Devel/Cover/Report/Json.pm
+++ b/lib/Devel/Cover/Report/Json.pm
@@ -13,6 +13,7 @@ use warnings;
 # VERSION
 
 use Devel::Cover::DB::IO::JSON;
+use Devel::Cover::Log qw( dcinfo );
 # use Devel::Cover::Dumper;  # For debugging
 
 sub add_runs {
@@ -34,10 +35,12 @@ sub report {
 
   my $json = { runs => add_runs($db), summary => $db->{summary} };
   # print "JSON: ", Dumper $json;
-  print "JSON sent to $options->{outputdir}/cover.json\n";
 
-  my $io = Devel::Cover::DB::IO::JSON->new(options => "pretty");
-  $io->write($json, "$options->{outputdir}/cover.json");
+  my $path = "$options->{outputdir}/cover.json";
+  my $io   = Devel::Cover::DB::IO::JSON->new(options => "pretty");
+  $io->write($json, $path);
+
+  dcinfo "JSON output written to $path";
 }
 
 1

--- a/lib/Devel/Cover/Test.pm
+++ b/lib/Devel/Cover/Test.pm
@@ -174,19 +174,19 @@ sub _normalise_line ($self, $get_line) {
     $_ = scalar $get_line->();
     $_ = "" unless defined;
     print STDERR $_ if $self->{debug};
-    redo            if /^Devel::Cover: merging run/;
+    redo            if /^cover: merging /;
     redo            if /^Set up gcc environment/;
     if (/Can't opendir\(.+\): No such file or directory/) {
       scalar $get_line->();
       redo;
     }
-    s/^(Reading database from ).*/$1/;
+    s/^(cover: Reading database from ).*/$1/;
     s|(__ANON__\[) .* (/tests/ \w+ : \d+ \])|$1$2|x;
     s/(Subroutine) +(Location)/$1 $2/;
     s/-+/-/;
     s/^ \.\.\. .* - \d+ \. \d+ \/*(\S+)\s*/$1/x;
     s/.* Devel \/ Cover \/*(\S+)\s*/$1/x;
-    s/^(Devel::Cover: merging run).*/$1/;
+    s/^(cover: merging ).*/$1/;
     s/^(Run: ).*/$1/;
     s/^(OS: ).*/$1/;
     s/^(Perl version: ).*/$1/;
@@ -285,10 +285,10 @@ sub _capture_cover_output ($self, $cover_com, $new_gold) {
   open my $cover_fh, "-|", "$cover_com 2>&1" or die "Cannot run $cover_com: $!";
   my $ng = "";
   while (my $l = <$cover_fh>) {
-    next if $l =~ /^Devel::Cover: merging run/;
+    next if $l =~ /^cover: merging /;
     $l =~ s/^($_: ).*$/$1.../
       for "Run", "Perl version", "OS", "Start", "Finish";
-    $l =~ s/^(Reading database from ).*$/$1.../;
+    $l =~ s/^(cover: Reading database from ).*$/$1.../;
     print STDERR $l if $self->{debug};
     print $gold_fh $l;
     $ng .= $l;

--- a/lib/Devel/Cover/Test.pm
+++ b/lib/Devel/Cover/Test.pm
@@ -15,7 +15,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 # VERSION
 
 use Carp qw( croak );
-use Test::More import => [ qw( is pass plan ) ];
+use Test::More import => [qw( is pass plan )];
 
 use Devel::Cover::Inc ();
 
@@ -350,7 +350,12 @@ sub create_gold ($self) {
   1
 }
 
-1
+"
+And as we sit here alone
+Looking for a reason to go on
+It's so clear that all we have now
+Are our thoughts of yesterday
+"
 
 __END__
 

--- a/t/internal/log.t
+++ b/t/internal/log.t
@@ -1,0 +1,118 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is )];
+
+use Devel::Cover::Log qw( dcerror dcinfo dcprogress );
+
+{
+  no feature "signatures";
+
+  sub capture (&) {
+    my ($code) = @_;
+    my ($out, $err) = ("", "");
+    open my $save_out, ">&", \*STDOUT or die "Cannot dup STDOUT: $!";
+    open my $save_err, ">&", \*STDERR or die "Cannot dup STDERR: $!";
+    close STDOUT or die "Cannot close STDOUT: $!";
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDOUT, ">", \$out or die "Cannot redirect STDOUT: $!";
+    open STDERR, ">", \$err or die "Cannot redirect STDERR: $!";
+    $code->();
+    close STDOUT or die "Cannot close STDOUT: $!";
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDOUT, ">&", $save_out or die "Cannot restore STDOUT: $!";
+    open STDERR, ">&", $save_err or die "Cannot restore STDERR: $!";
+    ($out, $err)
+  }
+}
+
+sub test_dcinfo_writes_to_stderr () {
+  local $Devel::Cover::Silent = 0;
+  my ($out, $err) = capture { dcinfo "hello" };
+  is $out, "",               "dcinfo: nothing on STDOUT";
+  is $err, "cover: hello\n", "dcinfo: prefixed message on STDERR";
+}
+
+sub test_dcinfo_silenced () {
+  local $Devel::Cover::Silent = 1;
+  my ($out, $err) = capture { dcinfo "hello" };
+  is $out, "", "dcinfo silent: nothing on STDOUT";
+  is $err, "", "dcinfo silent: nothing on STDERR";
+}
+
+sub test_dcerror_writes_to_stderr () {
+  local $Devel::Cover::Silent = 0;
+  my ($out, $err) = capture { dcerror "oops" };
+  is $out, "",              "dcerror: nothing on STDOUT";
+  is $err, "cover: oops\n", "dcerror: prefixed message on STDERR";
+}
+
+sub test_dcerror_not_silenced () {
+  local $Devel::Cover::Silent = 1;
+  my ($out, $err) = capture { dcerror "oops" };
+  is $out, "",              "dcerror silent: nothing on STDOUT";
+  is $err, "cover: oops\n", "dcerror silent: still emitted - not guarded";
+}
+
+sub test_dcprogress_writes_to_stderr () {
+  local $Devel::Cover::Silent = 0;
+  my ($out, $err) = capture { dcprogress "step 1" };
+  is $out, "",                "dcprogress: nothing on STDOUT";
+  is $err, "cover: step 1\n", "dcprogress: prefixed message on STDERR";
+}
+
+sub test_dcprogress_silenced () {
+  local $Devel::Cover::Silent = 1;
+  my ($out, $err) = capture { dcprogress "step 1" };
+  is $out, "", "dcprogress silent: nothing on STDOUT";
+  is $err, "", "dcprogress silent: nothing on STDERR";
+}
+
+sub test_prefix_override () {
+  local $Devel::Cover::Silent      = 0;
+  local $Devel::Cover::Log::Prefix = "gcov2perl";
+  my ($out, $err) = capture { dcinfo "writing" };
+  is $out, "",                     "prefix override: nothing on STDOUT";
+  is $err, "gcov2perl: writing\n", "prefix override: custom prefix used";
+}
+
+sub test_prefix_override_error () {
+  local $Devel::Cover::Silent      = 0;
+  local $Devel::Cover::Log::Prefix = "gcov2perl";
+  my ($out, $err) = capture { dcerror "bad" };
+  is $err, "gcov2perl: bad\n", "prefix override: dcerror uses custom prefix";
+}
+
+sub test_multiline_message () {
+  local $Devel::Cover::Silent = 0;
+  my ($out, $err) = capture { dcinfo "line 1\nline 2" };
+  is $err, "cover: line 1\nline 2\n",
+    "multiline: body preserved verbatim, single trailing newline added";
+}
+
+test_dcinfo_writes_to_stderr;
+test_dcinfo_silenced;
+test_dcerror_writes_to_stderr;
+test_dcerror_not_silenced;
+test_dcprogress_writes_to_stderr;
+test_dcprogress_silenced;
+test_prefix_override;
+test_prefix_override_error;
+test_multiline_message;
+
+done_testing;

--- a/test_output/cover/accessor.5.020000
+++ b/test_output/cover/accessor.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/alias.5.020000
+++ b/test_output/cover/alias.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------
 File          stmt   bran   cond    sub  total   slop
 ----------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/alias1.5.020000
+++ b/test_output/cover/alias1.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/and.5.020000
+++ b/test_output/cover/and.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 --------- ------ ------ ------ ------ ------ ------
 File        stmt   bran   cond    sub  total   slop
 --------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/any_all.5.042000
+++ b/test_output/cover/any_all.5.042000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
 File            stmt   bran   cond    sub  total   slop
 ------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/bigint.5.032000
+++ b/test_output/cover/bigint.5.032000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------ ------ ------ ------ ------ ------ ------
 File           stmt   bran   cond    sub  total   slop
 ------------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/branch_return_sub.5.020000
+++ b/test_output/cover/branch_return_sub.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------------------- ------ ------ ------ ------ ------ ------
 File                      stmt   bran   cond    sub  total   slop
 ----------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/change.5.020000
+++ b/test_output/cover/change.5.020000
@@ -1,7 +1,5 @@
-Reading database from ...
-Devel::Cover: Deleting old coverage for changed file tests/change
-
-
+cover: Reading database from ...
+cover: Deleting old coverage for changed file tests/change
 ------------ ------ ------ ------ ------ ------ ------
 File           stmt   bran   cond    sub  total   slop
 ------------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/circular_ref.5.020000
+++ b/test_output/cover/circular_ref.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------
 File                 stmt   bran   cond    sub  total   slop
 ------------------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/class38.5.038000
+++ b/test_output/cover/class38.5.038000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
 File            stmt   bran   cond    sub  total   slop
 ------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/class40.5.040000
+++ b/test_output/cover/class40.5.040000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
 File            stmt   bran   cond    sub  total   slop
 ------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/class42.5.042000
+++ b/test_output/cover/class42.5.042000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
 File            stmt   bran   cond    sub  total   slop
 ------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/cond_and.5.020000
+++ b/test_output/cover/cond_and.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------
 File             stmt   bran   cond    sub  total   slop
 -------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/cond_and.5.043008
+++ b/test_output/cover/cond_and.5.043008
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------
 File             stmt   bran   cond    sub  total   slop
 -------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/cond_branch.5.020000
+++ b/test_output/cover/cond_branch.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------
 File                stmt   bran   cond    sub  total   slop
 ----------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/cond_branch.5.043008
+++ b/test_output/cover/cond_branch.5.043008
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------
 File                stmt   bran   cond    sub  total   slop
 ----------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/cond_chained.5.020000
+++ b/test_output/cover/cond_chained.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------
 File                 stmt   bran   cond    sub  total   slop
 ------------------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/cond_or.5.020000
+++ b/test_output/cover/cond_or.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/cond_or.5.022000
+++ b/test_output/cover/cond_or.5.022000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/cond_or.5.026000
+++ b/test_output/cover/cond_or.5.026000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/cond_or.5.038000
+++ b/test_output/cover/cond_or.5.038000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/cond_or.5.043008
+++ b/test_output/cover/cond_or.5.043008
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/cond_or_interp.5.020000
+++ b/test_output/cover/cond_or_interp.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------
 File                   stmt   bran   cond    sub  total   slop
 -------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/cond_or_interp.5.028000
+++ b/test_output/cover/cond_or_interp.5.028000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------
 File                   stmt   bran   cond    sub  total   slop
 -------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/cond_xor.5.020000
+++ b/test_output/cover/cond_xor.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------
 File             stmt   bran   cond    sub  total   slop
 -------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/cond_xor.5.040000
+++ b/test_output/cover/cond_xor.5.040000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------
 File             stmt   bran   cond    sub  total   slop
 -------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/cond_xor_hp.5.040000
+++ b/test_output/cover/cond_xor_hp.5.040000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------
 File                stmt   bran   cond    sub  total   slop
 ----------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/cop.5.020000
+++ b/test_output/cover/cop.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 --------- ------ ------ ------ ------ ------ ------
 File        stmt   bran   cond    sub  total   slop
 --------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/dbm_cond.5.020000
+++ b/test_output/cover/dbm_cond.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------
 File             stmt   bran   cond    sub  total   slop
 -------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/dbm_cond.5.022000
+++ b/test_output/cover/dbm_cond.5.022000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------
 File             stmt   bran   cond    sub  total   slop
 -------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/default_param.5.020000
+++ b/test_output/cover/default_param.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------
 File                  stmt   bran   cond    sub  total   slop
 ------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/deparse.5.020000
+++ b/test_output/cover/deparse.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
 File            stmt   bran   cond    sub  total   slop
 ------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/destroy.5.020000
+++ b/test_output/cover/destroy.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
 File            stmt   bran   cond    sub  total   slop
 ------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/dynamic_subs.5.020000
+++ b/test_output/cover/dynamic_subs.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------
 File                 stmt   bran   cond    sub  total   slop
 ------------------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/empty.5.020000
+++ b/test_output/cover/empty.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----- ------ ------ ------ ------ ------ ------
 File    stmt   bran   cond    sub  total   slop
 ----- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/empty_else.5.020000
+++ b/test_output/cover/empty_else.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ---------------- ------ ------ ------ ------ ------ ------
 File               stmt   bran   cond    sub  total   slop
 ---------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/end_constant.5.020000
+++ b/test_output/cover/end_constant.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----- ------ ------ ------ ------ ------ ------
 File    stmt   bran   cond    sub  total   slop
 ----- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/eval1.5.020000
+++ b/test_output/cover/eval1.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------
 File          stmt   bran   cond    sub  total   slop
 ----------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/eval2.5.020000
+++ b/test_output/cover/eval2.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/eval3.5.020000
+++ b/test_output/cover/eval3.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------
 File          stmt   bran   cond    sub  total   slop
 ----------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/eval_merge.5.020000
+++ b/test_output/cover/eval_merge.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/eval_merge.t.5.020000
+++ b/test_output/cover/eval_merge.t.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/eval_merge_0.5.020000
+++ b/test_output/cover/eval_merge_0.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/eval_merge_1.5.020000
+++ b/test_output/cover/eval_merge_1.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/eval_merge_sep.t.5.020000
+++ b/test_output/cover/eval_merge_sep.t.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/eval_nested.5.020000
+++ b/test_output/cover/eval_nested.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------
 File                stmt   bran   cond    sub  total   slop
 ----------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/eval_string.5.020000
+++ b/test_output/cover/eval_string.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------
 File                stmt   bran   cond    sub  total   slop
 ----------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/eval_sub.t.5.020000
+++ b/test_output/cover/eval_sub.t.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------
 File          stmt   bran   cond    sub  total   slop
 ----------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/eval_use.t.5.020000
+++ b/test_output/cover/eval_use.t.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/exec.5.020000
+++ b/test_output/cover/exec.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------
 File         stmt   bran   cond    sub  total   slop
 ---------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/exec_die.5.020000
+++ b/test_output/cover/exec_die.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------
 File             stmt   bran   cond    sub  total   slop
 -------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/final_op.5.020000
+++ b/test_output/cover/final_op.5.020000
@@ -1,7 +1,5 @@
-Reading database from ...
-Devel::Cover: Can't find digest for tests/final_op
-
-
+cover: Reading database from ...
+cover: Can't find digest for tests/final_op
 ----- ------ ------ ------ ------ ------ ------
 File    stmt   bran   cond    sub  total   slop
 ----- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/fork.5.020000
+++ b/test_output/cover/fork.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------
 File         stmt   bran   cond    sub  total   slop
 ---------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/if.5.020000
+++ b/test_output/cover/if.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------
 File       stmt   bran   cond    sub  total   slop
 -------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/loop_condition.5.020000
+++ b/test_output/cover/loop_condition.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------
 File                   stmt   bran   cond    sub  total   slop
 -------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/md5.5.020000
+++ b/test_output/cover/md5.5.020000
@@ -1,7 +1,5 @@
-Reading database from ...
-Devel::Cover: Deleting old coverage for changed file tests/md5
-
-
+cover: Reading database from ...
+cover: Deleting old coverage for changed file tests/md5
 --------- ------ ------ ------ ------ ------ ------
 File        stmt   bran   cond    sub  total   slop
 --------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/module1.5.020000
+++ b/test_output/cover/module1.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/module2.5.020000
+++ b/test_output/cover/module2.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/module_ignore.5.020000
+++ b/test_output/cover/module_ignore.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------
 File                  stmt   bran   cond    sub  total   slop
 ------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/module_import.5.020000
+++ b/test_output/cover/module_import.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/module_relative.5.020000
+++ b/test_output/cover/module_relative.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/module_statements.5.020000
+++ b/test_output/cover/module_statements.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------------------- ------ ------ ------ ------ ------ ------
 File                      stmt   bran   cond    sub  total   slop
 ----------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/moo_cond.5.020000
+++ b/test_output/cover/moo_cond.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------
 File             stmt   bran   cond    sub  total   slop
 -------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/moose_basic.5.020000
+++ b/test_output/cover/moose_basic.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------
 File                stmt   bran   cond    sub  total   slop
 ----------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/moose_cond.5.020000
+++ b/test_output/cover/moose_cond.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ---------------- ------ ------ ------ ------ ------ ------
 File               stmt   bran   cond    sub  total   slop
 ---------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/moose_constraint.5.020000
+++ b/test_output/cover/moose_constraint.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ---------------------- ------ ------ ------ ------ ------ ------
 File                     stmt   bran   cond    sub  total   slop
 ---------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/overload_bool.5.020000
+++ b/test_output/cover/overload_bool.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------
 File                  stmt   bran   cond    sub  total   slop
 ------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/overload_bool2.5.020000
+++ b/test_output/cover/overload_bool2.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------
 File                   stmt   bran   cond    sub  total   slop
 -------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/overload_bool2.5.022000
+++ b/test_output/cover/overload_bool2.5.022000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------
 File                   stmt   bran   cond    sub  total   slop
 -------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/overload_bool2.5.038000
+++ b/test_output/cover/overload_bool2.5.038000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------
 File                   stmt   bran   cond    sub  total   slop
 -------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/overloaded.5.020000
+++ b/test_output/cover/overloaded.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ---------------- ------ ------ ------ ------ ------ ------
 File               stmt   bran   cond    sub  total   slop
 ---------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/padrange.5.020000
+++ b/test_output/cover/padrange.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------
 File             stmt   bran   cond    sub  total   slop
 -------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/padrange2.5.020000
+++ b/test_output/cover/padrange2.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------
 File              stmt   bran   cond    sub  total   slop
 --------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/padrange2.5.022000
+++ b/test_output/cover/padrange2.5.022000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------
 File              stmt   bran   cond    sub  total   slop
 --------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/pod.5.020000
+++ b/test_output/cover/pod.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/pod_nocp.5.020000
+++ b/test_output/cover/pod_nocp.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/readonly.5.020000
+++ b/test_output/cover/readonly.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------
 File             stmt   bran   cond    sub  total   slop
 -------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/recursive_sub.5.020000
+++ b/test_output/cover/recursive_sub.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------
 File                  stmt   bran   cond    sub  total   slop
 ------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/redefine_sub.5.020000
+++ b/test_output/cover/redefine_sub.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------
 File                 stmt   bran   cond    sub  total   slop
 ------------------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/require.5.020000
+++ b/test_output/cover/require.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 
 Common prefix: tests/
 

--- a/test_output/cover/signature.5.032000
+++ b/test_output/cover/signature.5.032000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------
 File              stmt   bran   cond    sub  total   slop
 --------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/skip.5.020000
+++ b/test_output/cover/skip.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------
 File         stmt   bran   cond    sub  total   slop
 ---------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/sort.5.020000
+++ b/test_output/cover/sort.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------
 File         stmt   bran   cond    sub  total   slop
 ---------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/sort_or.5.020000
+++ b/test_output/cover/sort_or.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
 File            stmt   bran   cond    sub  total   slop
 ------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/sort_or.5.022000
+++ b/test_output/cover/sort_or.5.022000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
 File            stmt   bran   cond    sub  total   slop
 ------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/sort_or.5.026000
+++ b/test_output/cover/sort_or.5.026000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
 File            stmt   bran   cond    sub  total   slop
 ------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/sort_or.5.043008
+++ b/test_output/cover/sort_or.5.043008
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
 File            stmt   bran   cond    sub  total   slop
 ------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/special_blocks.5.020000
+++ b/test_output/cover/special_blocks.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------
 File                   stmt   bran   cond    sub  total   slop
 -------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/statement.5.020000
+++ b/test_output/cover/statement.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------
 File              stmt   bran   cond    sub  total   slop
 --------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/subs_only.5.020000
+++ b/test_output/cover/subs_only.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------
 File              stmt   bran   cond    sub  total   slop
 --------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/t0.5.020000
+++ b/test_output/cover/t0.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------
 File       stmt   bran   cond    sub  total   slop
 -------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/t0.5.043008
+++ b/test_output/cover/t0.5.043008
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------
 File       stmt   bran   cond    sub  total   slop
 -------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/t1.5.020000
+++ b/test_output/cover/t1.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------
 File       stmt   bran   cond    sub  total   slop
 -------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/t2.5.020000
+++ b/test_output/cover/t2.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------
 File       stmt   bran   cond    sub  total   slop
 -------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/t2.5.043008
+++ b/test_output/cover/t2.5.043008
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------
 File       stmt   bran   cond    sub  total   slop
 -------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/taint.5.020000
+++ b/test_output/cover/taint.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------
 File          stmt   bran   cond    sub  total   slop
 ----------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/trivial.5.020000
+++ b/test_output/cover/trivial.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
 File            stmt   bran   cond    sub  total   slop
 ------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/uncoverable.5.020000
+++ b/test_output/cover/uncoverable.5.020000
@@ -1,7 +1,5 @@
-Reading database from ...
+cover: Reading database from ...
 2 unmatched uncoverable comments not found at end of tests/uncoverable
-
-
 ----------------- ------ ------ ------ ------ ------ ------
 File                stmt   bran   cond    sub  total   slop
 ----------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/uncoverable_error.5.020000
+++ b/test_output/cover/uncoverable_error.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----------------------- ------ ------ ------ ------ ------ ------
 File                      stmt   bran   cond    sub  total   slop
 ----------------------- ------ ------ ------ ------ ------ ------

--- a/test_output/cover/uncoverable_error_ignore.5.020000
+++ b/test_output/cover/uncoverable_error_ignore.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ------------------------------ ------ ------ ------ ------ ------ ------
 File                             stmt   bran   cond    sub  total   slop
 ------------------------------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/xor_constant_fold.5.020000
+++ b/test_output/cover/xor_constant_fold.5.020000
@@ -1,6 +1,4 @@
-Reading database from ...
-
-
+cover: Reading database from ...
 ----- ------ ------ ------ ------ ------ ------
 File    stmt   bran   cond    sub  total   slop
 ----- ------ ------ ------ ------ ------ ------


### PR DESCRIPTION
## Summary

The `cover` command and its reporters mixed STDOUT and STDERR for
diagnostics, `--silent` only muted some messages, and reporter completion
messages were inconsistent. This introduces `Devel::Cover::Log` as a single
point for diagnostic output so STDOUT is reserved for requested output and
`--silent` behaves predictably. Groundwork for adding progress output to
`Html_crisp`, which can be slow on large codebases.

## Changes

- Added `lib/Devel/Cover/Log.pm` exporting `dcinfo`, `dcerror`, `dcprogress`. All write to STDERR with a `"$Prefix: "` prefix (default `cover`). `dcinfo` and `dcprogress` honour `$Devel::Cover::Silent`; `dcerror` never does. `$Devel::Cover::Log::Prefix` is localisable.
- `dcprogress` currently aliases `dcinfo` as a stub for future tty-aware line-overwrite output.
- `bin/cover`: routed all progress, status, and error messages through `dcinfo`/`dcerror`. Moved error messages at lines 184/202 off STDOUT. Removed the unconditional `print "\n\n"`. Propagated `-silent` to `gcov2perl` child processes.
- `bin/gcov2perl`: added `-silent` option, set `$Devel::Cover::Log::Prefix` to `gcov2perl`, routed diagnostics through the Log module. Tidied POD indentation.
- `lib/Devel/Cover/DB.pm`, `DB/Digests.pm`, `DB/Structure.pm`, `Base/Editor.pm`: replaced ad-hoc `print STDERR ... unless $Silent` patterns with `dcinfo` calls.
- Reporters (`Html_basic`, `Html_crisp`, `Html_minimal`, `Html_subtle`, `Json`): unified completion messages via `dcinfo`. `Json` now emits the message after writing (previously before) and respects `--silent`. `Html_minimal` no longer prints the extra `done.`.
- `lib/Devel/Cover/Test.pm`: updated match patterns and normalisation to the new `cover:`-prefixed output.
- Added `t/internal/log.t` covering STDOUT/STDERR separation, silencing rules, prefix override, and multiline preservation.
- Regenerated golden files under `test_output/cover/` to match the new single-line `cover: Reading database from ...` header.

## Implications

- Users or scripts parsing `cover`/`gcov2perl` output must update to the `cover:`/`gcov2perl:` prefix and the new STDERR routing. Anything piping STDOUT to a file will now see only the requested output, which is the intended fix.
- `gcov2perl` gains a `-silent` flag it did not have before.
- Golden regeneration is mechanical and affects only the three header lines that the normaliser already collapses.

## Issue

Closes #454