### PR TITLE
GH-459 Toggle all errors from total badge

### DIFF
--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -553,7 +553,7 @@ HTML
   unless (is_na($tt->{pc})) {
     my $tt_cls = $fd->{uncompiled} ? "untested-stat" : $tt->{class};
     $o .= <<HTML;
-<span class="stat-badge $tt_cls tip-hover">
+<span class="stat-badge $tt_cls tip-hover" data-criterion="total">
 <span class="badge-label">@{[ crit_name("total") ]} $tt->{pc}%</span>
 @{[ cov_bar($tt->{pc}, $fd->{uncompiled}) ]}
 @{[ glass_tip("$tt->{covered} / $tt->{total}") ]}</span>
@@ -580,7 +580,8 @@ HTML
 <dl>
 <dt>Filter badges</dt>
 <dd>Click a criterion badge (stmt, bran, etc.) to expand all
-lines with errors of that type. Click again to close.</dd>
+lines with errors of that type. Click the total badge to expand every
+line that has any error. Click again to close.</dd>
 <dt>Line details</dt>
 <dd>Click any line with a &#x25b6; chevron to expand branch,
 condition, or subroutine detail.</dd>
@@ -595,7 +596,8 @@ breakdown.</dd>
 (or open detail when filtered)
 &middot; <kbd>Enter</kbd> toggle detail on current line
 &middot; <kbd>s</kbd> <kbd>b</kbd> <kbd>c</kbd> <kbd>u</kbd>
-<kbd>p</kbd> toggle filter for stmt / bran / cond / sub / pod
+<kbd>p</kbd> <kbd>t</kbd> toggle filter for
+stmt / bran / cond / sub / pod / total
 &middot; <kbd>[</kbd> / <kbd>]</kbd> prev/next file
 &middot; <kbd>?</kbd> toggle this help</dd>
 </dl>
@@ -2079,7 +2081,9 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
           if (!d || !d.classList.contains("line-detail"))
             return;
           var errors = row.getAttribute("data-errors") || "";
-          var match = errors.split(",").indexOf(crit) >= 0;
+          var match = crit === "total"
+            ? errors.length > 0
+            : errors.split(",").indexOf(crit) >= 0;
           d.hidden = !match;
           var ch = row.querySelector("td.chevron");
           if (ch) ch.textContent = match ? "\u25bc" : "\u25b6";
@@ -2141,7 +2145,7 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
 
     var badgeKeys = {
       s: "statement", b: "branch", c: "condition",
-      u: "subroutine", p: "pod"
+      u: "subroutine", p: "pod", t: "total"
     };
 
     document.addEventListener("keydown", function(e) {

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -598,7 +598,7 @@ breakdown.</dd>
 &middot; <kbd>s</kbd> <kbd>b</kbd> <kbd>c</kbd> <kbd>u</kbd>
 <kbd>p</kbd> <kbd>t</kbd> toggle filter for
 stmt / bran / cond / sub / pod / total
-&middot; <kbd>[</kbd> / <kbd>]</kbd> prev/next file
+&middot; <kbd>h</kbd> / <kbd>l</kbd> prev/next file
 &middot; <kbd>?</kbd> toggle this help</dd>
 </dl>
 </div>
@@ -2175,11 +2175,11 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
       else if (e.key === "Enter" && currentRow) {
         toggleDetail(currentRow);
       }
-      else if (e.key === "[") {
+      else if (e.key === "h") {
         var prev = document.querySelector(".nav-prev");
         if (prev) window.location = prev.href;
       }
-      else if (e.key === "]") {
+      else if (e.key === "l") {
         var next = document.querySelector(".nav-next");
         if (next) window.location = next.href;
       }

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -205,6 +205,18 @@ sub test_total_badge_filter () {
     "app.js: applyFilter special-cases total";
 }
 
+sub test_file_nav_keys () {
+  my ($covered) = grep /Covered-Calc/, keys %Golden;
+  my $file_page = $Golden{$covered};
+  like $file_page, qr/<kbd>h<\/kbd> \/ <kbd>l<\/kbd> prev\/next file/,
+    "file: help mentions h/l for file nav";
+  unlike $file_page, qr/<kbd>\[<\/kbd>/, "file: help no longer mentions [";
+
+  my $app_js = slurp(File::Spec->catfile($Outdir, "assets", "app.js"));
+  like $app_js, qr/e\.key\s*===\s*"h"/, "app.js: h key handled";
+  like $app_js, qr/e\.key\s*===\s*"l"/, "app.js: l key handled";
+}
+
 sub test_render_untested_page () {
   my ($untested) = grep /Uncovered-Calc/, keys %Golden;
   ok defined $untested, "golden untested file page exists";
@@ -276,6 +288,7 @@ sub main () {
   test_dir_row_slop;
   test_module_slop_badge;
   test_total_badge_filter;
+  test_file_nav_keys;
   test_render_untested_page;
   test_cov_cell_tooltips;
   test_untested_badge_tooltip;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -190,6 +190,21 @@ sub test_module_slop_badge () {
   like $got, qr/slop.*?help-toggle/s,  "header: SLOP badge before help button";
 }
 
+sub test_total_badge_filter () {
+  my ($covered) = grep /Covered-Calc/, keys %Golden;
+  ok defined $covered, "golden covered file page exists for total badge test";
+  my $file_page = $Golden{$covered};
+
+  like $file_page, qr/stat-badge[^"]*"[^>]*data-criterion="total"/,
+    "file: total badge has data-criterion";
+  like $file_page, qr/<kbd>t<\/kbd>/, "file: help mentions t key";
+
+  my $app_js = slurp(File::Spec->catfile($Outdir, "assets", "app.js"));
+  like $app_js, qr/t:\s*"total"/, "app.js: 't' keybinding maps to total filter";
+  like $app_js, qr/crit\s*===\s*"total"/,
+    "app.js: applyFilter special-cases total";
+}
+
 sub test_render_untested_page () {
   my ($untested) = grep /Uncovered-Calc/, keys %Golden;
   ok defined $untested, "golden untested file page exists";
@@ -260,6 +275,7 @@ sub main () {
   test_glass_tooltips;
   test_dir_row_slop;
   test_module_slop_badge;
+  test_total_badge_filter;
   test_render_untested_page;
   test_cov_cell_tooltips;
   test_untested_badge_tooltip;


### PR DESCRIPTION
## Summary

In the Html_crisp file page, the criterion badges (stmt, bran, cond, sub, pod) at the top of the header expand every line with an error of that type. The total badge was inert. Make it behave the same way - clicking it expands every line that has any coverage error, clicking again closes them.

Also replace the `[` / `]` file-navigation keybindings with `h` / `l` so they pair naturally with the existing `j` / `k` line navigation.

## Changes

- Render the total badge with `data-criterion="total"` so the existing click handler picks it up.
- Special-case `"total"` in `applyFilter` to match any row whose `data-errors` attribute is non-empty.
- Add `t: "total"` to `badgeKeys` for parity with the other filter keyboard shortcuts.
- Replace `[` / `]` with `h` / `l` for prev/next file navigation.
- Update the in-page help overlay text.
- Add `test_total_badge_filter` and `test_file_nav_keys` covering the markup, help text, and JS changes (via `assets/app.js`).

## Implications

- j / k cycles the currently-opened detail rows under the total filter, consistent with the other per-criterion filters. Statement-only error lines (no openable detail) remain reachable via no-filter j / k.
- `[` / `]` no longer navigate between files - users relying on those keys will need to switch to `h` / `l`.

## Issue

Closes #459