### PR TITLE
GH-462 Propagate results_dir to inner dc

### DIFF
--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -490,6 +490,7 @@ class Devel::Cover::Collection {
     # say "modules: ", Dumper $modules;
 
     my @cmd = ($self->dc_file, "--env", $env);
+    push @cmd, "--results_dir", $results_dir if defined $results_dir;
     push @cmd, "--verbose" if $verbose;
     my @command = (@cmd, "cpancover-docker-module");
     my @res     = iterate_as_array(


### PR DESCRIPTION
## Summary

Fixes the silent failure described in #462. When the outer pipeline is pointed at a non-default staging directory (e.g. `dc -e dev -r /tmp/x cpancover-test`), the per-module coverage run left only a `__failed__/<distdir>` marker and no `.out` log, with no visible error.

## Root cause

`Collection.pm::cover_modules` built `@cmd = (dc_file, "--env", $env)` and re-invoked `dc cpancover-docker-module` without propagating `--results_dir`. The inner `dc` therefore re-derived `results_dir` from `--env` alone and wrote the distdir and `.out` log to the env-default location. The outer Perl's `covered_dir($d)` check looked in the override path, found nothing, and called `set_failed` - with no error anywhere, because nothing actually errored. Symptoms matched #462 exactly: `__failed__/<distdir>` under the `-r` path, no `.out` log under the `-r` path, no distdir under the `-r` path.

## Changes

- Pass `--results_dir` to the child `dc` invocation when `$results_dir` is defined.

## Verification

Ran the exact reproducer from the issue on macOS 25.4 / Docker Desktop 28.5.2:

    rm -rf /tmp/x && mkdir /tmp/x
    dc -e dev -r /tmp/x cpancover-test

Before fix: `__failed__/Perl-Critic-PJCJ-v0.2.4` marker, no distdir, no `.out` log. After fix: `Perl-Critic-PJCJ-v0.2.4/` distdir with full HTML, `.out.gz` log, top-level `index.html`/`about.html`/`collection.css`/`collection.js`, empty `__failed__/`.

## Issue

Closes #462