### PR TITLE
GH-464 Fix uninit warnings in destruction

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -463,6 +463,7 @@ sub get_coverage {
 }
 
 sub get_location ($op) {
+  return if ${^GLOBAL_PHASE} eq "DESTRUCT";
   return unless $op->can("file");  # How does this happen?
   $File = $op->file;
   $Line = $op->line;
@@ -483,6 +484,8 @@ sub get_location ($op) {
 }
 
 sub use_file ($file) {
+  return 0 if ${^GLOBAL_PHASE} eq "DESTRUCT";
+
   state $find_filename = qr/
     (?:^\(eval\s \d+\)\[(.+):\d+\])      |
     (?:^\(eval\sin\s\w+\)\s(.+))         |
@@ -1242,6 +1245,7 @@ sub _add_pod_cover ($cv) {
 }
 
 sub _want_cover_for {
+  return if ${^GLOBAL_PHASE} eq "DESTRUCT";
   return unless defined $Sub_name;  # Only happens within Safe.pm, AFAIK
   return if length $File && !use_file($File);
   if (!$Self_cover_run && $File =~ /Devel\/Cover/) {

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -437,7 +437,7 @@ sub get_coverage {
     }
 
     my $inc;
-    $inc ||= $file =~ $_ for @Inc_re;
+    $inc ||= $file =~ $_ for grep defined, @Inc_re;
     if ($inc && ($^O eq "MSWin32" || $^O eq "cygwin")) {
       # Windows' Cwd::_win32_cwd() calls eval which will recurse back
       # here if we call abs_path, so we just assume it's normalised.
@@ -508,8 +508,10 @@ sub use_file ($file) {
 
   my $f = normalised_file($file);
 
-  for (@Select_re)          { return $Files{$file} = 1 if $f =~ $_ }
-  for (@Ignore_re, @Inc_re) { return $Files{$file} = 0 if $f =~ $_ }
+  for (grep defined, @Select_re) { return $Files{$file} = 1 if $f =~ $_ }
+  for (grep defined, @Ignore_re, @Inc_re) {
+    return $Files{$file} = 0 if $f =~ $_;
+  }
 
   $Files{$file} = -e $file ? 1 : 0;
   print STDERR __PACKAGE__ . qq(: Can't find file "$file": ignored.\n)
@@ -621,7 +623,7 @@ sub check_files {
   };
 
   @Cvs = map $_->[0],
-    sort { $a->[1] <=> $b->[1] || $a->[2] cmp $b->[2] } map [ $_, $l->($_) ],
+    sort { $a->[1] <=> $b->[1] || $a->[2] cmp $b->[2] } map [$_, $l->($_)],
     grep !$seen_cv{$$_}++, values %Cvs;
 
   # Hack to bump up the refcount of the subs.  If we don't do this then the
@@ -697,7 +699,7 @@ sub _report {
   $Run{collected} = \@collected;
   require Devel::Cover::DB::Structure;
   $Structure = Devel::Cover::DB::Structure->new(base => $DB,
-    loose_perms => $Loose_perms,);
+    loose_perms => $Loose_perms);
   $Structure->read_all;
   $Structure->add_criteria(@collected);
 
@@ -784,7 +786,7 @@ sub add_subroutine_cover ($op) {
   my $key = get_key($op);
   my $val = $Coverage->{statement}{$key} || 0;
   my ($n, $new) = $Structure->add_count("subroutine");
-  $Structure->add_subroutine($File, [ $Line, $Sub_name ]) if $new;
+  $Structure->add_subroutine($File, [$Line, $Sub_name]) if $new;
   $Run{count}{$File}{subroutine}[$n] += $val;
   my $vec = $Run{vec}{$File}{subroutine};
   vec($vec->{vec}, $n, 1) = $val ? 1 : 0;
@@ -832,13 +834,13 @@ sub add_branch_cover ($op, $type, $text, $file, $line) {
     # elsif => no subsequent elsifs or elses
     # True path taken if not short circuited.
     # False path taken if short circuited.
-    $c = [ $c->[1] + $c->[2], $c->[3] ];
+    $c = [$c->[1] + $c->[2], $c->[3]];
   } else {
-    $c = $Coverage->{branch}{$key} || [ 0, 0 ];
+    $c = $Coverage->{branch}{$key} || [0, 0];
   }
 
   my ($n, $new) = $Structure->add_count("branch");
-  $Structure->add_branch($file, [ $line, { text => $text } ]) if $new;
+  $Structure->add_branch($file, [$line, { text => $text }]) if $new;
   my $ccount = $Run{count}{$file};
   if (exists $ccount->{branch}[$n]) {
     $ccount->{branch}[$n][$_] += $c->[$_] for 0 .. $#$c;
@@ -870,15 +872,15 @@ sub add_condition_cover (
   if ($type eq "or" || $type eq "and") {
     my $r = $op->first->sibling;
     if ($c->[5] || _is_const_right($r)) {
-      $c     = [ $c->[3], $c->[1] + $c->[2] ];
+      $c     = [$c->[3], $c->[1] + $c->[2]];
       $count = 2;
     } else {
-      @$c    = $c->@[ $type eq "or" ? (3, 2, 1) : (3, 1, 2) ];
+      @$c    = $c->@[$type eq "or" ? (3, 2, 1) : (3, 1, 2)];
       $count = 3;
     }
   } elsif ($type eq "xor") {
     # !l&&!r  l&&!r  l&&r  !l&&r
-    @$c    = $c->@[ 3, 2, 4, 1 ];
+    @$c    = $c->@[3, 2, 4, 1];
     $count = 4;
   } else {
     die qq(Unknown type "$type" for conditional);
@@ -900,7 +902,7 @@ sub add_condition_cover (
   };
 
   my ($n, $new) = $Structure->add_count("condition");
-  $Structure->add_condition($File, [ $Line, $structure ]) if $new;
+  $Structure->add_condition($File, [$Line, $structure]) if $new;
   my $ccount = $Run{count}{$File};
   if (exists $ccount->{condition}[$n]) {
     $ccount->{condition}[$n][$_] += $c->[$_] for 0 .. $#$c;
@@ -1232,7 +1234,7 @@ sub _add_pod_cover ($cv) {
   return unless defined $covered;
 
   my ($n, $new) = $Structure->add_count("pod");
-  $Structure->add_pod($File, [ $Line, $Sub_name ]) if $new;
+  $Structure->add_pod($File, [$Line, $Sub_name]) if $new;
   $Run{count}{$File}{pod}[$n] += $covered;
   my $vec = $Run{vec}{$File}{pod};
   vec($vec->{vec}, $n, 1) = $covered ? 1 : 0;
@@ -1245,7 +1247,8 @@ sub _want_cover_for {
   if (!$Self_cover_run && $File =~ /Devel\/Cover/) {
     # Allow partial self-coverage: if -select patterns are active and this DC
     # module matches one, let it through for instrumentation.
-    return unless @Select_re && List::Util::any { $File =~ $_ } @Select_re;
+    return unless @Select_re && List::Util::any { defined && $File =~ $_ }
+    @Select_re;
   }
   return if $Self_cover_run && $File !~ /Devel\/Cover/;
   return
@@ -1347,9 +1350,9 @@ sub _deparse_binop_left ($cv, $op, $child, $prec, $use_dumper = 1) {
 }
 
 my %Logop_params = (
-  and => [ "and", 3, "&&", 11, "if" ],
-  or  => [ "or",  2, "||", 10, "unless" ],
-  dor => [ "//",  10 ],
+  and => ["and", 3, "&&", 11, "if"],
+  or  => ["or",  2, "||", 10, "unless"],
+  dor => ["//",  10],
 );
 
 # Check if a null-statement op is inside a cond_expr/elsif condition

--- a/t/internal/global_destruction.t
+++ b/t/internal/global_destruction.t
@@ -1,0 +1,77 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is )];
+
+# Regression test for GH-464.  During Perl's DESTRUCT phase, some of the
+# anonymous qr// bodies held by Devel::Cover's module-scoped arrays (@Inc_re,
+# @Ignore_re, @Select_re) may be freed before the arrays themselves.  If
+# coverage code runs during DESTRUCT (e.g. a DESTROY handler does `require
+# Some::Module`), the four loops that match paths against those arrays see undef
+# slots and emit warnings like "Use of uninitialized value $_ in regexp
+# compilation ... during global destruction".
+
+# The effect is non-deterministic; SV cleanup order is not fixed.  We require
+# Time::Local during DESTROY and run the reproducer many times. Time::Local is
+# chosen deliberately: empirically it has a ~55% hit rate per run on Perl
+# 5.42.2, whereas a trivial inline test module (even one with many subs or a
+# cascade of `use` statements) has a 0% hit rate.  The difference appears to be
+# down to SV-cleanup ordering rather than anything we can synthesise locally, so
+# rather than ship a bespoke trigger module that might not trigger, we depend on
+# Time::Local - a core module since Perl 5.0 and therefore always present on the
+# 5.20+ that Devel::Cover supports.  With 30 iterations the pre-fix false-green
+# probability is ~ 0.45 ** 30, i.e. ~ 4e-11.
+
+sub test_no_uninitialized_warning_during_global_destruction () {
+  my $tmpdir = tempdir(CLEANUP => 1);
+
+  my $script = File::Spec->catfile($tmpdir, "destruct.pl");
+  open my $fh, ">", $script or die "write $script: $!";
+  print $fh <<'EOS';
+package Guard;
+sub DESTROY { require Time::Local }
+package main;
+our $g = bless {}, "Guard";
+print "done\n";
+EOS
+  close $fh or die "close $script: $!";
+
+  my $iterations = 30;
+  my @failures;
+  for my $i (1 .. $iterations) {
+    my $db  = File::Spec->catdir($tmpdir, "cover_db_$i");
+    my $cmd = join " ", map qq("$_"), $^X, "-Mblib",
+      "-MDevel::Cover=-silent,1,-db,$db", $script;
+    my $output = `$cmd 2>&1`;
+    push @failures, "iter $i: $output"
+      if $output =~ /uninitialized.*global destruction/s;
+  }
+
+  is scalar @failures, 0,
+    "no uninitialized-value warnings across $iterations iterations"
+    or diag join "\n---\n", @failures[0 .. ($#failures < 2 ? $#failures : 2)];
+}
+
+sub main () {
+  test_no_uninitialized_warning_during_global_destruction;
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

Devel::Cover was emitting "Use of uninitialized value $_ in regexp compilation ... during global destruction" when a DESTROY handler triggered coverage-hook activity (typically via `require`). The warnings broke downstream test suites that assert clean stderr during global destruction - notably Try-Tiny-0.32's `t/global_destruction_load.t`, which in turn made cpancover flunk the whole module despite coverage being successfully collected.

## Root cause

`@Inc_re`, `@Ignore_re` and `@Select_re` hold anonymous `qr//` bodies built at `import()` time. Perl's SV cleanup during the DESTRUCT phase may free those qr// bodies before the arrays themselves, leaving undef slots. The four loops in `Devel::Cover.pm` that iterate those arrays then match `$file =~ $_` against undef and warn. SV cleanup order is not fixed, which is why the warning is non-deterministic.

## Changes

- Filter undef slots at the four affected loop sites (defensive belt).
- Short-circuit `get_location`, `use_file` and `_want_cover_for` when `${^GLOBAL_PHASE} eq "DESTRUCT"` (braces): by that point the END-phase report has already written the coverage DB, so any further hook activity is wasted anyway.
- Add a regression test `t/internal/global_destruction.t` that runs `require Time::Local` from a DESTROY handler under Devel::Cover, 30 times per run, to defeat the non-determinism.

## Issue

Closes #464