### PR TITLE
GH-344 Exclude Perl CORE headers from XS coverage

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Devel::Cover history
 {{$NEXT}}
 - *** BREAKING *** New detailed `json` reporter; existing summary
   reporter renamed to `json_summary` (Ricardo Signes) (GH-419)
+- *** BREAKING *** cover no longer walks the whole tree for .gcov
+  files; it consumes only those produced by its own gcov runs.  XS
+  sources outside cwd are skipped unless -gcov_chdir is set.
 - Add cpancover-docker-pull recipe (GH-377)
 - Fix spelling: led (Josh Soref) (GH-368)
 

--- a/Changes
+++ b/Changes
@@ -6,6 +6,9 @@ Devel::Cover history
 - *** BREAKING *** cover no longer walks the whole tree for .gcov
   files; it consumes only those produced by its own gcov runs.  XS
   sources outside cwd are skipped unless -gcov_chdir is set.
+- Exclude Perl CORE headers from XS coverage by default; cover
+  -relative_only now defaults on and gcov2perl skips CORE sources
+  (GH-344)
 - Add cpancover-docker-pull recipe (GH-377)
 - Fix spelling: led (Josh Soref) (GH-368)
 

--- a/bin/cover
+++ b/bin/cover
@@ -325,10 +325,37 @@ sub do_test ($dbname) {
   $test_result >>= 8;
 }
 
+sub run_gcov ($name, $dir, $gc, $seen) {
+  my $gcov_flags = "-abc";
+  $gcov_flags .= "r" if $Options->{relative_only};
+  my @args = $Options->{gcov_chdir} ? () : ("-o", $dir);
+  my @c    = ("gcov", $gcov_flags, @args, $name);
+  dcinfo "running @c";
+  my $cwd = $Options->{gcov_chdir} ? $dir : ".";
+  open my $fh, "-|", @c or do {
+    dcerror "cannot run @c: $!";
+    return;
+  };
+  while (my $line = <$fh>) {
+    print $line;
+    next unless $line =~ /^Creating '([^']+)'\s*$/;
+    my $path = $cwd eq "." ? $1 : "$cwd/$1";
+    $path =~ s{^\./}{};
+    push $gc->@*, $path unless $seen->{$path}++;
+  }
+  close $fh or dcinfo "gcov exited non-zero (exit $?)";
+}
+
 sub do_gcov ($dbname) {
   return unless $Options->{gcov};
+  my @gc;
+  my %seen;
   my $gc = sub () {
     return unless /\.(xs|cc?|hh?)$/;
+    # Without gcov_chdir, gcov runs from our cwd and can only read sources
+    # there.  Skip anything in a subdirectory: trying to gcov it produces a
+    # noisy error and a useless stub .gcov that contaminates this run.
+    return if !$Options->{gcov_chdir} && $File::Find::dir ne ".";
     for my $re ($Options->{ignore_re}->@*) {
       return if /$re/;
     }
@@ -339,23 +366,21 @@ sub do_gcov ($dbname) {
     my $graph_file = $_;
     $graph_file =~ s{\.\w+$}{.gcno};
     return unless -e $graph_file;
-    my $gcov_flags = "-abc";
-    $gcov_flags .= "r" if $Options->{relative_only};
-    my @args = $Options->{gcov_chdir} ? () : ("-o", $File::Find::dir);
-    my @c    = ("gcov", $gcov_flags, @args, $name);
-    dcinfo "running @c";
-    system @c;
+
+    # Capture gcov stdout to learn exactly which .gcov files this run
+    # produced; walking the tree afterwards picks up stale artefacts from
+    # unrelated builds (e.g. tmp/runs/<dist>/) that we don't own.
+    run_gcov($name, $File::Find::dir, \@gc, \%seen);
   };
   File::Find::find({ wanted => $gc, no_chdir => !$Options->{gcov_chdir} }, ".");
-  my @gc;
-  my $gp = sub () {
-    return unless /\.gcov$/;
+
+  # Drop .c/.h .gcov entries when the matching .xs.gcov is also present
+  # (xsubpp produces both, with the same coverage).
+  @gc = grep {
     my $xs = $_;
-    return if $xs =~ s/\.(cc?|hh?)\.gcov$/.xs.gcov/ && -e $xs;
-    s/^\.\///;
-    push @gc, $_;
-  };
-  File::Find::find({ wanted => $gp, no_chdir => 1 }, ".");
+    !($xs =~ s/\.(cc?|hh?)\.gcov$/.xs.gcov/ && -e $xs);
+  } @gc;
+
   if (@gc) {
     # Find the right gcov2perl based on this current script
     require Cwd;

--- a/bin/cover
+++ b/bin/cover
@@ -47,7 +47,7 @@ my $Options = {
   launch                   => 0,
   make                     => $Config{make},
   prefer_lib               => 0,
-  relative_only            => 0,
+  relative_only            => 1,
   report                   => [],
   report_c0                => 75,
   report_c1                => 90,
@@ -621,7 +621,7 @@ The following command line options are supported:
  -ignore filename      - don't report on the file           (default none)
  -select_re RE         - append to REs of files to select   (default none)
  -ignore_re RE         - append to REs of files to ignore   (default none)
- -relative_only        - for XS, ignore absolute paths      (default off)
+ -relative_only        - for XS, ignore absolute paths      (default on)
  -gcov_chdir           - for XS, run gcov in subdirs        (default off)
  -write [db]           - write the merged database          (default off)
  -delete               - drop database(s)                   (default off)
@@ -755,6 +755,15 @@ you are using gcc of course.  If you are using the C<-test> option will be
 turned on by default. If you have XS code in subdirectories, you will
 probably need to add the C<-gcov_chdir> option since gcov seems to work
 better with that.
+
+By default the C<-relative_only> option is enabled, which passes C<-r> to gcov
+so that source files reached via absolute paths (typically Perl's own CORE
+headers such as F<sv_inline.h>, F<inline.h>, and F<perlstatic.h>) are omitted
+from the coverage report.  These files are inlined into XS code and their
+coverage figures are rarely meaningful to the XS author.  As a second line of
+defence, C<gcov2perl> also skips any C<.gcov> whose source resolves into the
+Perl CORE directory.  Pass C<-no-relative_only> to C<cover>, or C<-no-skip-core>
+to C<gcov2perl>, to include this data.
 
 The C<-prefer_lib> option tells Devel::Cover to report on files in the lib
 directory even if they were used from the blib directory.

--- a/bin/gcov2perl
+++ b/bin/gcov2perl
@@ -18,6 +18,7 @@ no warnings qw( experimental::signatures experimental::postderef );
 use Devel::Cover::DB  ();
 use Devel::Cover::Log qw( dcerror dcinfo );
 
+use Config;
 use File::Path   qw( mkpath );
 use File::Spec   ();
 use Getopt::Long qw( GetOptions );
@@ -25,19 +26,43 @@ use Pod::Usage   qw( pod2usage );
 
 $Devel::Cover::Log::Prefix = "gcov2perl";
 
-my $Options = { db => "cover_db" };
+my $Options = { db => "cover_db", skip_core => 1 };
 
 sub get_options () {
   die "Bad option"
     unless GetOptions(
       $Options,  # Store the options in the Options hash
-      qw( db=s help|h! info|i! silent! version|v! ),
+      qw( db=s help|h! info|i! silent! skip_core|skip-core! version|v! ),
     );
   $Devel::Cover::Silent = 1 if $Options->{silent};
   print "$0 version " . __PACKAGE__->VERSION . "\n" and exit 0
     if $Options->{version};
   pod2usage(-exitval => 0, -verbose => 0) if $Options->{help};
   pod2usage(-exitval => 0, -verbose => 2) if $Options->{info};
+}
+
+sub core_dir () {
+  state $dir
+    = File::Spec->canonpath(File::Spec->catdir($Config{archlibexp}, "CORE"));
+  $dir;
+}
+
+sub is_core_path ($path) {
+  my $abs   = File::Spec->canonpath(File::Spec->rel2abs($path));
+  my @parts = File::Spec->splitdir($abs);
+  my @core  = File::Spec->splitdir(core_dir);
+  return 0 if @parts <= @core;
+  for my $i (0 .. $#core) {
+    return 0 if $parts[$i] ne $core[$i];
+  }
+  1;
+}
+
+sub resolve_source ($source, $dir) {
+  my $f = $source;
+  $f = File::Spec->abs2rel(File::Spec->catfile($dir, $f))
+    unless File::Spec->file_name_is_absolute($f);
+  $f;
 }
 
 sub add_cover ($file) {
@@ -64,9 +89,12 @@ sub add_cover ($file) {
   gcov_line: while (my $gcov_text = <$fh>) {
     # print "Processing line [$gcov_text]\n";
     if ($gcov_text =~ /^[^:]+:[^:]+:Source:(.*)$/) {
-      $f = $1;
-      $f = File::Spec->abs2rel(File::Spec->catfile($dir, $f))
-        unless File::Spec->file_name_is_absolute($f);
+      $f = resolve_source($1, $dir);
+      if ($Options->{skip_core} && is_core_path($f)) {
+        dcinfo "skipping Perl CORE source $f from $file";
+        close $fh or die "Can't close $file: $!\n";
+        return;
+      }
     }
     unless (defined $run{digests}{$f}) {
       unless (-f $f) {
@@ -164,11 +192,18 @@ Convert gcov files to Devel::Cover databases.
 The following command line options are supported:
 
   -db database    - specify the database to use
-  -silent         - suppress informational messages (default off)
+  -silent         - suppress informational messages          (default off)
+  -no-skip-core   - include Perl CORE headers in coverage    (default off)
 
   -h -help        - show help
   -i -info        - show documentation
   -v -version     - show version
+
+By default, C<gcov2perl> skips any C<.gcov> file whose source resolves into
+the Perl CORE directory (e.g. F<sv_inline.h>, F<inline.h>, F<perlstatic.h>).
+These files are inlined into XS code and produce coverage data that is rarely
+of interest to the XS author.  Pass C<-no-skip-core> to override and include
+them.
 
 =head1 DETAILS
 

--- a/t/internal/gcov2perl.t
+++ b/t/internal/gcov2perl.t
@@ -2,12 +2,12 @@
 
 use 5.20.0;
 use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
 
-use feature qw( signatures );
-no warnings qw( experimental::signatures );
+use Test::More import => [qw( diag done_testing is like ok unlike )];
 
-use Test::More import => [qw( done_testing is like ok )];
-
+use Config         qw( %Config );
 use File::Basename qw( dirname );
 use File::Copy     qw( copy );
 use File::Spec     ();
@@ -23,11 +23,11 @@ sub setup () {
 
   copy(
     File::Spec->catfile($Fixtures, "simple.c.fixture"),
-    File::Spec->catfile($tmpdir,   "simple.c")
+    File::Spec->catfile($tmpdir,   "simple.c"),
   ) or die "Failed to copy simple.c.fixture: $!";
   copy(
     File::Spec->catfile($Fixtures, "simple.c.gcov.fixture"),
-    File::Spec->catfile($tmpdir,   "simple.c.gcov")
+    File::Spec->catfile($tmpdir,   "simple.c.gcov"),
   ) or die "Failed to copy simple.c.gcov.fixture: $!";
 
   $tmpdir
@@ -55,9 +55,59 @@ sub test_gcov2perl ($tmpdir) {
   is @runs, 1, "one run directory created";
 }
 
+sub make_core_gcov ($tmpdir, $source) {
+  my $gcov_path = File::Spec->catfile($tmpdir, "core_header.h.gcov");
+  open my $fh, ">", $gcov_path or die "Cannot create $gcov_path: $!";
+  print $fh "        -:    0:Source:$source\n";
+  print $fh "        -:    0:Graph:core_header.gcno\n";
+  print $fh "        -:    0:Data:core_header.gcda\n";
+  print $fh "        -:    0:Runs:1\n";
+  print $fh "        1:    1:/* dummy executed line */\n";
+  close $fh or die "Cannot close $gcov_path: $!";
+  $gcov_path;
+}
+
+sub run_gcov2perl ($db_dir, $gcov_path, @extra) {
+  my $cmd = join " ", $^X, "-Iblib/lib", $Bin, "-db", $db_dir, @extra,
+    $gcov_path, "2>&1";
+  my $output    = `$cmd`;
+  my $exit_code = $? >> 8;
+  ($exit_code, $output);
+}
+
+sub test_skip_core ($tmpdir) {
+  my $core_dir    = File::Spec->catdir($Config{archlibexp}, "CORE");
+  my $core_source = File::Spec->catfile($core_dir, "perl.h");
+
+  unless (-f $core_source) {
+    diag "no $core_source - skipping CORE-skip tests";
+    return;
+  }
+
+  my $gcov_path = make_core_gcov($tmpdir, $core_source);
+
+  my $db_dir = File::Spec->catdir($tmpdir, "cover_db_core_default");
+  my ($exit_code, $output) = run_gcov2perl($db_dir, $gcov_path);
+  is $exit_code, 0, "gcov2perl exits successfully when given CORE source";
+  unlike $output, qr/Writing coverage database/,
+    "gcov2perl does not write database for CORE source by default";
+  ok !-d File::Spec->catdir($db_dir, "runs"),
+    "no runs directory created for CORE source by default";
+
+  my $db_dir_no = File::Spec->catdir($tmpdir, "cover_db_core_no_skip");
+  my ($exit_no, $output_no)
+    = run_gcov2perl($db_dir_no, $gcov_path, "-no-skip-core");
+  is $exit_no, 0, "gcov2perl exits successfully with -no-skip-core";
+  like $output_no, qr/Writing coverage database/,
+    "gcov2perl writes database for CORE source with -no-skip-core";
+  ok -d File::Spec->catdir($db_dir_no, "runs"),
+    "runs directory created for CORE source with -no-skip-core";
+}
+
 sub main () {
   my $tmpdir = setup;
   test_gcov2perl($tmpdir);
+  test_skip_core($tmpdir);
   done_testing;
 }
 

--- a/utils/dc
+++ b/utils/dc
@@ -1271,13 +1271,13 @@ cpan_module() {
   pi "Installing dependencies to $locallib"
   cpanm -n -L "$locallib" --installdeps .
 
-  # Build (with local deps visible)
-  pi "Building $module"
+  # Don't pre-build: a stale .o would suppress XS coverage in cover -test.
+  pi "Configuring $module"
   export PERL5LIB="$locallib/lib/perl5${PERL5LIB:+:$PERL5LIB}"
   if [[ -f Makefile.PL ]]; then
-    perl Makefile.PL && make
+    perl Makefile.PL
   elif [[ -f Build.PL ]]; then
-    perl Build.PL && ./Build
+    perl Build.PL
   else
     pf "No Makefile.PL or Build.PL found"
   fi
@@ -1335,16 +1335,16 @@ cpan_collection_module() {
   pi "Installing dependencies to $locallib"
   cpanm -n -L "$locallib" --installdeps .
 
-  # Build (with local deps visible)
+  # Don't pre-build: a stale .o would suppress XS coverage in cover -test.
   local saved_perl5lib="${PERL5LIB:-}"
   local saved_cover_opts="${DEVEL_COVER_TEST_OPTS:-}"
   local saved_cover_options="${DEVEL_COVER_OPTIONS:-}"
   export PERL5LIB="$locallib/lib/perl5${saved_perl5lib:+:$saved_perl5lib}"
-  pi "Building $module"
+  pi "Configuring $module"
   if [[ -f Makefile.PL ]]; then
-    perl Makefile.PL && make
+    perl Makefile.PL
   elif [[ -f Build.PL ]]; then
-    perl Build.PL && ./Build
+    perl Build.PL
   else
     pf "No Makefile.PL or Build.PL found"
   fi


### PR DESCRIPTION
## Summary

XS coverage runs were dragged down by Perl's own CORE headers
(sv_inline.h, inline.h, perlstatic.h) appearing in the report -
covered code that the XS author has no control over. While
investigating that, two longstanding bugs in the gcov collection
path also surfaced and are fixed here.

## Changes

- `cover` defaults `-relative_only` to on so gcov drops absolute-path
  sources. `gcov2perl` skips any `.gcov` whose source resolves under
  `archlibexp/CORE` as a backstop. Both behaviours can be disabled via
  `-no-relative_only` / `-no-skip-core`.
- `cover`'s gcov collection no longer walks the whole tree for `.gcov`
  files - it captures gcov's "Creating ..." stdout and consumes only
  what the current run produced. Previously a sibling distribution's
  build dir (e.g. under `tmp/runs/`) was slurped into the report.
- Without `-gcov_chdir`, `cover` no longer attempts to gcov sources in
  subdirectories (gcov can't read them from cwd anyway, and the
  attempt produced noisy errors plus useless stub `.gcov` files).
- `dc cpan-module` and `dc cpan-collection` no longer pre-build before
  invoking `cover -test`. The pre-`make` left a stale `.o` that
  subsequent coverage builds refused to recompile, silently dropping
  XS coverage flags.

## Implications

Two breaking changes are flagged in `Changes`:

- CORE headers now excluded from coverage by default (intended).
- Foreign `.gcov` files in nearby directories no longer slurped into
  the current run. Anyone relying on that behaviour can fall back to
  invoking `gcov2perl` directly with the file list.

Users with XS in subdirectories need to set `-gcov_chdir` to get
coverage; previously they got noisy errors and broken stubs.
Everyone else gets quieter output.

## Issue

Closes #344