### PR TITLE
GH-457 Add -jobs option for parallel test runs

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -102,6 +102,7 @@ sub get_options () {
         ignore_covered_err!
         ignore_re=s
         info|i!
+        jobs|j=i
         launch!
         make=s
         outputdir=s
@@ -288,6 +289,15 @@ sub mm_test_command () {
 # Decide whether to run ./Build test or make test
 sub test_command () { -e "Build" ? mb_test_command : mm_test_command }
 
+# Build the HARNESS_OPTIONS value for the spawned test run, honouring -jobs
+# and any pre-existing HARNESS_OPTIONS the user has set in the environment.
+sub harness_options () {
+  my $existing = $ENV{HARNESS_OPTIONS};
+  my $jobs     = $Options->{jobs};
+  return $existing unless defined $jobs && $jobs > 1;
+  defined $existing && length $existing ? "$existing:j$jobs" : "j$jobs"
+}
+
 sub do_test ($dbname) {
   return 0                  unless $Options->{test};
   delete_db($dbname, @ARGV) unless defined $Options->{delete};
@@ -310,6 +320,7 @@ sub do_test ($dbname) {
     "-MDevel::Cover=-db,$env_db_name$extra";
   local $ENV{HARNESS_PERL_SWITCHES} = $opts;
   local $ENV{PERL5OPT}              = $opts;
+  local $ENV{HARNESS_OPTIONS}       = harness_options();
 
   my $test = test_command;
 
@@ -632,6 +643,7 @@ The following command line options are supported:
  -test                 - drop database(s) and run make test (default off)
  -gcov                 - run gcov to cover XS code     (default on if using gcc)
  -make make_prog       - use the given 'make' program for 'make test'
+ -jobs N (-j N)        - run the test harness with N parallel workers
  -prefer_lib           - prefer files in lib                (default off)
  -ignore_covered_err   - allow covering uncoverable code    (default off)
 
@@ -749,6 +761,15 @@ For detailed instructions see the documentation for ExtUtils::MakeMaker at
 L<https://metacpan.org/module/ExtUtils::MakeMaker> or for Module::Build at
 L<https://metacpan.org/module/Module::Build> both of which come as standard
 in recent Perl distributions.
+
+The C<-jobs> option (also spellt C<-j>) asks the test harness to run that many
+test processes in parallel by setting C<HARNESS_OPTIONS=jN> for the spawned
+C<make test> or C<./Build test>.  Devel::Cover stores per-process runs
+separately under C<cover_db/runs/> and merges them at report time, so parallel
+test execution is safe by design.  Test suites that have ordering dependencies
+or shared resources may still need to remain sequential.  Any C<HARNESS_OPTIONS>
+already set in the environment is preserved; the C<jN> fragment is appended to
+it.
 
 The C<-gcov> option will try to run gcov on any XS code.  This requires that
 you are using gcc of course.  If you are using the C<-test> option will be

--- a/t/internal/cover_jobs.t
+++ b/t/internal/cover_jobs.t
@@ -1,0 +1,97 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Cwd                qw( getcwd );
+use File::Spec         ();
+use File::Temp         qw( tempdir );
+use FindBin            ();
+use lib $FindBin::Bin, qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing like note plan unlike )];
+
+my $Project   = getcwd;
+my $Cover     = File::Spec->catfile($Project, "bin", "cover");
+my $Blib_lib  = File::Spec->catdir($Project, "blib", "lib");
+my $Blib_arch = File::Spec->catdir($Project, "blib", "arch");
+
+unless (-f $Cover && -d $Blib_lib && -d $Blib_arch) {
+  plan skip_all => "build artefacts missing - run after `make`";
+  exit;
+}
+
+if ($^O eq "MSWin32") {
+  plan skip_all => "POSIX shell helper not portable to Windows";
+  exit;
+}
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+
+# A stand-in for `make` that simply reports what HARNESS_OPTIONS it saw.
+my $Fake_make = File::Spec->catfile($Tmpdir, "fake-make");
+{
+  open my $fh, ">", $Fake_make or die "open $Fake_make: $!";
+  print {$fh} <<'SH';
+#!/bin/sh
+printf 'CHILD_HARNESS_OPTIONS=%s\n' "$HARNESS_OPTIONS"
+exit 0
+SH
+  close $fh or die "close $Fake_make: $!";
+  chmod 0755, $Fake_make;
+}
+
+my $Db = File::Spec->catdir($Tmpdir, "cover_db");
+mkdir $Db or die "mkdir $Db: $!";
+
+sub run_cover (@extra_args) {
+  my $cmd = join " ", $^X, $Cover, "-test", "-silent", "-no-summary",
+    "-no-gcov", "-no-delete", "-make", $Fake_make, @extra_args, "-write", $Db;
+  my $out = `$cmd 2>/dev/null`;
+  note $out;
+  $out
+}
+
+sub test_long_form () {
+  like run_cover("-jobs", 3), qr/CHILD_HARNESS_OPTIONS=.*\bj3\b/,
+    "child harness sees HARNESS_OPTIONS=j3 when -jobs 3 passed";
+}
+
+sub test_short_form () {
+  like run_cover("-j", 5), qr/CHILD_HARNESS_OPTIONS=.*\bj5\b/,
+    "short form -j 5 also propagates";
+}
+
+sub test_no_jobs () {
+  unlike run_cover(), qr/CHILD_HARNESS_OPTIONS=.*\bj\d/,
+    "no -jobs leaves HARNESS_OPTIONS unset";
+}
+
+sub test_appends_to_existing () {
+  local $ENV{HARNESS_OPTIONS} = "c";
+  like run_cover("-jobs", 4), qr/CHILD_HARNESS_OPTIONS=c:j4\b/,
+    "-jobs appends to existing HARNESS_OPTIONS";
+}
+
+sub main () {
+  local $ENV{PERL5LIB} = join ":", $Blib_lib, $Blib_arch,
+    ($ENV{PERL5LIB} // ());
+  local $ENV{HARNESS_OPTIONS} = "";
+
+  test_long_form;
+  test_short_form;
+  test_no_jobs;
+  test_appends_to_existing;
+  done_testing;
+}
+
+main;

--- a/utils/dc
+++ b/utils/dc
@@ -55,11 +55,13 @@ Development:
                                        versions.  Multiple tests may be given.
   all-versions <cmd>                   Run a command across all Perl versions.
   build-and-test-all                   Clean build and run all tests.
-  cpan-collection <module> ...         Download CPAN modules and run their tests
-                                       under coverage, producing a combined
-                                       collection report.
-  cpan-module <module>                 Download a CPAN module and run its tests
-                                       under coverage.
+  cpan-collection <module> ... [-- args]
+                                       Download CPAN modules and run their tests
+                                       under coverage.  Args after "--" pass
+                                       through to "cover -test" for each module.
+  cpan-module <module> [args]          Download a CPAN module and run its tests
+                                       under coverage.  Trailing args pass
+                                       through to "cover" (eg -j 9, -no-launch).
   dc-cover                             Combined self-coverage for lib and report
                                        modules.
   dc-cover-lib                         Self-coverage for library modules (Path,
@@ -1234,6 +1236,8 @@ cpan_distdir() {
 
 cpan_module() {
   local module="${1:?No module specified}"
+  shift
+  local cover_args=("$@")
   local dc_root
   dc_root=$(cd "$srcdir/.." && pwd)
   local workdir="$dc_root/tmp/runs"
@@ -1282,10 +1286,13 @@ cpan_module() {
     pf "No Makefile.PL or Build.PL found"
   fi
 
-  # Run tests with coverage using local Devel::Cover
+  # Run tests with coverage using local Devel::Cover.  Trailing args from the
+  # recipe invocation pass through to `cover -test`, so users can append
+  # options such as `-j 9`, `-no-launch`, `-coverage statement`, etc.
   pi "Running tests with coverage (local Devel::Cover)"
   export DEVEL_COVER_TEST_OPTS="-Mblib=$dc_root"
-  perl "-Mblib=$dc_root" "$dc_root/bin/cover" -test -report html -launch
+  perl "-Mblib=$dc_root" "$dc_root/bin/cover" -test -report html -launch \
+    ${cover_args[@]:+"${cover_args[@]}"}
 
   pi "Done. Results in: $(pwd)/cover_db"
 }
@@ -1299,6 +1306,8 @@ cpan_collection_module() {
   local results_dir="${2:?No results_dir specified}"
   local dc_root="${3:?No dc_root specified}"
   local cpan_info="${4:?No cpan info specified}"
+  shift 4
+  local cover_args=("$@")
   local workdir="$dc_root/tmp/collection/work"
 
   local dist=${cpan_info##*/}
@@ -1354,8 +1363,8 @@ cpan_collection_module() {
   export DEVEL_COVER_OPTIONS="-ignore,^local/"
   export DEVEL_COVER_TEST_OPTS="-Mblib=$dc_root"
   local cover_cmd=(perl "-Mblib=$dc_root" "$dc_root/bin/cover")
-  "${cover_cmd[@]}" -test -report html_crisp \
-    -outputfile index.html || true
+  "${cover_cmd[@]}" -test -report html_crisp -outputfile index.html \
+    ${cover_args[@]:+"${cover_args[@]}"} || true
   "${cover_cmd[@]}" -report json_summary -nosummary || true
 
   # Move results to collection results_dir
@@ -1403,7 +1412,20 @@ cpan_collection() {
   dc_root=$(cd "$srcdir/.." && pwd)
   local results_dir="$dc_root/tmp/collection/results"
 
-  local modules=("$@")
+  # Split args at `--`: leading args are module names, trailing args pass
+  # through to each per-module `cover -test` invocation.
+  local modules=() cover_args=() seen_sep=0
+  local arg
+  for arg in "$@"; do
+    if ((seen_sep)); then
+      cover_args+=("$arg")
+    elif [[ "$arg" == "--" ]]; then
+      seen_sep=1
+    else
+      modules+=("$arg")
+    fi
+  done
+  ((${#modules[@]})) || pf "No modules specified"
   local distdirs=()
 
   # Resolve all modules up front (single cpanm --info call per module)
@@ -1419,7 +1441,7 @@ cpan_collection() {
 
   for i in "${!modules[@]}"; do
     cpan_collection_module "${modules[$i]}" "$results_dir" "$dc_root" \
-      "${infos[$i]}"
+      "${infos[$i]}" ${cover_args[@]:+"${cover_args[@]}"}
   done
 
   # Generate collection report via Collection.pm's generate_html


### PR DESCRIPTION
## Summary

Adds parallel test execution to `cover -test` via a new `-jobs N` (or `-j N`) option, which sets `HARNESS_OPTIONS=jN` for the spawned `make test` / `./Build test`. Devel::Cover already records per-process runs separately under `cover_db/runs/` and merges them at report time, so it does not introduce any new parallel-safety concerns of its own.

Also forwards trailing args from `dc cpan-module` and `dc cpan-collection` to the underlying `cover` invocation, so the new option (and any other `cover` flag) can be used from those wrappers without editing the recipe.

## Changes

- `bin/cover`: new `-jobs/-j` option that propagates as `HARNESS_OPTIONS=jN`, preserving any existing `HARNESS_OPTIONS` value.
- `t/internal/cover_jobs.t`: end-to-end test using a fake `make` to verify long form, short form, no-jobs, and existing-env-var append behaviour.
- `utils/dc`: `cpan-module <mod> [args]` and `cpan-collection <mod>... [-- args]` forward trailing args to `cover -test`.
- POD updated with usage notes for `-jobs`.

## Implications

Parallel runs under Devel::Cover are only as safe as parallel runs of the same suite without it. If a suite is not safe under a bare `prove -jN` (e.g. shared databases, fixed ports, ordering dependencies), `-jobs` will not make it safe. Default behaviour is unchanged: `-jobs` is opt-in.

## Issue

Closes #457