### PR TITLE
GH-474 Deep-link Html_crisp cells to filters

### DIFF
--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -131,8 +131,9 @@ sub cov_bar ($pc, $uncompiled) {
 sub cov_cell ($s, $uncompiled, $data_value = undef, $link = undef) {
   my $dv      = $data_value // (is_na($s->{pc}) ? -1 : $s->{pc});
   my $no_data = $uncompiled && !$R{have_ppi};
-  my $cls   = $no_data ? $s->{class} : "$s->{class} tip-hover";
-  my $tip   = $no_data ? ""          : glass_tip("$s->{covered} / $s->{total}");
+  my $no_tip  = $no_data || ($s->{total} // 0) == 0;
+  my $cls   = $no_tip ? $s->{class} : "$s->{class} tip-hover";
+  my $tip   = $no_tip ? ""          : glass_tip("$s->{covered} / $s->{total}");
   my $bar   = cov_bar($s->{pc}, $uncompiled);
   my $inner = "$s->{pc} $bar";
 
@@ -239,13 +240,17 @@ HTML
 }
 
 sub stat_badge ($c, $s) {
-  my $pct = $s->{pc};
-  my $suf = is_na($pct) ? "" : "%";
+  my $pct    = $s->{pc};
+  my $suf    = is_na($pct) ? "" : "%";
+  my $no_tip = ($s->{total} // 0) == 0;
+  my $cls    = $no_tip ? $s->{class} : "$s->{class} tip-hover";
+  my $tip    = $no_tip ? ""          : glass_tip("$s->{covered} / $s->{total}");
+
   <<HTML
-<span class="stat-badge $s->{class} tip-hover">
+<span class="stat-badge $cls">
 <span class="badge-label">@{[ crit_name($c) ]} $pct$suf</span>
 @{[ cov_bar($pct, 0) ]}
-@{[ glass_tip("$s->{covered} / $s->{total}") ]}</span>
+$tip</span>
 HTML
 }
 
@@ -551,14 +556,18 @@ sub render_file_page ($fd, $lines, $total, $prev_file, $next_file) {
 HTML
 
   for my $c ($R{criteria}->@*) {
-    my $s   = $total->{$c};
-    my $cls = $fd->{uncompiled} ? "untested-stat" : ($s->{class} || "stat-na");
-    my $suf = is_na($s->{pc})   ? ""              : "%";
+    my $s    = $total->{$c};
+    my $base = $fd->{uncompiled} ? "untested-stat" : ($s->{class} || "stat-na");
+    my $suf  = is_na($s->{pc})   ? ""              : "%";
+    my $no_tip = ($s->{total} // 0) == 0;
+    my $cls    = $no_tip ? $base : "$base tip-hover";
+    my $tip    = $no_tip ? ""    : glass_tip("$s->{covered} / $s->{total}");
+
     $o .= <<HTML;
-<span class="stat-badge $cls tip-hover" data-criterion="$c">
+<span class="stat-badge $cls" data-criterion="$c">
 <span class="badge-label">@{[ crit_name($c) ]} $s->{pc}$suf</span>
 @{[ cov_bar($s->{pc}, $fd->{uncompiled}) ]}
-@{[ glass_tip("$s->{covered} / $s->{total}") ]}</span>
+$tip</span>
 HTML
   }
 

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -84,11 +84,8 @@ sub untested_badge () {
   qq(<span class="untested-badge$cls">untested $tip</span>)
 }
 
-sub glass_tip ($text) {
-  qq(<span class="glass-tip">$text</span>)
-}
-
-sub is_na ($v) { !defined $v || $v eq "n/a" || $v eq "-" }
+sub glass_tip ($text) { qq(<span class="glass-tip">$text</span>) }
+sub is_na     ($v)    { !defined $v || $v eq "n/a" || $v eq "-" }
 
 sub slop_tip ($f) {
   return "" if is_na($f->{file_slop});

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -2159,7 +2159,7 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
       var hashCrit = hashMatch[1];
       for (var hi = 0; hi < badges.length; hi++) {
         if (badges[hi].getAttribute("data-criterion") === hashCrit) {
-          applyFilter(hashCrit);
+          toggleFilter(hashCrit);
           break;
         }
       }

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -30,7 +30,7 @@ use Devel::Cover::Path            qw( common_prefix );
 use File::Path     qw( mkpath );
 use Getopt::Long   qw( GetOptions );
 use HTML::Entities qw( encode_entities );
-use List::Util     qw( any );
+use List::Util     qw( any first );
 use POSIX          qw( strftime );
 our %R;
 my %Assets;
@@ -128,16 +128,16 @@ sub cov_bar ($pc, $uncompiled) {
   qq(<span class="$bar">\n$fill</span>\n)
 }
 
-sub cov_cell ($s, $uncompiled, $data_value = undef) {
+sub cov_cell ($s, $uncompiled, $data_value = undef, $link = undef) {
   my $dv      = $data_value // (is_na($s->{pc}) ? -1 : $s->{pc});
   my $no_data = $uncompiled && !$R{have_ppi};
-  my $cls = $no_data ? $s->{class} : "$s->{class} tip-hover";
-  my $tip = $no_data ? ""          : glass_tip("$s->{covered} / $s->{total}");
-  <<HTML
-<td class="$cls" data-value="$dv">
-$s->{pc} @{[ cov_bar($s->{pc}, $uncompiled) ]}
-$tip</td>
-HTML
+  my $cls   = $no_data ? $s->{class} : "$s->{class} tip-hover";
+  my $tip   = $no_data ? ""          : glass_tip("$s->{covered} / $s->{total}");
+  my $bar   = cov_bar($s->{pc}, $uncompiled);
+  my $inner = "$s->{pc} $bar";
+
+  $inner = qq(<a class="cell-link" href="$link">$inner</a>) if $link;
+  qq(<td class="$cls" data-value="$dv">$inner $tip</td>)
 }
 
 sub file_row ($f, $dir) {
@@ -146,7 +146,8 @@ sub file_row ($f, $dir) {
     = $f->{exists}
     ? qq(<a href="$f->{link}">$f->{basename}</a>)
     : $f->{basename};
-  my $badge = $f->{uncompiled} ? untested_badge() . "\n" : "";
+  my $badge    = $f->{uncompiled} ? untested_badge() . "\n" : "";
+  my $linkable = $f->{exists} && !$f->{uncompiled};
 
   my $o = <<HTML;
 <tr class="$cls" data-dir="$dir">
@@ -154,22 +155,26 @@ sub file_row ($f, $dir) {
 HTML
 
   for my $c ($R{criteria}->@*) {
-    $o .= cov_cell($f->{criteria}{$c}, $f->{uncompiled});
+    my $link = $linkable ? "$f->{link}#filter=$c" : undef;
+    $o .= cov_cell($f->{criteria}{$c}, $f->{uncompiled}, undef, $link);
   }
-  $o .= cov_cell($f->{total}, $f->{uncompiled}, $f->{total_sort});
-  $o .= slop_cell($f);
+  my $total_link = $linkable ? "$f->{link}#filter=total" : undef;
+  $o .= cov_cell($f->{total}, $f->{uncompiled}, $f->{total_sort}, $total_link);
+  $o .= slop_cell($f, $linkable ? $f->{link} : undef);
   $o .= "</tr>\n";
   $o
 }
 
-sub slop_cell ($f) {
-  my $slop = $f->{file_slop};
-  my $na   = is_na($slop);
-  my $dv   = $na ? -1   : $slop;
-  my $cls  = $na ? "na" : "tip-hover";
+sub slop_cell ($f, $link = undef) {
+  my $slop  = $f->{file_slop};
+  my $na    = is_na($slop);
+  my $dv    = $na   ? -1   : $slop;
+  my $cls   = $na   ? "na" : "tip-hover";
+  my $value = $link ? qq(<a class="cell-link" href="$link">$slop</a>) : $slop;
+
   <<HTML
 <td data-value="$dv" class="$cls">
-$slop @{[ slop_tip($f) ]}</td>
+$value @{[ slop_tip($f) ]}</td>
 HTML
 }
 
@@ -304,6 +309,9 @@ compressed to a 0-100 range. Hover for a breakdown: file CC,
 combined coverage, worst subs, and the raw CRAP score.</dd>
 <dt>Tooltips</dt>
 <dd>Hover any badge or coverage cell for covered/total counts.</dd>
+<dt>Cell click</dt>
+<dd>Click a coverage cell to open the file with that criterion
+filter active. Click a SLOP cell to open the file at the top.</dd>
 </dl>
 </div>
 </div>
@@ -358,13 +366,18 @@ HTML
 HTML
 
   for my $g (@groups) {
+    my $t = first { $_->{exists} && !$_->{uncompiled} } $g->{files}->@*;
     $o .= qq(<tr class="dir-header" data-dir="$g->{dir}">\n)
       . "<td>$g->{dir}</td>\n";
     for my $c ($R{criteria}->@*) {
-      $o .= cov_cell($g->{criteria}{$c}, 0);
+      $o .= cov_cell(
+        $g->{criteria}{$c},
+        0, undef, $t ? "$t->{link}#filter=$c" : undef,
+      );
     }
-    $o .= cov_cell($g->{total}, 0);
-    $o .= slop_cell($g);
+    $o .= cov_cell($g->{total}, 0, undef,
+      $t ? "$t->{link}#filter=total" : undef);
+    $o .= slop_cell($g, $t ? $t->{link} : undef);
     $o .= "</tr>\n";
     $o .= file_row($_, $g->{dir}) for $g->{files}->@*;
   }
@@ -1404,6 +1417,15 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
 
 .file-table td:first-child { text-align: left; }
 
+.file-table .cell-link {
+  display: block;
+  margin: -4px -10px;
+  padding: 4px 10px;
+  color: inherit;
+  text-decoration: none;
+}
+.file-table .cell-link:hover { opacity: 0.85; }
+
 .file-table tr { transition: background 0.15s ease; }
 .file-table tr:hover { background: var(--bg-alt); }
 
@@ -1999,6 +2021,7 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
 
     /* Directory collapse/expand */
     tbody.addEventListener("click", function(e) {
+      if (e.target.closest(".cell-link")) return;
       var dh = e.target.closest(".dir-header");
       if (!dh) return;
       var collapsed = dh.classList.toggle("collapsed");
@@ -2057,6 +2080,15 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
     var detailIdx = -1;
     var currentRow = null;
 
+    function syncHash(crit) {
+      var base = location.pathname + location.search;
+      var target = crit ? base + "#filter=" + crit : base;
+      if (location.href.replace(location.origin, "") !==
+          target.replace(location.origin, "")) {
+        history.replaceState(null, "", target);
+      }
+    }
+
     function clearFilter() {
       activeCriterion = null;
       detailIdx = -1;
@@ -2067,6 +2099,7 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
       badges.forEach(function(b) {
         b.classList.remove("badge-active");
       });
+      syncHash(null);
     }
 
     function applyFilter(crit) {
@@ -2096,6 +2129,7 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
         currentRow = first.previousElementSibling || first;
         scrollHighlight(currentRow);
       }
+      syncHash(crit);
     }
 
     function toggleFilter(crit) {
@@ -2112,6 +2146,18 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
         toggleFilter(badge.getAttribute("data-criterion"));
       });
     });
+
+    /* Apply filter from URL hash on load */
+    var hashMatch = (location.hash || "").match(/^#filter=([a-z]+)$/i);
+    if (hashMatch) {
+      var hashCrit = hashMatch[1];
+      for (var hi = 0; hi < badges.length; hi++) {
+        if (badges[hi].getAttribute("data-criterion") === hashCrit) {
+          applyFilter(hashCrit);
+          break;
+        }
+      }
+    }
 
     /* Keyboard navigation */
     var uncovered = document.querySelectorAll(
@@ -2270,8 +2316,8 @@ This module provides a modern HTML reporting mechanism for coverage data. It
 generates a single-page dashboard with file listing and per-file source views
 with inline branch, condition, and subroutine detail.
 
-Features include dark mode support, keyboard navigation, sortable columns, and
-inline condition truth tables.
+Features include dark mode support, keyboard navigation, sortable columns,
+inline condition truth tables, and deep-linkable filters.
 
 It is designed to be called from the C<cover> program.  It will add syntax
 highlighting if C<PPI::HTML> or C<Perl::Tidy> is installed.

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -244,8 +244,10 @@ sub test_cov_cell_tooltips () {
   my $na
     = _cov_cell({ pc => "n/a", class => "na", covered => 0, total => 0 }, 0, 1,
     );
-  like $na, qr/class="na tip-hover"/, "tested n/a cell: tip-hover kept";
-  like $na, qr/glass-tip">0 \/ 0</,   "tested n/a cell: glass-tip 0 / 0 kept";
+  unlike $na, qr/tip-hover/,
+    "tested n/a cell: no tip-hover (0/0 uninformative)";
+  unlike $na, qr/glass-tip/,
+    "tested n/a cell: no glass-tip (0/0 uninformative)";
 
   my $unc_ppi
     = _cov_cell({ pc => "0", class => "c0", covered => 0, total => 5 }, 1, 1);
@@ -294,6 +296,26 @@ sub test_slop_cell_link () {
     = Devel::Cover::Report::Html_crisp::slop_cell($f, "tests-foo.html");
   like $with_link, qr{<a class="cell-link" href="tests-foo\.html">33\.4</a>},
     "slop with link: anchor wraps slop value (no filter hash)";
+}
+
+sub test_stat_badge_no_tip_when_empty () {
+  no warnings "once";
+  local %Devel::Cover::Report::Html_crisp::R = (
+    full  => { statement => "Statement", total => "total" },
+    short => { statement => "stmt",      total => "total" },
+  );
+
+  my $empty = Devel::Cover::Report::Html_crisp::stat_badge(
+    "statement", { pc => "n/a", class => "na", covered => 0, total => 0 },
+  );
+  unlike $empty, qr/tip-hover/, "stat_badge: no tip-hover when total = 0";
+  unlike $empty, qr/glass-tip/, "stat_badge: no glass-tip when total = 0";
+
+  my $real = Devel::Cover::Report::Html_crisp::stat_badge(
+    "statement", { pc => "75.0", class => "c2", covered => 3, total => 4 },
+  );
+  like $real, qr/tip-hover/,         "stat_badge: tip-hover when total > 0";
+  like $real, qr{glass-tip">3 / 4<}, "stat_badge: glass-tip with counts";
 }
 
 sub test_index_filter_links () {
@@ -362,6 +384,7 @@ sub main () {
   test_cov_cell_tooltips;
   test_cov_cell_link;
   test_slop_cell_link;
+  test_stat_badge_no_tip_when_empty;
   test_index_filter_links;
   test_dir_header_links;
   test_app_js_hash_filter;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -52,6 +52,7 @@ sub _setup () {
     (my $name = $file) =~ s{.*/}{};
     $Golden{$name} = slurp($file);
   }
+  ok keys %Golden, "golden output captured";
 }
 
 sub test_crit_name () {
@@ -369,7 +370,6 @@ sub test_untested_badge_tooltip () {
 
 sub main () {
   _setup;
-  ok keys %Golden > 0, "golden output captured";
   test_crit_name;
   test_render_layout;
   test_render_index;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -226,10 +226,12 @@ sub test_render_untested_page () {
   like $got, qr/untested-badge/, "untested: has badge";
 }
 
-sub _cov_cell ($s, $uncompiled, $have_ppi) {
+sub _cov_cell ($s, $uncompiled, $have_ppi, %opts) {
   no warnings "once";
   local %Devel::Cover::Report::Html_crisp::R = (have_ppi => $have_ppi);
-  Devel::Cover::Report::Html_crisp::cov_cell($s, $uncompiled)
+  Devel::Cover::Report::Html_crisp::cov_cell(
+    $s, $uncompiled, $opts{data_value}, $opts{link},
+  )
 }
 
 sub test_cov_cell_tooltips () {
@@ -254,6 +256,73 @@ sub test_cov_cell_tooltips () {
     = _cov_cell({ pc => "-", class => "na", covered => 0, total => 0 }, 1, 0);
   unlike $unc_no_ppi, qr/tip-hover/, "untested without PPI: no tip-hover class";
   unlike $unc_no_ppi, qr/glass-tip/, "untested without PPI: no glass-tip";
+}
+
+sub test_cov_cell_link () {
+  my $no_link
+    = _cov_cell({ pc => "75.0", class => "c2", covered => 3, total => 4 }, 0,
+      1);
+  unlike $no_link, qr/<a class="cell-link"/, "no link: no anchor";
+
+  my $with_link = _cov_cell(
+    { pc => "75.0", class => "c2", covered => 3, total => 4 },
+    0, 1, link => "tests-foo.html#filter=condition",
+  );
+  like $with_link,
+    qr{<a class="cell-link" href="tests-foo\.html#filter=condition">},
+    "with link: anchor has correct href";
+  like $with_link, qr/<a class="cell-link"[^>]*>75\.0/,
+    "with link: anchor wraps the percent value";
+}
+
+sub test_slop_cell_link () {
+  no warnings "once";
+  local %Devel::Cover::Report::Html_crisp::R = ();
+
+  my $f = {
+    file_slop  => "33.4",
+    file_crap  => "12.5",
+    file_cc    => 5,
+    file_cov   => 80,
+    worst_subs => [],
+  };
+
+  my $no_link = Devel::Cover::Report::Html_crisp::slop_cell($f);
+  unlike $no_link, qr/<a class="cell-link"/, "slop no link: no anchor";
+
+  my $with_link
+    = Devel::Cover::Report::Html_crisp::slop_cell($f, "tests-foo.html");
+  like $with_link, qr{<a class="cell-link" href="tests-foo\.html">33\.4</a>},
+    "slop with link: anchor wraps slop value (no filter hash)";
+}
+
+sub test_index_filter_links () {
+  my $got = $Golden{"coverage.html"};
+  like $got, qr{cell-link" href="[^"]*#filter=statement"},
+    "index: statement cell links with #filter=statement";
+  like $got, qr{cell-link" href="[^"]*#filter=total"},
+    "index: total cell links with #filter=total";
+  like $got, qr{cell-link" href="[^"]*\.html">},
+    "index: SLOP cell links to file without #filter";
+}
+
+sub test_dir_header_links () {
+  my $got = $Golden{"coverage.html"};
+  my ($dir_block) = $got =~ m{(<tr class="dir-header".*?</tr>)}s;
+  ok defined $dir_block, "dir-header row found in golden index";
+  like $dir_block, qr/cell-link/,
+    "dir-header: cells wrapped in cell-link anchors";
+  like $dir_block, qr/#filter=/,
+    "dir-header: cell-link hrefs include filter hash";
+}
+
+sub test_app_js_hash_filter () {
+  my $app_js = slurp(File::Spec->catfile($Outdir, "assets", "app.js"));
+  like $app_js, qr/syncHash/,              "app.js: syncHash helper present";
+  like $app_js, qr/history\.replaceState/, "app.js: uses replaceState";
+  like $app_js, qr/#filter=/,              "app.js: filter hash referenced";
+  like $app_js, qr/location\.hash/,        "app.js: reads location.hash";
+  like $app_js, qr/cell-link/, "app.js: index click handler aware of cell-link";
 }
 
 sub test_untested_badge_tooltip () {
@@ -291,6 +360,11 @@ sub main () {
   test_file_nav_keys;
   test_render_untested_page;
   test_cov_cell_tooltips;
+  test_cov_cell_link;
+  test_slop_cell_link;
+  test_index_filter_links;
+  test_dir_header_links;
+  test_app_js_hash_filter;
   test_untested_badge_tooltip;
   done_testing;
 }


### PR DESCRIPTION
## Summary

Each coverage cell on the Html_crisp index now deep-links to the file's detail page with the matching criterion filter already active - the same view you'd get by opening the file and pressing `c`, `b`, `u`, etc. The filter state lives in the URL hash, so the link is shareable and survives reload.

## Changes

- Wrap each criterion / total / SLOP cell on the index in an anchor whose href carries the right `#filter=<criterion>` hash. Dir-header rows link to the worst-SLOP file in the group; SLOP cells link to the file without a filter.
- File-detail JS reads `#filter=<criterion>` on load and applies the filter, and rewrites the hash via `replaceState` when filters are toggled or cleared.
- Suppress hover tooltips that would have shown an uninformative `0 / 0` (dir-headers, n/a criterion cells, header summary badges with no items).

## Issue

Closes #474