### PR TITLE
Wrap Html_crisp header badges at narrow widths

### DIFF
--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1177,12 +1177,15 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   .stat-slop  { width: auto; }
 }
 
-/* Narrow: stack pills vertically */
+/* Narrow: wrap badges onto multiple lines, right-aligned. max-width clamps the
+(flex-shrink: 0) container to its parent so wrap actually engages instead of
+overflowing. */
 @container (max-width: 1200px) {
   .header-stats {
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 4px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    row-gap: 6px;
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
Fixes #475

## Summary

- Replace the column-stacking fallback in `.header-stats` with
  horizontal wrap (right-aligned), so badges no longer form a tall
  pillar beside the title at sub-1200px container widths.
- `max-width: 100%` clamps the (`flex-shrink: 0`) container to its
  parent so the wrap actually engages instead of overflowing at very
  narrow widths.

## Test plan

- [x] `t/internal/html_crisp.t` and `t/internal/html_crisp_render.t`
      pass.
- [x] Visual check at >1450px (unchanged single-row), ~1200px (title +
      single badge row), and very narrow simulated container widths
      (badges wrap onto multiple right-aligned rows, no overflow).