### PR TITLE
GH-490 Rename the SLOP risk metric to SCAR

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,7 +16,7 @@ Devel::Cover history
   implementation - condition coverage results may change (GH-446)
 - BREAKING: Add branch coverage for while, until and C-style for loop conditions
   (GH-449)
-- Add SLOP (Scaled Likelihood Of Problems) risk scoring to reports (GH-448)
+- Add SCAR (Scaled Complexity And Risk) risk scoring to reports (GH-448)
 - BREAKING: Exclude Perl CORE headers from XS coverage - -relative_only now
   defaults on and gcov2perl skips CORE sources (rwfranks) (GH-344)
 - BREAKING: cover consumes only its own .gcov files, not the whole tree - XS

--- a/docs/technical/scar.md
+++ b/docs/technical/scar.md
@@ -1,6 +1,6 @@
-# SLOP: Scaled Likelihood Of Problems
+# SCAR: Scaled Complexity And Risk
 
-SLOP is Devel::Cover's risk-scoring metric. It combines cyclomatic complexity
+SCAR is Devel::Cover's risk-scoring metric. It combines cyclomatic complexity
 and code coverage into a single number that answers: "where should I spend my
 testing effort?" This document records the research, the decisions, and the
 design.
@@ -103,7 +103,7 @@ PHPUnit and NDepend are the two most prominent implementations.
 
 ## Options Considered
 
-Seven approaches were evaluated before settling on CRAP + SLOP:
+Seven approaches were evaluated before settling on CRAP + SCAR:
 
 ### Option 1: Missed count
 
@@ -168,7 +168,7 @@ a CPAN distribution and is a significant new feature beyond a formula change.
 
 \* lcov uses missed count for sorting but does not call it "risk".
 
-## Why CRAP, and Why SLOP
+## Why CRAP, and Why SCAR
 
 CRAP was the clear winner: it is the only published, peer-reviewed, widely
 adopted coverage-based risk formula. It required cyclomatic complexity, which
@@ -181,25 +181,27 @@ scores 2,550. Even moderate codebases can produce scores in the tens or even
 hundreds of thousands. This makes it difficult to scan a table and quickly
 assess relative risk.
 
-SLOP compresses this range using a natural logarithm:
+SCAR compresses this range using a natural logarithm:
 
 ```text
-slop = crap > 1 ? ln(crap) * 10 : 0
+scar = crap > 1 ? ln(crap) * 10 : 0
 ```
 
 This maps the CRAP range of approximately 1-20,000 to roughly 0-100. Each +10
-SLOP represents approximately 2.7x worse CRAP (one e-fold). The standard CRAP
-threshold of 30 maps to SLOP ~34.
+SCAR represents approximately 2.7x worse CRAP (one e-fold). The standard CRAP
+threshold of 30 maps to SCAR ~34.
 
-The name "Scaled Likelihood Of Problems" was chosen to:
+The name "Scaled Complexity And Risk" was chosen to:
 
-- Describe what it measures (likelihood of problems, scaled for readability)
-- Be memorable and slightly irreverent (like CRAP itself)
+- Describe what it measures (complexity and the coverage-gap risk that drives
+  it, scaled for readability)
+- Be memorable and slightly irreverent (like CRAP itself), while a scar is an
+  apt image: a visible mark of damage, which is just what the metric points to
 - Distinguish it from raw CRAP in reports and documentation
 
 ### Display strategy
 
-SLOP is the primary displayed value in all reports. Raw CRAP remains accessible
+SCAR is the primary displayed value in all reports. Raw CRAP remains accessible
 in Html_crisp tooltips for users who want the standard metric. This gives the
 best of both worlds: a scannable, bounded number in the table, with the
 published metric one hover away.
@@ -208,7 +210,7 @@ published metric one hover away.
 
 Risk scoring is computed in `DB::calculate_summary` (via `summarise_complexity`)
 rather than in individual reporters. This means all reporters and CLI tools get
-SLOP data for free without duplicating the formula. The DB layer gains an
+SCAR data for free without duplicating the formula. The DB layer gains an
 opinion about what "risk" means, but the alternative - each reporter computing
 its own risk - leads to duplication and divergence. A shared utility module was
 considered but adds indirection for no practical benefit when there is exactly
@@ -377,14 +379,14 @@ At 100% coverage, CRAP equals CC (complexity alone). At 0% coverage, CRAP equals
 CC^2 + CC. The cubic exponent on the coverage gap makes the penalty steep: going
 from 90% to 80% coverage hurts much more than going from 50% to 40%.
 
-### SLOP
+### SCAR
 
 ```text
-slop = crap > 1 ? ln(crap) * 10 : 0
+scar = crap > 1 ? ln(crap) * 10 : 0
 ```
 
 The minimum possible CRAP score is 1 (a subroutine with CC=1 at 100% coverage:
-1^2 * 0^3 + 1 = 1). Since ln(1) = 0, SLOP is zero for a perfect score. The `> 1`
+1^2 * 0^3 + 1 = 1). Since ln(1) = 0, SCAR is zero for a perfect score. The `> 1`
 guard makes this explicit and avoids any floating-point edge cases near the
 boundary. The factor of 10 scales the range to roughly 0-100.
 
@@ -412,18 +414,18 @@ weaker than full basis path coverage. A subroutine with no coverable points
 
 ## Colour Thresholds
 
-The `slop_class` function maps SLOP values to the existing c0-c3 CSS classes
+The `scar_class` function maps SCAR values to the existing c0-c3 CSS classes
 used throughout Devel::Cover for coverage colouring. The thresholds are
 log-transforms of established CRAP boundaries:
 
-| SLOP range | CSS class | CRAP equivalent | Meaning        |
+| SCAR range | CSS class | CRAP equivalent | Meaning        |
 | ---------- | --------- | --------------- | -------------- |
 | < 16       | c3        | < 5             | Low risk       |
 | 16-34      | c2        | 5-30            | Moderate risk  |
 | 34-41      | c1        | 30-60           | High risk      |
 | >= 41      | c0        | >= 60           | Very high risk |
 
-The CRAP threshold of 30 (the accepted "unacceptable" boundary) maps to SLOP
+The CRAP threshold of 30 (the accepted "unacceptable" boundary) maps to SCAR
 ~34, sitting at the c2/c1 boundary.
 
 ## Aggregation Levels
@@ -441,7 +443,7 @@ File CC is computed as `sum(sub CCs) - count + 1`. The subtraction avoids
 double-counting the base paths: if a file has three subroutines with CC 3, 5,
 and 2, the file CC is `(3+5+2) - 3 + 1 = 8` rather than `10`. File coverage is
 the combined statement+branch+condition coverage from the summary. File CRAP and
-SLOP follow from these.
+SCAR follow from these.
 
 ### Per-directory
 
@@ -459,36 +461,36 @@ reducing complexity both lower the score.
 
 ### Summary (`cover -summary`)
 
-An always-on `slop` column appears after the `total` column, showing
-per-file `file_slop` and, for the Total row, `module_slop`. Formatting:
+An always-on `scar` column appears after the `total` column, showing
+per-file `file_scar` and, for the Total row, `module_scar`. Formatting:
 `%5.1f` for numeric values; `-` when the file is uncompiled without PPI
 (data unknown); `n/a` when the file has no coverable subs.
 
 ### Text report
 
-CC and SLOP columns appear in the covered/uncovered subroutine tables
+CC and SCAR columns appear in the covered/uncovered subroutine tables
 alongside call counts and source location.
 
 Each file section opens with a `File Summary` one-row table of
-`CC`, `Cov`, `CRAP`, and `SLOP`, followed by a `Worst Subroutines`
-digest listing the top three subroutines by CRAP (subs with zero SLOP are
-omitted). The banner is suppressed when the file has no SLOP data.
+`CC`, `Cov`, `CRAP`, and `SCAR`, followed by a `Worst Subroutines`
+digest listing the top three subroutines by CRAP (subs with zero SCAR are
+omitted). The banner is suppressed when the file has no SCAR data.
 
 When the report spans more than one file, a `Module Summary` one-row
-table at the top shows `Files`, `CC`, `Cov`, `CRAP`, and `SLOP`. When the
+table at the top shows `Files`, `CC`, `Cov`, `CRAP`, and `SCAR`. When the
 report spans more than one directory, a `Directory Summary` table at the
-end lists each directory's CC, coverage, CRAP and SLOP, sorted by SLOP
+end lists each directory's CC, coverage, CRAP and SCAR, sorted by SCAR
 descending.
 
 ### Html_crisp report
 
-- **Index page**: SLOP column in the file table, sortable. Tooltips show a
-  frosted-glass popup with the top SLOP subroutines and their raw CRAP scores.
-- **Top SLOP section**: Highlights the highest-SLOP files with inline pills.
+- **Index page**: SCAR column in the file table, sortable. Tooltips show a
+  frosted-glass popup with the top SCAR subroutines and their raw CRAP scores.
+- **Top SCAR section**: Highlights the highest-SCAR files with inline pills.
 - **Module badge**: A neutral stat-badge in the header showing the module-level
-  SLOP score.
-- **Directory rows**: Directory total rows include SLOP with tooltips.
-- **File pages**: Per-line SLOP detail in the subroutine section.
+  SCAR score.
+- **Directory rows**: Directory total rows include SCAR with tooltips.
+- **File pages**: Per-line SCAR detail in the subroutine section.
 
 ## Key Files
 
@@ -496,9 +498,9 @@ descending.
 | -------------------------------------- | -------------------------------- |
 | `lib/Devel/Cover.pm`                   | CC counting in `_get_cover_walk` |
 | `Cover.xs`                             | XS walker callbacks              |
-| `lib/Devel/Cover/DB.pm`                | CRAP/SLOP formulae, aggregation  |
+| `lib/Devel/Cover/DB.pm`                | CRAP/SCAR formulae, aggregation  |
 | `lib/Devel/Cover/DB/Structure.pm`      | CC and end-line storage          |
-| `lib/Devel/Cover/Report/Text.pm`       | Text report CC/SLOP columns      |
+| `lib/Devel/Cover/Report/Text.pm`       | Text report CC/SCAR columns      |
 | `lib/Devel/Cover/Report/Html_crisp.pm` | HTML report, tooltips            |
 | `lib/Devel/Cover/Web.pm`               | Shared CSS and tooltip base      |
 | `bin/cover`                            | Structure wiring in `manage_dbs` |

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -306,9 +306,9 @@ sub dir_summary ($self, $dir, $criterion = undef) {
   $d->{$criterion}
 }
 
-sub slop_sub_lookup ($self, $file) {
-  my $slop = $self->summary($file, "slop") or return {};
-  my $subs = $slop->{subs}                 or return {};
+sub scar_sub_lookup ($self, $file) {
+  my $scar = $self->summary($file, "scar") or return {};
+  my $subs = $scar->{subs}                 or return {};
   +{ map { ("$_->{line}\0$_->{name}" => $_) } @$subs }
 }
 
@@ -332,7 +332,7 @@ sub _crap ($cc, $cov_pct) {
   $cc**2 * (1 - $cov_pct / 100)**3 + $cc
 }
 
-sub _slop ($crap) {
+sub _scar ($crap) {
   $crap > 1 ? log($crap) * 10 : 0
 }
 
@@ -377,7 +377,7 @@ sub _file_cc_data ($file_obj, $cc_hash, $end_hash) {
             cc   => $cc,
             cov  => $cov,
             crap => $crap,
-            slop => _slop($crap),
+            scar => _scar($crap),
           };
       }
     }
@@ -419,12 +419,12 @@ sub _summarise_dir_complexity ($self, $s, $dir_files, $dir_stats) {
       my $dir_cc   = $ds->{cc_sum} - $ds->{cc_count} + 1;
       my $dir_cov  = _file_coverage($d);
       my $dir_crap = _crap($dir_cc, $dir_cov);
-      my $dir_slop = _slop($dir_crap);
-      $d->{slop} = {
+      my $dir_scar = _scar($dir_crap);
+      $d->{scar} = {
         file_cc   => $dir_cc,
         file_cov  => $dir_cov,
         file_crap => $dir_crap,
-        file_slop => $dir_slop,
+        file_scar => $dir_scar,
       };
     }
   }
@@ -449,7 +449,7 @@ sub _uncompiled_cc_data ($sub_data) {
         cc   => $cc,
         cov  => $cov,
         crap => $crap,
-        slop => _slop($crap),
+        scar => _scar($crap),
       };
   }
 
@@ -478,8 +478,8 @@ sub _record_file_complexity ($s, $file, $d, $dir_stats, $totals) {
   my $file_cc   = $d->{sum} - $count + 1;
   my $file_cov  = _file_coverage($s->{$file});
   my $file_crap = _crap($file_cc, $file_cov);
-  my $file_slop = _slop($file_crap);
-  $s->{$file}{slop} = {
+  my $file_scar = _scar($file_crap);
+  $s->{$file}{scar} = {
     max       => $d->{crap_max},
     mean      => $d->{crap_sum} / $count,
     count     => $count,
@@ -487,7 +487,7 @@ sub _record_file_complexity ($s, $file, $d, $dir_stats, $totals) {
     file_cc   => $file_cc,
     file_cov  => $file_cov,
     file_crap => $file_crap,
-    file_slop => $file_slop,
+    file_scar => $file_scar,
   };
 
   my $ds = $dir_stats->{ _file_dir($file) } ||= { cc_sum => 0, cc_count => 0 };
@@ -495,7 +495,7 @@ sub _record_file_complexity ($s, $file, $d, $dir_stats, $totals) {
   $ds->{cc_count} += $count;
 
   $totals->{fcrap_sum} += $file_crap;
-  $totals->{fslop_sum} += $file_slop;
+  $totals->{fscar_sum} += $file_scar;
   $totals->{fcrap_cnt}++;
   $totals->{max}       = $d->{max} if $d->{max} > $totals->{max};
   $totals->{sum}      += $d->{sum};
@@ -515,16 +515,16 @@ sub _record_total_complexity ($s, $totals) {
   my $module_cov  = _file_coverage($s->{Total});
   my $module_crap = _crap($module_cc, $module_cov);
   my $cnt         = $totals->{fcrap_cnt};
-  $s->{Total}{slop} = {
+  $s->{Total}{scar} = {
     max         => $totals->{crap_max},
     mean        => $totals->{crap_sum} / $totals->{count},
     count       => $totals->{count},
     file_crap   => $cnt ? $totals->{fcrap_sum} / $cnt : 0,
-    file_slop   => $cnt ? $totals->{fslop_sum} / $cnt : 0,
+    file_scar   => $cnt ? $totals->{fscar_sum} / $cnt : 0,
     module_cc   => $module_cc,
     module_cov  => $module_cov,
     module_crap => $module_crap,
-    module_slop => _slop($module_crap),
+    module_scar => _scar($module_crap),
   };
 }
 
@@ -537,7 +537,7 @@ sub summarise_complexity ($self, $s, $files) {
     crap_max  => 0,
     crap_sum  => 0,
     fcrap_sum => 0,
-    fslop_sum => 0,
+    fscar_sum => 0,
     fcrap_cnt => 0,
   );
   my %dir_stats;
@@ -602,10 +602,10 @@ sub _format_summary_pct ($options, $part, $criterion) {
   $x
 }
 
-sub _format_summary_slop ($self, $file, $part, $have_ppi) {
-  my $slop = $part->{slop};
-  if ($slop) {
-    my $v = $file eq "Total" ? $slop->{module_slop} : $slop->{file_slop};
+sub _format_summary_scar ($self, $file, $part, $have_ppi) {
+  my $scar = $part->{scar};
+  if ($scar) {
+    my $v = $file eq "Total" ? $scar->{module_scar} : $scar->{file_scar};
     return sprintf "%5.1f", $v if defined $v;
   }
   return "n/a" if $file eq "Total";
@@ -637,7 +637,7 @@ sub print_summary ($self, $files = undef, $criteria = undef, $opts = {}) {
     = !$ENV{DEVEL_COVER_TEST_SUITE}
     && $Has_term_size
     && -t STDOUT ? (Term::Size::chars(\*STDOUT))[0] : 80;
-  my $nc = $n + 1;               # criterion columns plus slop
+  my $nc = $n + 1;               # criterion columns plus scar
   my $fw = $width - $nc * 7 - 3;
 
   $fw = $max if $max < $fw;
@@ -652,7 +652,7 @@ sub print_summary ($self, $files = undef, $criteria = undef, $opts = {}) {
       grep $options{ $self->{all_criteria}[$_] },
       0 .. $self->{all_criteria}->$#*,
     ),
-    "slop";
+    "scar";
   printf STDOUT $fmt, "-" x $fw, ("------") x $nc;
 
   my $has_uncompiled;
@@ -670,7 +670,7 @@ sub print_summary ($self, $files = undef, $criteria = undef, $opts = {}) {
           grep $options{$_},
           $self->{all_criteria}->@*,
         ),
-        $self->_format_summary_slop($file, $s->{$file}, $have_ppi),
+        $self->_format_summary_scar($file, $s->{$file}, $have_ppi),
       );
   }
 
@@ -1391,19 +1391,19 @@ part of that criterion's summary.
 Access the directory-level summary hash for C<$dir>. Populated by
 L</summarise_complexity> during L</calculate_summary>.
 
-=head2 slop_sub_lookup
+=head2 scar_sub_lookup
 
-  my $lookup = $db->slop_sub_lookup($file);
+  my $lookup = $db->scar_sub_lookup($file);
 
-Return a hashref mapping C<"$line\0$name"> to per-subroutine SLOP detail from
-the summary data for C<$file>. Returns an empty hashref when no SLOP data
+Return a hashref mapping C<"$line\0$name"> to per-subroutine SCAR detail from
+the summary data for C<$file>. Returns an empty hashref when no SCAR data
 exists.
 
 =head2 summarise_complexity
 
   $db->summarise_complexity($summary, \@files);
 
-Compute per-file, per-directory, and total complexity and SLOP scores, storing
+Compute per-file, per-directory, and total complexity and SCAR scores, storing
 results into the C<$summary> hash. Called automatically by
 L</calculate_summary>.
 

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -88,28 +88,28 @@ sub untested_badge () {
 sub glass_tip ($text) { qq(<span class="glass-tip">$text</span>) }
 sub is_na     ($v)    { !defined $v || $v eq "n/a" || $v eq "-" }
 
-sub slop_tip ($f) {
-  return "" if is_na($f->{file_slop});
+sub scar_tip ($f) {
+  return "" if is_na($f->{file_scar});
   my $cov_cls = class($f->{file_cov}, $f->{file_cov} < 100, "total");
   my $o       = <<HTML;
-<div class="glass-tip slop-detail">
-<dl class="slop-tip-metrics">
+<div class="glass-tip scar-detail">
+<dl class="scar-tip-metrics">
 <dt>CC</dt><dd>$f->{file_cc}</dd>
 <dt>Cov</dt><dd class="$cov_cls">$f->{file_cov}%</dd>
 </dl>
 HTML
   if ($f->{worst_subs}->@*) {
-    $o .= qq(<dl class="slop-tip-subs">\n);
+    $o .= qq(<dl class="scar-tip-subs">\n);
     for ($f->{worst_subs}->@*) {
-      my $cls = slop_class($_->{slop});
+      my $cls = scar_class($_->{scar});
       $o .= qq(<dt>$_->{name}</dt><dd class="$cls">$_->{crap}</dd>\n);
     }
     $o .= "</dl>\n";
   }
   $o .= <<HTML;
-<div class="slop-tip-total">
-<span class="slop-tip-label">CRAP</span>
-<span class="slop-tip-value">$f->{file_crap}</span>
+<div class="scar-tip-total">
+<span class="scar-tip-label">CRAP</span>
+<span class="scar-tip-value">$f->{file_crap}</span>
 </div>
 </div>
 HTML
@@ -159,41 +159,41 @@ HTML
   }
   my $total_link = $linkable ? "$f->{link}#filter=total" : undef;
   $o .= cov_cell($f->{total}, $f->{uncompiled}, $f->{total_sort}, $total_link);
-  $o .= slop_cell($f, $linkable ? $f->{link} : undef);
+  $o .= scar_cell($f, $linkable ? $f->{link} : undef);
   $o .= "</tr>\n";
   $o
 }
 
-sub slop_cell ($f, $link = undef) {
-  my $slop  = $f->{file_slop};
-  my $na    = is_na($slop);
-  my $dv    = $na   ? -1   : $slop;
+sub scar_cell ($f, $link = undef) {
+  my $scar  = $f->{file_scar};
+  my $na    = is_na($scar);
+  my $dv    = $na   ? -1   : $scar;
   my $cls   = $na   ? "na" : "tip-hover";
-  my $value = $link ? qq(<a class="cell-link" href="$link">$slop</a>) : $slop;
+  my $value = $link ? qq(<a class="cell-link" href="$link">$scar</a>) : $scar;
 
   <<HTML
 <td data-value="$dv" class="$cls">
-$value @{[ slop_tip($f) ]}</td>
+$value @{[ scar_tip($f) ]}</td>
 HTML
 }
 
-sub _numeric_slop ($f) { is_na($f->{file_slop}) ? 0 : $f->{file_slop} }
+sub _numeric_scar ($f) { is_na($f->{file_scar}) ? 0 : $f->{file_scar} }
 
 sub render_worst_files ($worst) {
-  return "" unless @$worst && _numeric_slop($worst->[0]) > 0;
-  my $o = qq(<div class="worst-files">\n<h2>Top SLOP</h2>\n);
+  return "" unless @$worst && _numeric_scar($worst->[0]) > 0;
+  my $o = qq(<div class="worst-files">\n<h2>Top SCAR</h2>\n);
   for my $f (@$worst) {
-    next if _numeric_slop($f) == 0;
+    next if _numeric_scar($f) == 0;
     my $cls = $f->{uncompiled} ? "untested-worst" : $f->{total}{class};
     my $name
       = $f->{exists} ? qq(<a href="$f->{link}">$f->{short}</a>) : $f->{short};
     my $badge = $f->{uncompiled} ? untested_badge() . "\n" : "";
-    my $tip   = slop_tip($f);
-    my $slop  = $f->{file_slop};
+    my $tip   = scar_tip($f);
+    my $scar  = $f->{file_scar};
 
     $o .= <<HTML;
 <div class="worst-item $cls">
-  $name $badge<strong class="tip-hover">$slop $tip</strong>
+  $name $badge<strong class="tip-hover">$scar $tip</strong>
 </div>
 HTML
   }
@@ -256,7 +256,7 @@ sub render_index ($file_data, $total, $dist) {
   my @groups = build_dir_groups($file_data);
   my @worst
     = @$file_data
-    ? (sort { _numeric_slop($b) <=> _numeric_slop($a) } @$file_data)
+    ? (sort { _numeric_scar($b) <=> _numeric_scar($a) } @$file_data)
     [0 .. ($#$file_data > 4 ? 4 : $#$file_data)]
     : ();
 
@@ -274,14 +274,14 @@ HTML
   my $tt = $total->{total};
   $o .= stat_badge("total", $tt) unless is_na($tt->{pc});
 
-  my $ms = $R{db}->summary("Total", "slop");
-  if ($ms && defined $ms->{module_slop}) {
-    my $sv  = sprintf "%.1f", $ms->{module_slop};
+  my $ms = $R{db}->summary("Total", "scar");
+  if ($ms && defined $ms->{module_scar}) {
+    my $sv  = sprintf "%.1f", $ms->{module_scar};
     my $tip = sprintf "CC %d &middot; cov %.0f%% &middot; CRAP %.1f",
       $ms->{module_cc}, $ms->{module_cov}, $ms->{module_crap};
     $o .= <<HTML;
-<span class="stat-badge stat-slop tip-hover">
-<span class="badge-label">slop $sv</span>
+<span class="stat-badge stat-scar tip-hover">
+<span class="badge-label">scar $sv</span>
 @{[ glass_tip($tip) ]}</span>
 HTML
   }
@@ -306,15 +306,15 @@ Toggle "Hide 100% covered" to focus on incomplete files.</dd>
 <dt>Grouping</dt>
 <dd>Toggle "Group by directory" to organise files into
 collapsible groups. Click a directory row to collapse it.</dd>
-<dt>SLOP</dt>
-<dd>Scaled Likelihood Of Problems - a log-scaled CRAP score
+<dt>SCAR</dt>
+<dd>Scaled Complexity And Risk - a log-scaled CRAP score
 compressed to a 0-100 range. Hover for a breakdown: file CC,
 combined coverage, worst subs, and the raw CRAP score.</dd>
 <dt>Tooltips</dt>
 <dd>Hover any badge or coverage cell for covered/total counts.</dd>
 <dt>Cell click</dt>
 <dd>Click a coverage cell to open the file with that criterion
-filter active. Click a SLOP cell to open the file at the top.</dd>
+filter active. Click a SCAR cell to open the file at the top.</dd>
 </dl>
 </div>
 </div>
@@ -348,7 +348,7 @@ HTML
 HTML
 
   my $ncrit  = $R{criteria}->@*;
-  my $ncols  = $ncrit + 2;       # criteria + total + slop
+  my $ncols  = $ncrit + 2;       # criteria + total + scar
   my $crit_w = 70 / $ncols;
   $o
     .= qq(<table class="file-table">\n<colgroup>\n)
@@ -362,7 +362,7 @@ HTML
   }
   $o .= <<HTML;
 <th data-sort="total">@{[ crit_name('total') ]}</th>
-<th data-sort="slop">SLOP</th>
+<th data-sort="scar">SCAR</th>
 </tr>
 </thead>
 <tbody>
@@ -380,7 +380,7 @@ HTML
     }
     $o .= cov_cell($g->{total}, 0, undef,
       $t ? "$t->{link}#filter=total" : undef);
-    $o .= slop_cell($g, $t ? $t->{link} : undef);
+    $o .= scar_cell($g, $t ? $t->{link} : undef);
     $o .= "</tr>\n";
     $o .= file_row($_, $g->{dir}) for $g->{files}->@*;
   }
@@ -393,9 +393,9 @@ HTML
   )
 }
 
-sub slop_class ($slop) {
-  return "" unless defined $slop;
-  $slop < 16 ? "c3" : $slop < 34 ? "c2" : $slop < 41 ? "c1" : "c0"
+sub scar_class ($scar) {
+  return "" unless defined $scar;
+  $scar < 16 ? "c3" : $scar < 34 ? "c2" : $scar < 41 ? "c1" : "c0"
 }
 
 sub _summary_text ($covered, $total) {
@@ -473,9 +473,9 @@ sub render_line_detail ($line) {
       my $status  = $s->{covered} ? "called" : "not called";
       my $cc_info = "";
       if (defined $s->{cc}) {
-        my $cls  = slop_class($s->{slop});
-        my $slop = sprintf "%.1f", $s->{slop} // 0;
-        $cc_info = qq( <span class="$cls">CC=$s->{cc} SLOP=$slop</span>);
+        my $cls  = scar_class($s->{scar});
+        my $scar = sprintf "%.1f", $s->{scar} // 0;
+        $cc_info = qq( <span class="$cls">CC=$s->{cc} SCAR=$scar</span>);
       }
       $o .= <<HTML;
 <div class="detail">
@@ -644,11 +644,11 @@ HTML
 @{[ glass_tip("$tt->{covered} / $tt->{total}") ]}</span>
 HTML
   }
-  my $sl     = $fd->{file_slop};
-  my $sl_tip = is_na($sl) ? "" : slop_tip($fd);
+  my $sl     = $fd->{file_scar};
+  my $sl_tip = is_na($sl) ? "" : scar_tip($fd);
   $o .= <<HTML;
-<span class="stat-badge stat-slop tip-hover">
-SLOP $sl $sl_tip</span>
+<span class="stat-badge stat-scar tip-hover">
+SCAR $sl $sl_tip</span>
 HTML
 
   $o .= <<HTML;
@@ -674,7 +674,7 @@ condition, or subroutine detail.</dd>
 <dd>The strip on the right shows coverage at a glance. Click to
 jump to that line.</dd>
 <dt>Tooltips</dt>
-<dd>Hover badges for covered/total counts. Hover SLOP for a
+<dd>Hover badges for covered/total counts. Hover SCAR for a
 breakdown.</dd>
 <dt>Keyboard</dt>
 <dd><kbd>j</kbd> / <kbd>k</kbd> next/prev uncovered line
@@ -765,30 +765,30 @@ sub get_summary ($file, $criterion) {
   _format_criterion($R{db}->summary($file), $criterion)
 }
 
-sub _apply_slop ($f, $slop_data) {
-  if ($slop_data && defined $slop_data->{file_crap}) {
-    $f->{file_crap} = sprintf "%.1f", $slop_data->{file_crap};
-    $f->{file_slop} = sprintf "%.1f", $slop_data->{file_slop} // 0;
-    $f->{file_cc}   = $slop_data->{file_cc};
-    $f->{file_cov}  = sprintf "%.0f", $slop_data->{file_cov};
+sub _apply_scar ($f, $scar_data) {
+  if ($scar_data && defined $scar_data->{file_crap}) {
+    $f->{file_crap} = sprintf "%.1f", $scar_data->{file_crap};
+    $f->{file_scar} = sprintf "%.1f", $scar_data->{file_scar} // 0;
+    $f->{file_cc}   = $scar_data->{file_cc};
+    $f->{file_cov}  = sprintf "%.0f", $scar_data->{file_cov};
     my @sorted = sort { $b->{crap} <=> $a->{crap} } grep defined $_->{crap},
-      @{ $slop_data->{subs} || [] };
+      @{ $scar_data->{subs} || [] };
     $f->{worst_subs} = [
       map { {
         name => $_->{name},
         crap => sprintf("%.1f", $_->{crap}),
-        slop => $_->{slop},
+        scar => $_->{scar},
       } } @sorted[0 .. ($#sorted > 2 ? 2 : $#sorted)]
     ];
   } elsif ($f->{uncompiled}) {
     $f->{file_crap}  = "-";
-    $f->{file_slop}  = "-";
+    $f->{file_scar}  = "-";
     $f->{file_cc}    = "-";
     $f->{file_cov}   = "-";
     $f->{worst_subs} = [];
   } else {
     $f->{file_crap}  = 0;
-    $f->{file_slop}  = 0;
+    $f->{file_scar}  = 0;
     $f->{file_cc}    = 0;
     $f->{file_cov}   = 0;
     $f->{worst_subs} = [];
@@ -824,7 +824,7 @@ sub build_one_file ($file) {
   my $pc = $total->{pc} // "-";
   $f{total_pc}   = $pc;
   $f{total_sort} = is_na($pc) ? -1 : $pc;
-  _apply_slop(\%f, $R{db}->summary($file, "slop"));
+  _apply_scar(\%f, $R{db}->summary($file, "scar"));
   \%f
 }
 
@@ -834,7 +834,7 @@ sub build_file_data () {
     my $f = build_one_file($file);
     push @file_data, $f if $f;
   } sort {
-         _numeric_slop($b) <=> _numeric_slop($a)
+         _numeric_scar($b) <=> _numeric_scar($a)
       || ($a->{total_sort} // -1) <=> ($b->{total_sort} // -1)
       || $a->{name} cmp $b->{name}
   } @file_data
@@ -859,7 +859,7 @@ sub build_dir_groups ($file_data) {
     };
     $g->{pc}    = $g->{total}{pc};
     $g->{class} = $g->{total}{class};
-    _apply_slop($g, $R{db}->dir_summary($dir, "slop"));
+    _apply_scar($g, $R{db}->dir_summary($dir, "scar"));
     $g;
   } sort keys %dirs
 }
@@ -868,14 +868,14 @@ sub line_subroutines ($f, $n) {
   my $subs = $f->subroutine or return;
   my $loc  = $subs->location($n);
   return unless $loc && @$loc;
-  my $cl = $R{slop_subs} || {};
+  my $cl = $R{scar_subs} || {};
   map { {
     name    => encode_entities($_->name),
     covered => $_->covered,
     class   => oclass($_, "subroutine"),
     cc      => ($cl->{ "$n\0" . $_->name } // {})->{cc},
     crap    => ($cl->{ "$n\0" . $_->name } // {})->{crap},
-    slop    => ($cl->{ "$n\0" . $_->name } // {})->{slop},
+    scar    => ($cl->{ "$n\0" . $_->name } // {})->{scar},
   } } @$loc
 }
 
@@ -1167,7 +1167,7 @@ sub generate_file_pages ($outdir, $file_data) {
     my $fd = $file_data->[$idx];
     next unless $fd->{exists};
     my $file = $fd->{name};
-    $R{slop_subs} = $R{db}->slop_sub_lookup($file);
+    $R{scar_subs} = $R{db}->scar_sub_lookup($file);
     my $lines
       = $fd->{uncompiled}
       ? build_untested_source_lines($file)
@@ -1186,7 +1186,7 @@ sub generate_file_pages ($outdir, $file_data) {
       "$outdir/$fd->{link}",
       render_file_page($fd, $lines, \%file_total, $prev, $next),
     );
-    delete $R{slop_subs};
+    delete $R{scar_subs};
   }
 }
 
@@ -1305,7 +1305,7 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   .name-full  { display: none !important; }
   .name-short { display: inline !important; }
   .stat-badge { width: 140px; }
-  .stat-slop  { width: auto; }
+  .stat-scar  { width: auto; }
 }
 
 /* Narrow: wrap badges onto multiple lines, right-aligned. max-width clamps the
@@ -1326,7 +1326,7 @@ overflowing. */
   border-color: var(--border);
   color: var(--fg-muted);
 }
-.stat-slop {
+.stat-scar {
   background: var(--prefix-bg);
   border-color: var(--prefix-border);
   color: var(--fg);
@@ -1572,29 +1572,29 @@ overflowing. */
 .file-table .sort-asc::after { content: " \25b2"; }
 .file-table .sort-desc::after { content: " \25bc"; }
 
-/* SLOP detail tooltip overrides */
-.glass-tip.slop-detail {
+/* SCAR detail tooltip overrides */
+.glass-tip.scar-detail {
   padding: 8px 12px;
   font-weight: normal;
 }
 
-.slop-detail dl {
+.scar-detail dl {
   display: grid;
   grid-template-columns: auto auto;
   gap: 1px 12px;
   margin: 0;
   font-variant-numeric: tabular-nums;
 }
-.slop-detail dt { text-align: left; }
-.slop-detail dd { text-align: right; margin: 0; }
+.scar-detail dt { text-align: left; }
+.scar-detail dd { text-align: right; margin: 0; }
 
-.slop-tip-subs {
+.scar-tip-subs {
   border-top: 1px solid var(--tip-glass-sep);
   margin-top: 4px !important;
   padding-top: 4px;
 }
 
-.slop-tip-total {
+.scar-tip-total {
   display: flex;
   justify-content: space-between;
   gap: 12px;
@@ -1605,14 +1605,14 @@ overflowing. */
   font-variant-numeric: tabular-nums;
 }
 
-.slop-detail .c0,
-.slop-detail .c1,
-.slop-detail .c2,
-.slop-detail .c3 { background: transparent; }
-.slop-detail .c0 { color: var(--tip-c0); }
-.slop-detail .c1 { color: var(--tip-c1); }
-.slop-detail .c2 { color: var(--tip-c2); }
-.slop-detail .c3 { color: var(--tip-c3); }
+.scar-detail .c0,
+.scar-detail .c1,
+.scar-detail .c2,
+.scar-detail .c3 { background: transparent; }
+.scar-detail .c0 { color: var(--tip-c0); }
+.scar-detail .c1 { color: var(--tip-c1); }
+.scar-detail .c2 { color: var(--tip-c2); }
+.scar-detail .c3 { color: var(--tip-c3); }
 
 /* Header: tooltips below */
 .header .glass-tip {
@@ -2058,8 +2058,7 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
     var groupToggle = document.querySelector(".group-toggle");
 
     /* Read persisted state */
-    var sortCol = rget("sort-col", "slop");
-    if (sortCol === "crap") { sortCol = "slop"; rset("sort-col", "slop"); }
+    var sortCol = rget("sort-col", "scar");
     var sortDir = rget("sort-dir", "desc");
 
     var defaultGrouped = fileCount > 30;

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -104,16 +104,16 @@ sub print_dir_block ($db, $files, $prefix) {
 
   my @rows;
   for my $dir (@dirs) {
-    my $slop = $db->dir_summary($dir, "slop") or return;
+    my $scar = $db->dir_summary($dir, "scar") or return;
     my $display
       = $prefix && $dir =~ /^\Q$prefix\E(.*)/ ? ($1 || ".") : ($dir || ".");
     push @rows, {
         dir      => $display,
-        cc       => $slop->{file_cc},
-        cov      => sprintf("%.1f", $slop->{file_cov}),
-        crap     => sprintf("%.1f", $slop->{file_crap}),
-        slop     => sprintf("%.1f", $slop->{file_slop}),
-        sort_key => $slop->{file_slop},
+        cc       => $scar->{file_cc},
+        cov      => sprintf("%.1f", $scar->{file_cov}),
+        crap     => sprintf("%.1f", $scar->{file_crap}),
+        scar     => sprintf("%.1f", $scar->{file_scar}),
+        sort_key => $scar->{file_scar},
       };
   }
 
@@ -127,17 +127,17 @@ sub print_dir_block ($db, $files, $prefix) {
       cc => $r->{cc},
       cv => $r->{cov},
       cr => $r->{crap},
-      s  => $r->{slop},
+      s  => $r->{scar},
     );
   }
 
   say "Directory Summary";
   say "-----------------\n";
   my $tpl = "%-$maxw{d}s %$maxw{cc}s %$maxw{cv}s %$maxw{cr}s %$maxw{s}s\n";
-  printf $tpl, "Directory", "CC", "Cov", "CRAP", "SLOP";
+  printf $tpl, "Directory", "CC", "Cov", "CRAP", "SCAR";
   printf $tpl, "-" x $maxw{d}, "-" x $maxw{cc}, "-" x $maxw{cv},
     "-" x $maxw{cr}, "-" x $maxw{s};
-  printf $tpl, $_->{dir}, $_->{cc}, $_->{cov}, $_->{crap}, $_->{slop} for @rows;
+  printf $tpl, $_->{dir}, $_->{cc}, $_->{cov}, $_->{crap}, $_->{scar} for @rows;
   say "";
 }
 
@@ -159,18 +159,18 @@ sub _print_stat_table ($heading, $headers, $values) {
 
 sub print_module_banner ($db, $files) {
   return unless @$files > 1;
-  my $slop = $db->summary("Total", "slop");
-  return unless $slop && defined $slop->{module_slop};
+  my $scar = $db->summary("Total", "scar");
+  return unless $scar && defined $scar->{module_scar};
 
   _print_stat_table(
     "Module Summary",
-    [qw( Files CC Cov CRAP SLOP )],
+    [qw( Files CC Cov CRAP SCAR )],
     [
       scalar @$files,
-      $slop->{module_cc},
-      sprintf("%.1f", $slop->{module_cov}),
-      sprintf("%.1f", $slop->{module_crap}),
-      sprintf("%.1f", $slop->{module_slop}),
+      $scar->{module_cc},
+      sprintf("%.1f", $scar->{module_cov}),
+      sprintf("%.1f", $scar->{module_crap}),
+      sprintf("%.1f", $scar->{module_scar}),
     ],
   );
   say "";
@@ -187,7 +187,7 @@ sub _worst_subs_rows ($subs, $display_name, $limit = 3) {
     +{
       name => $_->{name},
       cc   => $_->{cc},
-      slop => sprintf("%.1f", $_->{slop} // 0),
+      scar => sprintf("%.1f", $_->{scar} // 0),
       loc  => "$display_name:$_->{line}",
     }
   } @sorted[0 .. $top]
@@ -196,21 +196,21 @@ sub _worst_subs_rows ($subs, $display_name, $limit = 3) {
 sub print_file_banner ($db, $file, $short) {
   say "$short->{$file}\n";
 
-  my $slop = $db->summary($file, "slop");
-  return unless $slop && defined $slop->{file_slop};
+  my $scar = $db->summary($file, "scar");
+  return unless $scar && defined $scar->{file_scar};
 
   _print_stat_table(
     "File Summary",
-    [qw( CC Cov CRAP SLOP )],
+    [qw( CC Cov CRAP SCAR )],
     [
-      $slop->{file_cc},
-      sprintf("%.1f", $slop->{file_cov}),
-      sprintf("%.1f", $slop->{file_crap}),
-      sprintf("%.1f", $slop->{file_slop}),
+      $scar->{file_cc},
+      sprintf("%.1f", $scar->{file_cov}),
+      sprintf("%.1f", $scar->{file_crap}),
+      sprintf("%.1f", $scar->{file_scar}),
     ],
   );
 
-  my @subs = grep $_->{slop} > 0, ($slop->{subs} || [])->@*;
+  my @subs = grep $_->{scar} > 0, ($scar->{subs} || [])->@*;
   return unless @subs;
 
   my @rows = _worst_subs_rows(\@subs, $short->{$file});
@@ -220,7 +220,7 @@ sub print_file_banner ($db, $file, $short) {
       \%maxw,
       n  => $r->{name},
       cc => $r->{cc},
-      s  => $r->{slop},
+      s  => $r->{scar},
       l  => $r->{loc},
     );
   }
@@ -228,9 +228,9 @@ sub print_file_banner ($db, $file, $short) {
   say "Worst Subroutines";
   say "-----------------\n";
   my $tpl = "%-$maxw{n}s %$maxw{cc}s %$maxw{s}s  %-$maxw{l}s\n";
-  printf $tpl, "Subroutine",   "CC",            "SLOP",         "Location";
+  printf $tpl, "Subroutine",   "CC",            "SCAR",         "Location";
   printf $tpl, "-" x $maxw{n}, "-" x $maxw{cc}, "-" x $maxw{s}, "-" x $maxw{l};
-  printf $tpl, $_->{name},     $_->{cc},        $_->{slop}, $_->{loc} for @rows;
+  printf $tpl, $_->{name},     $_->{cc},        $_->{scar}, $_->{loc} for @rows;
   say "";
 }
 
@@ -369,11 +369,11 @@ sub _update_maxw ($maxw, %vals) {
   }
 }
 
-sub _gather_subs ($dfile, $pods, $display_name, $slop_lookup) {
+sub _gather_subs ($dfile, $pods, $display_name, $scar_lookup) {
   my $subs = $dfile->subroutine or return;
   my %maxw = (h => 8, c => 5, p => 3, s => 10, cc => 3, cr => 5);
   my %by_type;
-  my $has_slop = %$slop_lookup;
+  my $has_scar = %$scar_lookup;
 
   for my $location ($subs->items) {
     my $l = $subs->location($location);
@@ -385,16 +385,16 @@ sub _gather_subs ($dfile, $pods, $display_name, $slop_lookup) {
       my $p = $e ? ($e->uncoverable ? "-" : "") . $e->covered : "";
       my $s = $sub->name;
 
-      my $info = $slop_lookup->{"$location\0$s"};
+      my $info = $scar_lookup->{"$location\0$s"};
       my $cc   = defined $info ? $info->{cc}                    : "";
-      my $cr   = defined $info ? sprintf("%.1f", $info->{slop}) : "";
+      my $cr   = defined $info ? sprintf("%.1f", $info->{scar}) : "";
 
       _update_maxw(\%maxw, h => $h, c => $c, s => $s, cc => $cc, cr => $cr);
       $maxw{p} = length $p if $p && length $p > $maxw{p};
 
       my $type = $sub->covered ? "covered" : "uncovered";
       push $by_type{$type}{$s}->@*,
-        [$c, $pods ? $p : (), $has_slop ? ($cc, $cr) : (), $h];
+        [$c, $pods ? $p : (), $has_scar ? ($cc, $cr) : (), $h];
     }
   }
 
@@ -404,26 +404,26 @@ sub _gather_subs ($dfile, $pods, $display_name, $slop_lookup) {
 sub print_subroutines ($db, $file, $options, $short) {
   my $dfile = $db->cover->file($file);
   my $pods  = $options->{show}{pod} && $dfile->pod;
-  my $cl    = $db->slop_sub_lookup($file);
+  my $cl    = $db->scar_sub_lookup($file);
 
   my ($by_type, $maxw) = _gather_subs($dfile, $pods, $short->{$file}, $cl);
   return unless $by_type;
 
-  my $has_slop = %$cl;
+  my $has_scar = %$cl;
   my $tpl      = "%-$maxw->{s}s %$maxw->{c}s ";
   $tpl .= "%$maxw->{p}s "  if $pods;
-  $tpl .= "%$maxw->{cc}s " if $has_slop;
-  $tpl .= "%$maxw->{cr}s " if $has_slop;
+  $tpl .= "%$maxw->{cc}s " if $has_scar;
+  $tpl .= "%$maxw->{cr}s " if $has_scar;
   $tpl .= "%-$maxw->{h}s\n";
 
   for my $type (sort keys %$by_type) {
     say ucfirst($type),            " Subroutines";
     say "-" x (12 + length $type), "\n";
     printf $tpl, "Subroutine", "Count", $pods ? "Pod" : (),
-      $has_slop ? ("CC", "SLOP") : (), "Location";
+      $has_scar ? ("CC", "SCAR") : (), "Location";
     printf $tpl, "-" x $maxw->{s}, "-" x $maxw->{c},
       $pods ? "-" x $maxw->{p} : (),
-      $has_slop ? ("-" x $maxw->{cc}, "-" x $maxw->{cr}) : (), "-" x $maxw->{h};
+      $has_scar ? ("-" x $maxw->{cc}, "-" x $maxw->{cr}) : (), "-" x $maxw->{h};
 
     for my $s (sort keys $by_type->{$type}->%*) {
       printf $tpl, $s, @$_
@@ -558,11 +558,11 @@ output lines are produced when a single source line has several coverage points
 Update column-width hash C<$maxw> in place: for each key in C<%vals>, set
 C<< $maxw->{$k} >> to the value's length if it exceeds the current maximum.
 
-=head2 _gather_subs ($dfile, $pods, $display_name, $slop_lookup)
+=head2 _gather_subs ($dfile, $pods, $display_name, $scar_lookup)
 
 Walk the subroutine and pod coverage data for a file, returning a hashref of
 covered/uncovered sub entries and a hashref of column widths for formatting.
-When C<$slop_lookup> is non-empty, CC and SLOP values are included in each
+When C<$scar_lookup> is non-empty, CC and SCAR values are included in each
 entry.
 
 =head1 SEE ALSO

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -259,7 +259,7 @@ sub test_signature_cc () {
 # CRAP (Change Risk Anti-Patterns) scoring tests.
 # Verifies that summarise_complexity computes per-sub combined coverage and CRAP
 # scores alongside existing complexity aggregation.
-sub test_slop_scoring () {
+sub test_scar_scoring () {
   my ($db_path, $script) = run_cover("cc_crap", $Crap_script);
 
   my $st = Devel::Cover::DB::Structure->new(base => $db_path);
@@ -275,57 +275,57 @@ sub test_slop_scoring () {
   );
 
   my ($file) = grep /cc_crap\.pl$/, keys $db->{summary}->%*;
-  ok defined $file, "slop: summary contains cover file";
+  ok defined $file, "scar: summary contains cover file";
 
-  my $slop = $db->{summary}{$file}{slop};
-  ok defined $slop, "slop: file summary has slop entry";
+  my $scar = $db->{summary}{$file}{scar};
+  ok defined $scar, "scar: file summary has scar entry";
 
-  ok exists $slop->{max},   "slop: has max";
-  ok exists $slop->{mean},  "slop: has mean";
-  ok exists $slop->{count}, "slop: has count";
-  ok exists $slop->{subs},  "slop: has subs";
+  ok exists $scar->{max},   "scar: has max";
+  ok exists $scar->{mean},  "scar: has mean";
+  ok exists $scar->{count}, "scar: has count";
+  ok exists $scar->{subs},  "scar: has subs";
 
   # Build lookup by sub name for easier assertions.
-  my %by_name = map { $_->{name} => $_ } $slop->{subs}->@*;
+  my %by_name = map { $_->{name} => $_ } $scar->{subs}->@*;
 
   # fully_covered: CC=1, cov=100%, CRAP = 1^2*(1-1)^3 + 1 = 1
   my $fc = $by_name{fully_covered};
-  ok defined $fc, "slop: fully_covered present";
-  is $fc->{cc},   1,   "slop: fully_covered CC = 1";
-  is $fc->{cov},  100, "slop: fully_covered cov = 100";
-  is $fc->{crap}, 1,   "slop: fully_covered CRAP = 1";
-  is $fc->{slop}, 0,   "slop: fully_covered SLOP = 0";
+  ok defined $fc, "scar: fully_covered present";
+  is $fc->{cc},   1,   "scar: fully_covered CC = 1";
+  is $fc->{cov},  100, "scar: fully_covered cov = 100";
+  is $fc->{crap}, 1,   "scar: fully_covered CRAP = 1";
+  is $fc->{scar}, 0,   "scar: fully_covered SCAR = 0";
 
   # uncalled: CC=1, cov=0%, CRAP = 1^2*(1-0)^3 + 1 = 2
   my $uc = $by_name{uncalled};
-  ok defined $uc, "slop: uncalled present";
-  is $uc->{cc},   1, "slop: uncalled CC = 1";
-  is $uc->{cov},  0, "slop: uncalled cov = 0";
-  is $uc->{crap}, 2, "slop: uncalled CRAP = 2";
-  ok abs($uc->{slop} - log(2) * 10) < 0.01, "slop: uncalled SLOP = ln(2)*10";
+  ok defined $uc, "scar: uncalled present";
+  is $uc->{cc},   1, "scar: uncalled CC = 1";
+  is $uc->{cov},  0, "scar: uncalled cov = 0";
+  is $uc->{crap}, 2, "scar: uncalled CRAP = 2";
+  ok abs($uc->{scar} - log(2) * 10) < 0.01, "scar: uncalled SCAR = ln(2)*10";
 
   # partial_branch: CC=2, partial coverage.
   # Bounds: cov=100% => CRAP=2, cov=0% => CRAP=6.
   my $pb = $by_name{partial_branch};
-  ok defined $pb, "slop: partial_branch present";
-  is $pb->{cc}, 2, "slop: partial_branch CC = 2";
-  ok $pb->{crap} > 2,           "slop: partial_branch CRAP > CC";
-  ok $pb->{crap} < 6,           "slop: partial_branch CRAP < CC^2+CC";
-  ok $pb->{slop} > 0,           "slop: partial_branch SLOP > 0";
-  ok $pb->{slop} > $uc->{slop}, "slop: partial_branch SLOP > uncalled SLOP";
+  ok defined $pb, "scar: partial_branch present";
+  is $pb->{cc}, 2, "scar: partial_branch CC = 2";
+  ok $pb->{crap} > 2,           "scar: partial_branch CRAP > CC";
+  ok $pb->{crap} < 6,           "scar: partial_branch CRAP < CC^2+CC";
+  ok $pb->{scar} > 0,           "scar: partial_branch SCAR > 0";
+  ok $pb->{scar} > $uc->{scar}, "scar: partial_branch SCAR > uncalled SCAR";
 
   # Total aggregation
-  my $ts = $db->{summary}{Total}{slop};
-  ok defined $ts,         "slop: Total has slop entry";
-  ok exists $ts->{max},   "slop: Total has max";
-  ok exists $ts->{mean},  "slop: Total has mean";
-  ok exists $ts->{count}, "slop: Total has count";
+  my $ts = $db->{summary}{Total}{scar};
+  ok defined $ts,         "scar: Total has scar entry";
+  ok exists $ts->{max},   "scar: Total has max";
+  ok exists $ts->{mean},  "scar: Total has mean";
+  ok exists $ts->{count}, "scar: Total has count";
 }
 
-# Text report CC/SLOP column tests.
-# Verifies that print_subroutines includes CC and SLOP columns
+# Text report CC/SCAR column tests.
+# Verifies that print_subroutines includes CC and SCAR columns
 # when CRAP summary data is available.
-sub test_text_report_slop () {
+sub test_text_report_scar () {
   my ($db_path, $script) = run_cover("cc_text", $Crap_script);
 
   my $st = Devel::Cover::DB::Structure->new(base => $db_path);
@@ -353,27 +353,27 @@ sub test_text_report_slop () {
     close $fh or die "Cannot close scalar ref: $!";
   }
 
-  # Header should contain CC and SLOP columns.
-  like $output, qr/^\s*Subroutine\b.*\bCC\b.*\bSLOP\b/m,
-    "text: header contains CC and SLOP columns";
+  # Header should contain CC and SCAR columns.
+  like $output, qr/^\s*Subroutine\b.*\bCC\b.*\bSCAR\b/m,
+    "text: header contains CC and SCAR columns";
 
-  # fully_covered: CC=1, SLOP=0.0 (CRAP=1, ln(1)*10=0)
+  # fully_covered: CC=1, SCAR=0.0 (CRAP=1, ln(1)*10=0)
   like $output, qr/fully_covered\s+\d+\s+1\s+0\.0\b/,
-    "text: fully_covered has CC=1 SLOP=0.0";
+    "text: fully_covered has CC=1 SCAR=0.0";
 
-  # uncalled: CC=1, SLOP=6.9 (CRAP=2, ln(2)*10=6.93)
+  # uncalled: CC=1, SCAR=6.9 (CRAP=2, ln(2)*10=6.93)
   like $output, qr/uncalled\s+\d+\s+1\s+6\.9\b/,
-    "text: uncalled has CC=1 SLOP=6.9";
+    "text: uncalled has CC=1 SCAR=6.9";
 
-  # partial_branch: CC=2, SLOP > 6.9
+  # partial_branch: CC=2, SCAR > 6.9
   like $output, qr/partial_branch\s+\d+\s+2\s+\d+\.\d/,
-    "text: partial_branch has CC=2 and a SLOP score";
+    "text: partial_branch has CC=2 and a SCAR score";
 }
 
 # File-level CRAP tests.
 # Verifies that summarise_complexity computes file_cc, file_cov,
 # and file_crap by treating the entire file as one sub body.
-sub test_file_level_slop () {
+sub test_file_level_scar () {
   my ($db_path, $script) = run_cover("cc_filecrap", $Crap_script);
 
   my $st = Devel::Cover::DB::Structure->new(base => $db_path);
@@ -389,62 +389,62 @@ sub test_file_level_slop () {
   );
 
   my ($file) = grep /cc_filecrap\.pl$/, keys $db->{summary}->%*;
-  ok defined $file, "fileslop: summary contains cover file";
+  ok defined $file, "filescar: summary contains cover file";
 
-  my $slop = $db->{summary}{$file}{slop};
-  ok defined $slop, "fileslop: file summary has slop entry";
+  my $scar = $db->{summary}{$file}{scar};
+  ok defined $scar, "filescar: file summary has scar entry";
 
   # file_cc = sum of per-sub CCs - count + 1
-  ok exists $slop->{file_cc}, "fileslop: has file_cc";
+  ok exists $scar->{file_cc}, "filescar: has file_cc";
   my $expected_cc_sum = 0;
-  $expected_cc_sum += $_->{cc} for $slop->{subs}->@*;
-  is $slop->{file_cc}, $expected_cc_sum - $slop->{count} + 1,
-    "fileslop: file_cc = sum(cc) - count + 1";
+  $expected_cc_sum += $_->{cc} for $scar->{subs}->@*;
+  is $scar->{file_cc}, $expected_cc_sum - $scar->{count} + 1,
+    "filescar: file_cc = sum(cc) - count + 1";
 
   # file_cov: combined stmt+branch+condition coverage
-  ok exists $slop->{file_cov}, "fileslop: has file_cov";
-  ok $slop->{file_cov} >= 0 && $slop->{file_cov} <= 100,
-    "fileslop: file_cov is 0..100";
+  ok exists $scar->{file_cov}, "filescar: has file_cov";
+  ok $scar->{file_cov} >= 0 && $scar->{file_cov} <= 100,
+    "filescar: file_cov is 0..100";
 
   # file_crap: CRAP formula applied to file-level inputs
-  ok exists $slop->{file_crap}, "fileslop: has file_crap";
-  my $cc            = $slop->{file_cc};
-  my $cov           = $slop->{file_cov};
+  ok exists $scar->{file_crap}, "filescar: has file_crap";
+  my $cc            = $scar->{file_cc};
+  my $cov           = $scar->{file_cov};
   my $expected_crap = $cc**2 * (1 - $cov / 100)**3 + $cc;
-  is $slop->{file_crap}, $expected_crap,
-    "fileslop: file_crap matches CRAP formula";
+  is $scar->{file_crap}, $expected_crap,
+    "filescar: file_crap matches CRAP formula";
 
-  # file_slop: ln(file_crap) * 10
-  ok exists $slop->{file_slop}, "fileslop: has file_slop";
-  my $expected_slop = $slop->{file_crap} > 1 ? log($slop->{file_crap}) * 10 : 0;
-  ok abs($slop->{file_slop} - $expected_slop) < 0.01,
-    "fileslop: file_slop = log(file_crap) * 10";
+  # file_scar: ln(file_crap) * 10
+  ok exists $scar->{file_scar}, "filescar: has file_scar";
+  my $expected_scar = $scar->{file_crap} > 1 ? log($scar->{file_crap}) * 10 : 0;
+  ok abs($scar->{file_scar} - $expected_scar) < 0.01,
+    "filescar: file_scar = log(file_crap) * 10";
 
   # Total aggregation
-  my $ts = $db->{summary}{Total}{slop};
-  ok defined $ts,             "fileslop: Total has slop entry";
-  ok exists $ts->{file_crap}, "fileslop: Total has file_crap";
-  ok exists $ts->{file_slop}, "fileslop: Total has file_slop";
+  my $ts = $db->{summary}{Total}{scar};
+  ok defined $ts,             "filescar: Total has scar entry";
+  ok exists $ts->{file_crap}, "filescar: Total has file_crap";
+  ok exists $ts->{file_scar}, "filescar: Total has file_scar";
 
-  # Module-level SLOP (whole-codebase CRAP)
-  ok exists $ts->{module_cc},   "fileslop: Total has module_cc";
-  ok exists $ts->{module_cov},  "fileslop: Total has module_cov";
-  ok exists $ts->{module_crap}, "fileslop: Total has module_crap";
-  ok exists $ts->{module_slop}, "fileslop: Total has module_slop";
-  ok $ts->{module_cc} > 0,      "fileslop: module_cc > 0";
+  # Module-level SCAR (whole-codebase CRAP)
+  ok exists $ts->{module_cc},   "filescar: Total has module_cc";
+  ok exists $ts->{module_cov},  "filescar: Total has module_cov";
+  ok exists $ts->{module_crap}, "filescar: Total has module_crap";
+  ok exists $ts->{module_scar}, "filescar: Total has module_scar";
+  ok $ts->{module_cc} > 0,      "filescar: module_cc > 0";
   my $mcc            = $ts->{module_cc};
   my $mcv            = $ts->{module_cov};
   my $expected_mcrap = $mcc**2 * (1 - $mcv / 100)**3 + $mcc;
   is $ts->{module_crap}, $expected_mcrap,
-    "fileslop: module_crap matches CRAP formula";
-  my $expected_mslop
+    "filescar: module_crap matches CRAP formula";
+  my $expected_mscar
     = $ts->{module_crap} > 1 ? log($ts->{module_crap}) * 10 : 0;
-  ok abs($ts->{module_slop} - $expected_mslop) < 0.01,
-    "fileslop: module_slop = log(module_crap) * 10";
+  ok abs($ts->{module_scar} - $expected_mscar) < 0.01,
+    "filescar: module_scar = log(module_crap) * 10";
 }
 
-sub test_dir_level_slop () {
-  my ($db_path, $script) = run_cover("cc_dirslop", $Crap_script);
+sub test_dir_level_scar () {
+  my ($db_path, $script) = run_cover("cc_dirscar", $Crap_script);
 
   my $st = Devel::Cover::DB::Structure->new(base => $db_path);
   $st->read_all;
@@ -459,38 +459,38 @@ sub test_dir_level_slop () {
   );
 
   # Directory summary should exist for the script's parent dir
-  my ($file) = grep /cc_dirslop\.pl$/, keys $db->{summary}->%*;
-  ok defined $file, "dirslop: file found in summary";
+  my ($file) = grep /cc_dirscar\.pl$/, keys $db->{summary}->%*;
+  ok defined $file, "dirscar: file found in summary";
   (my $dir = $file) =~ s|/[^/]+$||;
   my $ds = $db->dir_summary($dir);
-  ok defined $ds, "dirslop: dir summary exists";
+  ok defined $ds, "dirscar: dir summary exists";
 
   # Per-criterion aggregation
   for my $c (qw( statement branch condition total )) {
-    ok exists $ds->{$c},           "dirslop: has $c";
-    ok defined $ds->{$c}{covered}, "dirslop: $c has covered";
-    ok defined $ds->{$c}{total},   "dirslop: $c has total";
+    ok exists $ds->{$c},           "dirscar: has $c";
+    ok defined $ds->{$c}{covered}, "dirscar: $c has covered";
+    ok defined $ds->{$c}{total},   "dirscar: $c has total";
   }
 
-  # SLOP entry
-  my $slop = $ds->{slop};
-  ok defined $slop,             "dirslop: has slop entry";
-  ok exists $slop->{file_cc},   "dirslop: has file_cc";
-  ok exists $slop->{file_cov},  "dirslop: has file_cov";
-  ok exists $slop->{file_crap}, "dirslop: has file_crap";
-  ok exists $slop->{file_slop}, "dirslop: has file_slop";
+  # SCAR entry
+  my $scar = $ds->{scar};
+  ok defined $scar,             "dirscar: has scar entry";
+  ok exists $scar->{file_cc},   "dirscar: has file_cc";
+  ok exists $scar->{file_cov},  "dirscar: has file_cov";
+  ok exists $scar->{file_crap}, "dirscar: has file_crap";
+  ok exists $scar->{file_scar}, "dirscar: has file_scar";
 
   # dir_cc should equal the single file's file_cc (one file in the directory)
-  my $file_slop = $db->{summary}{$file}{slop};
-  is $slop->{file_cc}, $file_slop->{file_cc},
-    "dirslop: dir cc matches single file cc";
+  my $file_scar = $db->{summary}{$file}{scar};
+  is $scar->{file_cc}, $file_scar->{file_cc},
+    "dirscar: dir cc matches single file cc";
 
   # CRAP formula
-  my $cc            = $slop->{file_cc};
-  my $cov           = $slop->{file_cov};
+  my $cc            = $scar->{file_cc};
+  my $cov           = $scar->{file_cov};
   my $expected_crap = $cc**2 * (1 - $cov / 100)**3 + $cc;
-  is $slop->{file_crap}, $expected_crap,
-    "dirslop: dir crap matches CRAP formula";
+  is $scar->{file_crap}, $expected_crap,
+    "dirscar: dir crap matches CRAP formula";
 }
 
 # Helper: run the text report against a fresh db built from Crap_script and
@@ -519,24 +519,24 @@ sub _text_report_for ($label, $script = $Crap_script, @coverage) {
   $output
 }
 
-# Per-file SLOP banner tests.
+# Per-file SCAR banner tests.
 # Verifies the text report emits a per-file banner showing
-# CC / Coverage / CRAP / SLOP, plus a worst-subs digest.
+# CC / Coverage / CRAP / SCAR, plus a worst-subs digest.
 sub test_text_file_banner () {
   my $output = _text_report_for("tx_banner");
 
   like $output, qr/^File Summary\b/m, "banner: File Summary heading present";
-  like $output, qr/\bCC\b.*\bCov\b.*\bCRAP\b.*\bSLOP\b/,
+  like $output, qr/\bCC\b.*\bCov\b.*\bCRAP\b.*\bSCAR\b/,
     "banner: metrics table header";
   like $output, qr/^\s*\d+\s+\d+\.\d+\s+\d+\.\d+\s+\d+\.\d+\s*$/m,
     "banner: metrics table data row";
 
   like $output, qr/^Worst Subroutines\b/m,
     "banner: Worst Subroutines heading present";
-  like $output, qr/\bSubroutine\b.*\bCC\b.*\bSLOP\b.*\bLocation\b/,
+  like $output, qr/\bSubroutine\b.*\bCC\b.*\bSCAR\b.*\bLocation\b/,
     "banner: worst-subs table header";
   like $output, qr/\bpartial_branch\b.*\d+\s+\d+\.\d+\s+\S*tx_banner\.pl:\d+/,
-    "banner: partial_branch appears in worst-subs with CC/SLOP/location";
+    "banner: partial_branch appears in worst-subs with CC/SCAR/location";
 }
 
 # Run a two-file coverage session by having the main script require a sibling
@@ -610,7 +610,7 @@ sub _multi_file_report ($label, $split_dirs = 0) {
   $output
 }
 
-# Module-level SLOP block tests.
+# Module-level SCAR block tests.
 # Verifies the text report emits a Module Summary block at the top when more
 # than one file is reported.
 sub test_text_module_block () {
@@ -618,7 +618,7 @@ sub test_text_module_block () {
 
   like $output, qr/^Module Summary\b/m,
     "module: Module Summary heading present";
-  like $output, qr/\bFiles\b.*\bCC\b.*\bCov\b.*\bCRAP\b.*\bSLOP\b/,
+  like $output, qr/\bFiles\b.*\bCC\b.*\bCov\b.*\bCRAP\b.*\bSCAR\b/,
     "module: metrics table header";
   like $output, qr/^\s*\d+\s+\d+\s+\d+\.\d+\s+\d+\.\d+\s+\d+\.\d+\s*$/m,
     "module: metrics table data row";
@@ -630,7 +630,7 @@ sub test_text_module_block () {
     "module: appears before per-file banners";
 }
 
-# Directory SLOP block tests.
+# Directory SCAR block tests.
 # Verifies the text report emits a Directory Summary table at the end
 # when more than one directory spans the reported files.
 sub test_text_dir_block () {
@@ -638,7 +638,7 @@ sub test_text_dir_block () {
 
   like $output, qr/^Directory Summary\b/m,
     "dir: Directory Summary heading present";
-  like $output, qr/\bDirectory\b.*\bCC\b.*\bCov\b.*\bCRAP\b.*\bSLOP\b/,
+  like $output, qr/\bDirectory\b.*\bCC\b.*\bCov\b.*\bCRAP\b.*\bSCAR\b/,
     "dir: table header present";
 
   # Directory block should appear after the last File Summary.
@@ -655,11 +655,11 @@ sub test_text_dir_block_suppressed () {
     "dir: suppressed when only one directory in report";
 }
 
-# print_summary SLOP column tests.
-# Verifies that DB::print_summary emits a slop column after the criteria
-# columns, with per-file file_slop and Total module_slop.
-sub test_print_summary_slop () {
-  my ($db_path, $script) = run_cover("ps_slop", $Crap_script);
+# print_summary SCAR column tests.
+# Verifies that DB::print_summary emits a scar column after the criteria
+# columns, with per-file file_scar and Total module_scar.
+sub test_print_summary_scar () {
+  my ($db_path, $script) = run_cover("ps_scar", $Crap_script);
 
   my $st = Devel::Cover::DB::Structure->new(base => $db_path);
   $st->read_all;
@@ -680,23 +680,23 @@ sub test_print_summary_slop () {
     close $fh or die "Cannot close scalar ref: $!";
   }
 
-  like $output, qr/\bslop\b/, "summary: header contains slop column";
+  like $output, qr/\bscar\b/, "summary: header contains scar column";
 
-  my ($file_row) = $output =~ /^(\S*ps_slop\.pl\s.+)$/m;
+  my ($file_row) = $output =~ /^(\S*ps_scar\.pl\s.+)$/m;
   ok defined $file_row, "summary: file row found";
   my @file_cols = split " ", $file_row // "";
   is @file_cols, 7,
-    "summary: file row has name + 5 criteria + slop (7 cols)";
+    "summary: file row has name + 5 criteria + scar (7 cols)";
   like $file_cols[-1], qr/^\d+\.\d$/,
-    "summary: file row slop column is numeric";
+    "summary: file row scar column is numeric";
 
   my ($total_row) = $output =~ /^(Total\s.+)$/m;
   ok defined $total_row, "summary: Total row found";
   my @total_cols = split " ", $total_row // "";
   is @total_cols, 7,
-    "summary: Total row has label + 5 criteria + slop (7 cols)";
+    "summary: Total row has label + 5 criteria + scar (7 cols)";
   like $total_cols[-1], qr/^\d+\.\d$/,
-    "summary: Total row slop column is numeric";
+    "summary: Total row scar column is numeric";
 }
 
 sub main () {
@@ -704,11 +704,11 @@ sub main () {
   test_summary_aggregation;
   test_end_lines;
   test_signature_cc;
-  test_slop_scoring;
-  test_text_report_slop;
-  test_file_level_slop;
-  test_dir_level_slop;
-  test_print_summary_slop;
+  test_scar_scoring;
+  test_text_report_scar;
+  test_file_level_scar;
+  test_dir_level_scar;
+  test_print_summary_scar;
   test_text_file_banner;
   test_text_module_block;
   test_text_dir_block;

--- a/t/internal/html_crisp.t
+++ b/t/internal/html_crisp.t
@@ -72,14 +72,14 @@ sub test_html_crisp_report () {
     like $content, qr/Uncovered\/Utils\.pm.*?\b0\.0\b/s,
       "0.0 shown for Uncovered/Utils.pm (PPI estimates)";
 
-    # SLOP tooltip and numeric value for untested files
-    like $content, qr/Uncovered\/Calc\.pm.*?slop-detail/s,
-      "SLOP tooltip present for Uncovered/Calc.pm";
-    like $content, qr/Uncovered\/Calc\.pm.*?slop-tip-subs/s,
-      "SLOP tooltip has worst subs for Uncovered/Calc.pm";
-    # The SLOP cell should have a numeric data-value, not -1
+    # SCAR tooltip and numeric value for untested files
+    like $content, qr/Uncovered\/Calc\.pm.*?scar-detail/s,
+      "SCAR tooltip present for Uncovered/Calc.pm";
+    like $content, qr/Uncovered\/Calc\.pm.*?scar-tip-subs/s,
+      "SCAR tooltip has worst subs for Uncovered/Calc.pm";
+    # The SCAR cell should have a numeric data-value, not -1
     like $content, qr/Uncovered\/Calc\.pm.*?class="tip-hover"[^>]*>\s*[\d.]+/s,
-      "SLOP cell has numeric value for Uncovered/Calc.pm";
+      "SCAR cell has numeric value for Uncovered/Calc.pm";
   } else {
     like $content, qr/Uncovered\/Calc\.pm.*?<td[^>]*>\s*-\s/s,
       "- shown for Uncovered/Calc.pm (no PPI)";

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -115,9 +115,9 @@ sub test_render_index () {
   like $got,   qr/class="worst-files"/,     "has worst files";
   like $got,   qr/class="dist-bar"/,        "has distribution bar";
   like $got,   qr/class="filter-bar"/,      "has filter bar";
-  like $got,   qr/data-sort="slop"/,        "has SLOP column";
+  like $got,   qr/data-sort="scar"/,        "has SCAR column";
   unlike $got, qr/data-sort="risk"/,        "no risk column";
-  like $got,   qr/Top SLOP/,                "worst files heading";
+  like $got,   qr/Top SCAR/,                "worst files heading";
   like $got,   qr/Covered\/Calc\.pm/,       "Covered/Calc.pm present";
   like $got,   qr/Covered\/Full\.pm/,       "Covered/Full.pm present";
   like $got,   qr/Uncovered\/Calc\.pm/,     "Uncovered/Calc.pm present";
@@ -151,16 +151,16 @@ sub test_tooltip_structure () {
   my $got = $Golden{"coverage.html"};
 
   # Unified glass tooltip system
-  like $got, qr/class="glass-tip slop-detail"/,
-    "tooltip: has glass-tip slop-detail";
-  like $got, qr/class="slop-tip-metrics"/, "tooltip: has metrics section";
-  like $got, qr/class="slop-tip-subs"/,    "tooltip: has subs section";
-  like $got, qr/class="slop-tip-total"/,   "tooltip: has total section";
+  like $got, qr/class="glass-tip scar-detail"/,
+    "tooltip: has glass-tip scar-detail";
+  like $got, qr/class="scar-tip-metrics"/, "tooltip: has metrics section";
+  like $got, qr/class="scar-tip-subs"/,    "tooltip: has subs section";
+  like $got, qr/class="scar-tip-total"/,   "tooltip: has total section";
 
   # Colour coding inside tooltips
-  like $got, qr/slop-tip-metrics.*?class="c[0-3]"/s,
+  like $got, qr/scar-tip-metrics.*?class="c[0-3]"/s,
     "tooltip: coverage value has colour class";
-  like $got, qr/slop-tip-subs.*?class="c[0-3]"/s,
+  like $got, qr/scar-tip-subs.*?class="c[0-3]"/s,
     "tooltip: sub entry has colour class";
 }
 
@@ -173,23 +173,23 @@ sub test_glass_tooltips () {
   unlike $index, qr/class="[^"]*has-tip/,   "glass: no has-tip class";
   unlike $index, qr/data-tip="/,            "glass: no data-tip attributes";
 
-  # File page SLOP badge uses tip-hover
+  # File page SCAR badge uses tip-hover
   my ($covered) = grep /Covered-Calc/, keys %Golden;
   my $file_page = $Golden{$covered};
-  like $file_page,   qr/stat-slop tip-hover/, "glass: SLOP badge has tip-hover";
-  unlike $file_page, qr/slop-hover/,          "glass: no slop-hover class";
+  like $file_page,   qr/stat-scar tip-hover/, "glass: SCAR badge has tip-hover";
+  unlike $file_page, qr/scar-hover/,          "glass: no scar-hover class";
 }
 
-sub test_dir_row_slop () {
+sub test_dir_row_scar () {
   my $got = $Golden{"coverage.html"};
-  like $got, qr/dir-header.*?tip-hover.*?slop-detail/s,
-    "dir row: has SLOP tooltip";
+  like $got, qr/dir-header.*?tip-hover.*?scar-detail/s,
+    "dir row: has SCAR tooltip";
 }
 
-sub test_module_slop_badge () {
+sub test_module_scar_badge () {
   my $got = $Golden{"coverage.html"};
-  like $got, qr/stat-badge.*?slop\b/s, "header: has SLOP stat badge";
-  like $got, qr/slop.*?help-toggle/s,  "header: SLOP badge before help button";
+  like $got, qr/stat-badge.*?scar\b/s, "header: has SCAR stat badge";
+  like $got, qr/scar.*?help-toggle/s,  "header: SCAR badge before help button";
 }
 
 sub test_total_badge_filter () {
@@ -279,25 +279,25 @@ sub test_cov_cell_link () {
     "with link: anchor wraps the percent value";
 }
 
-sub test_slop_cell_link () {
+sub test_scar_cell_link () {
   no warnings "once";
   local %Devel::Cover::Report::Html_crisp::R = ();
 
   my $f = {
-    file_slop  => "33.4",
+    file_scar  => "33.4",
     file_crap  => "12.5",
     file_cc    => 5,
     file_cov   => 80,
     worst_subs => [],
   };
 
-  my $no_link = Devel::Cover::Report::Html_crisp::slop_cell($f);
-  unlike $no_link, qr/<a class="cell-link"/, "slop no link: no anchor";
+  my $no_link = Devel::Cover::Report::Html_crisp::scar_cell($f);
+  unlike $no_link, qr/<a class="cell-link"/, "scar no link: no anchor";
 
   my $with_link
-    = Devel::Cover::Report::Html_crisp::slop_cell($f, "tests-foo.html");
+    = Devel::Cover::Report::Html_crisp::scar_cell($f, "tests-foo.html");
   like $with_link, qr{<a class="cell-link" href="tests-foo\.html">33\.4</a>},
-    "slop with link: anchor wraps slop value (no filter hash)";
+    "scar with link: anchor wraps scar value (no filter hash)";
 }
 
 sub test_stat_badge_no_tip_when_empty () {
@@ -327,7 +327,7 @@ sub test_index_filter_links () {
   like $got, qr{cell-link" href="[^"]*#filter=total"},
     "index: total cell links with #filter=total";
   like $got, qr{cell-link" href="[^"]*\.html">},
-    "index: SLOP cell links to file without #filter";
+    "index: SCAR cell links to file without #filter";
 }
 
 sub test_dir_header_links () {
@@ -660,14 +660,14 @@ sub main () {
   test_render_file_page;
   test_tooltip_structure;
   test_glass_tooltips;
-  test_dir_row_slop;
-  test_module_slop_badge;
+  test_dir_row_scar;
+  test_module_scar_badge;
   test_total_badge_filter;
   test_file_nav_keys;
   test_render_untested_page;
   test_cov_cell_tooltips;
   test_cov_cell_link;
-  test_slop_cell_link;
+  test_scar_cell_link;
   test_stat_badge_no_tip_when_empty;
   test_index_filter_links;
   test_dir_header_links;

--- a/test_output/cover/accessor.5.020000
+++ b/test_output/cover/accessor.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 Accessor_maker.pm  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 accessor           100.0  100.0    n/a    n/a  100.0  100.0   11.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     2  3 100.0  3.0 11.0
 
@@ -30,7 +30,7 @@ Accessor_maker.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -51,7 +51,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 BEGIN          1   1   0.0 Accessor_maker.pm:4
 __ANON__       4   1   0.0 Accessor_maker.pm:5
@@ -63,14 +63,14 @@ accessor
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  3 100.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location   
+Subroutine CC SCAR  Location   
 ---------- -- ----  -----------
 test        3 11.0  accessor:13
 
@@ -117,7 +117,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 accessor:4 
 BEGIN          1   1   0.0 accessor:7 

--- a/test_output/cover/accessor.5.028000
+++ b/test_output/cover/accessor.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 Accessor_maker.pm  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 accessor           100.0  100.0    n/a    n/a  100.0  100.0   11.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     2  3 100.0  3.0 11.0
 
@@ -30,7 +30,7 @@ Accessor_maker.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -51,7 +51,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 BEGIN          1   1   0.0 Accessor_maker.pm:4
 __ANON__       4   1   0.0 Accessor_maker.pm:5
@@ -63,14 +63,14 @@ accessor
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  3 100.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location   
+Subroutine CC SCAR  Location   
 ---------- -- ----  -----------
 test        3 11.0  accessor:13
 
@@ -117,7 +117,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 accessor:4 
 BEGIN          1   1   0.0 accessor:7 

--- a/test_output/cover/alias.5.020000
+++ b/test_output/cover/alias.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------ ------
-File          stmt   bran   cond   mcdc    sub  total   slop
+File          stmt   bran   cond   mcdc    sub  total   scar
 ----------- ------ ------ ------ ------ ------ ------ ------
 tests/alias  100.0  100.0    n/a    n/a  100.0  100.0    6.9
 Total        100.0  100.0    n/a    n/a  100.0  100.0    6.9
@@ -18,14 +18,14 @@ tests/alias
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  2 100.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location      
+Subroutine CC SCAR  Location      
 ---------- -- ----  --------------
 is_3digits  2  6.9  tests/alias:13
 
@@ -68,7 +68,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 is_3digits     2   2   6.9 tests/alias:13
 

--- a/test_output/cover/alias.5.028000
+++ b/test_output/cover/alias.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------ ------
-File          stmt   bran   cond   mcdc    sub  total   slop
+File          stmt   bran   cond   mcdc    sub  total   scar
 ----------- ------ ------ ------ ------ ------ ------ ------
 tests/alias  100.0  100.0    n/a    n/a  100.0  100.0    6.9
 Total        100.0  100.0    n/a    n/a  100.0  100.0    6.9
@@ -18,14 +18,14 @@ tests/alias
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  2 100.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location      
+Subroutine CC SCAR  Location      
 ---------- -- ----  --------------
 is_3digits  2  6.9  tests/alias:13
 
@@ -68,7 +68,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 is_3digits     2   2   6.9 tests/alias:13
 

--- a/test_output/cover/alias1.5.020000
+++ b/test_output/cover/alias1.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 --------- ------ ------ ------ ------ ------ ------ ------
-File        stmt   bran   cond   mcdc    sub  total   slop
+File        stmt   bran   cond   mcdc    sub  total   scar
 --------- ------ ------ ------ ------ ------ ------ ------
 Alias1.pm  100.0  100.0    n/a    n/a  100.0  100.0    6.9
 alias1     100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     2  2 100.0  2.0  6.9
 
@@ -30,14 +30,14 @@ Alias1.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  2 100.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location    
+Subroutine CC SCAR  Location    
 ---------- -- ----  ------------
 is_3digits  2  6.9  Alias1.pm:19
 
@@ -86,7 +86,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location    
+Subroutine Count  CC  SCAR Location    
 ---------- ----- --- ----- ------------
 BEGIN          1   1   0.0 Alias1.pm:10
 BEGIN          1   1   0.0 Alias1.pm:11
@@ -99,7 +99,7 @@ alias1
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -136,7 +136,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location 
+Subroutine Count  CC  SCAR Location 
 ---------- ----- --- ----- ---------
 BEGIN          1   1   0.0 alias1:10
 BEGIN          1   1   0.0 alias1:11

--- a/test_output/cover/alias1.5.028000
+++ b/test_output/cover/alias1.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 --------- ------ ------ ------ ------ ------ ------ ------
-File        stmt   bran   cond   mcdc    sub  total   slop
+File        stmt   bran   cond   mcdc    sub  total   scar
 --------- ------ ------ ------ ------ ------ ------ ------
 Alias1.pm  100.0  100.0    n/a    n/a  100.0  100.0    6.9
 alias1     100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     2  2 100.0  2.0  6.9
 
@@ -30,14 +30,14 @@ Alias1.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  2 100.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location    
+Subroutine CC SCAR  Location    
 ---------- -- ----  ------------
 is_3digits  2  6.9  Alias1.pm:19
 
@@ -86,7 +86,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location    
+Subroutine Count  CC  SCAR Location    
 ---------- ----- --- ----- ------------
 BEGIN          1   1   0.0 Alias1.pm:10
 BEGIN          1   1   0.0 Alias1.pm:11
@@ -99,7 +99,7 @@ alias1
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -136,7 +136,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location 
+Subroutine Count  CC  SCAR Location 
 ---------- ----- --- ----- ---------
 BEGIN          1   1   0.0 alias1:10
 BEGIN          1   1   0.0 alias1:11

--- a/test_output/cover/and.5.020000
+++ b/test_output/cover/and.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------- ------ ------ ------ ------ ------ ------ ------
-File        stmt   bran   cond   mcdc    sub  total   slop
+File        stmt   bran   cond   mcdc    sub  total   scar
 --------- ------ ------ ------ ------ ------ ------ ------
 tests/and   63.6   50.0   33.3    0.0    n/a   36.9    n/a
 Total       63.6   50.0   33.3    0.0    n/a   36.9    n/a

--- a/test_output/cover/and.5.028000
+++ b/test_output/cover/and.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------- ------ ------ ------ ------ ------ ------ ------
-File        stmt   bran   cond   mcdc    sub  total   slop
+File        stmt   bran   cond   mcdc    sub  total   scar
 --------- ------ ------ ------ ------ ------ ------ ------
 tests/and   63.6   50.0   33.3    0.0    n/a   36.9    n/a
 Total       63.6   50.0   33.3    0.0    n/a   36.9    n/a

--- a/test_output/cover/and.5.042002
+++ b/test_output/cover/and.5.042002
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------- ------ ------ ------ ------ ------ ------ ------
-File        stmt   bran   cond   mcdc    sub  total   slop
+File        stmt   bran   cond   mcdc    sub  total   scar
 --------- ------ ------ ------ ------ ------ ------ ------
 tests/and   63.6   50.0   33.3    0.0    n/a   36.9    n/a
 Total       63.6   50.0   33.3    0.0    n/a   36.9    n/a

--- a/test_output/cover/any_all.5.042000
+++ b/test_output/cover/any_all.5.042000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/any_all  100.0   50.0    n/a    n/a  100.0   93.5   11.0
 Total          100.0   50.0    n/a    n/a  100.0   93.5   11.0
@@ -18,14 +18,14 @@ tests/any_all
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  3 92.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location        
+Subroutine CC SCAR  Location        
 ---------- -- ----  ----------------
 main        3 11.3  tests/any_all:20
 
@@ -81,7 +81,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 tests/any_all:13
 BEGIN          1   1   0.0 tests/any_all:14

--- a/test_output/cover/bigint.5.032000
+++ b/test_output/cover/bigint.5.032000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------ ------ ------ ------ ------ ------ ------ ------
-File           stmt   bran   cond   mcdc    sub  total   slop
+File           stmt   bran   cond   mcdc    sub  total   scar
 ------------ ------ ------ ------ ------ ------ ------ ------
 tests/bigint  100.0   50.0    n/a    n/a  100.0   93.7    0.0
 Total         100.0   50.0    n/a    n/a  100.0   93.7    0.0
@@ -18,7 +18,7 @@ tests/bigint
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 92.3  1.0  0.0
 
@@ -61,7 +61,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location       
+Subroutine Count  CC  SCAR Location       
 ---------- ----- --- ----- ---------------
 BEGIN          1   1   0.0 tests/bigint:13
 BEGIN          1   1   0.0 tests/bigint:14

--- a/test_output/cover/branch_return_sub.5.020000
+++ b/test_output/cover/branch_return_sub.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------------- ------ ------ ------ ------ ------ ------ ------
-File                      stmt   bran   cond   mcdc    sub  total   slop
+File                      stmt   bran   cond   mcdc    sub  total   scar
 ----------------------- ------ ------ ------ ------ ------ ------ ------
 tests/branch_return_sub  100.0  100.0  100.0  100.0  100.0  100.0   11.0
 Total                    100.0  100.0  100.0  100.0  100.0  100.0   11.0
@@ -18,14 +18,14 @@ tests/branch_return_sub
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  3 100.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location                  
+Subroutine CC SCAR  Location                  
 ---------- -- ----  --------------------------
 my_sqrt     3 11.0  tests/branch_return_sub:14
 
@@ -90,7 +90,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location                  
+Subroutine Count  CC  SCAR Location                  
 ---------- ----- --- ----- --------------------------
 BEGIN          1   1   0.0 tests/branch_return_sub:10
 BEGIN          1   1   0.0 tests/branch_return_sub:11

--- a/test_output/cover/branch_return_sub.5.028000
+++ b/test_output/cover/branch_return_sub.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------------- ------ ------ ------ ------ ------ ------ ------
-File                      stmt   bran   cond   mcdc    sub  total   slop
+File                      stmt   bran   cond   mcdc    sub  total   scar
 ----------------------- ------ ------ ------ ------ ------ ------ ------
 tests/branch_return_sub  100.0  100.0  100.0  100.0  100.0  100.0   11.0
 Total                    100.0  100.0  100.0  100.0  100.0  100.0   11.0
@@ -18,14 +18,14 @@ tests/branch_return_sub
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  3 100.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location                  
+Subroutine CC SCAR  Location                  
 ---------- -- ----  --------------------------
 my_sqrt     3 11.0  tests/branch_return_sub:14
 
@@ -90,7 +90,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location                  
+Subroutine Count  CC  SCAR Location                  
 ---------- ----- --- ----- --------------------------
 BEGIN          1   1   0.0 tests/branch_return_sub:10
 BEGIN          1   1   0.0 tests/branch_return_sub:11

--- a/test_output/cover/change.5.020000
+++ b/test_output/cover/change.5.020000
@@ -1,7 +1,7 @@
 cover: Reading database from ...
 cover: Deleting old coverage for changed file tests/change
 ------------ ------ ------ ------ ------ ------ ------ ------
-File           stmt   bran   cond   mcdc    sub  total   slop
+File           stmt   bran   cond   mcdc    sub  total   scar
 ------------ ------ ------ ------ ------ ------ ------ ------
 tests/change  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total         100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -25,7 +25,7 @@ tests/change
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -50,7 +50,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location       
+Subroutine Count  CC  SCAR Location       
 ---------- ----- --- ----- ---------------
 new_sub        1   1   0.0 tests/change:12
 

--- a/test_output/cover/change.5.028000
+++ b/test_output/cover/change.5.028000
@@ -1,7 +1,7 @@
 cover: Reading database from ...
 cover: Deleting old coverage for changed file tests/change
 ------------ ------ ------ ------ ------ ------ ------ ------
-File           stmt   bran   cond   mcdc    sub  total   slop
+File           stmt   bran   cond   mcdc    sub  total   scar
 ------------ ------ ------ ------ ------ ------ ------ ------
 tests/change  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total         100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -25,7 +25,7 @@ tests/change
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -50,7 +50,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location       
+Subroutine Count  CC  SCAR Location       
 ---------- ----- --- ----- ---------------
 new_sub        1   1   0.0 tests/change:12
 

--- a/test_output/cover/circular_ref.5.020000
+++ b/test_output/cover/circular_ref.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------ ------
-File                 stmt   bran   cond   mcdc    sub  total   slop
+File                 stmt   bran   cond   mcdc    sub  total   scar
 ------------------ ------ ------ ------ ------ ------ ------ ------
 tests/circular_ref   83.3    0.0    n/a    n/a   66.6   63.6    7.9
 Total                83.3    0.0    n/a    n/a   66.6   63.6    7.9
@@ -18,14 +18,14 @@ tests/circular_ref
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 62.5  2.2  7.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location            
+Subroutine CC SCAR  Location            
 ---------- -- ----  --------------------
 f           2 17.9  tests/circular_ref:8
 
@@ -54,7 +54,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 BEGIN          1   1   0.0 tests/circular_ref:4
 BEGIN          1   1   0.0 tests/circular_ref:5
@@ -62,7 +62,7 @@ BEGIN          1   1   0.0 tests/circular_ref:5
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 f              0   2  17.9 tests/circular_ref:8
 

--- a/test_output/cover/circular_ref.5.028000
+++ b/test_output/cover/circular_ref.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------ ------
-File                 stmt   bran   cond   mcdc    sub  total   slop
+File                 stmt   bran   cond   mcdc    sub  total   scar
 ------------------ ------ ------ ------ ------ ------ ------ ------
 tests/circular_ref   83.3    0.0    n/a    n/a   66.6   63.6    7.9
 Total                83.3    0.0    n/a    n/a   66.6   63.6    7.9
@@ -18,14 +18,14 @@ tests/circular_ref
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 62.5  2.2  7.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location            
+Subroutine CC SCAR  Location            
 ---------- -- ----  --------------------
 f           2 17.9  tests/circular_ref:8
 
@@ -54,7 +54,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 BEGIN          1   1   0.0 tests/circular_ref:4
 BEGIN          1   1   0.0 tests/circular_ref:5
@@ -62,7 +62,7 @@ BEGIN          1   1   0.0 tests/circular_ref:5
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 f              0   2  17.9 tests/circular_ref:8
 

--- a/test_output/cover/class38.5.038000
+++ b/test_output/cover/class38.5.038000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/class38   94.5   50.0    n/a    n/a   85.7   81.1   24.8
 Total           94.5   50.0    n/a    n/a   85.7   81.1   24.8
@@ -18,14 +18,14 @@ tests/class38
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 11 80.0 12.0 24.8
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location        
+Subroutine CC SCAR  Location        
 ---------- -- ----  ----------------
 main        9 24.1  tests/class38:44
 is_loud     2  7.6  tests/class38:33
@@ -118,7 +118,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 tests/class38:13
 BEGIN          1   1   0.0 tests/class38:14
@@ -136,7 +136,7 @@ speak          1   1   0.0 tests/class38:39
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 unused         0   1   6.9 tests/class38:27
 unused_dog     0   1   6.9 tests/class38:40

--- a/test_output/cover/class40.5.040000
+++ b/test_output/cover/class40.5.040000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/class40   94.8   50.0    n/a    n/a   85.7   80.0   26.8
 Total           94.8   50.0    n/a    n/a   85.7   80.0   26.8
@@ -18,14 +18,14 @@ tests/class40
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 13 78.7 14.6 26.8
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location        
+Subroutine CC SCAR  Location        
 ---------- -- ----  ----------------
 main       11 26.6  tests/class40:44
 is_loud     2  7.6  tests/class40:33
@@ -122,7 +122,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 tests/class40:13
 BEGIN          1   1   0.0 tests/class40:14
@@ -140,7 +140,7 @@ speak          1   1   0.0 tests/class40:39
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 unused         0   1   6.9 tests/class40:27
 unused_dog     0   1   6.9 tests/class40:40

--- a/test_output/cover/class42.5.042000
+++ b/test_output/cover/class42.5.042000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/class42   95.4   50.0    n/a    n/a   87.5   80.2   28.5
 Total           95.4   50.0    n/a    n/a   87.5   80.2   28.5
@@ -18,14 +18,14 @@ tests/class42
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 15 78.6 17.2 28.5
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location        
+Subroutine CC SCAR  Location        
 ---------- -- ----  ----------------
 main       13 28.7  tests/class42:49
 is_loud     2  7.6  tests/class42:33
@@ -132,7 +132,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  SLOP Location        
+Subroutine   Count  CC  SCAR Location        
 ------------ ----- --- ----- ----------------
 BEGIN            1   1   0.0 tests/class42:13
 BEGIN            1   1   0.0 tests/class42:14
@@ -152,7 +152,7 @@ speak            1   1   0.0 tests/class42:44
 Uncovered Subroutines
 ---------------------
 
-Subroutine   Count  CC  SLOP Location        
+Subroutine   Count  CC  SCAR Location        
 ------------ ----- --- ----- ----------------
 unused           0   1   6.9 tests/class42:27
 unused_dog       0   1   6.9 tests/class42:45

--- a/test_output/cover/cond_and.5.020000
+++ b/test_output/cover/cond_and.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/cond_and   96.0   50.0   50.0   25.0  100.0   68.3    7.3
 Total            96.0   50.0   50.0   25.0  100.0   68.3    7.3
@@ -18,14 +18,14 @@ tests/cond_and
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 73.5  2.1  7.3
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location         
+Subroutine CC SCAR  Location         
 ---------- -- ----  -----------------
 pas         2  7.6  tests/cond_and:50
 
@@ -129,7 +129,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/cond_and:10
 BEGIN          1   1   0.0 tests/cond_and:11

--- a/test_output/cover/cond_and.5.028000
+++ b/test_output/cover/cond_and.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/cond_and   96.0   50.0   50.0   25.0  100.0   68.3    7.3
 Total            96.0   50.0   50.0   25.0  100.0   68.3    7.3
@@ -18,14 +18,14 @@ tests/cond_and
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 73.5  2.1  7.3
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location         
+Subroutine CC SCAR  Location         
 ---------- -- ----  -----------------
 pas         2  7.6  tests/cond_and:50
 
@@ -129,7 +129,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/cond_and:10
 BEGIN          1   1   0.0 tests/cond_and:11

--- a/test_output/cover/cond_and.5.043008
+++ b/test_output/cover/cond_and.5.043008
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/cond_and   96.0   50.0   50.0   25.0  100.0   68.3    7.3
 Total            96.0   50.0   50.0   25.0  100.0   68.3    7.3
@@ -18,14 +18,14 @@ tests/cond_and
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 73.5  2.1  7.3
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location         
+Subroutine CC SCAR  Location         
 ---------- -- ----  -----------------
 pas         2  7.6  tests/cond_and:50
 
@@ -129,7 +129,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/cond_and:10
 BEGIN          1   1   0.0 tests/cond_and:11

--- a/test_output/cover/cond_branch.5.020000
+++ b/test_output/cover/cond_branch.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 tests/cond_branch   90.2   79.3   32.9   19.5  100.0   70.1   30.0
 Total               90.2   79.3   32.9   19.5  100.0   70.1   30.0
@@ -18,14 +18,14 @@ tests/cond_branch
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 16 74.8 20.1 30.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location             
+Subroutine CC SCAR  Location             
 ---------- -- ----  ---------------------
 __ANON__    2 14.6  tests/cond_branch:230
 __ANON__    3 11.0  tests/cond_branch:245
@@ -519,7 +519,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location             
+Subroutine Count  CC  SCAR Location             
 ---------- ----- --- ----- ---------------------
 BEGIN          1   1   0.0 tests/cond_branch:10 
 BEGIN          1   1   0.0 tests/cond_branch:11 

--- a/test_output/cover/cond_branch.5.043008
+++ b/test_output/cover/cond_branch.5.043008
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 tests/cond_branch   90.2   79.3   32.9   19.5  100.0   70.1   30.0
 Total               90.2   79.3   32.9   19.5  100.0   70.1   30.0
@@ -18,14 +18,14 @@ tests/cond_branch
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 16 74.8 20.1 30.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location             
+Subroutine CC SCAR  Location             
 ---------- -- ----  ---------------------
 __ANON__    2 14.6  tests/cond_branch:230
 __ANON__    3 11.0  tests/cond_branch:245
@@ -519,7 +519,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location             
+Subroutine Count  CC  SCAR Location             
 ---------- ----- --- ----- ---------------------
 BEGIN          1   1   0.0 tests/cond_branch:10 
 BEGIN          1   1   0.0 tests/cond_branch:11 

--- a/test_output/cover/cond_chained.5.020000
+++ b/test_output/cover/cond_chained.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------ ------
-File                 stmt   bran   cond   mcdc    sub  total   slop
+File                 stmt   bran   cond   mcdc    sub  total   scar
 ------------------ ------ ------ ------ ------ ------ ------ ------
 tests/cond_chained  100.0   83.3   86.6   50.0  100.0   82.9   25.0
 Total               100.0   83.3   86.6   50.0  100.0   82.9   25.0
@@ -18,14 +18,14 @@ tests/cond_chained
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 12 90.0 12.1 25.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location             
+Subroutine CC SCAR  Location             
 ---------- -- ----  ---------------------
 t3          6 18.6  tests/cond_chained:16
 t1          4 13.9  tests/cond_chained:4 
@@ -96,7 +96,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location             
+Subroutine Count  CC  SCAR Location             
 ---------- ----- --- ----- ---------------------
 t1             1   4  13.9 tests/cond_chained:4 
 t2             1   4  13.9 tests/cond_chained:10

--- a/test_output/cover/cond_or.5.020000
+++ b/test_output/cover/cond_or.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 cond_or      89.4   33.3   64.4   38.2   60.0   64.1    7.4
 cond_or.pl  100.0    n/a   57.5   15.0  100.0   62.2   33.4
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2 22 72.1 32.5 34.8
 
@@ -30,14 +30,14 @@ cond_or
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 70.9  2.1  7.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location  
+Subroutine CC SCAR  Location  
 ---------- -- ----  ----------
 __ANON__    2 13.0  cond_or:81
 __ANON__    1  0.2  cond_or:71
@@ -237,7 +237,7 @@ use strict;
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   1   0.0 cond_or:13
 BEGIN          1   1   0.0 cond_or:14
@@ -246,7 +246,7 @@ BEGIN          1   1   0.0 cond_or:24
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 __ANON__       0   1   0.2 cond_or:71
 __ANON__       0   2  13.0 cond_or:81
@@ -257,14 +257,14 @@ cond_or.pl
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 21 74.6 28.2 33.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 cond_dor   21 34.2  cond_or.pl:14
 
@@ -375,7 +375,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 BEGIN          1   1   0.0 cond_or.pl:10
 BEGIN          1   1   0.0 cond_or.pl:11

--- a/test_output/cover/cond_or.5.022000
+++ b/test_output/cover/cond_or.5.022000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 cond_or      89.4   33.3   64.4   38.2   60.0   64.1    7.4
 cond_or.pl  100.0    n/a   57.5   15.0  100.0   62.2   33.4
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2 22 72.1 32.5 34.8
 
@@ -30,14 +30,14 @@ cond_or
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 70.9  2.1  7.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location  
+Subroutine CC SCAR  Location  
 ---------- -- ----  ----------
 __ANON__    2 13.0  cond_or:81
 __ANON__    1  0.2  cond_or:71
@@ -237,7 +237,7 @@ use strict;
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   1   0.0 cond_or:13
 BEGIN          1   1   0.0 cond_or:14
@@ -246,7 +246,7 @@ BEGIN          1   1   0.0 cond_or:24
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 __ANON__       0   1   0.2 cond_or:71
 __ANON__       0   2  13.0 cond_or:81
@@ -257,14 +257,14 @@ cond_or.pl
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 21 74.6 28.2 33.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 cond_dor   21 34.2  cond_or.pl:14
 
@@ -375,7 +375,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 BEGIN          1   1   0.0 cond_or.pl:10
 BEGIN          1   1   0.0 cond_or.pl:11

--- a/test_output/cover/cond_or.5.026000
+++ b/test_output/cover/cond_or.5.026000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 cond_or      89.4   33.3   64.4   38.2   60.0   64.1    7.4
 cond_or.pl  100.0    n/a   57.5   15.0  100.0   62.2   33.4
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2 22 72.1 32.5 34.8
 
@@ -30,14 +30,14 @@ cond_or
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 70.9  2.1  7.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location  
+Subroutine CC SCAR  Location  
 ---------- -- ----  ----------
 __ANON__    2 13.0  cond_or:81
 __ANON__    1  0.2  cond_or:71
@@ -233,7 +233,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   1   0.0 cond_or:13
 BEGIN          1   1   0.0 cond_or:14
@@ -242,7 +242,7 @@ BEGIN          1   1   0.0 cond_or:24
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 __ANON__       0   1   0.2 cond_or:71
 __ANON__       0   2  13.0 cond_or:81
@@ -253,14 +253,14 @@ cond_or.pl
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 21 74.6 28.2 33.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 cond_dor   21 34.2  cond_or.pl:14
 
@@ -371,7 +371,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 BEGIN          1   1   0.0 cond_or.pl:10
 BEGIN          1   1   0.0 cond_or.pl:11

--- a/test_output/cover/cond_or.5.028000
+++ b/test_output/cover/cond_or.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 cond_or      89.4   33.3   64.4   38.2   60.0   64.1    7.4
 cond_or.pl  100.0    n/a   57.5   15.0  100.0   62.2   33.4
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2 22 72.1 32.5 34.8
 
@@ -30,14 +30,14 @@ cond_or
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 70.9  2.1  7.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location  
+Subroutine CC SCAR  Location  
 ---------- -- ----  ----------
 __ANON__    2 13.0  cond_or:81
 __ANON__    1  0.2  cond_or:71
@@ -233,7 +233,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   1   0.0 cond_or:13
 BEGIN          1   1   0.0 cond_or:14
@@ -242,7 +242,7 @@ BEGIN          1   1   0.0 cond_or:24
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 __ANON__       0   1   0.2 cond_or:71
 __ANON__       0   2  13.0 cond_or:81
@@ -253,14 +253,14 @@ cond_or.pl
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 21 74.6 28.2 33.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 cond_dor   21 34.2  cond_or.pl:14
 
@@ -371,7 +371,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 BEGIN          1   1   0.0 cond_or.pl:10
 BEGIN          1   1   0.0 cond_or.pl:11

--- a/test_output/cover/cond_or.5.038000
+++ b/test_output/cover/cond_or.5.038000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 cond_or      89.4   33.3   63.3   34.2   60.0   62.8    7.4
 cond_or.pl  100.0    n/a   57.5   15.0  100.0   62.2   33.4
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2 22 71.8 32.9 34.9
 
@@ -30,14 +30,14 @@ cond_or
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 70.4  2.1  7.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location  
+Subroutine CC SCAR  Location  
 ---------- -- ----  ----------
 __ANON__    2 13.0  cond_or:81
 __ANON__    1  0.6  cond_or:71
@@ -236,7 +236,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   1   0.0 cond_or:13
 BEGIN          1   1   0.0 cond_or:14
@@ -245,7 +245,7 @@ BEGIN          1   1   0.0 cond_or:24
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 __ANON__       0   1   0.6 cond_or:71
 __ANON__       0   2  13.0 cond_or:81
@@ -256,14 +256,14 @@ cond_or.pl
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 21 74.6 28.2 33.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 cond_dor   21 34.2  cond_or.pl:14
 
@@ -374,7 +374,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 BEGIN          1   1   0.0 cond_or.pl:10
 BEGIN          1   1   0.0 cond_or.pl:11

--- a/test_output/cover/cond_or.5.043008
+++ b/test_output/cover/cond_or.5.043008
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 cond_or      89.4   33.3   63.3   34.2   60.0   62.8    7.4
 cond_or.pl  100.0    n/a   57.5   15.0  100.0   62.2   33.4
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2 22 71.8 32.9 34.9
 
@@ -30,14 +30,14 @@ cond_or
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 70.4  2.1  7.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location  
+Subroutine CC SCAR  Location  
 ---------- -- ----  ----------
 __ANON__    2 13.0  cond_or:81
 __ANON__    1  0.6  cond_or:71
@@ -236,7 +236,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   1   0.0 cond_or:13
 BEGIN          1   1   0.0 cond_or:14
@@ -245,7 +245,7 @@ BEGIN          1   1   0.0 cond_or:24
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 __ANON__       0   1   0.6 cond_or:71
 __ANON__       0   2  13.0 cond_or:81
@@ -256,14 +256,14 @@ cond_or.pl
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 21 74.6 28.2 33.4
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 cond_dor   21 34.2  cond_or.pl:14
 
@@ -374,7 +374,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 BEGIN          1   1   0.0 cond_or.pl:10
 BEGIN          1   1   0.0 cond_or.pl:11

--- a/test_output/cover/cond_or_interp.5.020000
+++ b/test_output/cover/cond_or_interp.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------ ------
-File                   stmt   bran   cond   mcdc    sub  total   slop
+File                   stmt   bran   cond   mcdc    sub  total   scar
 -------------------- ------ ------ ------ ------ ------ ------ ------
 tests/cond_or_interp  100.0  100.0   83.6   54.8  100.0   81.5    0.0
 Total                 100.0  100.0   83.6   54.8  100.0   81.5    0.0
@@ -18,7 +18,7 @@ tests/cond_or_interp
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 90.7  1.0  0.0
 
@@ -191,7 +191,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location               
+Subroutine Count  CC  SCAR Location               
 ---------- ----- --- ----- -----------------------
 BEGIN          1   1   0.0 tests/cond_or_interp:26
 BEGIN          1   1   0.0 tests/cond_or_interp:27

--- a/test_output/cover/cond_or_interp.5.028000
+++ b/test_output/cover/cond_or_interp.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------ ------
-File                   stmt   bran   cond   mcdc    sub  total   slop
+File                   stmt   bran   cond   mcdc    sub  total   scar
 -------------------- ------ ------ ------ ------ ------ ------ ------
 tests/cond_or_interp  100.0  100.0   95.3   92.0  100.0   96.2    0.0
 Total                 100.0  100.0   95.3   92.0  100.0   96.2    0.0
@@ -18,7 +18,7 @@ tests/cond_or_interp
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 97.5  1.0  0.0
 
@@ -191,7 +191,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location               
+Subroutine Count  CC  SCAR Location               
 ---------- ----- --- ----- -----------------------
 BEGIN          1   1   0.0 tests/cond_or_interp:26
 BEGIN          1   1   0.0 tests/cond_or_interp:27

--- a/test_output/cover/cond_xor.5.020000
+++ b/test_output/cover/cond_xor.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/cond_xor  100.0    n/a   66.6   66.6  100.0   82.8    0.0
 Total           100.0    n/a   66.6   66.6  100.0   82.8    0.0
@@ -18,7 +18,7 @@ tests/cond_xor
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 85.2  1.0  0.0
 
@@ -79,7 +79,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/cond_xor:10
 BEGIN          1   1   0.0 tests/cond_xor:11

--- a/test_output/cover/cond_xor.5.028000
+++ b/test_output/cover/cond_xor.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/cond_xor  100.0    n/a   66.6   66.6  100.0   82.8    0.0
 Total           100.0    n/a   66.6   66.6  100.0   82.8    0.0
@@ -18,7 +18,7 @@ tests/cond_xor
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 85.2  1.0  0.0
 
@@ -79,7 +79,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/cond_xor:10
 BEGIN          1   1   0.0 tests/cond_xor:11

--- a/test_output/cover/cond_xor.5.040000
+++ b/test_output/cover/cond_xor.5.040000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/cond_xor  100.0    n/a   66.6   66.6  100.0   82.8    0.0
 Total           100.0    n/a   66.6   66.6  100.0   82.8    0.0
@@ -18,7 +18,7 @@ tests/cond_xor
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 85.2  1.0  0.0
 
@@ -79,7 +79,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/cond_xor:10
 BEGIN          1   1   0.0 tests/cond_xor:11

--- a/test_output/cover/cond_xor_hp.5.040000
+++ b/test_output/cover/cond_xor_hp.5.040000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 tests/cond_xor_hp  100.0    n/a   66.6   33.3  100.0   77.7   18.1
 Total              100.0    n/a   66.6   33.3  100.0   77.7   18.1
@@ -18,14 +18,14 @@ tests/cond_xor_hp
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  6 85.2  6.1 18.1
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location            
+Subroutine CC SCAR  Location            
 ---------- -- ----  --------------------
 main        6 18.4  tests/cond_xor_hp:17
 
@@ -92,7 +92,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 BEGIN          1   1   0.0 tests/cond_xor_hp:13
 BEGIN          1   1   0.0 tests/cond_xor_hp:14

--- a/test_output/cover/cop.5.020000
+++ b/test_output/cover/cop.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------- ------ ------ ------ ------ ------ ------ ------
-File        stmt   bran   cond   mcdc    sub  total   slop
+File        stmt   bran   cond   mcdc    sub  total   scar
 --------- ------ ------ ------ ------ ------ ------ ------
 tests/cop   91.6    n/a    n/a    n/a   75.0   87.5    0.0
 Total       91.6    n/a    n/a    n/a   75.0   87.5    0.0
@@ -18,14 +18,14 @@ tests/cop
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 91.7  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location    
+Subroutine CC SCAR  Location    
 ---------- -- ----  ------------
 __ANON__    1  1.2  tests/cop:15
 
@@ -58,7 +58,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location    
+Subroutine Count  CC  SCAR Location    
 ---------- ----- --- ----- ------------
 BEGIN          1   1   0.0 tests/cop:10
 BEGIN          1   1   0.0 tests/cop:11
@@ -67,7 +67,7 @@ BEGIN          1   1   0.0 tests/cop:13
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location    
+Subroutine Count  CC  SCAR Location    
 ---------- ----- --- ----- ------------
 __ANON__       0   1   1.2 tests/cop:15
 

--- a/test_output/cover/cop.5.028000
+++ b/test_output/cover/cop.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------- ------ ------ ------ ------ ------ ------ ------
-File        stmt   bran   cond   mcdc    sub  total   slop
+File        stmt   bran   cond   mcdc    sub  total   scar
 --------- ------ ------ ------ ------ ------ ------ ------
 tests/cop   91.6    n/a    n/a    n/a   75.0   87.5    0.0
 Total       91.6    n/a    n/a    n/a   75.0   87.5    0.0
@@ -18,14 +18,14 @@ tests/cop
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 91.7  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location    
+Subroutine CC SCAR  Location    
 ---------- -- ----  ------------
 __ANON__    1  1.2  tests/cop:15
 
@@ -58,7 +58,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location    
+Subroutine Count  CC  SCAR Location    
 ---------- ----- --- ----- ------------
 BEGIN          1   1   0.0 tests/cop:10
 BEGIN          1   1   0.0 tests/cop:11
@@ -67,7 +67,7 @@ BEGIN          1   1   0.0 tests/cop:13
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location    
+Subroutine Count  CC  SCAR Location    
 ---------- ----- --- ----- ------------
 __ANON__       0   1   1.2 tests/cop:15
 

--- a/test_output/cover/custom_op.5.038000
+++ b/test_output/cover/custom_op.5.038000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------ ------
-File              stmt   bran   cond   mcdc    sub  total   slop
+File              stmt   bran   cond   mcdc    sub  total   scar
 --------------- ------ ------ ------ ------ ------ ------ ------
 tests/custom_op   91.6   50.0   33.3    0.0  100.0   69.5    0.2
 Total             91.6   50.0   33.3    0.0  100.0   69.5    0.2
@@ -18,7 +18,7 @@ tests/custom_op
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 73.7  1.0  0.2
 
@@ -91,7 +91,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location          
+Subroutine Count  CC  SCAR Location          
 ---------- ----- --- ----- ------------------
 BEGIN          1   1   0.0 tests/custom_op:15
 BEGIN          1   1   0.0 tests/custom_op:16

--- a/test_output/cover/dbm_cond.5.020000
+++ b/test_output/cover/dbm_cond.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/dbm_cond  100.0  100.0    n/a    n/a  100.0  100.0   11.0
 Total           100.0  100.0    n/a    n/a  100.0  100.0   11.0
@@ -18,14 +18,14 @@ tests/dbm_cond
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  3 100.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location         
+Subroutine CC SCAR  Location         
 ---------- -- ----  -----------------
 testdbm     2  6.9  tests/dbm_cond:26
 testh       2  6.9  tests/dbm_cond:36
@@ -106,7 +106,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/dbm_cond:13
 BEGIN          1   1   0.0 tests/dbm_cond:14

--- a/test_output/cover/dbm_cond.5.022000
+++ b/test_output/cover/dbm_cond.5.022000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/dbm_cond  100.0  100.0    n/a    n/a  100.0  100.0   11.0
 Total           100.0  100.0    n/a    n/a  100.0  100.0   11.0
@@ -18,14 +18,14 @@ tests/dbm_cond
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  3 100.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location         
+Subroutine CC SCAR  Location         
 ---------- -- ----  -----------------
 testdbm     2  6.9  tests/dbm_cond:26
 testh       2  6.9  tests/dbm_cond:36
@@ -106,7 +106,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/dbm_cond:13
 BEGIN          1   1   0.0 tests/dbm_cond:14

--- a/test_output/cover/dbm_cond.5.028000
+++ b/test_output/cover/dbm_cond.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/dbm_cond  100.0  100.0    n/a    n/a  100.0  100.0   11.0
 Total           100.0  100.0    n/a    n/a  100.0  100.0   11.0
@@ -18,14 +18,14 @@ tests/dbm_cond
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  3 100.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location         
+Subroutine CC SCAR  Location         
 ---------- -- ----  -----------------
 testdbm     2  6.9  tests/dbm_cond:26
 testh       2  6.9  tests/dbm_cond:36
@@ -106,7 +106,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/dbm_cond:13
 BEGIN          1   1   0.0 tests/dbm_cond:14

--- a/test_output/cover/default_param.5.020000
+++ b/test_output/cover/default_param.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------ ------
-File                  stmt   bran   cond   mcdc    sub  total   slop
+File                  stmt   bran   cond   mcdc    sub  total   scar
 ------------------- ------ ------ ------ ------ ------ ------ ------
 tests/default_param  100.0    n/a  100.0  100.0  100.0  100.0   13.9
 Total                100.0    n/a  100.0  100.0  100.0  100.0   13.9
@@ -18,14 +18,14 @@ tests/default_param
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  4 100.0  4.0 13.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location              
+Subroutine CC SCAR  Location              
 ---------- -- ----  ----------------------
 p           4 13.9  tests/default_param:14
 
@@ -80,7 +80,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location              
+Subroutine Count  CC  SCAR Location              
 ---------- ----- --- ----- ----------------------
 BEGIN          1   1   0.0 tests/default_param:10
 BEGIN          1   1   0.0 tests/default_param:11

--- a/test_output/cover/default_param.5.028000
+++ b/test_output/cover/default_param.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------ ------
-File                  stmt   bran   cond   mcdc    sub  total   slop
+File                  stmt   bran   cond   mcdc    sub  total   scar
 ------------------- ------ ------ ------ ------ ------ ------ ------
 tests/default_param  100.0    n/a  100.0  100.0  100.0  100.0   13.9
 Total                100.0    n/a  100.0  100.0  100.0  100.0   13.9
@@ -18,14 +18,14 @@ tests/default_param
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  4 100.0  4.0 13.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location              
+Subroutine CC SCAR  Location              
 ---------- -- ----  ----------------------
 p           4 13.9  tests/default_param:14
 
@@ -80,7 +80,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location              
+Subroutine Count  CC  SCAR Location              
 ---------- ----- --- ----- ----------------------
 BEGIN          1   1   0.0 tests/default_param:10
 BEGIN          1   1   0.0 tests/default_param:11

--- a/test_output/cover/default_param.5.040000
+++ b/test_output/cover/default_param.5.040000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------ ------
-File                  stmt   bran   cond   mcdc    sub  total   slop
+File                  stmt   bran   cond   mcdc    sub  total   scar
 ------------------- ------ ------ ------ ------ ------ ------ ------
 tests/default_param  100.0    n/a  100.0  100.0  100.0  100.0   13.9
 Total                100.0    n/a  100.0  100.0  100.0  100.0   13.9
@@ -18,14 +18,14 @@ tests/default_param
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  4 100.0  4.0 13.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location              
+Subroutine CC SCAR  Location              
 ---------- -- ----  ----------------------
 p           4 13.9  tests/default_param:14
 
@@ -80,7 +80,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location              
+Subroutine Count  CC  SCAR Location              
 ---------- ----- --- ----- ----------------------
 BEGIN          1   1   0.0 tests/default_param:10
 BEGIN          1   1   0.0 tests/default_param:11

--- a/test_output/cover/deparse.5.020000
+++ b/test_output/cover/deparse.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/deparse   91.6    n/a    n/a    n/a   75.0   87.5    0.0
 Total           91.6    n/a    n/a    n/a   75.0   87.5    0.0
@@ -18,14 +18,14 @@ tests/deparse
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 91.7  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location        
+Subroutine CC SCAR  Location        
 ---------- -- ----  ----------------
 __ANON__    1  6.9  tests/deparse:16
 
@@ -60,7 +60,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 tests/deparse:10
 BEGIN          1   1   0.0 tests/deparse:11
@@ -69,7 +69,7 @@ BEGIN          1   1   0.0 tests/deparse:13
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 __ANON__       0   1   6.9 tests/deparse:16
 

--- a/test_output/cover/deparse.5.028000
+++ b/test_output/cover/deparse.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/deparse   91.6    n/a    n/a    n/a   75.0   87.5    0.0
 Total           91.6    n/a    n/a    n/a   75.0   87.5    0.0
@@ -18,14 +18,14 @@ tests/deparse
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 91.7  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location        
+Subroutine CC SCAR  Location        
 ---------- -- ----  ----------------
 __ANON__    1  6.9  tests/deparse:16
 
@@ -60,7 +60,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 tests/deparse:10
 BEGIN          1   1   0.0 tests/deparse:11
@@ -69,7 +69,7 @@ BEGIN          1   1   0.0 tests/deparse:13
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 __ANON__       0   1   6.9 tests/deparse:16
 

--- a/test_output/cover/destroy.5.020000
+++ b/test_output/cover/destroy.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/destroy  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total          100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/destroy
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -51,7 +51,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 DESTROY        1   1   0.0 tests/destroy:17
 new            1   1   0.0 tests/destroy:12

--- a/test_output/cover/destroy.5.028000
+++ b/test_output/cover/destroy.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/destroy  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total          100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/destroy
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -51,7 +51,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 DESTROY        1   1   0.0 tests/destroy:17
 new            1   1   0.0 tests/destroy:12

--- a/test_output/cover/dor_rhs.5.020000
+++ b/test_output/cover/dor_rhs.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond    sub  total   slop
+File            stmt   bran   cond    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------
 tests/dor_rhs  100.0   50.0   33.3  100.0   70.3   28.4
 Total          100.0   50.0   33.3  100.0   70.3   28.4
@@ -18,14 +18,14 @@ tests/dor_rhs
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 12 67.0 17.2 28.4
 
 Worst Subroutines
 -----------------
 
-Subroutine     CC SLOP  Location        
+Subroutine     CC SCAR  Location        
 -------------- -- ----  ----------------
 chained_rhs     3 13.3  tests/dor_rhs:82
 glob_hash_rhs   2  8.1  tests/dor_rhs:35
@@ -175,7 +175,7 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine     Count  CC  SLOP Location        
+Subroutine     Count  CC  SCAR Location        
 -------------- ----- --- ----- ----------------
 BEGIN              1   1   0.0 tests/dor_rhs:4 
 aref_rhs           1   2   7.6 tests/dor_rhs:57

--- a/test_output/cover/dor_rhs.5.022000
+++ b/test_output/cover/dor_rhs.5.022000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond    sub  total   slop
+File            stmt   bran   cond    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------
 tests/dor_rhs  100.0   50.0   33.3  100.0   70.3   28.4
 Total          100.0   50.0   33.3  100.0   70.3   28.4
@@ -18,14 +18,14 @@ tests/dor_rhs
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 12 67.0 17.2 28.4
 
 Worst Subroutines
 -----------------
 
-Subroutine     CC SLOP  Location        
+Subroutine     CC SCAR  Location        
 -------------- -- ----  ----------------
 chained_rhs     3 13.3  tests/dor_rhs:82
 glob_hash_rhs   2  8.1  tests/dor_rhs:35
@@ -175,7 +175,7 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine     Count  CC  SLOP Location        
+Subroutine     Count  CC  SCAR Location        
 -------------- ----- --- ----- ----------------
 BEGIN              1   1   0.0 tests/dor_rhs:4 
 aref_rhs           1   2   7.6 tests/dor_rhs:57

--- a/test_output/cover/dor_rhs.5.026000
+++ b/test_output/cover/dor_rhs.5.026000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond    sub  total   slop
+File            stmt   bran   cond    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------
 tests/dor_rhs  100.0   50.0   33.3  100.0   70.3   28.4
 Total          100.0   50.0   33.3  100.0   70.3   28.4
@@ -18,14 +18,14 @@ tests/dor_rhs
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 12 67.0 17.2 28.4
 
 Worst Subroutines
 -----------------
 
-Subroutine     CC SLOP  Location        
+Subroutine     CC SCAR  Location        
 -------------- -- ----  ----------------
 chained_rhs     3 13.3  tests/dor_rhs:82
 glob_hash_rhs   2  8.1  tests/dor_rhs:35
@@ -175,7 +175,7 @@ line  err      %      l  !l&&r !l&&!r   expr
 Covered Subroutines
 -------------------
 
-Subroutine     Count  CC  SLOP Location        
+Subroutine     Count  CC  SCAR Location        
 -------------- ----- --- ----- ----------------
 BEGIN              1   1   0.0 tests/dor_rhs:4 
 aref_rhs           1   2   7.6 tests/dor_rhs:57

--- a/test_output/cover/dynamic_subs.5.020000
+++ b/test_output/cover/dynamic_subs.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------ ------
-File                 stmt   bran   cond   mcdc    sub  total   slop
+File                 stmt   bran   cond   mcdc    sub  total   scar
 ------------------ ------ ------ ------ ------ ------ ------ ------
 tests/dynamic_subs   97.2   75.0    n/a    n/a   80.0   92.0   11.0
 Total                97.2   75.0    n/a    n/a   80.0   92.0   11.0
@@ -18,14 +18,14 @@ tests/dynamic_subs
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  3 95.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location             
+Subroutine CC SCAR  Location             
 ---------- -- ----  ---------------------
 __ANON__    2  7.2  tests/dynamic_subs:16
 unused      1  6.9  tests/dynamic_subs:10
@@ -110,7 +110,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location             
+Subroutine Count  CC  SCAR Location             
 ---------- ----- --- ----- ---------------------
 AUTOLOAD       3   2   6.9 tests/dynamic_subs:41
 BEGIN          1   1   0.0 tests/dynamic_subs:31
@@ -124,7 +124,7 @@ gen            4   1   0.0 tests/dynamic_subs:14
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location             
+Subroutine Count  CC  SCAR Location             
 ---------- ----- --- ----- ---------------------
 empty          0   1   0.0 tests/dynamic_subs:11
 unused         0   1   6.9 tests/dynamic_subs:10

--- a/test_output/cover/dynamic_subs.5.028000
+++ b/test_output/cover/dynamic_subs.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------ ------
-File                 stmt   bran   cond   mcdc    sub  total   slop
+File                 stmt   bran   cond   mcdc    sub  total   scar
 ------------------ ------ ------ ------ ------ ------ ------ ------
 tests/dynamic_subs   97.2   75.0    n/a    n/a   80.0   92.0   11.0
 Total                97.2   75.0    n/a    n/a   80.0   92.0   11.0
@@ -18,14 +18,14 @@ tests/dynamic_subs
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  3 95.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location             
+Subroutine CC SCAR  Location             
 ---------- -- ----  ---------------------
 __ANON__    2  7.2  tests/dynamic_subs:16
 unused      1  6.9  tests/dynamic_subs:10
@@ -110,7 +110,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location             
+Subroutine Count  CC  SCAR Location             
 ---------- ----- --- ----- ---------------------
 AUTOLOAD       3   2   6.9 tests/dynamic_subs:41
 BEGIN          1   1   0.0 tests/dynamic_subs:31
@@ -124,7 +124,7 @@ gen            4   1   0.0 tests/dynamic_subs:14
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location             
+Subroutine Count  CC  SCAR Location             
 ---------- ----- --- ----- ---------------------
 empty          0   1   0.0 tests/dynamic_subs:11
 unused         0   1   6.9 tests/dynamic_subs:10

--- a/test_output/cover/empty.5.020000
+++ b/test_output/cover/empty.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 Total    n/a    n/a    n/a    n/a    n/a    n/a    n/a
 ----- ------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/empty.5.028000
+++ b/test_output/cover/empty.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 Total    n/a    n/a    n/a    n/a    n/a    n/a    n/a
 ----- ------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/empty_else.5.020000
+++ b/test_output/cover/empty_else.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------- ------ ------ ------ ------ ------ ------ ------
-File               stmt   bran   cond   mcdc    sub  total   slop
+File               stmt   bran   cond   mcdc    sub  total   scar
 ---------------- ------ ------ ------ ------ ------ ------ ------
 tests/empty_else  100.0   50.0    n/a    n/a  100.0   88.2    7.0
 Total             100.0   50.0    n/a    n/a  100.0   88.2    7.0
@@ -18,14 +18,14 @@ tests/empty_else
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 85.7  2.0  7.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location           
+Subroutine CC SCAR  Location           
 ---------- -- ----  -------------------
 test_sub    2  7.2  tests/empty_else:23
 
@@ -77,7 +77,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 BEGIN          1   1   0.0 tests/empty_else:13
 BEGIN          1   1   0.0 tests/empty_else:14

--- a/test_output/cover/empty_else.5.028000
+++ b/test_output/cover/empty_else.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------- ------ ------ ------ ------ ------ ------ ------
-File               stmt   bran   cond   mcdc    sub  total   slop
+File               stmt   bran   cond   mcdc    sub  total   scar
 ---------------- ------ ------ ------ ------ ------ ------ ------
 tests/empty_else  100.0   50.0    n/a    n/a  100.0   88.2    7.0
 Total             100.0   50.0    n/a    n/a  100.0   88.2    7.0
@@ -18,14 +18,14 @@ tests/empty_else
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 85.7  2.0  7.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location           
+Subroutine CC SCAR  Location           
 ---------- -- ----  -------------------
 test_sub    2  7.2  tests/empty_else:23
 
@@ -77,7 +77,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 BEGIN          1   1   0.0 tests/empty_else:13
 BEGIN          1   1   0.0 tests/empty_else:14

--- a/test_output/cover/end_constant.5.020000
+++ b/test_output/cover/end_constant.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 Total    n/a    n/a    n/a    n/a    n/a    n/a    n/a
 ----- ------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/end_constant.5.028000
+++ b/test_output/cover/end_constant.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 Total    n/a    n/a    n/a    n/a    n/a    n/a    n/a
 ----- ------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/eval1.5.020000
+++ b/test_output/cover/eval1.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------ ------
-File          stmt   bran   cond   mcdc    sub  total   slop
+File          stmt   bran   cond   mcdc    sub  total   scar
 ----------- ------ ------ ------ ------ ------ ------ ------
 tests/eval1   96.1   50.0    n/a    n/a   85.7   91.4    6.9
 Total         96.1   50.0    n/a    n/a   85.7   91.4    6.9
@@ -18,14 +18,14 @@ tests/eval1
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 92.9  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location      
+Subroutine CC SCAR  Location      
 ---------- -- ----  --------------
 BEGIN       2  7.1  tests/eval1:13
 f           1  0.1  tests/eval1:24
@@ -103,7 +103,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 BEGIN          1   1   0.0 tests/eval1:10
 BEGIN          1   1   0.0 tests/eval1:11
@@ -115,7 +115,7 @@ h              3   1   0.1 tests/eval1:24
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 g              0   1   0.1 tests/eval1:24
 

--- a/test_output/cover/eval1.5.028000
+++ b/test_output/cover/eval1.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------ ------
-File          stmt   bran   cond   mcdc    sub  total   slop
+File          stmt   bran   cond   mcdc    sub  total   scar
 ----------- ------ ------ ------ ------ ------ ------ ------
 tests/eval1   96.1   50.0    n/a    n/a   85.7   91.4    6.9
 Total         96.1   50.0    n/a    n/a   85.7   91.4    6.9
@@ -18,14 +18,14 @@ tests/eval1
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 92.9  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location      
+Subroutine CC SCAR  Location      
 ---------- -- ----  --------------
 BEGIN       2  7.1  tests/eval1:13
 f           1  0.1  tests/eval1:24
@@ -103,7 +103,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 BEGIN          1   1   0.0 tests/eval1:10
 BEGIN          1   1   0.0 tests/eval1:11
@@ -115,7 +115,7 @@ h              3   1   0.1 tests/eval1:24
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 g              0   1   0.1 tests/eval1:24
 

--- a/test_output/cover/eval2.5.020000
+++ b/test_output/cover/eval2.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 E3.pm    0.0    n/a    n/a    n/a    0.0    0.0    6.9
 E4.pm    0.0    n/a    n/a    n/a    0.0    0.0    6.9
@@ -21,7 +21,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     3  1 76.7  1.0  0.1
 
@@ -31,14 +31,14 @@ E3.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E3          1  6.9  E3.pm:12
 
@@ -62,7 +62,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             0   1   6.9 E3.pm:12
 
@@ -72,14 +72,14 @@ E4.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E4          1  6.9  E4.pm:12
 
@@ -103,7 +103,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E4             0   1   6.9 E4.pm:12
 
@@ -113,14 +113,14 @@ eval2
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 82.1  1.0  0.1
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 BEGIN       1  0.0  eval2:16
 BEGIN       1  0.0  eval2:18
@@ -189,7 +189,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 BEGIN          1   1   0.0 eval2:10
 BEGIN          1   1   0.0 eval2:16

--- a/test_output/cover/eval2.5.028000
+++ b/test_output/cover/eval2.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 E3.pm    0.0    n/a    n/a    n/a    0.0    0.0    6.9
 E4.pm    0.0    n/a    n/a    n/a    0.0    0.0    6.9
@@ -21,7 +21,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     3  1 76.7  1.0  0.1
 
@@ -31,14 +31,14 @@ E3.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E3          1  6.9  E3.pm:12
 
@@ -62,7 +62,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             0   1   6.9 E3.pm:12
 
@@ -72,14 +72,14 @@ E4.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E4          1  6.9  E4.pm:12
 
@@ -103,7 +103,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E4             0   1   6.9 E4.pm:12
 
@@ -113,14 +113,14 @@ eval2
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 82.1  1.0  0.1
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 BEGIN       1  0.0  eval2:16
 BEGIN       1  0.0  eval2:18
@@ -189,7 +189,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 BEGIN          1   1   0.0 eval2:10
 BEGIN          1   1   0.0 eval2:16

--- a/test_output/cover/eval3.5.020000
+++ b/test_output/cover/eval3.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------ ------
-File          stmt   bran   cond   mcdc    sub  total   slop
+File          stmt   bran   cond   mcdc    sub  total   scar
 ----------- ------ ------ ------ ------ ------ ------ ------
 tests/eval3   89.4   50.0   50.0    0.0  100.0   77.4    0.1
 Total         89.4   50.0   50.0    0.0  100.0   77.4    0.1
@@ -18,14 +18,14 @@ tests/eval3
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 77.8  1.0  0.1
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location      
+Subroutine CC SCAR  Location      
 ---------- -- ----  --------------
 s2          1  0.0  tests/eval3:16
 s3          1  0.0  tests/eval3:18
@@ -93,7 +93,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 BEGIN          1   1   0.0 tests/eval3:10
 s2             1   1   0.0 tests/eval3:16

--- a/test_output/cover/eval3.5.028000
+++ b/test_output/cover/eval3.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------ ------
-File          stmt   bran   cond   mcdc    sub  total   slop
+File          stmt   bran   cond   mcdc    sub  total   scar
 ----------- ------ ------ ------ ------ ------ ------ ------
 tests/eval3   89.4   50.0   50.0    0.0  100.0   77.4    0.1
 Total         89.4   50.0   50.0    0.0  100.0   77.4    0.1
@@ -18,14 +18,14 @@ tests/eval3
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 77.8  1.0  0.1
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location      
+Subroutine CC SCAR  Location      
 ---------- -- ----  --------------
 s2          1  0.0  tests/eval3:16
 s3          1  0.0  tests/eval3:18
@@ -93,7 +93,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 BEGIN          1   1   0.0 tests/eval3:10
 s2             1   1   0.0 tests/eval3:16

--- a/test_output/cover/eval_merge.5.020000
+++ b/test_output/cover/eval_merge.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 E2.pm       100.0    n/a    n/a    n/a  100.0  100.0    0.0
 E3.pm       100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -21,7 +21,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     3  1 77.8  1.0  0.1
 
@@ -31,7 +31,7 @@ E2.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -55,7 +55,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             1   1   0.0 E2.pm:12
 
@@ -65,7 +65,7 @@ E3.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -89,7 +89,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             1   1   0.0 E3.pm:12
 
@@ -99,7 +99,7 @@ eval_merge
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 76.0  1.0  0.1
 
@@ -168,7 +168,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 BEGIN          1   1   0.0 eval_merge:10
 BEGIN          1   1   0.0 eval_merge:15

--- a/test_output/cover/eval_merge.5.028000
+++ b/test_output/cover/eval_merge.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 E2.pm       100.0    n/a    n/a    n/a  100.0  100.0    0.0
 E3.pm       100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -21,7 +21,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     3  1 77.8  1.0  0.1
 
@@ -31,7 +31,7 @@ E2.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -55,7 +55,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             1   1   0.0 E2.pm:12
 
@@ -65,7 +65,7 @@ E3.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -89,7 +89,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             1   1   0.0 E3.pm:12
 
@@ -99,7 +99,7 @@ eval_merge
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 76.0  1.0  0.1
 
@@ -168,7 +168,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 BEGIN          1   1   0.0 eval_merge:10
 BEGIN          1   1   0.0 eval_merge:15

--- a/test_output/cover/eval_merge.t.5.020000
+++ b/test_output/cover/eval_merge.t.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 E2.pm       100.0    n/a    n/a    n/a  100.0  100.0    0.0
 E3.pm       100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -28,7 +28,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     4  1 100.0  1.0  0.0
 
@@ -38,7 +38,7 @@ E2.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -62,7 +62,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             1   1   0.0 E2.pm:12
 
@@ -72,7 +72,7 @@ E3.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -96,7 +96,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             2   1   0.0 E3.pm:12
 
@@ -106,7 +106,7 @@ E4.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -130,7 +130,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E4             1   1   0.0 E4.pm:12
 
@@ -140,7 +140,7 @@ eval_merge
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -215,7 +215,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 BEGIN          2   1   0.0 eval_merge:10
 BEGIN          1   1   0.0 eval_merge:15

--- a/test_output/cover/eval_merge.t.5.028000
+++ b/test_output/cover/eval_merge.t.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 E2.pm       100.0    n/a    n/a    n/a  100.0  100.0    0.0
 E3.pm       100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -28,7 +28,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     4  1 100.0  1.0  0.0
 
@@ -38,7 +38,7 @@ E2.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -62,7 +62,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             1   1   0.0 E2.pm:12
 
@@ -72,7 +72,7 @@ E3.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -96,7 +96,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             2   1   0.0 E3.pm:12
 
@@ -106,7 +106,7 @@ E4.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -130,7 +130,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E4             1   1   0.0 E4.pm:12
 
@@ -140,7 +140,7 @@ eval_merge
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -215,7 +215,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 BEGIN          2   1   0.0 eval_merge:10
 BEGIN          1   1   0.0 eval_merge:15

--- a/test_output/cover/eval_merge_0.5.020000
+++ b/test_output/cover/eval_merge_0.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ------------ ------ ------ ------ ------ ------ ------ ------
-File           stmt   bran   cond   mcdc    sub  total   slop
+File           stmt   bran   cond   mcdc    sub  total   scar
 ------------ ------ ------ ------ ------ ------ ------ ------
 E2.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
 E3.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -21,7 +21,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     3  1 100.0  1.0  0.0
 
@@ -31,7 +31,7 @@ E2.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -55,7 +55,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             1   1   0.0 E2.pm:12
 
@@ -65,7 +65,7 @@ E3.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -89,7 +89,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             1   1   0.0 E3.pm:12
 
@@ -99,7 +99,7 @@ eval_merge_0
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -131,7 +131,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location       
+Subroutine Count  CC  SCAR Location       
 ---------- ----- --- ----- ---------------
 BEGIN          1   1   0.0 eval_merge_0:10
 BEGIN          1   1   0.0 eval_merge_0:12

--- a/test_output/cover/eval_merge_0.5.028000
+++ b/test_output/cover/eval_merge_0.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ------------ ------ ------ ------ ------ ------ ------ ------
-File           stmt   bran   cond   mcdc    sub  total   slop
+File           stmt   bran   cond   mcdc    sub  total   scar
 ------------ ------ ------ ------ ------ ------ ------ ------
 E2.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
 E3.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -21,7 +21,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     3  1 100.0  1.0  0.0
 
@@ -31,7 +31,7 @@ E2.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -55,7 +55,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             1   1   0.0 E2.pm:12
 
@@ -65,7 +65,7 @@ E3.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -89,7 +89,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             1   1   0.0 E3.pm:12
 
@@ -99,7 +99,7 @@ eval_merge_0
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -131,7 +131,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location       
+Subroutine Count  CC  SCAR Location       
 ---------- ----- --- ----- ---------------
 BEGIN          1   1   0.0 eval_merge_0:10
 BEGIN          1   1   0.0 eval_merge_0:12

--- a/test_output/cover/eval_merge_1.5.020000
+++ b/test_output/cover/eval_merge_1.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ------------ ------ ------ ------ ------ ------ ------ ------
-File           stmt   bran   cond   mcdc    sub  total   slop
+File           stmt   bran   cond   mcdc    sub  total   scar
 ------------ ------ ------ ------ ------ ------ ------ ------
 E3.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
 E4.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -21,7 +21,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     3  1 100.0  1.0  0.0
 
@@ -31,7 +31,7 @@ E3.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -55,7 +55,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             1   1   0.0 E3.pm:12
 
@@ -65,7 +65,7 @@ E4.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -89,7 +89,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E4             1   1   0.0 E4.pm:12
 
@@ -99,7 +99,7 @@ eval_merge_1
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -131,7 +131,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location       
+Subroutine Count  CC  SCAR Location       
 ---------- ----- --- ----- ---------------
 BEGIN          1   1   0.0 eval_merge_1:10
 BEGIN          1   1   0.0 eval_merge_1:12

--- a/test_output/cover/eval_merge_1.5.028000
+++ b/test_output/cover/eval_merge_1.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ------------ ------ ------ ------ ------ ------ ------ ------
-File           stmt   bran   cond   mcdc    sub  total   slop
+File           stmt   bran   cond   mcdc    sub  total   scar
 ------------ ------ ------ ------ ------ ------ ------ ------
 E3.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
 E4.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -21,7 +21,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     3  1 100.0  1.0  0.0
 
@@ -31,7 +31,7 @@ E3.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -55,7 +55,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             1   1   0.0 E3.pm:12
 
@@ -65,7 +65,7 @@ E4.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -89,7 +89,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E4             1   1   0.0 E4.pm:12
 
@@ -99,7 +99,7 @@ eval_merge_1
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -131,7 +131,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location       
+Subroutine Count  CC  SCAR Location       
 ---------- ----- --- ----- ---------------
 BEGIN          1   1   0.0 eval_merge_1:10
 BEGIN          1   1   0.0 eval_merge_1:12

--- a/test_output/cover/eval_merge_sep.t.5.020000
+++ b/test_output/cover/eval_merge_sep.t.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ------------ ------ ------ ------ ------ ------ ------ ------
-File           stmt   bran   cond   mcdc    sub  total   slop
+File           stmt   bran   cond   mcdc    sub  total   scar
 ------------ ------ ------ ------ ------ ------ ------ ------
 E2.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
 E3.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -29,7 +29,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     5  1 100.0  1.0  0.0
 
@@ -39,7 +39,7 @@ E2.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -63,7 +63,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             1   1   0.0 E2.pm:12
 
@@ -73,7 +73,7 @@ E3.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -97,7 +97,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             2   1   0.0 E3.pm:12
 
@@ -107,7 +107,7 @@ E4.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -131,7 +131,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E4             1   1   0.0 E4.pm:12
 
@@ -141,7 +141,7 @@ eval_merge_0
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -173,7 +173,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location       
+Subroutine Count  CC  SCAR Location       
 ---------- ----- --- ----- ---------------
 BEGIN          1   1   0.0 eval_merge_0:10
 BEGIN          1   1   0.0 eval_merge_0:12
@@ -185,7 +185,7 @@ eval_merge_1
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -217,7 +217,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location       
+Subroutine Count  CC  SCAR Location       
 ---------- ----- --- ----- ---------------
 BEGIN          1   1   0.0 eval_merge_1:10
 BEGIN          1   1   0.0 eval_merge_1:12

--- a/test_output/cover/eval_merge_sep.t.5.028000
+++ b/test_output/cover/eval_merge_sep.t.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ------------ ------ ------ ------ ------ ------ ------ ------
-File           stmt   bran   cond   mcdc    sub  total   slop
+File           stmt   bran   cond   mcdc    sub  total   scar
 ------------ ------ ------ ------ ------ ------ ------ ------
 E2.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
 E3.pm         100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -29,7 +29,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     5  1 100.0  1.0  0.0
 
@@ -39,7 +39,7 @@ E2.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -63,7 +63,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             1   1   0.0 E2.pm:12
 
@@ -73,7 +73,7 @@ E3.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -97,7 +97,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             2   1   0.0 E3.pm:12
 
@@ -107,7 +107,7 @@ E4.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -131,7 +131,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E4             1   1   0.0 E4.pm:12
 
@@ -141,7 +141,7 @@ eval_merge_0
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -173,7 +173,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location       
+Subroutine Count  CC  SCAR Location       
 ---------- ----- --- ----- ---------------
 BEGIN          1   1   0.0 eval_merge_0:10
 BEGIN          1   1   0.0 eval_merge_0:12
@@ -185,7 +185,7 @@ eval_merge_1
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -217,7 +217,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location       
+Subroutine Count  CC  SCAR Location       
 ---------- ----- --- ----- ---------------
 BEGIN          1   1   0.0 eval_merge_1:10
 BEGIN          1   1   0.0 eval_merge_1:12

--- a/test_output/cover/eval_nested.5.020000
+++ b/test_output/cover/eval_nested.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 tests/eval_nested  100.0    n/a   50.0    0.0  100.0   78.9    0.0
 Total              100.0    n/a   50.0    0.0  100.0   78.9    0.0
@@ -18,7 +18,7 @@ tests/eval_nested
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 85.7  1.0  0.0
 
@@ -69,7 +69,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 BEGIN          1   1   0.0 tests/eval_nested:10
 BEGIN          1   1   0.0 tests/eval_nested:11

--- a/test_output/cover/eval_nested.5.028000
+++ b/test_output/cover/eval_nested.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 tests/eval_nested  100.0    n/a   50.0    0.0  100.0   78.9    0.0
 Total              100.0    n/a   50.0    0.0  100.0   78.9    0.0
@@ -18,7 +18,7 @@ tests/eval_nested
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 85.7  1.0  0.0
 
@@ -69,7 +69,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 BEGIN          1   1   0.0 tests/eval_nested:10
 BEGIN          1   1   0.0 tests/eval_nested:11

--- a/test_output/cover/eval_string.5.020000
+++ b/test_output/cover/eval_string.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 tests/eval_string   85.7   50.0    n/a    n/a  100.0   80.0    7.1
 Total               85.7   50.0    n/a    n/a  100.0   80.0    7.1
@@ -18,14 +18,14 @@ tests/eval_string
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 77.8  2.0  7.1
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location            
+Subroutine CC SCAR  Location            
 ---------- -- ----  --------------------
 ev          2  7.4  tests/eval_string:30
 
@@ -96,7 +96,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 BEGIN          1   1   0.0 tests/eval_string:2 
 BEGIN          1   1   0.0 tests/eval_string:3 

--- a/test_output/cover/eval_string.5.028000
+++ b/test_output/cover/eval_string.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 tests/eval_string   85.7   50.0    n/a    n/a  100.0   80.0    7.1
 Total               85.7   50.0    n/a    n/a  100.0   80.0    7.1
@@ -18,14 +18,14 @@ tests/eval_string
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 77.8  2.0  7.1
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location            
+Subroutine CC SCAR  Location            
 ---------- -- ----  --------------------
 ev          2  7.4  tests/eval_string:30
 
@@ -96,7 +96,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 BEGIN          1   1   0.0 tests/eval_string:2 
 BEGIN          1   1   0.0 tests/eval_string:3 

--- a/test_output/cover/eval_sub.t.5.020000
+++ b/test_output/cover/eval_sub.t.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------ ------
-File          stmt   bran   cond   mcdc    sub  total   slop
+File          stmt   bran   cond   mcdc    sub  total   scar
 ----------- ------ ------ ------ ------ ------ ------ ------
 tests/eval3  100.0  100.0  100.0  100.0  100.0  100.0    0.0
 Total        100.0  100.0  100.0  100.0  100.0  100.0    0.0
@@ -36,7 +36,7 @@ tests/eval3
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -103,7 +103,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 BEGIN          4   1   0.0 tests/eval3:10
 s1             3   1   0.0 tests/eval3:14

--- a/test_output/cover/eval_sub.t.5.028000
+++ b/test_output/cover/eval_sub.t.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------ ------
-File          stmt   bran   cond   mcdc    sub  total   slop
+File          stmt   bran   cond   mcdc    sub  total   scar
 ----------- ------ ------ ------ ------ ------ ------ ------
 tests/eval3  100.0  100.0  100.0  100.0  100.0  100.0    0.0
 Total        100.0  100.0  100.0  100.0  100.0  100.0    0.0
@@ -36,7 +36,7 @@ tests/eval3
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -103,7 +103,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 BEGIN          4   1   0.0 tests/eval3:10
 s1             3   1   0.0 tests/eval3:14

--- a/test_output/cover/eval_use.t.5.020000
+++ b/test_output/cover/eval_use.t.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 E2.pm    0.0    n/a    n/a    n/a    0.0    0.0    6.9
 E3.pm    0.0    n/a    n/a    n/a    0.0    0.0    6.9
@@ -40,7 +40,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     4  1 91.2  1.0  0.0
 
@@ -50,14 +50,14 @@ E2.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E2          1  6.9  E2.pm:12
 
@@ -81,7 +81,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             0   1   6.9 E2.pm:12
 
@@ -91,14 +91,14 @@ E3.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E3          1  6.9  E3.pm:12
 
@@ -122,7 +122,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             0   1   6.9 E3.pm:12
 
@@ -132,14 +132,14 @@ E4.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E4          1  6.9  E4.pm:12
 
@@ -163,7 +163,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E4             0   1   6.9 E4.pm:12
 
@@ -173,7 +173,7 @@ eval2
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -244,7 +244,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 BEGIN          4   1   0.0 eval2:10
 BEGIN          2   1   0.0 eval2:14

--- a/test_output/cover/eval_use.t.5.028000
+++ b/test_output/cover/eval_use.t.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 E2.pm    0.0    n/a    n/a    n/a    0.0    0.0    6.9
 E3.pm    0.0    n/a    n/a    n/a    0.0    0.0    6.9
@@ -40,7 +40,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     4  1 91.2  1.0  0.0
 
@@ -50,14 +50,14 @@ E2.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E2          1  6.9  E2.pm:12
 
@@ -81,7 +81,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             0   1   6.9 E2.pm:12
 
@@ -91,14 +91,14 @@ E3.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E3          1  6.9  E3.pm:12
 
@@ -122,7 +122,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E3             0   1   6.9 E3.pm:12
 
@@ -132,14 +132,14 @@ E4.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E4          1  6.9  E4.pm:12
 
@@ -163,7 +163,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E4             0   1   6.9 E4.pm:12
 
@@ -173,7 +173,7 @@ eval2
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -244,7 +244,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 BEGIN          4   1   0.0 eval2:10
 BEGIN          2   1   0.0 eval2:14

--- a/test_output/cover/exec.5.020000
+++ b/test_output/cover/exec.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 tests/exec   66.6    n/a    n/a    n/a    n/a   66.6    n/a
 Total        66.6    n/a    n/a    n/a    n/a   66.6    n/a

--- a/test_output/cover/exec.5.028000
+++ b/test_output/cover/exec.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 tests/exec   66.6    n/a    n/a    n/a    n/a   66.6    n/a
 Total        66.6    n/a    n/a    n/a    n/a   66.6    n/a

--- a/test_output/cover/exec_die.5.020000
+++ b/test_output/cover/exec_die.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/exec_die   50.0   50.0    n/a    n/a    0.0   45.4    1.2
 Total            50.0   50.0    n/a    n/a    0.0   45.4    1.2
@@ -18,14 +18,14 @@ tests/exec_die
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 50.0  1.1  1.2
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location         
+Subroutine CC SCAR  Location         
 ---------- -- ----  -----------------
 __ANON__    1  6.9  tests/exec_die:18
 
@@ -65,7 +65,7 @@ line  err      %   true  false   branch
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 __ANON__       0   1   6.9 tests/exec_die:18
 

--- a/test_output/cover/exec_die.5.028000
+++ b/test_output/cover/exec_die.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/exec_die   50.0   50.0    n/a    n/a    0.0   45.4    1.2
 Total            50.0   50.0    n/a    n/a    0.0   45.4    1.2
@@ -18,14 +18,14 @@ tests/exec_die
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 50.0  1.1  1.2
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location         
+Subroutine CC SCAR  Location         
 ---------- -- ----  -----------------
 __ANON__    1  6.9  tests/exec_die:18
 
@@ -65,7 +65,7 @@ line  err      %   true  false   branch
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 __ANON__       0   1   6.9 tests/exec_die:18
 

--- a/test_output/cover/final_op.5.020000
+++ b/test_output/cover/final_op.5.020000
@@ -1,7 +1,7 @@
 cover: Reading database from ...
 cover: Can't find digest for tests/final_op
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 Total    n/a    n/a    n/a    n/a    n/a    n/a    n/a
 ----- ------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/final_op.5.028000
+++ b/test_output/cover/final_op.5.028000
@@ -1,7 +1,7 @@
 cover: Reading database from ...
 cover: Can't find digest for tests/final_op
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 Total    n/a    n/a    n/a    n/a    n/a    n/a    n/a
 ----- ------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/fork.5.020000
+++ b/test_output/cover/fork.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 tests/fork  100.0   75.0    n/a    n/a    n/a   90.9    n/a
 Total       100.0   75.0    n/a    n/a    n/a   90.9    n/a

--- a/test_output/cover/fork.5.028000
+++ b/test_output/cover/fork.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 tests/fork  100.0   75.0    n/a    n/a    n/a   90.9    n/a
 Total       100.0   75.0    n/a    n/a    n/a   90.9    n/a

--- a/test_output/cover/if.5.020000
+++ b/test_output/cover/if.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------ ------
-File       stmt   bran   cond   mcdc    sub  total   slop
+File       stmt   bran   cond   mcdc    sub  total   scar
 -------- ------ ------ ------ ------ ------ ------ ------
 tests/if   85.0   50.0    n/a    n/a  100.0   75.0    0.2
 Total      85.0   50.0    n/a    n/a  100.0   75.0    0.2
@@ -18,7 +18,7 @@ tests/if
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 73.3  1.0  0.2
 
@@ -83,7 +83,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 tests/if:10
 BEGIN          1   1   0.0 tests/if:11

--- a/test_output/cover/if.5.028000
+++ b/test_output/cover/if.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------ ------
-File       stmt   bran   cond   mcdc    sub  total   slop
+File       stmt   bran   cond   mcdc    sub  total   scar
 -------- ------ ------ ------ ------ ------ ------ ------
 tests/if   85.0   50.0    n/a    n/a  100.0   75.0    0.2
 Total      85.0   50.0    n/a    n/a  100.0   75.0    0.2
@@ -18,7 +18,7 @@ tests/if
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 73.3  1.0  0.2
 
@@ -83,7 +83,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 tests/if:10
 BEGIN          1   1   0.0 tests/if:11

--- a/test_output/cover/loop_condition.5.020000
+++ b/test_output/cover/loop_condition.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------ ------
-File                   stmt   bran   cond   mcdc    sub  total   slop
+File                   stmt   bran   cond   mcdc    sub  total   scar
 -------------------- ------ ------ ------ ------ ------ ------ ------
 tests/loop_condition   94.2   66.6   66.6   50.0  100.0   80.5    0.1
 Total                  94.2   66.6   66.6   50.0  100.0   80.5    0.1
@@ -18,7 +18,7 @@ tests/loop_condition
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 80.9  1.0  0.1
 
@@ -134,7 +134,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location               
+Subroutine Count  CC  SCAR Location               
 ---------- ----- --- ----- -----------------------
 BEGIN          1   1   0.0 tests/loop_condition:13
 BEGIN          1   1   0.0 tests/loop_condition:14

--- a/test_output/cover/loop_condition.5.028000
+++ b/test_output/cover/loop_condition.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------ ------
-File                   stmt   bran   cond   mcdc    sub  total   slop
+File                   stmt   bran   cond   mcdc    sub  total   scar
 -------------------- ------ ------ ------ ------ ------ ------ ------
 tests/loop_condition   94.2   66.6   66.6   50.0  100.0   80.5    0.1
 Total                  94.2   66.6   66.6   50.0  100.0   80.5    0.1
@@ -18,7 +18,7 @@ tests/loop_condition
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 80.9  1.0  0.1
 
@@ -134,7 +134,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location               
+Subroutine Count  CC  SCAR Location               
 ---------- ----- --- ----- -----------------------
 BEGIN          1   1   0.0 tests/loop_condition:13
 BEGIN          1   1   0.0 tests/loop_condition:14

--- a/test_output/cover/mcdc_basic.5.020000
+++ b/test_output/cover/mcdc_basic.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------- ------ ------ ------ ------ ------ ------ ------
-File               stmt   bran   cond   mcdc    sub  total   slop
+File               stmt   bran   cond   mcdc    sub  total   scar
 ---------------- ------ ------ ------ ------ ------ ------ ------
 tests/mcdc_basic  100.0    n/a   96.3   93.3  100.0   97.8   23.0
 Total             100.0    n/a   96.3   93.3  100.0   97.8   23.0
@@ -18,14 +18,14 @@ tests/mcdc_basic
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 10 98.5 10.0 23.0
 
 Worst Subroutines
 -----------------
 
-Subroutine  CC SLOP  Location           
+Subroutine  CC SCAR  Location           
 ----------- -- ----  -------------------
 chained_and  3 11.0  tests/mcdc_basic:24
 chained_or   3 11.0  tests/mcdc_basic:29
@@ -169,7 +169,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  SLOP Location           
+Subroutine   Count  CC  SCAR Location           
 ------------ ----- --- ----- -------------------
 BEGIN            1   1   0.0 tests/mcdc_basic:10
 BEGIN            1   1   0.0 tests/mcdc_basic:11

--- a/test_output/cover/mcdc_constant_right.5.020000
+++ b/test_output/cover/mcdc_constant_right.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------------- ------ ------ ------ ------ ------ ------ ------
-File                        stmt   bran   cond   mcdc    sub  total   slop
+File                        stmt   bran   cond   mcdc    sub  total   scar
 ------------------------- ------ ------ ------ ------ ------ ------ ------
 tests/mcdc_constant_right  100.0    n/a  100.0  100.0  100.0  100.0   13.9
 Total                      100.0    n/a  100.0  100.0  100.0  100.0   13.9
@@ -18,14 +18,14 @@ tests/mcdc_constant_right
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  4 100.0  4.0 13.9
 
 Worst Subroutines
 -----------------
 
-Subroutine     CC SLOP  Location                    
+Subroutine     CC SCAR  Location                    
 -------------- -- ----  ----------------------------
 and_const_true  2  6.9  tests/mcdc_constant_right:14
 or_const_false  2  6.9  tests/mcdc_constant_right:19
@@ -117,7 +117,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine     Count  CC  SLOP Location                    
+Subroutine     Count  CC  SCAR Location                    
 -------------- ----- --- ----- ----------------------------
 BEGIN              1   1   0.0 tests/mcdc_constant_right:10
 BEGIN              1   1   0.0 tests/mcdc_constant_right:11

--- a/test_output/cover/mcdc_demo.5.020000
+++ b/test_output/cover/mcdc_demo.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------ ------
-File              stmt   bran   cond   mcdc    sub  total   slop
+File              stmt   bran   cond   mcdc    sub  total   scar
 --------------- ------ ------ ------ ------ ------ ------ ------
 tests/mcdc_demo  100.0    n/a  100.0   66.6  100.0   96.3   11.0
 Total            100.0    n/a  100.0   66.6  100.0   96.3   11.0
@@ -18,14 +18,14 @@ tests/mcdc_demo
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  3 100.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location          
+Subroutine CC SCAR  Location          
 ---------- -- ----  ------------------
 may_edit    3 11.0  tests/mcdc_demo:29
 
@@ -110,7 +110,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location          
+Subroutine Count  CC  SCAR Location          
 ---------- ----- --- ----- ------------------
 BEGIN          1   1   0.0 tests/mcdc_demo:25
 BEGIN          1   1   0.0 tests/mcdc_demo:26

--- a/test_output/cover/mcdc_signatures.5.020000
+++ b/test_output/cover/mcdc_signatures.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------------- ------ ------ ------ ------ ------ ------ ------
-File                    stmt   bran   cond   mcdc    sub  total   slop
+File                    stmt   bran   cond   mcdc    sub  total   scar
 --------------------- ------ ------ ------ ------ ------ ------ ------
 tests/mcdc_signatures  100.0   66.6  100.0   25.0  100.0   89.0   24.9
 Total                  100.0   66.6  100.0   25.0  100.0   89.0   24.9
@@ -18,14 +18,14 @@ tests/mcdc_signatures
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
 12 91.4 12.1 24.9
 
 Worst Subroutines
 -----------------
 
-Subroutine   CC SLOP  Location                
+Subroutine   CC SCAR  Location                
 ------------ -- ----  ------------------------
 nested        6 18.0  tests/mcdc_signatures:25
 and_decision  4 14.0  tests/mcdc_signatures:23
@@ -154,7 +154,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  SLOP Location                
+Subroutine   Count  CC  SCAR Location                
 ------------ ----- --- ----- ------------------------
 BEGIN            1   1   0.0 tests/mcdc_signatures:18
 BEGIN            1   1   0.0 tests/mcdc_signatures:19

--- a/test_output/cover/mcdc_signatures.5.026000
+++ b/test_output/cover/mcdc_signatures.5.026000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------------- ------ ------ ------ ------ ------ ------ ------
-File                    stmt   bran   cond   mcdc    sub  total   slop
+File                    stmt   bran   cond   mcdc    sub  total   scar
 --------------------- ------ ------ ------ ------ ------ ------ ------
 tests/mcdc_signatures  100.0  100.0  100.0   25.0  100.0   95.5   17.9
 Total                  100.0  100.0  100.0   25.0  100.0   95.5   17.9
@@ -18,14 +18,14 @@ tests/mcdc_signatures
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  6 100.0  6.0 17.9
 
 Worst Subroutines
 -----------------
 
-Subroutine   CC SLOP  Location                
+Subroutine   CC SCAR  Location                
 ------------ -- ----  ------------------------
 nested        4 13.9  tests/mcdc_signatures:25
 and_decision  2  6.9  tests/mcdc_signatures:23
@@ -145,7 +145,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  SLOP Location                
+Subroutine   Count  CC  SCAR Location                
 ------------ ----- --- ----- ------------------------
 BEGIN            1   1   0.0 tests/mcdc_signatures:18
 BEGIN            1   1   0.0 tests/mcdc_signatures:19

--- a/test_output/cover/mcdc_signatures.5.032000
+++ b/test_output/cover/mcdc_signatures.5.032000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------------- ------ ------ ------ ------ ------ ------ ------
-File                    stmt   bran   cond   mcdc    sub  total   slop
+File                    stmt   bran   cond   mcdc    sub  total   scar
 --------------------- ------ ------ ------ ------ ------ ------ ------
 tests/mcdc_signatures  100.0  100.0  100.0   25.0  100.0   94.3   17.9
 Total                  100.0  100.0  100.0   25.0  100.0   94.3   17.9
@@ -18,14 +18,14 @@ tests/mcdc_signatures
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  6 100.0  6.0 17.9
 
 Worst Subroutines
 -----------------
 
-Subroutine   CC SLOP  Location                
+Subroutine   CC SCAR  Location                
 ------------ -- ----  ------------------------
 nested        4 13.9  tests/mcdc_signatures:25
 and_decision  2  6.9  tests/mcdc_signatures:23
@@ -133,7 +133,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  SLOP Location                
+Subroutine   Count  CC  SCAR Location                
 ------------ ----- --- ----- ------------------------
 BEGIN            1   1   0.0 tests/mcdc_signatures:18
 BEGIN            1   1   0.0 tests/mcdc_signatures:19

--- a/test_output/cover/mcdc_signatures.5.043008
+++ b/test_output/cover/mcdc_signatures.5.043008
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------------- ------ ------ ------ ------ ------ ------ ------
-File                    stmt   bran   cond   mcdc    sub  total   slop
+File                    stmt   bran   cond   mcdc    sub  total   scar
 --------------------- ------ ------ ------ ------ ------ ------ ------
 tests/mcdc_signatures  100.0  100.0  100.0   25.0  100.0   94.3   17.9
 Total                  100.0  100.0  100.0   25.0  100.0   94.3   17.9
@@ -18,14 +18,14 @@ tests/mcdc_signatures
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  6 100.0  6.0 17.9
 
 Worst Subroutines
 -----------------
 
-Subroutine   CC SLOP  Location                
+Subroutine   CC SCAR  Location                
 ------------ -- ----  ------------------------
 nested        4 13.9  tests/mcdc_signatures:25
 and_decision  2  6.9  tests/mcdc_signatures:23
@@ -133,7 +133,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  SLOP Location                
+Subroutine   Count  CC  SCAR Location                
 ------------ ----- --- ----- ------------------------
 BEGIN            1   1   0.0 tests/mcdc_signatures:18
 BEGIN            1   1   0.0 tests/mcdc_signatures:19

--- a/test_output/cover/mcdc_xor.5.020000
+++ b/test_output/cover/mcdc_xor.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/mcdc_xor  100.0    n/a  100.0  100.0  100.0  100.0    6.9
 Total           100.0    n/a  100.0  100.0  100.0  100.0    6.9
@@ -18,14 +18,14 @@ tests/mcdc_xor
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  2 100.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine   CC SLOP  Location         
+Subroutine   CC SCAR  Location         
 ------------ -- ----  -----------------
 xor_decision  2  6.9  tests/mcdc_xor:14
 
@@ -89,7 +89,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  SLOP Location         
+Subroutine   Count  CC  SCAR Location         
 ------------ ----- --- ----- -----------------
 BEGIN            1   1   0.0 tests/mcdc_xor:10
 BEGIN            1   1   0.0 tests/mcdc_xor:11

--- a/test_output/cover/mcdc_xor.5.028000
+++ b/test_output/cover/mcdc_xor.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/mcdc_xor  100.0    n/a  100.0  100.0  100.0  100.0    6.9
 Total           100.0    n/a  100.0  100.0  100.0  100.0    6.9
@@ -18,14 +18,14 @@ tests/mcdc_xor
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  2 100.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine   CC SLOP  Location         
+Subroutine   CC SCAR  Location         
 ------------ -- ----  -----------------
 xor_decision  2  6.9  tests/mcdc_xor:14
 
@@ -89,7 +89,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  SLOP Location         
+Subroutine   Count  CC  SCAR Location         
 ------------ ----- --- ----- -----------------
 BEGIN            1   1   0.0 tests/mcdc_xor:10
 BEGIN            1   1   0.0 tests/mcdc_xor:11

--- a/test_output/cover/mcdc_xor.5.040000
+++ b/test_output/cover/mcdc_xor.5.040000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/mcdc_xor  100.0    n/a  100.0  100.0  100.0  100.0    6.9
 Total           100.0    n/a  100.0  100.0  100.0  100.0    6.9
@@ -18,14 +18,14 @@ tests/mcdc_xor
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  2 100.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine   CC SLOP  Location         
+Subroutine   CC SCAR  Location         
 ------------ -- ----  -----------------
 xor_decision  2  6.9  tests/mcdc_xor:14
 
@@ -89,7 +89,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  SLOP Location         
+Subroutine   Count  CC  SCAR Location         
 ------------ ----- --- ----- -----------------
 BEGIN            1   1   0.0 tests/mcdc_xor:10
 BEGIN            1   1   0.0 tests/mcdc_xor:11

--- a/test_output/cover/md5.5.020000
+++ b/test_output/cover/md5.5.020000
@@ -1,7 +1,7 @@
 cover: Reading database from ...
 cover: Deleting old coverage for changed file tests/md5
 --------- ------ ------ ------ ------ ------ ------ ------
-File        stmt   bran   cond   mcdc    sub  total   slop
+File        stmt   bran   cond   mcdc    sub  total   scar
 --------- ------ ------ ------ ------ ------ ------ ------
 tests/md5  100.0    n/a    n/a    n/a    n/a  100.0    n/a
 Total      100.0    n/a    n/a    n/a    n/a  100.0    n/a

--- a/test_output/cover/md5.5.028000
+++ b/test_output/cover/md5.5.028000
@@ -1,7 +1,7 @@
 cover: Reading database from ...
 cover: Deleting old coverage for changed file tests/md5
 --------- ------ ------ ------ ------ ------ ------ ------
-File        stmt   bran   cond   mcdc    sub  total   slop
+File        stmt   bran   cond   mcdc    sub  total   scar
 --------- ------ ------ ------ ------ ------ ------ ------
 tests/md5  100.0    n/a    n/a    n/a    n/a  100.0    n/a
 Total      100.0    n/a    n/a    n/a    n/a  100.0    n/a

--- a/test_output/cover/module1.5.020000
+++ b/test_output/cover/module1.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 Module1.pm   25.0    n/a    n/a    n/a   25.0   25.0    3.5
 module1      94.7   50.0    n/a    n/a  100.0   92.3    0.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2  1 72.4  1.0  0.2
 
@@ -30,14 +30,14 @@ Module1.pm
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 25.0  1.4  3.5
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 _aa         1  6.9  Module1.pm:14
 xx          1  6.9  Module1.pm:20
@@ -84,14 +84,14 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 zz            11   1   0.0 Module1.pm:29
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 _aa            0   1   6.9 Module1.pm:14
 xx             0   1   6.9 Module1.pm:20
@@ -103,7 +103,7 @@ module1
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 90.5  1.0  0.0
 
@@ -161,7 +161,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   1   0.0 module1:12
 BEGIN          1   1   0.0 module1:13

--- a/test_output/cover/module1.5.028000
+++ b/test_output/cover/module1.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 Module1.pm   25.0    n/a    n/a    n/a   25.0   25.0    3.5
 module1      94.7   50.0    n/a    n/a  100.0   92.3    0.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2  1 72.4  1.0  0.2
 
@@ -30,14 +30,14 @@ Module1.pm
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 25.0  1.4  3.5
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 _aa         1  6.9  Module1.pm:14
 xx          1  6.9  Module1.pm:20
@@ -84,14 +84,14 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 zz            11   1   0.0 Module1.pm:29
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 _aa            0   1   6.9 Module1.pm:14
 xx             0   1   6.9 Module1.pm:20
@@ -103,7 +103,7 @@ module1
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 90.5  1.0  0.0
 
@@ -161,7 +161,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   1   0.0 module1:12
 BEGIN          1   1   0.0 module1:13

--- a/test_output/cover/module2.5.020000
+++ b/test_output/cover/module2.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 Module2.pm   25.0    n/a    n/a    n/a   25.0   25.0    3.5
 module2      94.7   50.0    n/a    n/a  100.0   92.3    0.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2  1 72.4  1.0  0.2
 
@@ -30,14 +30,14 @@ Module2.pm
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 25.0  1.4  3.5
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 _aa         1  6.9  Module2.pm:14
 _xx         1  6.9  Module2.pm:20
@@ -84,14 +84,14 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 zz            11   1   0.0 Module2.pm:29
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 _aa            0   1   6.9 Module2.pm:14
 _xx            0   1   6.9 Module2.pm:20
@@ -103,7 +103,7 @@ module2
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 90.5  1.0  0.0
 
@@ -161,7 +161,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   1   0.0 module2:12
 BEGIN          1   1   0.0 module2:13

--- a/test_output/cover/module2.5.028000
+++ b/test_output/cover/module2.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 Module2.pm   25.0    n/a    n/a    n/a   25.0   25.0    3.5
 module2      94.7   50.0    n/a    n/a  100.0   92.3    0.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2  1 72.4  1.0  0.2
 
@@ -30,14 +30,14 @@ Module2.pm
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 25.0  1.4  3.5
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 _aa         1  6.9  Module2.pm:14
 _xx         1  6.9  Module2.pm:20
@@ -84,14 +84,14 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 zz            11   1   0.0 Module2.pm:29
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 _aa            0   1   6.9 Module2.pm:14
 _xx            0   1   6.9 Module2.pm:20
@@ -103,7 +103,7 @@ module2
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 90.5  1.0  0.0
 
@@ -161,7 +161,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   1   0.0 module2:12
 BEGIN          1   1   0.0 module2:13

--- a/test_output/cover/module_ignore.5.020000
+++ b/test_output/cover/module_ignore.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------ ------
-File                  stmt   bran   cond   mcdc    sub  total   slop
+File                  stmt   bran   cond   mcdc    sub  total   scar
 ------------------- ------ ------ ------ ------ ------ ------ ------
 tests/module_ignore  100.0  100.0    n/a    n/a  100.0  100.0    0.0
 Total                100.0  100.0    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/module_ignore
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -71,7 +71,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location              
+Subroutine Count  CC  SCAR Location              
 ---------- ----- --- ----- ----------------------
 BEGIN          1   1   0.0 tests/module_ignore:12
 BEGIN          1   1   0.0 tests/module_ignore:13

--- a/test_output/cover/module_ignore.5.028000
+++ b/test_output/cover/module_ignore.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------ ------
-File                  stmt   bran   cond   mcdc    sub  total   slop
+File                  stmt   bran   cond   mcdc    sub  total   scar
 ------------------- ------ ------ ------ ------ ------ ------ ------
 tests/module_ignore  100.0  100.0    n/a    n/a  100.0  100.0    0.0
 Total                100.0  100.0    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/module_ignore
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -71,7 +71,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location              
+Subroutine Count  CC  SCAR Location              
 ---------- ----- --- ----- ----------------------
 BEGIN          1   1   0.0 tests/module_ignore:12
 BEGIN          1   1   0.0 tests/module_ignore:13

--- a/test_output/cover/module_import.5.020000
+++ b/test_output/cover/module_import.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------------- ------ ------ ------ ------ ------ ------ ------
-File               stmt   bran   cond   mcdc    sub  total   slop
+File               stmt   bran   cond   mcdc    sub  total   scar
 ---------------- ------ ------ ------ ------ ------ ------ ------
 Module_import.pm  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 module_import     100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     2  1 100.0  1.0  0.0
 
@@ -30,7 +30,7 @@ Module_import.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -54,7 +54,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 import         1   1   0.0 Module_import.pm:11
 
@@ -64,7 +64,7 @@ module_import
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -88,7 +88,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 module_import:10
 BEGIN          1   1   0.0 module_import:12

--- a/test_output/cover/module_import.5.028000
+++ b/test_output/cover/module_import.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------------- ------ ------ ------ ------ ------ ------ ------
-File               stmt   bran   cond   mcdc    sub  total   slop
+File               stmt   bran   cond   mcdc    sub  total   scar
 ---------------- ------ ------ ------ ------ ------ ------ ------
 Module_import.pm  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 module_import     100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     2  1 100.0  1.0  0.0
 
@@ -30,7 +30,7 @@ Module_import.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -54,7 +54,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 import         1   1   0.0 Module_import.pm:11
 
@@ -64,7 +64,7 @@ module_import
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -88,7 +88,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 module_import:10
 BEGIN          1   1   0.0 module_import:12

--- a/test_output/cover/module_relative.5.020000
+++ b/test_output/cover/module_relative.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------------- ------ ------ ------ ------ ------ ------ ------
-File               stmt   bran   cond   mcdc    sub  total   slop
+File               stmt   bran   cond   mcdc    sub  total   scar
 ---------------- ------ ------ ------ ------ ------ ------ ------
 Module_import.pm  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 module_relative   100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     2  1 100.0  1.0  0.0
 
@@ -30,7 +30,7 @@ Module_import.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -54,7 +54,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 import         1   1   0.0 Module_import.pm:11
 
@@ -64,7 +64,7 @@ module_relative
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -96,7 +96,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location          
+Subroutine Count  CC  SCAR Location          
 ---------- ----- --- ----- ------------------
 BEGIN          1   1   0.0 module_relative:13
 BEGIN          1   1   0.0 module_relative:14

--- a/test_output/cover/module_relative.5.028000
+++ b/test_output/cover/module_relative.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------------- ------ ------ ------ ------ ------ ------ ------
-File               stmt   bran   cond   mcdc    sub  total   slop
+File               stmt   bran   cond   mcdc    sub  total   scar
 ---------------- ------ ------ ------ ------ ------ ------ ------
 Module_import.pm  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 module_relative   100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     2  1 100.0  1.0  0.0
 
@@ -30,7 +30,7 @@ Module_import.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -54,7 +54,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 import         1   1   0.0 Module_import.pm:11
 
@@ -64,7 +64,7 @@ module_relative
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -96,7 +96,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location          
+Subroutine Count  CC  SCAR Location          
 ---------- ----- --- ----- ------------------
 BEGIN          1   1   0.0 module_relative:13
 BEGIN          1   1   0.0 module_relative:14

--- a/test_output/cover/module_statements.5.020000
+++ b/test_output/cover/module_statements.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------------- ------ ------ ------ ------ ------ ------ ------
-File                      stmt   bran   cond   mcdc    sub  total   slop
+File                      stmt   bran   cond   mcdc    sub  total   scar
 ----------------------- ------ ------ ------ ------ ------ ------ ------
 tests/module_statements   75.8   50.0    n/a    n/a   66.6   72.5    0.2
 Total                     75.8   50.0    n/a    n/a   66.6   72.5    0.2
@@ -18,14 +18,14 @@ tests/module_statements
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 74.2  1.0  0.2
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location                  
+Subroutine CC SCAR  Location                  
 ---------- -- ----  --------------------------
 _aa         1  6.9  tests/module_statements:40
 xx          1  6.9  tests/module_statements:46
@@ -114,7 +114,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location                  
+Subroutine Count  CC  SCAR Location                  
 ---------- ----- --- ----- --------------------------
 BEGIN          1   1   0.0 tests/module_statements:12
 BEGIN          1   1   0.0 tests/module_statements:13
@@ -126,7 +126,7 @@ zz            11   1   0.0 tests/module_statements:55
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location                  
+Subroutine Count  CC  SCAR Location                  
 ---------- ----- --- ----- --------------------------
 _aa            0   1   6.9 tests/module_statements:40
 xx             0   1   6.9 tests/module_statements:46

--- a/test_output/cover/module_statements.5.028000
+++ b/test_output/cover/module_statements.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------------- ------ ------ ------ ------ ------ ------ ------
-File                      stmt   bran   cond   mcdc    sub  total   slop
+File                      stmt   bran   cond   mcdc    sub  total   scar
 ----------------------- ------ ------ ------ ------ ------ ------ ------
 tests/module_statements   75.8   50.0    n/a    n/a   66.6   72.5    0.2
 Total                     75.8   50.0    n/a    n/a   66.6   72.5    0.2
@@ -18,14 +18,14 @@ tests/module_statements
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 74.2  1.0  0.2
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location                  
+Subroutine CC SCAR  Location                  
 ---------- -- ----  --------------------------
 _aa         1  6.9  tests/module_statements:40
 xx          1  6.9  tests/module_statements:46
@@ -114,7 +114,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location                  
+Subroutine Count  CC  SCAR Location                  
 ---------- ----- --- ----- --------------------------
 BEGIN          1   1   0.0 tests/module_statements:12
 BEGIN          1   1   0.0 tests/module_statements:13
@@ -126,7 +126,7 @@ zz            11   1   0.0 tests/module_statements:55
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location                  
+Subroutine Count  CC  SCAR Location                  
 ---------- ----- --- ----- --------------------------
 _aa            0   1   6.9 tests/module_statements:40
 xx             0   1   6.9 tests/module_statements:46

--- a/test_output/cover/moo_cond.5.020000
+++ b/test_output/cover/moo_cond.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/moo_cond  100.0  100.0    n/a    n/a  100.0  100.0   11.0
 Total           100.0  100.0    n/a    n/a  100.0  100.0   11.0
@@ -18,14 +18,14 @@ tests/moo_cond
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  3 100.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location         
+Subroutine CC SCAR  Location         
 ---------- -- ----  -----------------
 trigger     3 11.0  tests/moo_cond:27
 
@@ -79,7 +79,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/moo_cond:13
 BEGIN          1   1   0.0 tests/moo_cond:14

--- a/test_output/cover/moo_cond.5.028000
+++ b/test_output/cover/moo_cond.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/moo_cond  100.0  100.0    n/a    n/a  100.0  100.0   11.0
 Total           100.0  100.0    n/a    n/a  100.0  100.0   11.0
@@ -18,14 +18,14 @@ tests/moo_cond
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  3 100.0  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location         
+Subroutine CC SCAR  Location         
 ---------- -- ----  -----------------
 trigger     3 11.0  tests/moo_cond:27
 
@@ -79,7 +79,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/moo_cond:13
 BEGIN          1   1   0.0 tests/moo_cond:14

--- a/test_output/cover/moose_basic.5.020000
+++ b/test_output/cover/moose_basic.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 tests/moose_basic  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total              100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/moose_basic
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -45,7 +45,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 BEGIN          1   1   0.0 tests/moose_basic:14
 

--- a/test_output/cover/moose_basic.5.028000
+++ b/test_output/cover/moose_basic.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 tests/moose_basic  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total              100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/moose_basic
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -45,7 +45,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 BEGIN          1   1   0.0 tests/moose_basic:14
 

--- a/test_output/cover/moose_cond.5.020000
+++ b/test_output/cover/moose_cond.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------- ------ ------ ------ ------ ------ ------ ------
-File               stmt   bran   cond   mcdc    sub  total   slop
+File               stmt   bran   cond   mcdc    sub  total   scar
 ---------------- ------ ------ ------ ------ ------ ------ ------
 tests/moose_cond  100.0    n/a   75.0   50.0  100.0   92.8   11.0
 Total             100.0    n/a   75.0   50.0  100.0   92.8   11.0
@@ -18,14 +18,14 @@ tests/moose_cond
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  3 95.5  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location           
+Subroutine CC SCAR  Location           
 ---------- -- ----  -------------------
 wagh        3 11.1  tests/moose_cond:30
 
@@ -95,7 +95,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 BEGIN          1   1   0.0 tests/moose_cond:13
 BEGIN          1   1   0.0 tests/moose_cond:14

--- a/test_output/cover/moose_cond.5.028000
+++ b/test_output/cover/moose_cond.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------- ------ ------ ------ ------ ------ ------ ------
-File               stmt   bran   cond   mcdc    sub  total   slop
+File               stmt   bran   cond   mcdc    sub  total   scar
 ---------------- ------ ------ ------ ------ ------ ------ ------
 tests/moose_cond  100.0    n/a   75.0   50.0  100.0   92.8   11.0
 Total             100.0    n/a   75.0   50.0  100.0   92.8   11.0
@@ -18,14 +18,14 @@ tests/moose_cond
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  3 95.5  3.0 11.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location           
+Subroutine CC SCAR  Location           
 ---------- -- ----  -------------------
 wagh        3 11.1  tests/moose_cond:30
 
@@ -95,7 +95,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 BEGIN          1   1   0.0 tests/moose_cond:13
 BEGIN          1   1   0.0 tests/moose_cond:14

--- a/test_output/cover/moose_constraint.5.020000
+++ b/test_output/cover/moose_constraint.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------------- ------ ------ ------ ------ ------ ------ ------
-File                     stmt   bran   cond   mcdc    sub  total   slop
+File                     stmt   bran   cond   mcdc    sub  total   scar
 ---------------------- ------ ------ ------ ------ ------ ------ ------
 tests/moose_constraint  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total                   100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/moose_constraint
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -59,7 +59,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location                 
+Subroutine Count  CC  SCAR Location                 
 ---------- ----- --- ----- -------------------------
 BEGIN          1   1   0.0 tests/moose_constraint:13
 BEGIN          1   1   0.0 tests/moose_constraint:17

--- a/test_output/cover/moose_constraint.5.028000
+++ b/test_output/cover/moose_constraint.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------------- ------ ------ ------ ------ ------ ------ ------
-File                     stmt   bran   cond   mcdc    sub  total   slop
+File                     stmt   bran   cond   mcdc    sub  total   scar
 ---------------------- ------ ------ ------ ------ ------ ------ ------
 tests/moose_constraint  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total                   100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/moose_constraint
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -59,7 +59,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location                 
+Subroutine Count  CC  SCAR Location                 
 ---------- ----- --- ----- -------------------------
 BEGIN          1   1   0.0 tests/moose_constraint:13
 BEGIN          1   1   0.0 tests/moose_constraint:17

--- a/test_output/cover/overload_bool.5.020000
+++ b/test_output/cover/overload_bool.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------ ------
-File                  stmt   bran   cond   mcdc    sub  total   slop
+File                  stmt   bran   cond   mcdc    sub  total   scar
 ------------------- ------ ------ ------ ------ ------ ------ ------
 tests/overload_bool   69.2   50.0   50.0    0.0   25.0   52.0    0.5
 Total                 69.2   50.0   50.0    0.0   25.0   52.0    0.5
@@ -18,14 +18,14 @@ tests/overload_bool
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 63.2  1.1  0.5
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location              
+Subroutine CC SCAR  Location              
 ---------- -- ----  ----------------------
 __ANON__    1  6.9  tests/overload_bool:12
 render      1  6.9  tests/overload_bool:16
@@ -96,14 +96,14 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location              
+Subroutine Count  CC  SCAR Location              
 ---------- ----- --- ----- ----------------------
 BEGIN          1   1   0.6 tests/overload_bool:13
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location              
+Subroutine Count  CC  SCAR Location              
 ---------- ----- --- ----- ----------------------
 __ANON__       0   1   6.9 tests/overload_bool:12
 __ANON__       0   1   0.6 tests/overload_bool:13

--- a/test_output/cover/overload_bool.5.028000
+++ b/test_output/cover/overload_bool.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------ ------
-File                  stmt   bran   cond   mcdc    sub  total   slop
+File                  stmt   bran   cond   mcdc    sub  total   scar
 ------------------- ------ ------ ------ ------ ------ ------ ------
 tests/overload_bool   69.2   50.0   50.0    0.0   25.0   52.0    0.5
 Total                 69.2   50.0   50.0    0.0   25.0   52.0    0.5
@@ -18,14 +18,14 @@ tests/overload_bool
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 63.2  1.1  0.5
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location              
+Subroutine CC SCAR  Location              
 ---------- -- ----  ----------------------
 __ANON__    1  6.9  tests/overload_bool:12
 render      1  6.9  tests/overload_bool:16
@@ -96,14 +96,14 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location              
+Subroutine Count  CC  SCAR Location              
 ---------- ----- --- ----- ----------------------
 BEGIN          1   1   0.6 tests/overload_bool:13
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location              
+Subroutine Count  CC  SCAR Location              
 ---------- ----- --- ----- ----------------------
 __ANON__       0   1   6.9 tests/overload_bool:12
 __ANON__       0   1   0.6 tests/overload_bool:13

--- a/test_output/cover/overload_bool2.5.020000
+++ b/test_output/cover/overload_bool2.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------ ------
-File                   stmt   bran   cond   mcdc    sub  total   slop
+File                   stmt   bran   cond   mcdc    sub  total   scar
 -------------------- ------ ------ ------ ------ ------ ------ ------
 tests/overload_bool2  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total                 100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/overload_bool2
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -58,7 +58,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location               
+Subroutine Count  CC  SCAR Location               
 ---------- ----- --- ----- -----------------------
 BEGIN          1   1   0.0 tests/overload_bool2:10
 BEGIN          1   1   0.0 tests/overload_bool2:11

--- a/test_output/cover/overload_bool2.5.022000
+++ b/test_output/cover/overload_bool2.5.022000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------ ------
-File                   stmt   bran   cond   mcdc    sub  total   slop
+File                   stmt   bran   cond   mcdc    sub  total   scar
 -------------------- ------ ------ ------ ------ ------ ------ ------
 tests/overload_bool2  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total                 100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/overload_bool2
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -59,7 +59,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location               
+Subroutine Count  CC  SCAR Location               
 ---------- ----- --- ----- -----------------------
 BEGIN          1   1   0.0 tests/overload_bool2:10
 BEGIN          1   1   0.0 tests/overload_bool2:11

--- a/test_output/cover/overload_bool2.5.028000
+++ b/test_output/cover/overload_bool2.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------ ------
-File                   stmt   bran   cond   mcdc    sub  total   slop
+File                   stmt   bran   cond   mcdc    sub  total   scar
 -------------------- ------ ------ ------ ------ ------ ------ ------
 tests/overload_bool2  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total                 100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/overload_bool2
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -59,7 +59,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location               
+Subroutine Count  CC  SCAR Location               
 ---------- ----- --- ----- -----------------------
 BEGIN          1   1   0.0 tests/overload_bool2:10
 BEGIN          1   1   0.0 tests/overload_bool2:11

--- a/test_output/cover/overload_bool2.5.038000
+++ b/test_output/cover/overload_bool2.5.038000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------ ------
-File                   stmt   bran   cond   mcdc    sub  total   slop
+File                   stmt   bran   cond   mcdc    sub  total   scar
 -------------------- ------ ------ ------ ------ ------ ------ ------
 tests/overload_bool2  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total                 100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/overload_bool2
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -59,7 +59,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location               
+Subroutine Count  CC  SCAR Location               
 ---------- ----- --- ----- -----------------------
 BEGIN          1   1   0.0 tests/overload_bool2:10
 BEGIN          1   1   0.0 tests/overload_bool2:11

--- a/test_output/cover/overloaded.5.020000
+++ b/test_output/cover/overloaded.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------- ------ ------ ------ ------ ------ ------ ------
-File               stmt   bran   cond   mcdc    sub  total   slop
+File               stmt   bran   cond   mcdc    sub  total   scar
 ---------------- ------ ------ ------ ------ ------ ------ ------
 tests/overloaded  100.0   50.0    n/a    n/a  100.0   93.7    0.0
 Total             100.0   50.0    n/a    n/a  100.0   93.7    0.0
@@ -18,7 +18,7 @@ tests/overloaded
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 91.7  1.0  0.0
 
@@ -65,7 +65,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 BEGIN          1   1   0.0 tests/overloaded:18
 new            1   1   0.0 tests/overloaded:17

--- a/test_output/cover/overloaded.5.028000
+++ b/test_output/cover/overloaded.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------- ------ ------ ------ ------ ------ ------ ------
-File               stmt   bran   cond   mcdc    sub  total   slop
+File               stmt   bran   cond   mcdc    sub  total   scar
 ---------------- ------ ------ ------ ------ ------ ------ ------
 tests/overloaded  100.0   50.0    n/a    n/a  100.0   93.7    0.0
 Total             100.0   50.0    n/a    n/a  100.0   93.7    0.0
@@ -18,7 +18,7 @@ tests/overloaded
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 91.7  1.0  0.0
 
@@ -65,7 +65,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location           
+Subroutine Count  CC  SCAR Location           
 ---------- ----- --- ----- -------------------
 BEGIN          1   1   0.0 tests/overloaded:18
 new            1   1   0.0 tests/overloaded:17

--- a/test_output/cover/padrange.5.020000
+++ b/test_output/cover/padrange.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/padrange  100.0    n/a    n/a    n/a    n/a  100.0    n/a
 Total           100.0    n/a    n/a    n/a    n/a  100.0    n/a

--- a/test_output/cover/padrange.5.028000
+++ b/test_output/cover/padrange.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/padrange  100.0    n/a    n/a    n/a    n/a  100.0    n/a
 Total           100.0    n/a    n/a    n/a    n/a  100.0    n/a

--- a/test_output/cover/padrange2.5.020000
+++ b/test_output/cover/padrange2.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------ ------
-File              stmt   bran   cond   mcdc    sub  total   slop
+File              stmt   bran   cond   mcdc    sub  total   scar
 --------------- ------ ------ ------ ------ ------ ------ ------
 tests/padrange2  100.0   75.0    n/a    n/a  100.0   93.7    0.0
 Total            100.0   75.0    n/a    n/a  100.0   93.7    0.0
@@ -18,7 +18,7 @@ tests/padrange2
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 92.9  1.0  0.0
 
@@ -54,7 +54,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/padrange2:3
 BEGIN          1   1   0.0 tests/padrange2:4

--- a/test_output/cover/padrange2.5.022000
+++ b/test_output/cover/padrange2.5.022000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------ ------
-File              stmt   bran   cond   mcdc    sub  total   slop
+File              stmt   bran   cond   mcdc    sub  total   scar
 --------------- ------ ------ ------ ------ ------ ------ ------
 tests/padrange2  100.0   75.0    n/a    n/a  100.0   93.7    0.0
 Total            100.0   75.0    n/a    n/a  100.0   93.7    0.0
@@ -18,7 +18,7 @@ tests/padrange2
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 92.9  1.0  0.0
 
@@ -54,7 +54,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/padrange2:3
 BEGIN          1   1   0.0 tests/padrange2:4

--- a/test_output/cover/padrange2.5.028000
+++ b/test_output/cover/padrange2.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------ ------
-File              stmt   bran   cond   mcdc    sub  total   slop
+File              stmt   bran   cond   mcdc    sub  total   scar
 --------------- ------ ------ ------ ------ ------ ------ ------
 tests/padrange2  100.0   75.0    n/a    n/a  100.0   93.7    0.0
 Total            100.0   75.0    n/a    n/a  100.0   93.7    0.0
@@ -18,7 +18,7 @@ tests/padrange2
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 92.9  1.0  0.0
 
@@ -54,7 +54,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location         
+Subroutine Count  CC  SCAR Location         
 ---------- ----- --- ----- -----------------
 BEGIN          1   1   0.0 tests/padrange2:3
 BEGIN          1   1   0.0 tests/padrange2:4

--- a/test_output/cover/pod.5.020000
+++ b/test_output/cover/pod.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------
-File          pod  total   slop
+File          pod  total   scar
 ---------- ------ ------ ------
 Module1.pm   50.0   50.0    0.0
 PodMod.pm    66.6   66.6    0.0
@@ -21,7 +21,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     3  1 100.0  1.0  0.0
 
@@ -31,14 +31,14 @@ Module1.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 _aa         1  6.9  Module1.pm:14
 xx          1  6.9  Module1.pm:20
@@ -47,7 +47,7 @@ yy          1  6.9  Module1.pm:25
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod  CC  SLOP Location     
+Subroutine Count Pod  CC  SCAR Location     
 ---------- ----- --- --- ----- -------------
 _aa            0       1   6.9 Module1.pm:14
 xx             0       1   6.9 Module1.pm:20
@@ -60,14 +60,14 @@ PodMod.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location    
+Subroutine CC SCAR  Location    
 ---------- -- ----  ------------
 vv          1  6.9  PodMod.pm:12
 ww          1  6.9  PodMod.pm:13
@@ -76,14 +76,14 @@ yy          1  6.9  PodMod.pm:14
 Covered Subroutines
 -------------------
 
-Subroutine Count Pod  CC  SLOP Location    
+Subroutine Count Pod  CC  SCAR Location    
 ---------- ----- --- --- ----- ------------
 BEGIN          1       1   0.0 PodMod.pm:10
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod  CC  SLOP Location    
+Subroutine Count Pod  CC  SCAR Location    
 ---------- ----- --- --- ----- ------------
 vv             0   1   1   6.9 PodMod.pm:12
 ww             0   0   1   6.9 PodMod.pm:13
@@ -95,21 +95,21 @@ pod
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 xx          1  6.9  pod:24  
 
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 BEGIN          1   1   0.0 pod:14  
 BEGIN          1   1   0.0 pod:15  
@@ -119,7 +119,7 @@ BEGIN          1   1   0.0 pod:19
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 xx             0   1   6.9 pod:24  
 

--- a/test_output/cover/pod_nocp.5.020000
+++ b/test_output/cover/pod_nocp.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ---------- ------ ------ ------
-File          pod  total   slop
+File          pod  total   scar
 ---------- ------ ------ ------
 Module1.pm   50.0   50.0    0.0
 PodMod.pm    33.3   33.3    0.0
@@ -21,7 +21,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC   Cov CRAP SLOP
+Files CC   Cov CRAP SCAR
 ----- -- ----- ---- ----
     3  1 100.0  1.0  0.0
 
@@ -31,14 +31,14 @@ Module1.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 _aa         1  6.9  Module1.pm:14
 xx          1  6.9  Module1.pm:20
@@ -47,7 +47,7 @@ yy          1  6.9  Module1.pm:25
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod  CC  SLOP Location     
+Subroutine Count Pod  CC  SCAR Location     
 ---------- ----- --- --- ----- -------------
 _aa            0       1   6.9 Module1.pm:14
 xx             0       1   6.9 Module1.pm:20
@@ -60,14 +60,14 @@ PodMod.pm
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location    
+Subroutine CC SCAR  Location    
 ---------- -- ----  ------------
 vv          1  6.9  PodMod.pm:12
 ww          1  6.9  PodMod.pm:13
@@ -76,14 +76,14 @@ yy          1  6.9  PodMod.pm:14
 Covered Subroutines
 -------------------
 
-Subroutine Count Pod  CC  SLOP Location    
+Subroutine Count Pod  CC  SCAR Location    
 ---------- ----- --- --- ----- ------------
 BEGIN          1       1   0.0 PodMod.pm:10
 
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count Pod  CC  SLOP Location    
+Subroutine Count Pod  CC  SCAR Location    
 ---------- ----- --- --- ----- ------------
 vv             0   1   1   6.9 PodMod.pm:12
 ww             0   0   1   6.9 PodMod.pm:13
@@ -95,21 +95,21 @@ pod_nocp
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location   
+Subroutine CC SCAR  Location   
 ---------- -- ----  -----------
 xx          1  6.9  pod_nocp:24
 
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 pod_nocp:14
 BEGIN          1   1   0.0 pod_nocp:15
@@ -119,7 +119,7 @@ BEGIN          1   1   0.0 pod_nocp:19
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 xx             0   1   6.9 pod_nocp:24
 

--- a/test_output/cover/readonly.5.020000
+++ b/test_output/cover/readonly.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/readonly  100.0  100.0    n/a    n/a  100.0  100.0   16.1
 Total           100.0  100.0    n/a    n/a  100.0  100.0   16.1
@@ -18,14 +18,14 @@ tests/readonly
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  5 100.0  5.0 16.1
 
 Worst Subroutines
 -----------------
 
-Subroutine             CC SLOP  Location         
+Subroutine             CC SCAR  Location         
 ---------------------- -- ----  -----------------
 test_readonly_coverage  3 11.0  tests/readonly:23
 test_posix_regexp       3 11.0  tests/readonly:34
@@ -95,7 +95,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine             Count  CC  SLOP Location         
+Subroutine             Count  CC  SCAR Location         
 ---------------------- ----- --- ----- -----------------
 BEGIN                      1   1   0.0 tests/readonly:13
 BEGIN                      1   1   0.0 tests/readonly:14

--- a/test_output/cover/readonly.5.028000
+++ b/test_output/cover/readonly.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------- ------ ------ ------ ------ ------ ------ ------
-File             stmt   bran   cond   mcdc    sub  total   slop
+File             stmt   bran   cond   mcdc    sub  total   scar
 -------------- ------ ------ ------ ------ ------ ------ ------
 tests/readonly  100.0  100.0    n/a    n/a  100.0  100.0   16.1
 Total           100.0  100.0    n/a    n/a  100.0  100.0   16.1
@@ -18,14 +18,14 @@ tests/readonly
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  5 100.0  5.0 16.1
 
 Worst Subroutines
 -----------------
 
-Subroutine             CC SLOP  Location         
+Subroutine             CC SCAR  Location         
 ---------------------- -- ----  -----------------
 test_readonly_coverage  3 11.0  tests/readonly:23
 test_posix_regexp       3 11.0  tests/readonly:34
@@ -95,7 +95,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine             Count  CC  SLOP Location         
+Subroutine             Count  CC  SCAR Location         
 ---------------------- ----- --- ----- -----------------
 BEGIN                      1   1   0.0 tests/readonly:13
 BEGIN                      1   1   0.0 tests/readonly:14

--- a/test_output/cover/recursive_sub.5.020000
+++ b/test_output/cover/recursive_sub.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------ ------
-File                  stmt   bran   cond   mcdc    sub  total   slop
+File                  stmt   bran   cond   mcdc    sub  total   scar
 ------------------- ------ ------ ------ ------ ------ ------ ------
 tests/recursive_sub  100.0  100.0    n/a    n/a  100.0  100.0    6.9
 Total                100.0  100.0    n/a    n/a  100.0  100.0    6.9
@@ -18,14 +18,14 @@ tests/recursive_sub
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  2 100.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine     CC SLOP  Location              
+Subroutine     CC SCAR  Location              
 -------------- -- ----  ----------------------
 recursive_func  2  6.9  tests/recursive_sub:14
 
@@ -64,7 +64,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine     Count  CC  SLOP Location              
+Subroutine     Count  CC  SCAR Location              
 -------------- ----- --- ----- ----------------------
 BEGIN              1   1   0.0 tests/recursive_sub:10
 recursive_func     4   2   6.9 tests/recursive_sub:14

--- a/test_output/cover/recursive_sub.5.028000
+++ b/test_output/cover/recursive_sub.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------- ------ ------ ------ ------ ------ ------ ------
-File                  stmt   bran   cond   mcdc    sub  total   slop
+File                  stmt   bran   cond   mcdc    sub  total   scar
 ------------------- ------ ------ ------ ------ ------ ------ ------
 tests/recursive_sub  100.0  100.0    n/a    n/a  100.0  100.0    6.9
 Total                100.0  100.0    n/a    n/a  100.0  100.0    6.9
@@ -18,14 +18,14 @@ tests/recursive_sub
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  2 100.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine     CC SLOP  Location              
+Subroutine     CC SCAR  Location              
 -------------- -- ----  ----------------------
 recursive_func  2  6.9  tests/recursive_sub:14
 
@@ -64,7 +64,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine     Count  CC  SLOP Location              
+Subroutine     Count  CC  SCAR Location              
 -------------- ----- --- ----- ----------------------
 BEGIN              1   1   0.0 tests/recursive_sub:10
 recursive_func     4   2   6.9 tests/recursive_sub:14

--- a/test_output/cover/redefine_sub.5.020000
+++ b/test_output/cover/redefine_sub.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------ ------
-File                 stmt   bran   cond   mcdc    sub  total   slop
+File                 stmt   bran   cond   mcdc    sub  total   scar
 ------------------ ------ ------ ------ ------ ------ ------ ------
 tests/redefine_sub  100.0  100.0    n/a    n/a  100.0  100.0    6.9
 Total               100.0  100.0    n/a    n/a  100.0  100.0    6.9
@@ -18,14 +18,14 @@ tests/redefine_sub
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  2 100.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location            
+Subroutine CC SCAR  Location            
 ---------- -- ----  --------------------
 s1          2  6.9  tests/redefine_sub:4
 
@@ -63,7 +63,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location             
+Subroutine Count  CC  SCAR Location             
 ---------- ----- --- ----- ---------------------
 __ANON__       2   1   0.0 tests/redefine_sub:15
 s1             2   2   6.9 tests/redefine_sub:4 

--- a/test_output/cover/redefine_sub.5.028000
+++ b/test_output/cover/redefine_sub.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------ ------
-File                 stmt   bran   cond   mcdc    sub  total   slop
+File                 stmt   bran   cond   mcdc    sub  total   scar
 ------------------ ------ ------ ------ ------ ------ ------ ------
 tests/redefine_sub  100.0  100.0    n/a    n/a  100.0  100.0    6.9
 Total               100.0  100.0    n/a    n/a  100.0  100.0    6.9
@@ -18,14 +18,14 @@ tests/redefine_sub
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  2 100.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location            
+Subroutine CC SCAR  Location            
 ---------- -- ----  --------------------
 s1          2  6.9  tests/redefine_sub:4
 
@@ -63,7 +63,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location             
+Subroutine Count  CC  SCAR Location             
 ---------- ----- --- ----- ---------------------
 __ANON__       2   1   0.0 tests/redefine_sub:15
 s1             2   2   6.9 tests/redefine_sub:4 

--- a/test_output/cover/require.5.020000
+++ b/test_output/cover/require.5.020000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ------- ------ ------ ------ ------ ------ ------ ------
-File      stmt   bran   cond   mcdc    sub  total   slop
+File      stmt   bran   cond   mcdc    sub  total   scar
 ------- ------ ------ ------ ------ ------ ------ ------
 E2.pm      0.0    n/a    n/a    n/a    0.0    0.0    6.9
 require  100.0   50.0    n/a    n/a  100.0   90.9    7.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2  2 80.0  2.0  7.1
 
@@ -30,14 +30,14 @@ E2.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E2          1  6.9  E2.pm:12
 
@@ -61,7 +61,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             0   1   6.9 E2.pm:12
 
@@ -71,14 +71,14 @@ require
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 88.9  2.0  7.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location  
+Subroutine CC SCAR  Location  
 ---------- -- ----  ----------
 BEGIN       2  7.1  require:10
 
@@ -112,7 +112,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   2   7.1 require:10
 BEGIN          1   1   0.0 require:11

--- a/test_output/cover/require.5.028000
+++ b/test_output/cover/require.5.028000
@@ -3,7 +3,7 @@ cover: Reading database from ...
 Common prefix: tests/
 
 ------- ------ ------ ------ ------ ------ ------ ------
-File      stmt   bran   cond   mcdc    sub  total   slop
+File      stmt   bran   cond   mcdc    sub  total   scar
 ------- ------ ------ ------ ------ ------ ------ ------
 E2.pm      0.0    n/a    n/a    n/a    0.0    0.0    6.9
 require  100.0   50.0    n/a    n/a  100.0   90.9    7.0
@@ -20,7 +20,7 @@ Finish: ...
 Module Summary
 --------------
 
-Files CC  Cov CRAP SLOP
+Files CC  Cov CRAP SCAR
 ----- -- ---- ---- ----
     2  2 80.0  2.0  7.1
 
@@ -30,14 +30,14 @@ E2.pm
 File Summary
 ------------
 
-CC Cov CRAP SLOP
+CC Cov CRAP SCAR
 -- --- ---- ----
  1 0.0  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location
+Subroutine CC SCAR  Location
 ---------- -- ----  --------
 E2          1  6.9  E2.pm:12
 
@@ -61,7 +61,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location
+Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- --------
 E2             0   1   6.9 E2.pm:12
 
@@ -71,14 +71,14 @@ require
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 88.9  2.0  7.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location  
+Subroutine CC SCAR  Location  
 ---------- -- ----  ----------
 BEGIN       2  7.1  require:10
 
@@ -112,7 +112,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location  
+Subroutine Count  CC  SCAR Location  
 ---------- ----- --- ----- ----------
 BEGIN          1   2   7.1 require:10
 BEGIN          1   1   0.0 require:11

--- a/test_output/cover/signature.5.032000
+++ b/test_output/cover/signature.5.032000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------ ------
-File              stmt   bran   cond   mcdc    sub  total   slop
+File              stmt   bran   cond   mcdc    sub  total   scar
 --------------- ------ ------ ------ ------ ------ ------ ------
 tests/signature  100.0   50.0    n/a    n/a  100.0   94.4    6.9
 Total            100.0   50.0    n/a    n/a  100.0   94.4    6.9
@@ -18,14 +18,14 @@ tests/signature
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  2 92.9  2.0  6.9
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location          
+Subroutine CC SCAR  Location          
 ---------- -- ----  ------------------
 xx          2  6.9  tests/signature:17
 
@@ -70,7 +70,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location          
+Subroutine Count  CC  SCAR Location          
 ---------- ----- --- ----- ------------------
 BEGIN          1   1   0.0 tests/signature:13
 BEGIN          1   1   0.0 tests/signature:14

--- a/test_output/cover/skip.5.020000
+++ b/test_output/cover/skip.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 tests/skip   83.3   50.0    n/a    n/a  100.0   72.7   11.8
 Total        83.3   50.0    n/a    n/a  100.0   72.7   11.8
@@ -18,14 +18,14 @@ tests/skip
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  3 70.0  3.2 11.8
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 main        3 12.0  tests/skip:11
 
@@ -63,7 +63,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 main           1   3  12.0 tests/skip:11
 

--- a/test_output/cover/skip.5.028000
+++ b/test_output/cover/skip.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 tests/skip   83.3   50.0    n/a    n/a  100.0   72.7   11.8
 Total        83.3   50.0    n/a    n/a  100.0   72.7   11.8
@@ -18,14 +18,14 @@ tests/skip
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  3 70.0  3.2 11.8
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 main        3 12.0  tests/skip:11
 
@@ -63,7 +63,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location     
+Subroutine Count  CC  SCAR Location     
 ---------- ----- --- ----- -------------
 main           1   3  12.0 tests/skip:11
 

--- a/test_output/cover/sort.5.020000
+++ b/test_output/cover/sort.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 tests/sort   96.0    n/a    n/a    n/a   85.7   93.7    0.0
 Total        96.0    n/a    n/a    n/a   85.7   93.7    0.0
@@ -18,14 +18,14 @@ tests/sort
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 96.0  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 forwards    1  6.9  tests/sort:15
 
@@ -92,7 +92,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  SLOP Location     
+Subroutine   Count  CC  SCAR Location     
 ------------ ----- --- ----- -------------
 BEGIN            1   1   0.0 tests/sort:3 
 BEGIN            1   1   0.0 tests/sort:30
@@ -104,7 +104,7 @@ xyz              8   1   0.0 tests/sort:42
 Uncovered Subroutines
 ---------------------
 
-Subroutine   Count  CC  SLOP Location     
+Subroutine   Count  CC  SCAR Location     
 ------------ ----- --- ----- -------------
 forwards         0   1   6.9 tests/sort:15
 

--- a/test_output/cover/sort.5.028000
+++ b/test_output/cover/sort.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------- ------ ------ ------ ------ ------ ------ ------
-File         stmt   bran   cond   mcdc    sub  total   slop
+File         stmt   bran   cond   mcdc    sub  total   scar
 ---------- ------ ------ ------ ------ ------ ------ ------
 tests/sort   96.0    n/a    n/a    n/a   85.7   93.7    0.0
 Total        96.0    n/a    n/a    n/a   85.7   93.7    0.0
@@ -18,14 +18,14 @@ tests/sort
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 96.0  1.0  0.0
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location     
+Subroutine CC SCAR  Location     
 ---------- -- ----  -------------
 forwards    1  6.9  tests/sort:15
 
@@ -92,7 +92,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine   Count  CC  SLOP Location     
+Subroutine   Count  CC  SCAR Location     
 ------------ ----- --- ----- -------------
 BEGIN            1   1   0.0 tests/sort:3 
 BEGIN            1   1   0.0 tests/sort:30
@@ -104,7 +104,7 @@ xyz              8   1   0.0 tests/sort:42
 Uncovered Subroutines
 ---------------------
 
-Subroutine   Count  CC  SLOP Location     
+Subroutine   Count  CC  SCAR Location     
 ------------ ----- --- ----- -------------
 forwards         0   1   6.9 tests/sort:15
 

--- a/test_output/cover/sort_or.5.020000
+++ b/test_output/cover/sort_or.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/sort_or  100.0   66.6    n/a    n/a  100.0   88.2    0.0
 Total          100.0   66.6    n/a    n/a  100.0   88.2    0.0
@@ -18,7 +18,7 @@ tests/sort_or
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 87.5  1.0  0.0
 
@@ -115,7 +115,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 tests/sort_or:10
 BEGIN          1   1   0.0 tests/sort_or:11

--- a/test_output/cover/sort_or.5.022000
+++ b/test_output/cover/sort_or.5.022000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/sort_or  100.0   66.6    n/a    n/a  100.0   88.2    0.0
 Total          100.0   66.6    n/a    n/a  100.0   88.2    0.0
@@ -18,7 +18,7 @@ tests/sort_or
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 87.5  1.0  0.0
 
@@ -117,7 +117,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 tests/sort_or:10
 BEGIN          1   1   0.0 tests/sort_or:11

--- a/test_output/cover/sort_or.5.026000
+++ b/test_output/cover/sort_or.5.026000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/sort_or  100.0   66.6    n/a    n/a  100.0   88.2    0.0
 Total          100.0   66.6    n/a    n/a  100.0   88.2    0.0
@@ -18,7 +18,7 @@ tests/sort_or
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 87.5  1.0  0.0
 
@@ -117,7 +117,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 tests/sort_or:10
 BEGIN          1   1   0.0 tests/sort_or:11

--- a/test_output/cover/sort_or.5.028000
+++ b/test_output/cover/sort_or.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/sort_or  100.0   66.6    n/a    n/a  100.0   88.2    0.0
 Total          100.0   66.6    n/a    n/a  100.0   88.2    0.0
@@ -18,7 +18,7 @@ tests/sort_or
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 87.5  1.0  0.0
 
@@ -117,7 +117,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 tests/sort_or:10
 BEGIN          1   1   0.0 tests/sort_or:11

--- a/test_output/cover/sort_or.5.043008
+++ b/test_output/cover/sort_or.5.043008
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/sort_or  100.0   66.6    n/a    n/a  100.0   88.2    0.0
 Total          100.0   66.6    n/a    n/a  100.0   88.2    0.0
@@ -18,7 +18,7 @@ tests/sort_or
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 87.5  1.0  0.0
 
@@ -117,7 +117,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location        
+Subroutine Count  CC  SCAR Location        
 ---------- ----- --- ----- ----------------
 BEGIN          1   1   0.0 tests/sort_or:10
 BEGIN          1   1   0.0 tests/sort_or:11

--- a/test_output/cover/special_blocks.5.020000
+++ b/test_output/cover/special_blocks.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------ ------
-File                   stmt   bran   cond   mcdc    sub  total   slop
+File                   stmt   bran   cond   mcdc    sub  total   scar
 -------------------- ------ ------ ------ ------ ------ ------ ------
 tests/special_blocks  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total                 100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/special_blocks
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -63,7 +63,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location               
+Subroutine Count  CC  SCAR Location               
 ---------- ----- --- ----- -----------------------
 BEGIN          1   1   0.0 tests/special_blocks:10
 BEGIN          1   1   0.0 tests/special_blocks:11

--- a/test_output/cover/special_blocks.5.028000
+++ b/test_output/cover/special_blocks.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------------------- ------ ------ ------ ------ ------ ------ ------
-File                   stmt   bran   cond   mcdc    sub  total   slop
+File                   stmt   bran   cond   mcdc    sub  total   scar
 -------------------- ------ ------ ------ ------ ------ ------ ------
 tests/special_blocks  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total                 100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/special_blocks
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -63,7 +63,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location               
+Subroutine Count  CC  SCAR Location               
 ---------- ----- --- ----- -----------------------
 BEGIN          1   1   0.0 tests/special_blocks:10
 BEGIN          1   1   0.0 tests/special_blocks:11

--- a/test_output/cover/statement.5.020000
+++ b/test_output/cover/statement.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------ ------
-File              stmt   bran   cond   mcdc    sub  total   slop
+File              stmt   bran   cond   mcdc    sub  total   scar
 --------------- ------ ------ ------ ------ ------ ------ ------
 tests/statement  100.0    n/a    n/a    n/a    n/a  100.0    n/a
 Total            100.0    n/a    n/a    n/a    n/a  100.0    n/a

--- a/test_output/cover/statement.5.028000
+++ b/test_output/cover/statement.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------ ------
-File              stmt   bran   cond   mcdc    sub  total   slop
+File              stmt   bran   cond   mcdc    sub  total   scar
 --------------- ------ ------ ------ ------ ------ ------ ------
 tests/statement  100.0    n/a    n/a    n/a    n/a  100.0    n/a
 Total            100.0    n/a    n/a    n/a    n/a  100.0    n/a

--- a/test_output/cover/subs_only.5.020000
+++ b/test_output/cover/subs_only.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------ ------
-File              stmt   bran   cond   mcdc    sub  total   slop
+File              stmt   bran   cond   mcdc    sub  total   scar
 --------------- ------ ------ ------ ------ ------ ------ ------
 tests/subs_only  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total            100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/subs_only
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -57,7 +57,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location          
+Subroutine Count  CC  SCAR Location          
 ---------- ----- --- ----- ------------------
 xx            11   1   0.0 tests/subs_only:20
 

--- a/test_output/cover/subs_only.5.028000
+++ b/test_output/cover/subs_only.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 --------------- ------ ------ ------ ------ ------ ------ ------
-File              stmt   bran   cond   mcdc    sub  total   slop
+File              stmt   bran   cond   mcdc    sub  total   scar
 --------------- ------ ------ ------ ------ ------ ------ ------
 tests/subs_only  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total            100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/subs_only
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -57,7 +57,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location          
+Subroutine Count  CC  SCAR Location          
 ---------- ----- --- ----- ------------------
 xx            11   1   0.0 tests/subs_only:20
 

--- a/test_output/cover/t0.5.020000
+++ b/test_output/cover/t0.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------ ------
-File       stmt   bran   cond   mcdc    sub  total   slop
+File       stmt   bran   cond   mcdc    sub  total   scar
 -------- ------ ------ ------ ------ ------ ------ ------
 tests/t0   94.1   62.5   66.6   50.0  100.0   81.2    0.1
 Total      94.1   62.5   66.6   50.0  100.0   81.2    0.1
@@ -18,7 +18,7 @@ tests/t0
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 82.1  1.0  0.1
 
@@ -100,7 +100,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 tests/t0:10
 BEGIN          1   1   0.0 tests/t0:11

--- a/test_output/cover/t0.5.028000
+++ b/test_output/cover/t0.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------ ------
-File       stmt   bran   cond   mcdc    sub  total   slop
+File       stmt   bran   cond   mcdc    sub  total   scar
 -------- ------ ------ ------ ------ ------ ------ ------
 tests/t0   94.1   62.5   66.6   50.0  100.0   81.2    0.1
 Total      94.1   62.5   66.6   50.0  100.0   81.2    0.1
@@ -18,7 +18,7 @@ tests/t0
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 82.1  1.0  0.1
 
@@ -100,7 +100,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 tests/t0:10
 BEGIN          1   1   0.0 tests/t0:11

--- a/test_output/cover/t0.5.043008
+++ b/test_output/cover/t0.5.043008
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------ ------
-File       stmt   bran   cond   mcdc    sub  total   slop
+File       stmt   bran   cond   mcdc    sub  total   scar
 -------- ------ ------ ------ ------ ------ ------ ------
 tests/t0   94.1   62.5   66.6   50.0  100.0   81.2    0.1
 Total      94.1   62.5   66.6   50.0  100.0   81.2    0.1
@@ -18,7 +18,7 @@ tests/t0
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 82.1  1.0  0.1
 
@@ -100,7 +100,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 tests/t0:10
 BEGIN          1   1   0.0 tests/t0:11

--- a/test_output/cover/t1.5.020000
+++ b/test_output/cover/t1.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------ ------
-File       stmt   bran   cond   mcdc    sub  total   slop
+File       stmt   bran   cond   mcdc    sub  total   scar
 -------- ------ ------ ------ ------ ------ ------ ------
 tests/t1  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total     100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/t1
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -51,7 +51,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 tests/t1:10
 BEGIN          1   1   0.0 tests/t1:11

--- a/test_output/cover/t1.5.028000
+++ b/test_output/cover/t1.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------ ------
-File       stmt   bran   cond   mcdc    sub  total   slop
+File       stmt   bran   cond   mcdc    sub  total   scar
 -------- ------ ------ ------ ------ ------ ------ ------
 tests/t1  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total     100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/t1
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -51,7 +51,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 tests/t1:10
 BEGIN          1   1   0.0 tests/t1:11

--- a/test_output/cover/t2.5.020000
+++ b/test_output/cover/t2.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------ ------
-File       stmt   bran   cond   mcdc    sub  total   slop
+File       stmt   bran   cond   mcdc    sub  total   scar
 -------- ------ ------ ------ ------ ------ ------ ------
 tests/t2   93.7   50.0    n/a    n/a  100.0   84.0    0.1
 Total      93.7   50.0    n/a    n/a  100.0   84.0    0.1
@@ -18,7 +18,7 @@ tests/t2
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 81.8  1.0  0.1
 
@@ -77,7 +77,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 tests/t2:10
 BEGIN          1   1   0.0 tests/t2:11

--- a/test_output/cover/t2.5.028000
+++ b/test_output/cover/t2.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------ ------
-File       stmt   bran   cond   mcdc    sub  total   slop
+File       stmt   bran   cond   mcdc    sub  total   scar
 -------- ------ ------ ------ ------ ------ ------ ------
 tests/t2   93.7   50.0    n/a    n/a  100.0   84.0    0.1
 Total      93.7   50.0    n/a    n/a  100.0   84.0    0.1
@@ -18,7 +18,7 @@ tests/t2
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 81.8  1.0  0.1
 
@@ -77,7 +77,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 tests/t2:10
 BEGIN          1   1   0.0 tests/t2:11

--- a/test_output/cover/t2.5.043008
+++ b/test_output/cover/t2.5.043008
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 -------- ------ ------ ------ ------ ------ ------ ------
-File       stmt   bran   cond   mcdc    sub  total   slop
+File       stmt   bran   cond   mcdc    sub  total   scar
 -------- ------ ------ ------ ------ ------ ------ ------
 tests/t2   93.7   50.0    n/a    n/a  100.0   84.0    0.1
 Total      93.7   50.0    n/a    n/a  100.0   84.0    0.1
@@ -18,7 +18,7 @@ tests/t2
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  1 81.8  1.0  0.1
 
@@ -77,7 +77,7 @@ line  err      %   true  false   branch
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location   
+Subroutine Count  CC  SCAR Location   
 ---------- ----- --- ----- -----------
 BEGIN          1   1   0.0 tests/t2:10
 BEGIN          1   1   0.0 tests/t2:11

--- a/test_output/cover/taint.5.020000
+++ b/test_output/cover/taint.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------ ------
-File          stmt   bran   cond   mcdc    sub  total   slop
+File          stmt   bran   cond   mcdc    sub  total   scar
 ----------- ------ ------ ------ ------ ------ ------ ------
 tests/taint  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total        100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/taint
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -52,7 +52,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 BEGIN          1   1   0.0 tests/taint:10
 BEGIN          1   1   0.0 tests/taint:11

--- a/test_output/cover/taint.5.028000
+++ b/test_output/cover/taint.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------- ------ ------ ------ ------ ------ ------ ------
-File          stmt   bran   cond   mcdc    sub  total   slop
+File          stmt   bran   cond   mcdc    sub  total   scar
 ----------- ------ ------ ------ ------ ------ ------ ------
 tests/taint  100.0    n/a    n/a    n/a  100.0  100.0    0.0
 Total        100.0    n/a    n/a    n/a  100.0  100.0    0.0
@@ -18,7 +18,7 @@ tests/taint
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -52,7 +52,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location      
+Subroutine Count  CC  SCAR Location      
 ---------- ----- --- ----- --------------
 BEGIN          1   1   0.0 tests/taint:10
 BEGIN          1   1   0.0 tests/taint:11

--- a/test_output/cover/trivial.5.020000
+++ b/test_output/cover/trivial.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/trivial  100.0    n/a    n/a    n/a    n/a  100.0    n/a
 Total          100.0    n/a    n/a    n/a    n/a  100.0    n/a

--- a/test_output/cover/trivial.5.028000
+++ b/test_output/cover/trivial.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ------------- ------ ------ ------ ------ ------ ------ ------
-File            stmt   bran   cond   mcdc    sub  total   slop
+File            stmt   bran   cond   mcdc    sub  total   scar
 ------------- ------ ------ ------ ------ ------ ------ ------
 tests/trivial  100.0    n/a    n/a    n/a    n/a  100.0    n/a
 Total          100.0    n/a    n/a    n/a    n/a  100.0    n/a

--- a/test_output/cover/uncoverable.5.020000
+++ b/test_output/cover/uncoverable.5.020000
@@ -1,7 +1,7 @@
 cover: Reading database from ...
 2 unmatched uncoverable comments not found at end of tests/uncoverable
 ----------------- ------ ------ ------ ------ ------ ------ ------
-File                stmt   bran   cond   mcdc    sub  total   slop
+File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------
 tests/uncoverable  100.0  100.0  100.0  100.0  100.0  100.0    0.0
 Total              100.0  100.0  100.0  100.0  100.0  100.0    0.0
@@ -19,7 +19,7 @@ tests/uncoverable
 File Summary
 ------------
 
-CC   Cov CRAP SLOP
+CC   Cov CRAP SCAR
 -- ----- ---- ----
  1 100.0  1.0  0.0
 
@@ -145,7 +145,7 @@ line  err      %  cov  tot   missing                expr
 Uncovered Subroutines
 ---------------------
 
-Subroutine Count  CC  SLOP Location            
+Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
 z             -0   1   0.0 tests/uncoverable:44
 

--- a/test_output/cover/uncoverable_error.5.020000
+++ b/test_output/cover/uncoverable_error.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----------------------- ------ ------ ------ ------ ------ ------ ------
-File                      stmt   bran   cond   mcdc    sub  total   slop
+File                      stmt   bran   cond   mcdc    sub  total   scar
 ----------------------- ------ ------ ------ ------ ------ ------ ------
 tests/uncoverable_error   82.3   70.0   83.3  100.0  100.0   82.0   21.5
 Total                     82.3   70.0   83.3  100.0  100.0   82.0   21.5
@@ -18,14 +18,14 @@ tests/uncoverable_error
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  8 78.8  8.6 21.5
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location                  
+Subroutine CC SCAR  Location                  
 ---------- -- ----  --------------------------
 main        8 21.7  tests/uncoverable_error:17
 
@@ -122,7 +122,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location                  
+Subroutine Count  CC  SCAR Location                  
 ---------- ----- --- ----- --------------------------
 main           1   8  21.7 tests/uncoverable_error:17
 usub          -1   1   0.0 tests/uncoverable_error:13

--- a/test_output/cover/uncoverable_error_ignore.5.020000
+++ b/test_output/cover/uncoverable_error_ignore.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------------------- ------ ------ ------ ------ ------ ------ ------
-File                           stmt   bran   cond   mcdc    sub  total   slop
+File                           stmt   bran   cond   mcdc    sub  total   scar
 ---------------------------- ------ ------ ------ ------ ------ ------ ------
 .../uncoverable_error_ignore   82.3   80.0   66.6   50.0  100.0   76.9   21.5
 Total                          82.3   80.0   66.6   50.0  100.0   76.9   21.5
@@ -18,14 +18,14 @@ tests/uncoverable_error_ignore
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  8 78.8  8.6 21.5
 
 Worst Subroutines
 -----------------
 
-Subroutine CC SLOP  Location                         
+Subroutine CC SCAR  Location                         
 ---------- -- ----  ---------------------------------
 main        8 21.7  tests/uncoverable_error_ignore:19
 
@@ -122,7 +122,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine Count  CC  SLOP Location                         
+Subroutine Count  CC  SCAR Location                         
 ---------- ----- --- ----- ---------------------------------
 main           1   8  21.7 tests/uncoverable_error_ignore:19
 usub          -1   1   0.0 tests/uncoverable_error_ignore:15

--- a/test_output/cover/uncoverable_mcdc.5.020000
+++ b/test_output/cover/uncoverable_mcdc.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------------- ------ ------ ------ ------ ------ ------ ------
-File                     stmt   bran   cond   mcdc    sub  total   slop
+File                     stmt   bran   cond   mcdc    sub  total   scar
 ---------------------- ------ ------ ------ ------ ------ ------ ------
 tests/uncoverable_mcdc  100.0    n/a   83.3  100.0  100.0   95.8   16.1
 Total                   100.0    n/a   83.3  100.0  100.0   95.8   16.1
@@ -18,14 +18,14 @@ tests/uncoverable_mcdc
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  5 94.3  5.0 16.1
 
 Worst Subroutines
 -----------------
 
-Subroutine       CC SLOP  Location                 
+Subroutine       CC SCAR  Location                 
 ---------------- -- ----  -------------------------
 compound_inner    3 11.0  tests/uncoverable_mcdc:37
 dor_default       2  7.1  tests/uncoverable_mcdc:17
@@ -126,7 +126,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine       Count  CC  SLOP Location                 
+Subroutine       Count  CC  SCAR Location                 
 ---------------- ----- --- ----- -------------------------
 BEGIN                1   1   0.0 tests/uncoverable_mcdc:10
 BEGIN                1   1   0.0 tests/uncoverable_mcdc:11

--- a/test_output/cover/uncoverable_mcdc.5.022000
+++ b/test_output/cover/uncoverable_mcdc.5.022000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ---------------------- ------ ------ ------ ------ ------ ------ ------
-File                     stmt   bran   cond   mcdc    sub  total   slop
+File                     stmt   bran   cond   mcdc    sub  total   scar
 ---------------------- ------ ------ ------ ------ ------ ------ ------
 tests/uncoverable_mcdc  100.0    n/a   83.3  100.0  100.0   95.8   16.1
 Total                   100.0    n/a   83.3  100.0  100.0   95.8   16.1
@@ -18,14 +18,14 @@ tests/uncoverable_mcdc
 File Summary
 ------------
 
-CC  Cov CRAP SLOP
+CC  Cov CRAP SCAR
 -- ---- ---- ----
  5 94.3  5.0 16.1
 
 Worst Subroutines
 -----------------
 
-Subroutine       CC SLOP  Location                 
+Subroutine       CC SCAR  Location                 
 ---------------- -- ----  -------------------------
 compound_inner    3 11.0  tests/uncoverable_mcdc:37
 dor_default       2  7.1  tests/uncoverable_mcdc:17
@@ -126,7 +126,7 @@ line  err      %  cov  tot   missing                expr
 Covered Subroutines
 -------------------
 
-Subroutine       Count  CC  SLOP Location                 
+Subroutine       Count  CC  SCAR Location                 
 ---------------- ----- --- ----- -------------------------
 BEGIN                1   1   0.0 tests/uncoverable_mcdc:10
 BEGIN                1   1   0.0 tests/uncoverable_mcdc:11

--- a/test_output/cover/xor_constant_fold.5.020000
+++ b/test_output/cover/xor_constant_fold.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 Total    n/a    n/a    n/a    n/a    n/a    n/a    n/a
 ----- ------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/xor_constant_fold.5.028000
+++ b/test_output/cover/xor_constant_fold.5.028000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
 ----- ------ ------ ------ ------ ------ ------ ------
-File    stmt   bran   cond   mcdc    sub  total   slop
+File    stmt   bran   cond   mcdc    sub  total   scar
 ----- ------ ------ ------ ------ ------ ------ ------
 Total    n/a    n/a    n/a    n/a    n/a    n/a    n/a
 ----- ------ ------ ------ ------ ------ ------ ------


### PR DESCRIPTION
## Summary

Rename the risk metric SLOP (Scaled Likelihood Of Problems) to SCAR (Scaled Complexity And Risk). The name now carries strong associations with AI-generated output, which we do not want the metric to imply. SCAR keeps the irreverent feel of the CRAP metric it derives from, and reads aptly as a visible mark of damage.

The metric is unreleased (introduced under `{{$NEXT}}` by GH-448), so this is a straight rename with no migration burden for released users.

## Changes

- Rename every SLOP/slop identifier, hash key, CSS class, column header and POD reference across the DB, Text and Html_crisp reporters.
- Rename `docs/technical/slop.md` to `scar.md` and update the naming rationale and acronym expansion.
- Update the affected internal tests and the 188 golden report files.
- Drop the Html_crisp sort-column migration for the intermediate `crap` and `slop` names, since neither was ever released.

## Issue

Closes #490