### PR TITLE
GH-492 Colour the SCAR metric by its own value

### DIFF
--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -168,7 +168,8 @@ sub scar_cell ($f, $link = undef) {
   my $scar  = $f->{file_scar};
   my $na    = is_na($scar);
   my $dv    = $na   ? -1   : $scar;
-  my $cls   = $na   ? "na" : "tip-hover";
+  my $sc    = $na   ? "na" : "scar-" . scar_class($scar);
+  my $cls   = $na   ? "na" : "scar-val $sc tip-hover";
   my $value = $link ? qq(<a class="cell-link" href="$link">$scar</a>) : $scar;
 
   <<HTML
@@ -184,7 +185,7 @@ sub render_worst_files ($worst) {
   my $o = qq(<div class="worst-files">\n<h2>Top SCAR</h2>\n);
   for my $f (@$worst) {
     next if _numeric_scar($f) == 0;
-    my $cls = $f->{uncompiled} ? "untested-worst" : $f->{total}{class};
+    my $cls = "scar-" . scar_class($f->{file_scar});
     my $name
       = $f->{exists} ? qq(<a href="$f->{link}">$f->{short}</a>) : $f->{short};
     my $badge = $f->{uncompiled} ? untested_badge() . "\n" : "";
@@ -277,11 +278,12 @@ HTML
   my $ms = $R{db}->summary("Total", "scar");
   if ($ms && defined $ms->{module_scar}) {
     my $sv  = sprintf "%.1f", $ms->{module_scar};
+    my $sc  = "scar-" . scar_class($ms->{module_scar});
     my $tip = sprintf "CC %d &middot; cov %.0f%% &middot; CRAP %.1f",
       $ms->{module_cc}, $ms->{module_cov}, $ms->{module_crap};
     $o .= <<HTML;
 <span class="stat-badge stat-scar tip-hover">
-<span class="badge-label">scar $sv</span>
+<span class="badge-label">scar <span class="$sc">$sv</span></span>
 @{[ glass_tip($tip) ]}</span>
 HTML
   }
@@ -645,10 +647,13 @@ HTML
 HTML
   }
   my $sl     = $fd->{file_scar};
-  my $sl_tip = is_na($sl) ? "" : scar_tip($fd);
+  my $sl_na  = is_na($sl);
+  my $sl_tip = $sl_na ? "" : scar_tip($fd);
+  my $sl_val
+    = $sl_na ? $sl : qq(<span class="scar-@{[ scar_class($sl) ]}">$sl</span>);
   $o .= <<HTML;
 <span class="stat-badge stat-scar tip-hover">
-SCAR $sl $sl_tip</span>
+SCAR $sl_val $sl_tip</span>
 HTML
 
   $o .= <<HTML;
@@ -1565,6 +1570,18 @@ overflowing. */
   text-decoration: none;
 }
 .file-table .cell-link:hover { opacity: 0.85; }
+
+/* SCAR colouring: coloured text/outline by risk, never a full fill */
+td.scar-val { font-weight: 600; }
+.scar-c0 { color: var(--tip-c0); }
+.scar-c1 { color: var(--tip-c1); }
+.scar-c2 { color: var(--tip-c2); }
+.scar-c3 { color: var(--tip-c3); }
+
+.worst-item.scar-c0 { border-color: var(--tip-c0); }
+.worst-item.scar-c1 { border-color: var(--tip-c1); }
+.worst-item.scar-c2 { border-color: var(--tip-c2); }
+.worst-item.scar-c3 { border-color: var(--tip-c3); }
 
 .file-table tr { transition: background 0.15s ease; }
 .file-table tr:hover { background: var(--bg-alt); }

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -178,6 +178,8 @@ sub test_glass_tooltips () {
   my $file_page = $Golden{$covered};
   like $file_page,   qr/stat-scar tip-hover/, "glass: SCAR badge has tip-hover";
   unlike $file_page, qr/scar-hover/,          "glass: no scar-hover class";
+  like $file_page, qr/SCAR <span class="scar-c[0-3]">/,
+    "file: SCAR badge number coloured by its own value";
 }
 
 sub test_dir_row_scar () {
@@ -190,6 +192,8 @@ sub test_module_scar_badge () {
   my $got = $Golden{"coverage.html"};
   like $got, qr/stat-badge.*?scar\b/s, "header: has SCAR stat badge";
   like $got, qr/scar.*?help-toggle/s,  "header: SCAR badge before help button";
+  like $got, qr/scar <span class="scar-c[0-3]">/,
+    "header: SCAR badge number coloured by its own value";
 }
 
 sub test_total_badge_filter () {
@@ -293,11 +297,53 @@ sub test_scar_cell_link () {
 
   my $no_link = Devel::Cover::Report::Html_crisp::scar_cell($f);
   unlike $no_link, qr/<a class="cell-link"/, "scar no link: no anchor";
+  like $no_link, qr/<td data-value="33\.4" class="scar-val scar-c2 tip-hover">/,
+    "scar cell coloured by its own value (33.4 -> scar-c2, text only)";
 
   my $with_link
     = Devel::Cover::Report::Html_crisp::scar_cell($f, "tests-foo.html");
   like $with_link, qr{<a class="cell-link" href="tests-foo\.html">33\.4</a>},
     "scar with link: anchor wraps scar value (no filter hash)";
+}
+
+sub test_render_worst_files_colour () {
+  my $worst = [{
+    file_scar  => "50",
+    file_crap  => "60",
+    file_cc    => 10,
+    file_cov   => 95,
+    short      => "Hot/Spot.pm",
+    exists     => 0,
+    uncompiled => 0,
+    worst_subs => [],
+    total      => { class => "c3" },
+  }];
+
+  my $got = Devel::Cover::Report::Html_crisp::render_worst_files($worst);
+  like $got, qr/class="worst-item scar-c0"/,
+    "worst item outlined by scar value (50 -> scar-c0)";
+  unlike $got, qr/worst-item scar-c3/,
+    "worst item not coloured by total coverage";
+}
+
+sub test_render_worst_files_untested_colour () {
+  my $worst = [{
+    file_scar  => "37.4",
+    file_crap  => "40",
+    file_cc    => 8,
+    file_cov   => 0,
+    short      => "Uncovered/Full.pm",
+    exists     => 0,
+    uncompiled => 1,
+    worst_subs => [],
+    total      => { class => "c0" },
+  }];
+
+  my $got = Devel::Cover::Report::Html_crisp::render_worst_files($worst);
+  like $got, qr/class="worst-item scar-c1"/,
+    "untested worst item outlined by scar value (37.4 -> scar-c1)";
+  unlike $got, qr/untested-worst/,
+    "untested worst item no longer greyed by untested state";
 }
 
 sub test_stat_badge_no_tip_when_empty () {
@@ -668,6 +714,8 @@ sub main () {
   test_cov_cell_tooltips;
   test_cov_cell_link;
   test_scar_cell_link;
+  test_render_worst_files_colour;
+  test_render_worst_files_untested_colour;
   test_stat_badge_no_tip_when_empty;
   test_index_filter_links;
   test_dir_header_links;


### PR DESCRIPTION
Fixes #492

## Summary

Colour the SCAR risk metric by its own value throughout the Html_crisp report, so problematic files are easier to pick out at a glance.

- The Top SCAR list previously took its colour from each file's total coverage, so a high-risk but well-covered file could appear reassuringly green. It is now coloured by the SCAR value, and untested files are no longer specially greyed so they match the rest.
- The SCAR table column and the SCAR summary badges (page header and file detail pages) were not colour-coded at all; they are now coloured by their own value.
- SCAR uses coloured text, with an outline for the Top SCAR chips, rather than the full background fill of the coverage cells. This keeps the table legible and reuses the existing coverage colour scale, so no new colours are introduced.