### PR TITLE
GH-496 Validate uncoverable mcdc pair markers

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1889,6 +1889,10 @@ in the order the report lists them), leaving the rest counted as normal:
   # uncoverable mcdc pair:2
   $x = $a || $b || $c;
 
+An invalid position warns and the marker is ignored: C<pair:0> when the
+comment is parsed, and a position greater than the number of atomic conditions
+in the decision when the report is generated.
+
 As for conditions, the "count" value selects between several decisions on one
 line.
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -889,13 +889,47 @@ sub delete_uncoverable ($self, $deletes) {
 sub clean_uncoverable ($self) {
 }
 
-sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
-  my $cr    = join "|", $self->{all_criteria}->@*;
-  my $uc    = qr/(.*)# uncoverable ($cr)(.*)/;  # regex for uncoverable comments
+sub _uncoverable_details ($criterion, $info, $file, $line) {
   my %types = (
     branch    => { true => 0, false => 1 },
     condition => { left => 0, right => 1, false => 2 },
   );
+  my ($count, $class, $note, $type) = (1, "default", "");
+
+  if ($criterion eq "branch" || $criterion eq "condition") {
+    if ($info =~ /^\s*(\w+)(?:\s|$)/) {
+      my $t = $1;
+      $type = $types{$criterion}{$t};
+      unless (defined $type) {
+        warn "Unknown type $t found parsing "
+          . "uncoverable $criterion at $file:$line\n";
+        $type = 999;  # partly magic number
+      }
+    }
+  }
+
+  # e.g.: count:1 | count:2,5 | count:1,4..7
+  my $c = qr/\d+(?:\.\.\d+)?/;
+  if ($info =~ /count:($c(?:,$c)*)/) { $count = $1 }
+  my @counts = map { m/^(\d+)\.\.(\d+)$/ ? ($1 .. $2) : $_ } split m/,/, $count;
+  if ($info =~ /class:(\w+)/) { $class = $1 }
+  if ($info =~ /note:(.+)/)   { $note  = $1 }
+  # mcdc atomic condition N (1-based)
+  if ($info =~ /pair:(\d+)/) {
+    if ($1) { $type = $1 - 1 }
+    else {
+      warn "Invalid pair:$1 (pairs are numbered from 1) parsing "
+        . "uncoverable $criterion at $file:$line\n";
+      return;
+    }
+  }
+
+  (\@counts, $type, $class, $note)
+}
+
+sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
+  my $cr = join "|", $self->{all_criteria}->@*;
+  my $uc = qr/(.*)# uncoverable ($cr)(.*)/;  # regex for uncoverable comments
 
   # Look for uncoverable comments
   open my $fh, "<", $file or do {
@@ -909,31 +943,10 @@ sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
     next unless /$uc/ || @waiting;
     if ($2) {
       my ($code, $criterion, $info) = ($1, $2, $3);
-      my ($count, $class, $note, $type) = (1, "default", "");
+      my ($counts, $type, $class, $note)
+        = _uncoverable_details($criterion, $info, $file, $.);
 
-      if ($criterion eq "branch" || $criterion eq "condition") {
-        if ($info =~ /^\s*(\w+)(?:\s|$)/) {
-          my $t = $1;
-          $type = $types{$criterion}{$t};
-          unless (defined $type) {
-            warn "Unknown type $t found parsing "
-              . "uncoverable $criterion at $file:$.\n";
-            $type = 999;  # partly magic number
-          }
-        }
-      }
-
-      # e.g.: count:1 | count:2,5 | count:1,4..7
-      my $c = qr/\d+(?:\.\.\d+)?/;
-      $count = $1 if $info =~ /count:($c(?:,$c)*)/;
-      my @counts = map { m/^(\d+)\.\.(\d+)$/ ? ($1 .. $2) : $_ } split m/,/,
-        $count;
-      if ($info =~ /class:(\w+)/) { $class = $1 }
-      if ($info =~ /note:(.+)/)   { $note  = $1 }
-      # mcdc atomic condition N (1-based)
-      if ($info =~ /pair:(\d+)/) { $type = $1 - 1 }
-
-      for my $c (@counts) {
+      for my $c (($counts // [])->@*) {
         # no warnings "uninitialized";
         # warn "pushing $criterion, $c - 1, $type, $class, $note";
         push @waiting, [$criterion, $c - 1, $type, $class, $note];
@@ -1038,7 +1051,7 @@ sub _derive_mcdc ($self, $cover, $uncoverable = {}) {
   require Devel::Cover::Condition_table;
   require Devel::Cover::Mcdc::Analyser;
 
-  for my $cf (values %$cover) {
+  while (my ($file, $cf) = each %$cover) {
     my $cc = $cf->{condition} or next;
     next if exists $cf->{mcdc};
 
@@ -1069,7 +1082,8 @@ sub _derive_mcdc ($self, $cover, $uncoverable = {}) {
         # The analyser's set is derived from the table's rows, so trust it only
         # for a proven table; for an unproven one the rows are the evidence we
         # distrust, leaving the explicit markers as the only excuse.
-        my @uncov = (_mcdc_uncoverable($unc, $line, $n, $total) // [])->@*;
+        my @uncov
+          = (_mcdc_uncoverable($unc, $file, $line, $n, $total) // [])->@*;
         $uncov[$_] ||= 1 for $table->proven ? keys $r->{uncoverable}->%* : ();
         $decision->[2] = \@uncov if @uncov;
 
@@ -1082,16 +1096,20 @@ sub _derive_mcdc ($self, $cover, $uncoverable = {}) {
 
 # Per-column uncoverable vector for one mcdc decision, or undef if unmarked. A
 # marker with a column marks that condition; one without marks every column.
-sub _mcdc_uncoverable ($unc, $line, $n, $total) {
+sub _mcdc_uncoverable ($unc, $file, $line, $n, $total) {
   my $marks = $unc && $unc->{$line}[$n] or return undef;
   my @uncov;
   for my $mark (@$marks) {
     my ($col, $class) = @$mark;
     my $flag = $class || 1;
-    if (defined $col) {
+    if (!defined $col) {
+      $uncov[$_] = $flag for 0 .. $total - 1;
+    } elsif ($col >= 0 && $col < $total) {
       $uncov[$col] = $flag;
     } else {
-      $uncov[$_] = $flag for 0 .. $total - 1;
+      warn "Ignoring uncoverable mcdc pair:"
+        . ($col + 1)
+        . " out of range (1..$total) at $file:$line\n";
     }
   }
   \@uncov

--- a/t/internal/uncoverable_mcdc_pair.t
+++ b/t/internal/uncoverable_mcdc_pair.t
@@ -1,0 +1,103 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# "# uncoverable mcdc pair:N" is 1-based.  pair:0 and columns past the
+# decision's width must warn and be ignored, never abort the report (GH-496).
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is is_deeply like ok )];
+
+use Devel::Cover::DB ();
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+
+sub parse_comments ($source) {
+  my $path = File::Spec->catfile($Tmpdir, "source.pl");
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $source;
+  close $fh or die "Cannot close $path: $!";
+
+  my $unc = {};
+  my @warnings;
+  local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+  Devel::Cover::DB->new->uncoverable_comments($unc, $path, "digest");
+  ($unc, \@warnings, $path)
+}
+
+sub test_pair_zero_is_rejected () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my ($a, $b) = (1, 1);
+# uncoverable mcdc pair:0
+my $r = $a && $b;
+PERL
+  is @$warnings, 1, "pair:0: one warning";
+  like $warnings->[0], qr/\bpair:0\b/,  "pair:0: warning names the marker";
+  like $warnings->[0], qr/\Q$path\E:2/, "pair:0: warning gives file:line";
+  ok !exists $unc->{digest}{mcdc}, "pair:0: marker is ignored";
+}
+
+sub test_pair_one_is_recorded () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $always = 1;
+# uncoverable mcdc pair:1
+my $r = $always && $b;
+PERL
+  is @$warnings, 0, "pair:1: no warnings";
+  is_deeply $unc->{digest}{mcdc}{3}, [[[0, "default", ""]]],
+    "pair:1: column 0 marked";
+}
+
+sub mcdc_uncoverable ($marks, $total) {
+  my @warnings;
+  local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+  my $uncov = do {
+
+    package Devel::Cover::DB;
+    _mcdc_uncoverable({ 7 => [$marks] }, "source.pl", 7, 0, $total)
+  };
+  ($uncov, \@warnings)
+}
+
+sub test_out_of_range_column_warns () {
+  my ($uncov, $warnings) = mcdc_uncoverable([[5, "default", ""]], 2);
+  is @$warnings, 1, "pair:6: one warning";
+  like $warnings->[0], qr/\bpair:6\b/,   "pair:6: warning names the marker";
+  like $warnings->[0], qr/source\.pl:7/, "pair:6: warning gives file:line";
+  ok !(grep defined, @$uncov), "pair:6: no column marked";
+}
+
+sub test_negative_column_warns () {
+  my ($uncov, $warnings) = mcdc_uncoverable([[-1, "default", ""]], 2);
+  is @$warnings, 1, "negative column: one warning";
+  ok !(grep defined, @$uncov), "negative column: no column marked";
+}
+
+sub test_bare_marker_marks_all_columns () {
+  my ($uncov, $warnings) = mcdc_uncoverable([[undef, "default", ""]], 2);
+  is @$warnings, 0, "bare marker: no warnings";
+  is_deeply $uncov, ["default", "default"], "bare marker: every column marked";
+}
+
+test_pair_zero_is_rejected;
+test_pair_one_is_recorded;
+test_out_of_range_column_warns;
+test_negative_column_warns;
+test_bare_marker_marks_all_columns;
+
+done_testing;


### PR DESCRIPTION
## Summary

A `# uncoverable mcdc pair:0` comment aborted the entire cover run with a fatal negative array subscript, and a column past the decision's width was silently ignored. Both are user typos in a documented 1-based marker, and a malformed comment should never abort reporting. Bad markers now warn with the file and line, are skipped, and the report generates as normal.

## Changes

- Reject `pair:0` when parsing uncoverable comments, with a warning naming the marker and its location.
- Warn and skip out-of-range or negative columns when deriving MC/DC, which also protects markers arriving via a `.uncoverable` file.
- Extract marker attribute parsing into `_uncoverable_details` to keep `uncoverable_comments` within perlcritic's complexity limit.
- Add `t/internal/uncoverable_mcdc_pair.t` covering rejection, range checks, and the valid-marker paths.
- Document the 1-based numbering and the new warnings in the `Devel::Cover` POD.

## Ticket

Closes #496