### PR TITLE
GH-498 Record one MC/DC vector per evaluation

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -122,11 +122,20 @@ typedef struct {
  * 1 (true) or 2 (X / not yet observed) for column i.  Slots start as X and
  * are filled in as leaves resolve; columns under a short-circuited subtree
  * stay X.
+ *
+ * cx_ix is cxstack_ix at push time.  A non-local exit (die, goto, last)
+ * out of a decision leaves its frame on the stack; such a frame is
+ * detected as stale because its cx_ix is deeper than the current context,
+ * and is discarded rather than recorded - an abandoned evaluation must
+ * record nothing.  cx_ix also separates recursive invocations of the same
+ * decision: an outer invocation's frame has a shallower cx_ix and so is
+ * kept when the inner invocation pushes its own frame.
  */
 typedef struct {
   OP   *root_addr;
   int   width;
   int  *vector;
+  I32   cx_ix;
 } dc_dctx;
 
 typedef struct {
@@ -950,6 +959,7 @@ static IV       dc_meta_iv(pTHX_ HV *meta, const char *key, I32 keylen);
 static dc_dctx *dc_stack_find_root(pTHX_ OP *root_addr);
 static dc_dctx *dc_stack_top(pTHX);
 static void     dc_stack_pop(pTHX);
+static void     dc_stack_discard_stale(pTHX);
 static void     dc_snapshot(pTHX_ dc_dctx *d);
 
 static void add_condition(pTHX_ SV *cond_ref, int value) {
@@ -991,7 +1001,9 @@ static void add_condition(pTHX_ SV *cond_ref, int value) {
      * value: 1 = right false, 2 = right true, 3/4 = xor-with-true-left.
      */
     if (!final && collecting(Mcdc)) {
-      HV *m = dc_lookup_or_build_decision_meta(aTHX_ op, find_runcv(NULL));
+      HV *m;
+      dc_stack_discard_stale(aTHX);
+      m = dc_lookup_or_build_decision_meta(aTHX_ op, find_runcv(NULL));
       if (m) {
         OP      *root_addr =
           INT2PTR(OP *, dc_meta_iv(aTHX_ m, "root_addr", 9));
@@ -1214,11 +1226,52 @@ static void cover_cond(pTHX)
  * Resolve conditions deferred from sort blocks.  The stack top holds the sort
  * comparator's final value - the right operand of the outermost || whose
  * right->op_next was NULL.
+ *
+ * MC/DC resolution mirrors add_condition: write each deferred logop's
+ * right-operand leaf column, then snapshot and pop the decision roots.
+ * This runs once per comparator invocation (each comparison runs in its
+ * own runops loop), so each invocation records its own vector.
  */
 static void resolve_deferred_conditionals(pTHX_ AV *dc, I32 base) {
+  dMY_CXT;
   if (av_len(dc) >= base) {
     dSP;
     int true_ish = SvTRUE(TOPs);
+
+    if (collecting(Mcdc)) {
+      I32 i;
+      dc_stack_discard_stale(aTHX);
+
+      for (i = base; i <= av_len(dc); i++) {
+        OP *op = INT2PTR(OP *, SvIV(*av_fetch(dc, i, 0)));
+        HV *m  = dc_lookup_or_build_decision_meta(aTHX_ op, find_runcv(NULL));
+        if (m) {
+          OP      *root_addr  =
+            INT2PTR(OP *, dc_meta_iv(aTHX_ m, "root_addr", 9));
+          int      leaf_right = dc_meta_iv(aTHX_ m, "leaf_col_right", 14);
+          dc_dctx *d          = dc_stack_find_root(aTHX_ root_addr);
+
+          if (d && leaf_right >= 0 && leaf_right < d->width)
+            d->vector[leaf_right] = true_ish ? DC_VECTOR_TRUE
+                                             : DC_VECTOR_FALSE;
+        }
+      }
+
+      for (i = base; i <= av_len(dc); i++) {
+        OP *op = INT2PTR(OP *, SvIV(*av_fetch(dc, i, 0)));
+        HV *m  = dc_lookup_or_build_decision_meta(aTHX_ op, find_runcv(NULL));
+        if (m && dc_meta_iv(aTHX_ m, "is_root", 7) == 1) {
+          OP *root_addr =
+            INT2PTR(OP *, dc_meta_iv(aTHX_ m, "root_addr", 9));
+          dc_dctx *d = dc_stack_find_root(aTHX_ root_addr);
+          if (d) {
+            dc_snapshot(aTHX_ d);
+            if (dc_stack_top(aTHX) == d) dc_stack_pop(aTHX);
+          }
+        }
+      }
+    }
+
     while (av_len(dc) >= base) {
       SV *sv = av_pop(dc);
       OP *cond_op = INT2PTR(OP *, SvIV(sv));
@@ -1501,7 +1554,21 @@ static void dc_walk_cv_decisions(pTHX_ CV *cv) {
     if (is_root) {
       int width = dc_enumerate_columns(aTHX_ cache, lop, lop, 0);
       HV *meta  = dc_meta_entry(aTHX_ cache, lop);
+      OP *entry = lop,
+         *left;
       (void)hv_stores(meta, "width", newSViv(width));
+
+      /*
+       * Mark the decision's entry logop: the deepest logop on the left
+       * operand chain, and so the first logop to fire on every evaluation
+       * of the decision.  Its firing marks the start of a fresh
+       * evaluation, which always gets a fresh DC frame.
+       */
+      while ((left = dc_skipped_operand(aTHX_ entry, 0))
+             && dc_is_logop_type(left->op_type))
+        entry = left;
+      (void)hv_stores(dc_meta_entry(aTHX_ cache, entry), "is_entry",
+                      newSViv(1));
     }
   }
 
@@ -1574,6 +1641,13 @@ static HV *dc_lookup_or_build_decision_meta(pTHX_ OP *op, CV *cv) {
  * the same DC, and the outer root pops on resolution.  Sub-calls inside a
  * decision push their own decisions on top because their root_addr differs;
  * those decisions resolve before control returns to the outer.
+ *
+ * Non-local exits break that discipline: a frame whose evaluation was
+ * abandoned stays on the stack.  Every entry point into the stack first
+ * discards stale frames (cx_ix deeper than the current context), and a
+ * decision's entry logop - the first logop to fire on every evaluation -
+ * always pushes a fresh frame, removing any leftover frame for the same
+ * root at the same or deeper context depth.
  */
 static IV dc_meta_iv(pTHX_ HV *meta, const char *key, I32 keylen) {
   SV **slot = hv_fetch(meta, key, keylen, 0);
@@ -1610,6 +1684,7 @@ static dc_dctx *dc_stack_push(pTHX_ OP *root_addr, int width) {
   d = &MY_CXT.dc_stack.items[MY_CXT.dc_stack.count++];
   d->root_addr = root_addr;
   d->width     = width;
+  d->cx_ix     = cxstack_ix;
   Newx(d->vector, width > 0 ? width : 1, int);
   for (i = 0; i < width; i++) d->vector[i] = DC_VECTOR_X;
   return d;
@@ -1622,6 +1697,31 @@ static void dc_stack_pop(pTHX) {
     Safefree(MY_CXT.dc_stack.items[MY_CXT.dc_stack.count].vector);
     MY_CXT.dc_stack.items[MY_CXT.dc_stack.count].vector = NULL;
   }
+}
+
+/* Remove a frame from anywhere in the stack, closing the gap. */
+static void dc_stack_remove(pTHX_ dc_dctx *d) {
+  dMY_CXT;
+  int idx = (int)(d - MY_CXT.dc_stack.items);
+  if (idx < 0 || idx >= MY_CXT.dc_stack.count) return;
+  Safefree(d->vector);
+  Move(&MY_CXT.dc_stack.items[idx + 1], &MY_CXT.dc_stack.items[idx],
+       MY_CXT.dc_stack.count - idx - 1, dc_dctx);
+  MY_CXT.dc_stack.count--;
+}
+
+/*
+ * Discard frames abandoned by a non-local exit: any frame pushed in a
+ * context deeper than the current one belongs to an evaluation that no
+ * longer exists.  Such frames always form the top of the stack at the
+ * moment they become detectable, so popping from the top suffices.
+ */
+static void dc_stack_discard_stale(pTHX) {
+  dMY_CXT;
+  while (MY_CXT.dc_stack.count
+         && MY_CXT.dc_stack.items[MY_CXT.dc_stack.count - 1].cx_ix
+            > cxstack_ix)
+    dc_stack_pop(aTHX);
 }
 
 /*
@@ -1692,6 +1792,8 @@ static void dc_snapshot_on_short_circuit(pTHX) {
   root_addr = INT2PTR(OP *, dc_meta_iv(aTHX_ meta, "root_addr", 9));
   cur       = PL_op;
 
+  dc_stack_discard_stale(aTHX);
+
   while (cur) {
     if (cur == root_addr) {
       dc_dctx *top = dc_stack_top(aTHX);
@@ -1713,16 +1815,15 @@ static void dc_snapshot_on_short_circuit(pTHX) {
 }
 
 /*
- * Drain any DCs left over at program end (early return / die / exit out of
- * a decision).  Each is snapshotted in its current partial state so the
- * observation is not lost.
+ * Discard any DCs left over at program end.  A frame still on the stack
+ * here belongs to an evaluation that never completed (die / exit / goto
+ * out of a decision); recording its partial vector would fabricate an
+ * observation no execution produced.
  */
 static void finalise_decisions(pTHX) {
   dMY_CXT;
-  while (MY_CXT.dc_stack.count) {
-    dc_snapshot(aTHX_ &MY_CXT.dc_stack.items[MY_CXT.dc_stack.count - 1]);
+  while (MY_CXT.dc_stack.count)
     dc_stack_pop(aTHX);
-  }
 }
 
 static void cover_logop(pTHX) {
@@ -1797,10 +1898,25 @@ static void cover_logop(pTHX) {
           INT2PTR(OP *, dc_meta_iv(aTHX_ meta, "root_addr", 9));
         int      width     = dc_meta_iv(aTHX_ meta, "width",         5);
         int      leaf_left = dc_meta_iv(aTHX_ meta, "leaf_col_left", 13);
-        dc_dctx *d         = dc_stack_find_root(aTHX_ root_addr);
+        int      is_entry  = dc_meta_iv(aTHX_ meta, "is_entry",      8) == 1;
+        dc_dctx *d;
 
-        if (!d && width > 0)
+        dc_stack_discard_stale(aTHX);
+        d = dc_stack_find_root(aTHX_ root_addr);
+
+        if (is_entry && width > 0) {
+          /*
+           * A fresh evaluation of this decision starts here.  A leftover
+           * frame at the same or deeper context depth was abandoned by a
+           * non-local exit - discard it.  A shallower frame belongs to an
+           * outer invocation still in flight (recursion) and is kept; the
+           * fresh frame shadows it until resolution.
+           */
+          if (d && d->cx_ix >= cxstack_ix) dc_stack_remove(aTHX_ d);
           d = dc_stack_push(aTHX_ root_addr, width);
+        } else if (!d && width > 0) {
+          d = dc_stack_push(aTHX_ root_addr, width);
+        }
 
         if (d && leaf_left >= 0 && leaf_left < d->width)
           d->vector[leaf_left] = leftval_true_ish ? DC_VECTOR_TRUE

--- a/docs/technical/mcdc.md
+++ b/docs/technical/mcdc.md
@@ -303,14 +303,22 @@ buggy implementation as MC/DC-satisfied.
 
 Audit-grade MC/DC therefore needs per-execution combined-input data. `Cover.xs`
 records each decision's input vector at runtime: a small stack
-(`MY_CXT.decision_inputs`) tracks the active decision; `cover_logop` and
+(`MY_CXT.dc_stack`) tracks the decisions in flight; `cover_logop` and
 `add_condition` write each leaf's observed truth value into the current vector,
-and snapshot it on short-circuit-at-root or on the same-type chain reaching the
-root. Column metadata (which logop is a decision root, which leaf maps to which
-column index) is computed lazily on first encounter of each CV by walking the
-optree from `CvROOT`. The walk uses `op_first` / `OpSIBLING` chains rather than
-`op_sibparent` to preserve the 5.20 minimum (`op_sibparent` requires
-`PERL_OP_PARENT`, added in 5.22 and made default in 5.26).
+and snapshot it into `MY_CXT.decision_inputs` on short-circuit-at-root, on the
+same-type chain reaching the root, or - for decisions ending a sort comparator -
+per invocation from `resolve_deferred_conditionals`. Each evaluation of a
+decision gets its own frame: the decision's entry logop (the first to fire on
+every evaluation) always pushes a fresh one, so recursive invocations record
+separately. Frames record `cxstack_ix` at push; a frame abandoned by a
+non-local exit (`die`, `goto`, `last`) is detected by its now-too-deep context
+depth and discarded without recording - an abandoned evaluation must record
+nothing, since a partial vector would fabricate an observation no execution
+produced. Column metadata (which logop is a decision root, which leaf
+maps to which column index) is computed lazily on first encounter of each CV by
+walking the optree from `CvROOT`. The walk uses `op_first` / `OpSIBLING` chains
+rather than `op_sibparent` to preserve the 5.20 minimum (`op_sibparent`
+requires `PERL_OP_PARENT`, added in 5.22 and made default in 5.26).
 
 `Condition_table::for_line` accepts an optional parallel array of
 observed-vector hashes; when present, each synthesised row is marked `covered=1`

--- a/t/internal/decision_inputs.t
+++ b/t/internal/decision_inputs.t
@@ -210,6 +210,92 @@ sub test_unproven_ignores_derived_uncoverable () {
     "every atomic of an unproven table is reported missing";
 }
 
+# The recorder must record one accurate vector per completed evaluation
+# and nothing for abandoned ones.  A die out of a decision abandons its
+# frame; the next execution must not inherit the aborted execution's
+# column values.
+sub test_die_discards_abandoned_evaluation () {
+  my $script = write_script("die_mid_decision.pl", <<'PERL');
+sub f { die "boom" }
+sub d { my ($a, $b) = @_; my $r = ($a && $b && f()) ? 1 : 0; $r }
+eval { d(1, 1) };
+d(0, 1);
+PERL
+
+  my ($db, $path) = run_under_cover($script, "die_mid_decision");
+  my $di = decision_inputs_for($db, $path);
+  ok $di, "decision_inputs present for die_mid_decision";
+
+  my @recorded = grep defined, @$di;
+  is @recorded, 1, "one decision recorded";
+  is_deeply $recorded[0], { "0|X|X" => 1 },
+    "aborted evaluation records nothing; completed one is not contaminated";
+}
+
+# Recursion through the same decision must record one vector per
+# invocation, not merge the inner invocation into the outer's frame.
+sub test_recursion_records_each_invocation () {
+  my $script = write_script("recursive_decision.pl", <<'PERL');
+sub r { my ($n) = @_; my $v = ($n <= 0) || r($n - 1); $v }
+my $x = r(1);
+PERL
+
+  my ($db, $path) = run_under_cover($script, "recursive_decision");
+  my $di = decision_inputs_for($db, $path);
+  ok $di, "decision_inputs present for recursive_decision";
+
+  my @recorded = grep defined, @$di;
+  is @recorded, 1, "one decision recorded";
+  is_deeply $recorded[0], { "0|1" => 1, "1|X" => 1 },
+    "outer and inner invocations each record their own vector";
+}
+
+# A decision resolving while an abandoned inner frame is still on the
+# stack must be counted once, and the abandoned frame must record
+# nothing.
+sub test_abandoned_inner_frame_not_double_counted () {
+  my $script = write_script("abandoned_inner.pl", <<'PERL');
+sub f { die "x" }
+sub d { my ($a, $b) = @_; my $r = $a || eval { my $v = $b && f(); $v }; $r }
+d(0, 1);
+PERL
+
+  my ($db, $path) = run_under_cover($script, "abandoned_inner");
+  my $di = decision_inputs_for($db, $path);
+  ok $di, "decision_inputs present for abandoned_inner";
+
+  my @recorded = grep defined, @$di;
+  is @recorded, 1, "only the completed outer decision is recorded";
+  is_deeply $recorded[0], { "0|0" => 1 }, "outer vector counted exactly once";
+}
+
+# A decision ending a sort comparator resolves via the deferred path;
+# each comparator invocation must record its own vector rather than
+# blending values across invocations.  The ternary keeps the || classified
+# as a condition rather than a statement-level branch.
+sub test_sort_block_records_per_invocation () {
+  my $script = write_script("sort_block.pl", <<'PERL');
+my $numeric = 1;
+sub srt {
+  my @l = @_;
+  my @s = sort { $numeric ? ($a <=> $b) || ($a cmp $b) : 0 } @l;
+  @s
+}
+srt(1, 1);
+srt(1, 1);
+srt(2, 1);
+PERL
+
+  my ($db, $path) = run_under_cover($script, "sort_block");
+  my $di = decision_inputs_for($db, $path);
+  ok $di, "decision_inputs present for sort_block";
+
+  my @recorded = grep defined, @$di;
+  is @recorded, 1, "one decision recorded";
+  is_deeply $recorded[0], { "0|0" => 2, "1|X" => 1 },
+    "each comparator invocation records its own vector";
+}
+
 sub test_add_condition_cross_run_merge () {
   my $db = bless {}, "Devel::Cover::DB";
   my $cc = {};
@@ -248,6 +334,14 @@ sub main () {
     \&test_void_compound_no_false_coverage;
   subtest "unproven ignores derived uncoverable" =>
     \&test_unproven_ignores_derived_uncoverable;
+  subtest "die discards abandoned evaluation" =>
+    \&test_die_discards_abandoned_evaluation;
+  subtest "recursion records each invocation" =>
+    \&test_recursion_records_each_invocation;
+  subtest "abandoned inner frame not double counted" =>
+    \&test_abandoned_inner_frame_not_double_counted;
+  subtest "sort block records per invocation" =>
+    \&test_sort_block_records_per_invocation;
   subtest "cross-run merge"     => \&test_add_condition_cross_run_merge;
   subtest "xor four-slot merge" => \&test_add_condition_xor_four_slot_merge;
 

--- a/test_output/cover/mcdc_nonlocal.5.020000
+++ b/test_output/cover/mcdc_nonlocal.5.020000
@@ -1,0 +1,153 @@
+cover: Reading database from ...
+------------------- ------ ------ ------ ------ ------ ------ ------
+File                  stmt   bran   cond   mcdc    sub  total   scar
+------------------- ------ ------ ------ ------ ------ ------ ------
+tests/mcdc_nonlocal  100.0   50.0   66.6   14.2  100.0   78.9   19.6
+Total                100.0   50.0   66.6   14.2  100.0   78.9   19.6
+------------------- ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/mcdc_nonlocal
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 7 86.0  7.1 19.6
+
+Worst Subroutines
+-----------------
+
+Subroutine        CC SCAR  Location              
+----------------- -- ----  ----------------------
+dies_mid_decision  4 14.6  tests/mcdc_nonlocal:23
+sorted             3 11.3  tests/mcdc_nonlocal:42
+recurse            2  7.0  tests/mcdc_nonlocal:31
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10                                             # Non-local exits, recursion and sort blocks through the MC/DC recorder.
+11                                             # Each decision must record one accurate input vector per completed
+12                                             # evaluation and nothing for abandoned ones.
+13                                             
+14             1                           1   use strict;
+               1                               
+               1                               
+15             1                           1   use warnings;
+               1                               
+               1                               
+16                                             
+17             1                           1   sub boom { die "boom\n" }
+18                                             
+19                                             # A die out of the right operand abandons the evaluation; the following
+20                                             # short-circuiting call must record its own honest vector, not one
+21                                             # contaminated by the aborted evaluation's column values.
+22                                             sub dies_mid_decision {
+23             2                           2     my ($p, $q) = @_;
+24    ***      2   * 50   * 66   *  0            my $r = ($p && $q && boom()) ? 1 : 0;
+      ***                 * 66                 
+25             1                                 $r
+26                                             }
+27                                             
+28                                             # Recursion through the same decision: the outer and inner invocations
+29                                             # must each record their own vector.
+30                                             sub recurse {
+31             2                           2     my ($n) = @_;
+32    ***      2          * 66   *  0            my $v = ($n <= 0) || recurse($n - 1);
+33             2                                 $v
+34                                             }
+35                                             
+36                                             # A decision ending a sort comparator resolves via the deferred path once
+37                                             # per comparator invocation.  The ternary keeps the || classified as a
+38                                             # condition rather than a statement-level branch.
+39             1                               my $Numeric = 1;
+40                                             
+41                                             sub sorted {
+42             3                           3     my @l = @_;
+43    ***      3   * 50   * 66   * 50            my @s = sort { $Numeric ? ($a <=> $b) || ($a cmp $b) : 0 } @l;
+               3                               
+44                                               @s
+45             3                               }
+46                                             
+47                                             sub main {
+48             1                           1     eval { dies_mid_decision(1, 1) };
+               1                               
+49             1                                 dies_mid_decision(0, 1);
+50                                             
+51             1                                 my $x = recurse(1);
+52                                             
+53             1                                 my @r;
+54             1                                 push @r, sorted(1, 1);
+55             1                                 push @r, sorted(1, 1);
+56             1                                 push @r, sorted(2, 1);
+57                                             }
+58                                             
+59             1                               main();
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+24    ***     50      0      1   $p && $q && boom() ? :
+43    ***     50      3      0   $Numeric ? :
+
+
+Conditions
+----------
+
+and 3 conditions
+
+line  err      %     !l  l&&!r   l&&r   expr
+----- --- ------ ------ ------ ------   ----
+24    ***     66      1      1      0   $p and $q and boom()
+      ***     66      1      0      1   $p and $q
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+32    ***     66      1      1      0   $n <= 0 || recurse($n - 1)
+43    ***     66      1      0      2   $a <=> $b or $a cmp $b
+
+
+MC/DC
+-----
+
+line  err      %  cov  tot   missing                expr
+----- --- ------ ---- ----   --------------------   ----
+24    ***      0    0    3   $p, $q, boom()         $p and $q and boom()
+32    ***      0    0    2   $n <= 0, recurse($n - 1)   $n <= 0 || recurse($n - 1)
+43    ***     50    1    2   $a cmp $b              $a <=> $b or $a cmp $b
+
+
+Covered Subroutines
+-------------------
+
+Subroutine        Count  CC  SCAR Location              
+----------------- ----- --- ----- ----------------------
+BEGIN                 1   1   0.0 tests/mcdc_nonlocal:14
+BEGIN                 1   1   0.0 tests/mcdc_nonlocal:15
+boom                  1   1   0.0 tests/mcdc_nonlocal:17
+dies_mid_decision     2   4  14.6 tests/mcdc_nonlocal:23
+main                  1   1   0.0 tests/mcdc_nonlocal:48
+recurse               2   2   7.0 tests/mcdc_nonlocal:31
+sorted                3   3  11.3 tests/mcdc_nonlocal:42
+
+

--- a/tests/mcdc_nonlocal
+++ b/tests/mcdc_nonlocal
@@ -1,0 +1,59 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Non-local exits, recursion and sort blocks through the MC/DC recorder.
+# Each decision must record one accurate input vector per completed
+# evaluation and nothing for abandoned ones.
+
+use strict;
+use warnings;
+
+sub boom { die "boom\n" }
+
+# A die out of the right operand abandons the evaluation; the following
+# short-circuiting call must record its own honest vector, not one
+# contaminated by the aborted evaluation's column values.
+sub dies_mid_decision {
+  my ($p, $q) = @_;
+  my $r = ($p && $q && boom()) ? 1 : 0;
+  $r
+}
+
+# Recursion through the same decision: the outer and inner invocations
+# must each record their own vector.
+sub recurse {
+  my ($n) = @_;
+  my $v = ($n <= 0) || recurse($n - 1);
+  $v
+}
+
+# A decision ending a sort comparator resolves via the deferred path once
+# per comparator invocation.  The ternary keeps the || classified as a
+# condition rather than a statement-level branch.
+my $Numeric = 1;
+
+sub sorted {
+  my @l = @_;
+  my @s = sort { $Numeric ? ($a <=> $b) || ($a cmp $b) : 0 } @l;
+  @s
+}
+
+sub main {
+  eval { dies_mid_decision(1, 1) };
+  dies_mid_decision(0, 1);
+
+  my $x = recurse(1);
+
+  my @r;
+  push @r, sorted(1, 1);
+  push @r, sorted(1, 1);
+  push @r, sorted(2, 1);
+}
+
+main();


### PR DESCRIPTION
## Summary

The MC/DC input-vector recorder lost or corrupted observations when an evaluation did not run to completion in the normal way: a `die` (or `goto`/`last`) out of a decision left a stale frame that contaminated the next execution's vector, recursion through the same decision merged invocations into one frame, a decision resolving under a stranded frame was counted twice, and decisions ending a sort comparator blended all comparator invocations into a single vector. The recorder now records one accurate vector per completed evaluation and nothing for abandoned ones.

## Changes

- Decision frames record the context stack depth at push; frames abandoned by a non-local exit are detected by their now-too-deep depth and discarded instead of recorded.
- A decision's entry logop (the first to fire on every evaluation) always pushes a fresh frame, so recursive invocations record separately.
- The deferred-conditionals path now snapshots and pops sort-block decisions once per comparator invocation.
- Frames left over at the end of the run are discarded rather than snapshotted, since a partial vector would fabricate an observation no execution produced.
- Internal tests cover all four cases, and a new end-to-end fixture (`tests/mcdc_nonlocal`) covers them through report generation.

## Ticket

Closes #498