### PR TITLE
GH-500 Record cascaded short-circuits in chains

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -1771,6 +1771,17 @@ static void dc_snapshot(pTHX_ dc_dctx *d) {
 }
 
 /*
+ * Nulled ops are not executed but may sit in an op_next chain (e.g. the
+ * nulled tree root of an element access); step to the op that actually
+ * runs.
+ */
+static OP *skip_nulled_ops(OP *o) {
+  while (o && (o->op_type == OP_NULL || o->op_type == OP_LINESEQ))
+    o = o->op_next;
+  return o;
+}
+
+/*
  * Snapshot+pop the active DC if PL_op's short-circuit completes the
  * decision.  SC at PL_op completes the decision when PL_op is the
  * decision root, OR when SC propagates up a same-type chain of logops
@@ -1807,7 +1818,7 @@ static void dc_snapshot_on_short_circuit(pTHX) {
       OP *sib = OpSIBLING(cLOGOPx(cur)->op_first);
       OP *up;
       if (!sib) return;
-      up = sib->op_next;
+      up = skip_nulled_ops(sib->op_next);
       if (!up || up->op_type != PL_op->op_type) return;
       cur = up;
     }
@@ -2035,7 +2046,7 @@ static void cover_logop(pTHX) {
       }
     } else {
       /* short circuit */
-      OP *up = OpSIBLING(cLOGOP->op_first)->op_next;
+      OP *up = skip_nulled_ops(OpSIBLING(cLOGOP->op_first)->op_next);
       OP *skipped;
 
       while (up && up->op_type == PL_op->op_type) {
@@ -2043,9 +2054,7 @@ static void cover_logop(pTHX) {
                up, PL_op_name[up->op_type], up->op_next,
                PL_op, PL_op_name[PL_op->op_type], PL_op->op_next));
         add_conditional(aTHX_ up, 3);
-        if (up->op_next == PL_op->op_next)
-          break;
-        up = OpSIBLING(cLOGOPx(up)->op_first)->op_next;
+        up = skip_nulled_ops(OpSIBLING(cLOGOPx(up)->op_first)->op_next);
       }
       add_conditional(aTHX_ PL_op, 3);
 

--- a/docs/technical/mcdc.md
+++ b/docs/technical/mcdc.md
@@ -307,7 +307,10 @@ records each decision's input vector at runtime: a small stack
 `add_condition` write each leaf's observed truth value into the current vector,
 and snapshot it into `MY_CXT.decision_inputs` on short-circuit-at-root, on the
 same-type chain reaching the root, or - for decisions ending a sort comparator -
-per invocation from `resolve_deferred_conditionals`. Each evaluation of a
+per invocation from `resolve_deferred_conditionals`. The chain walk follows
+each right operand's `op_next`, stepping through nulled ops (the tree roots of
+element accesses, which are not executed but whose `op_next` still leads on) to
+reach the enclosing logop. Each evaluation of a
 decision gets its own frame: the decision's entry logop (the first to fire on
 every evaluation) always pushes a fresh one, so recursive invocations record
 separately. Frames record `cxstack_ix` at push; a frame abandoned by a

--- a/t/internal/condition_chain.t
+++ b/t/internal/condition_chain.t
@@ -1,0 +1,123 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# A short-circuit that resolves a chain of same-type logops takes one
+# jump: Perl points the op_next of chained logops past their parents,
+# so the outer logops never execute.  The recorder climbs the chain to
+# mark each skipped logop as short-circuited.  The climb must survive
+# nulled right operands (element accesses) and chains of more than two
+# logops.
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( abs_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is is_deeply ok subtest )];
+
+use Devel::Cover::DB ();
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+
+sub write_script ($name, $content) {
+  my $path = File::Spec->catfile($Tmpdir, $name);
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $content;
+  close $fh or die "Cannot close $path: $!";
+  $path
+}
+
+sub run_under_cover ($script, $label) {
+  my $cover_db   = File::Spec->catdir($Tmpdir, "cover_db_$label");
+  my $abs_tmpdir = abs_path($Tmpdir);
+  my @cmd        = (
+    $^X,
+    "-Iblib/lib",
+    "-Iblib/arch",
+    "-MDevel::Cover=-db,$cover_db,-silent,1,"
+      . "-coverage,condition,+select,$abs_tmpdir",
+    $script,
+  );
+  system(@cmd) == 0 or die "Failed to run script under Devel::Cover: @cmd";
+
+  my $db = Devel::Cover::DB->new(db => $cover_db);
+  $db->merge_runs;
+  ($db->cover, abs_path($script))
+}
+
+# Condition hit counts for a line, outermost record first.  Records come
+# back in outermost-first order but the text is the stable identity, so
+# sort by text length: an outer record's text contains its inner ones.
+sub values_for ($cover, $file, $line) {
+  my $cond = $cover->file($file)->criterion("condition") or return [];
+  my @recs
+    = sort { length $b->{text} <=> length $a->{text} }
+    map +{ text => $_->text, values => [$_->values] },
+    ($cond->location($line) // [])->@*;
+  [map $_->{values}, @recs]
+}
+
+# decide(1, 0, 0, 0) short-circuits at the innermost logop; the jump
+# skips both outer logops, which must each be marked short-circuited
+# (slot 0, the "l" column for or).
+sub test_lexical_chain_cascade () {
+  my $script = write_script("lex_chain.pl", <<'PERL');
+sub decide { my ($a, $b, $c, $d) = @_; my $r = $a || $b || $c || $d; $r }
+decide(1, 0, 0, 0);
+PERL
+
+  my ($cover, $path) = run_under_cover($script, "lex_chain");
+  is_deeply values_for($cover, $path, 1), [[1, 0, 0], [1, 0, 0], [1, 0, 0]],
+    "every logop in the chain is marked short-circuited";
+}
+
+# The right operands here are hash elements, whose optree roots are
+# nulled ops; the climb must step through them to reach the outer
+# logop.
+sub test_element_chain_cascade () {
+  my $script = write_script("element_chain.pl", <<'PERL');
+sub decide { my %h = @_; my $r = $h{a} || $h{b} || $h{c}; $r }
+decide(a => 1, b => 0, c => 0);
+PERL
+
+  my ($cover, $path) = run_under_cover($script, "element_chain");
+  is_deeply values_for($cover, $path, 1), [[1, 0, 0], [1, 0, 0]],
+    "both logops marked short-circuited through nulled operands";
+}
+
+# A short-circuit at the outermost logop only must not over-mark the
+# inner one, which evaluated fully.
+sub test_root_short_circuit_no_overmark () {
+  my $script = write_script("root_sc.pl", <<'PERL');
+sub decide { my %h = @_; my $r = $h{a} || $h{b} || $h{c}; $r }
+decide(a => 0, b => 1, c => 0);
+PERL
+
+  my ($cover, $path) = run_under_cover($script, "root_sc");
+  is_deeply values_for($cover, $path, 1), [[1, 0, 0], [0, 1, 0]],
+    "outer marked short-circuited once, inner marked fully evaluated";
+}
+
+sub main () {
+  subtest "lexical chain cascade" => \&test_lexical_chain_cascade;
+  subtest "element chain cascade" => \&test_element_chain_cascade;
+  subtest "root short circuit no overmark" =>
+    \&test_root_short_circuit_no_overmark;
+
+  done_testing;
+}
+
+main;

--- a/t/internal/decision_inputs.t
+++ b/t/internal/decision_inputs.t
@@ -296,6 +296,42 @@ PERL
     "each comparator invocation records its own vector";
 }
 
+# A short-circuit deep in a chain resolves the whole decision in one
+# jump.  The recorder must still snapshot the vector when the chain's
+# operands are element accesses, whose optree roots are nulled ops, and
+# when the cascade spans more than two logops.
+sub test_chain_cascades_record_short_circuits () {
+  my $script = write_script("chain_cascade.pl", <<'PERL');
+sub h3 { my %h = @_; my $r = $h{a} || $h{b} || $h{c}; $r }
+h3(a => 1, b => 0, c => 0);
+h3(a => 0, b => 1, c => 0);
+h3(a => 0, b => 0, c => 1);
+h3(a => 0, b => 0, c => 0);
+sub l4 { my ($a, $b, $c, $d) = @_; my $r = $a || $b || $c || $d; $r }
+l4(1, 0, 0, 0);
+sub a5 { my @v = @_; my $r = $v[0] || $v[1] || $v[2] || $v[3] || $v[4]; $r }
+a5(1, 0, 0, 0, 0);
+PERL
+
+  my ($db, $path) = run_under_cover($script, "chain_cascade");
+  my $di = decision_inputs_for($db, $path);
+  ok $di, "decision_inputs present for chain_cascade";
+
+  my %by_width;
+  for my $d (grep defined, @$di) {
+    my @cols = split /\|/, (keys %$d)[0];
+    $by_width{ 0 + @cols } = $d;
+  }
+
+  is_deeply $by_width{3},
+    { "1|X|X" => 1, "0|1|X" => 1, "0|0|1" => 1, "0|0|0" => 1 },
+    "hash-element chain records a vector at every short-circuit depth";
+  is_deeply $by_width{4}, { "1|X|X|X" => 1 },
+    "lexical chain records a two-level cascaded short-circuit";
+  is_deeply $by_width{5}, { "1|X|X|X|X" => 1 },
+    "array-element chain records a three-level cascaded short-circuit";
+}
+
 sub test_add_condition_cross_run_merge () {
   my $db = bless {}, "Devel::Cover::DB";
   my $cc = {};
@@ -342,6 +378,8 @@ sub main () {
     \&test_abandoned_inner_frame_not_double_counted;
   subtest "sort block records per invocation" =>
     \&test_sort_block_records_per_invocation;
+  subtest "chain cascades record short circuits" =>
+    \&test_chain_cascades_record_short_circuits;
   subtest "cross-run merge"     => \&test_add_condition_cross_run_merge;
   subtest "xor four-slot merge" => \&test_add_condition_xor_four_slot_merge;
 

--- a/test_output/cover/cond_chain_elements.5.020000
+++ b/test_output/cover/cond_chain_elements.5.020000
@@ -1,0 +1,137 @@
+cover: Reading database from ...
+------------------------- ------ ------ ------ ------ ------ ------ ------
+File                        stmt   bran   cond   mcdc    sub  total   scar
+------------------------- ------ ------ ------ ------ ------ ------ ------
+tests/cond_chain_elements  100.0    n/a   70.8   27.2  100.0   77.2   22.2
+Total                      100.0    n/a   70.8   27.2  100.0   77.2   22.2
+------------------------- ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/cond_chain_elements
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 9 85.7  9.2 22.2
+
+Worst Subroutines
+-----------------
+
+Subroutine    CC SCAR  Location                    
+------------- -- ----  ----------------------------
+array_chain    4 15.2  tests/cond_chain_elements:26
+lexical_chain  4 14.5  tests/cond_chain_elements:32
+hash_chain     3 11.0  tests/cond_chain_elements:20
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10                                             # Cascaded short-circuits through chains of logops.  A short-circuit deep
+11                                             # in a chain resolves the whole decision in one jump; every skipped logop
+12                                             # must be marked short-circuited and the MC/DC vector recorded, including
+13                                             # when the operands are element accesses whose optree roots are nulled
+14                                             # ops.
+15                                             
+16             1                           1   use strict;
+               1                               
+               1                               
+17             1                           1   use warnings;
+               1                               
+               1                               
+18                                             
+19                                             sub hash_chain {
+20             4                           4     my %h = @_;
+21             4           100    100            my $r = $h{a} || $h{b} || $h{c};
+                           100                 
+22             4                                 $r
+23                                             }
+24                                             
+25                                             sub array_chain {
+26             2                           2     my @v = @_;
+27    ***      2          * 33   *  0            my $r = $v[0] || $v[1] || $v[2] || $v[3];
+      ***                 * 66                 
+      ***                 * 66                 
+28             2                                 $r
+29                                             }
+30                                             
+31                                             sub lexical_chain {
+32             2                           2     my ($a, $b, $c, $d) = @_;
+33    ***      2          * 66   *  0            my $r = $a || $b || $c || $d;
+      ***                 * 66                 
+      ***                 * 66                 
+34             2                                 $r
+35                                             }
+36                                             
+37                                             sub main {
+38             1                           1     my @r;
+39                                             
+40             1                                 push @r, hash_chain(a => 1, b => 0, c => 0);
+41             1                                 push @r, hash_chain(a => 0, b => 1, c => 0);
+42             1                                 push @r, hash_chain(a => 0, b => 0, c => 1);
+43             1                                 push @r, hash_chain(a => 0, b => 0, c => 0);
+44                                             
+45             1                                 push @r, array_chain(1, 0, 0, 0);
+46             1                                 push @r, array_chain(0, 0, 1, 0);
+47                                             
+48             1                                 push @r, lexical_chain(1, 0, 0, 0);
+49             1                                 push @r, lexical_chain(0, 0, 0, 1);
+50                                             }
+51                                             
+52             1                               main();
+
+
+Conditions
+----------
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+21           100      2      1      1   $h{'a'} || $h{'b'} || $h{'c'}
+             100      1      1      2   $h{"a"} or $h{"b"}
+27    ***     33      2      0      0   $v[0] || $v[1] || $v[2] || $v[3]
+      ***     66      1      1      0   $v[0] or $v[1] or $v[2]
+      ***     66      1      0      1   $v[0] or $v[1]
+33    ***     66      1      1      0   $a || $b || $c || $d
+      ***     66      1      0      1   $a or $b or $c
+      ***     66      1      0      1   $a or $b
+
+
+MC/DC
+-----
+
+line  err      %  cov  tot   missing                expr
+----- --- ------ ---- ----   --------------------   ----
+21           100    3    3                          $h{'a'} || $h{'b'} || $h{'c'}
+27    ***      0    0    4   $v[0], $v[1], $v[2], $v[3]   $v[0] || $v[1] || $v[2] || $v[3]
+33    ***      0    0    4   $a, $b, $c, $d         $a || $b || $c || $d
+
+
+Covered Subroutines
+-------------------
+
+Subroutine    Count  CC  SCAR Location                    
+------------- ----- --- ----- ----------------------------
+BEGIN             1   1   0.0 tests/cond_chain_elements:16
+BEGIN             1   1   0.0 tests/cond_chain_elements:17
+array_chain       2   4  15.2 tests/cond_chain_elements:26
+hash_chain        4   3  11.0 tests/cond_chain_elements:20
+lexical_chain     2   4  14.5 tests/cond_chain_elements:32
+main              1   1   0.0 tests/cond_chain_elements:38
+
+

--- a/test_output/cover/cond_chained.5.020000
+++ b/test_output/cover/cond_chained.5.020000
@@ -2,8 +2,8 @@ cover: Reading database from ...
 ------------------ ------ ------ ------ ------ ------ ------ ------
 File                 stmt   bran   cond   mcdc    sub  total   scar
 ------------------ ------ ------ ------ ------ ------ ------ ------
-tests/cond_chained  100.0   83.3   86.6   50.0  100.0   82.9   25.0
-Total               100.0   83.3   86.6   50.0  100.0   82.9   25.0
+tests/cond_chained  100.0  100.0   86.6   50.0  100.0   85.3   24.9
+Total               100.0  100.0   86.6   50.0  100.0   85.3   24.9
 ------------------ ------ ------ ------ ------ ------ ------ ------
 
 
@@ -20,14 +20,14 @@ File Summary
 
 CC  Cov CRAP SCAR
 -- ---- ---- ----
-12 90.0 12.1 25.0
+12 93.3 12.0 24.9
 
 Worst Subroutines
 -----------------
 
 Subroutine CC SCAR  Location             
 ---------- -- ----  ---------------------
-t3          6 18.6  tests/cond_chained:16
+t3          6 18.1  tests/cond_chained:16
 t1          4 13.9  tests/cond_chained:4 
 t2          4 13.9  tests/cond_chained:10
 
@@ -48,7 +48,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 14                                             
 15                                             sub t3 {
 16             1                           1       for my $x (0, 1, 2) {
-17    ***      3   * 50   * 66   *  0                  last if $x && $x == 2 && $x == 2 && $x == 2;
+17    ***      3    100   * 66   *  0                  last if $x && $x == 2 && $x == 2 && $x == 2;
       ***                 * 66                 
                            100                 
 18                                                 }
@@ -66,7 +66,7 @@ line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
 5            100      1      2   if $x and $x == 2
 11           100      1      2   if $x and $x == 2
-17    ***     50      1      0   if $x and $x == 2 and $x == 2 and $x == 2
+17           100      1      2   if $x and $x == 2 and $x == 2 and $x == 2
 
 
 Conditions
@@ -78,7 +78,7 @@ line  err      %     !l  l&&!r   l&&r   expr
 ----- --- ------ ------ ------ ------   ----
 5            100      1      1      1   $x and $x == 2
 11           100      1      1      1   $x and $x == 2
-17    ***     66      1      0      1   $x and $x == 2 and $x == 2 and $x == 2
+17    ***     66      2      0      1   $x and $x == 2 and $x == 2 and $x == 2
       ***     66      2      0      1   $x and $x == 2 and $x == 2
              100      1      1      1   $x and $x == 2
 
@@ -100,6 +100,6 @@ Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- ---------------------
 t1             1   4  13.9 tests/cond_chained:4 
 t2             1   4  13.9 tests/cond_chained:10
-t3             1   6  18.6 tests/cond_chained:16
+t3             1   6  18.1 tests/cond_chained:16
 
 

--- a/tests/cond_chain_elements
+++ b/tests/cond_chain_elements
@@ -1,0 +1,52 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Cascaded short-circuits through chains of logops.  A short-circuit deep
+# in a chain resolves the whole decision in one jump; every skipped logop
+# must be marked short-circuited and the MC/DC vector recorded, including
+# when the operands are element accesses whose optree roots are nulled
+# ops.
+
+use strict;
+use warnings;
+
+sub hash_chain {
+  my %h = @_;
+  my $r = $h{a} || $h{b} || $h{c};
+  $r
+}
+
+sub array_chain {
+  my @v = @_;
+  my $r = $v[0] || $v[1] || $v[2] || $v[3];
+  $r
+}
+
+sub lexical_chain {
+  my ($a, $b, $c, $d) = @_;
+  my $r = $a || $b || $c || $d;
+  $r
+}
+
+sub main {
+  my @r;
+
+  push @r, hash_chain(a => 1, b => 0, c => 0);
+  push @r, hash_chain(a => 0, b => 1, c => 0);
+  push @r, hash_chain(a => 0, b => 0, c => 1);
+  push @r, hash_chain(a => 0, b => 0, c => 0);
+
+  push @r, array_chain(1, 0, 0, 0);
+  push @r, array_chain(0, 0, 1, 0);
+
+  push @r, lexical_chain(1, 0, 0, 0);
+  push @r, lexical_chain(0, 0, 0, 1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Chains of `&&`/`||` conditions built from array or hash elements lost coverage whenever an evaluation short-circuited below the outermost logop. The recorder compensates for Perl's one-jump short-circuit by climbing the chain, but the climb read each right operand's `op_next` directly, and for element accesses that is a nulled op, so the climb aborted. MC/DC lost the evaluation's input vector entirely, so code like `$opt{a} || $opt{b} || $opt{c}` could never reach 100% MC/DC, and condition coverage never marked the outer logops as short-circuited. The condition climb also stopped one logop early on chains of three or more, so even lexical chains under-reported - a `last if $a && $b && $c` branch showed 50% with both outcomes taken.

## Changes

- Skip nulled ops when following `op_next` in both short-circuit climbs, matching the full-evaluation hijack path, and let the condition climb run to the top of the chain.
- Internal tests for input vectors at every cascade depth and for the short-circuit marks, plus an end-to-end fixture covering hash, array, and lexical chains.
- Regenerate the `cond_chained` golden file with the corrected branch and condition figures; output is identical on all tested Perl versions.

## Implications

- Condition, branch, and MC/DC figures can rise on existing code with chained conditions, so users' recorded coverage may change without any change to their code or tests.

## Ticket

Closes #500