### PR TITLE
GH-482 Share run-under-cover helper in tests

### DIFF
--- a/t/internal/compound_logop.t
+++ b/t/internal/compound_logop.t
@@ -23,14 +23,9 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Cwd        qw( abs_path );
-use File::Spec ();
-use File::Temp qw( tempdir );
 use Test::More import => [qw( diag done_testing is isnt ok )];
 
-use Devel::Cover::DB ();
-
-my $Tmpdir = tempdir(CLEANUP => 1);
+use Devel::Cover::Test::Internal qw( write_script run_under_cover );
 
 # Bare statement-level sub bodies (the context that triggers the drop), called
 # in non-void context so the right operand's value is observed.
@@ -62,32 +57,6 @@ my ($Cover,     $Path,    $Cond);
 my ($Or_or,     $And_and, $Or_and);
 my ($Left_only, $Or_flow, $Dor_join, $Not_join);
 
-sub write_script ($name, $content) {
-  my $path = File::Spec->catfile($Tmpdir, $name);
-  open my $fh, ">", $path or die "Cannot write $path: $!";
-  print $fh $content;
-  close $fh or die "Cannot close $path: $!";
-  $path
-}
-
-sub run_under_cover ($script, $label, @criteria) {
-  my $cover_db   = File::Spec->catdir($Tmpdir, "cover_db_$label");
-  my $abs_tmpdir = abs_path($Tmpdir);
-  my $coverage   = @criteria ? "-coverage," . join(",", @criteria) . "," : "";
-  my @cmd        = (
-    $^X, "-Iblib/lib", "-Iblib/arch",
-    "-MDevel::Cover=-db,$cover_db,-silent,1,${coverage}+select,$abs_tmpdir",
-    $script,
-  );
-  system(@cmd) == 0 or die "Failed to run script under Devel::Cover: @cmd";
-
-  my $db = Devel::Cover::DB->new(db => $cover_db);
-  $db->merge_runs;
-  # Devel::Cover resolves symlinks (e.g. /tmp -> /private/tmp on macOS)
-  my $real_path = abs_path($script);
-  ($db->cover, $real_path)
-}
-
 # Return { line => [ { type => ..., text => ... }, ... ] } for every recorded
 # condition in the file.
 sub conditions_for ($cover, $file) {
@@ -116,7 +85,9 @@ sub line_with ($content, $tag) {
 sub _setup () {
   return if $Cover;
   my $prog = write_script("compound_logop.pl", $Source);
-  ($Cover, $Path) = run_under_cover($prog, "compound_logop", "condition");
+  my ($db, $path)
+    = run_under_cover($prog, "compound_logop", criteria => ["condition"]);
+  ($Cover, $Path) = ($db->cover, $path);
   $Cond = conditions_for($Cover, $Path);
 
   $Or_or   = $Cond->{ line_with($Source, "# OR_OR") }   // [];

--- a/t/internal/condition_chain.t
+++ b/t/internal/condition_chain.t
@@ -23,40 +23,9 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Cwd        qw( abs_path );
-use File::Spec ();
-use File::Temp qw( tempdir );
 use Test::More import => [qw( done_testing is is_deeply ok subtest )];
 
-use Devel::Cover::DB ();
-
-my $Tmpdir = tempdir(CLEANUP => 1);
-
-sub write_script ($name, $content) {
-  my $path = File::Spec->catfile($Tmpdir, $name);
-  open my $fh, ">", $path or die "Cannot write $path: $!";
-  print $fh $content;
-  close $fh or die "Cannot close $path: $!";
-  $path
-}
-
-sub run_under_cover ($script, $label) {
-  my $cover_db   = File::Spec->catdir($Tmpdir, "cover_db_$label");
-  my $abs_tmpdir = abs_path($Tmpdir);
-  my @cmd        = (
-    $^X,
-    "-Iblib/lib",
-    "-Iblib/arch",
-    "-MDevel::Cover=-db,$cover_db,-silent,1,"
-      . "-coverage,condition,+select,$abs_tmpdir",
-    $script,
-  );
-  system(@cmd) == 0 or die "Failed to run script under Devel::Cover: @cmd";
-
-  my $db = Devel::Cover::DB->new(db => $cover_db);
-  $db->merge_runs;
-  ($db->cover, abs_path($script))
-}
+use Devel::Cover::Test::Internal qw( write_script run_under_cover );
 
 # Condition hit counts for a line, outermost record first.  Records come
 # back in outermost-first order but the text is the stable identity, so
@@ -79,8 +48,9 @@ sub decide { my ($a, $b, $c, $d) = @_; my $r = $a || $b || $c || $d; $r }
 decide(1, 0, 0, 0);
 PERL
 
-  my ($cover, $path) = run_under_cover($script, "lex_chain");
-  is_deeply values_for($cover, $path, 1), [[1, 0, 0], [1, 0, 0], [1, 0, 0]],
+  my ($db, $path)
+    = run_under_cover($script, "lex_chain", criteria => ["condition"]);
+  is_deeply values_for($db->cover, $path, 1), [[1, 0, 0], [1, 0, 0], [1, 0, 0]],
     "every logop in the chain is marked short-circuited";
 }
 
@@ -93,8 +63,9 @@ sub decide { my %h = @_; my $r = $h{a} || $h{b} || $h{c}; $r }
 decide(a => 1, b => 0, c => 0);
 PERL
 
-  my ($cover, $path) = run_under_cover($script, "element_chain");
-  is_deeply values_for($cover, $path, 1), [[1, 0, 0], [1, 0, 0]],
+  my ($db, $path)
+    = run_under_cover($script, "element_chain", criteria => ["condition"]);
+  is_deeply values_for($db->cover, $path, 1), [[1, 0, 0], [1, 0, 0]],
     "both logops marked short-circuited through nulled operands";
 }
 
@@ -106,8 +77,9 @@ sub decide { my %h = @_; my $r = $h{a} || $h{b} || $h{c}; $r }
 decide(a => 0, b => 1, c => 0);
 PERL
 
-  my ($cover, $path) = run_under_cover($script, "root_sc");
-  is_deeply values_for($cover, $path, 1), [[1, 0, 0], [0, 1, 0]],
+  my ($db, $path)
+    = run_under_cover($script, "root_sc", criteria => ["condition"]);
+  is_deeply values_for($db->cover, $path, 1), [[1, 0, 0], [0, 1, 0]],
     "outer marked short-circuited once, inner marked fully evaluated";
 }
 

--- a/t/internal/decision_inputs.t
+++ b/t/internal/decision_inputs.t
@@ -20,46 +20,17 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Cwd        qw( abs_path );
-use File::Spec ();
-use File::Temp qw( tempdir );
 use Test::More import => [qw( done_testing is is_deeply ok subtest )];
 
-use Devel::Cover::DB   ();
-use Devel::Cover::Mcdc ();
-
-my $Tmpdir = tempdir(CLEANUP => 1);
+use Devel::Cover::DB             ();
+use Devel::Cover::Mcdc           ();
+use Devel::Cover::Test::Internal qw( write_script run_under_cover );
 
 # A mock condition entry matching the structure Devel::Cover produces:
 #   [0] hit counts per outcome, [1] {type, left, op, right}, [2] uncoverable
 #   markers per outcome.
 sub mock_condition ($class, $hits, $info, $unc = undef) {
   bless [$hits, $info, $unc], "Devel::Cover::$class"
-}
-
-sub write_script ($name, $content) {
-  my $path = File::Spec->catfile($Tmpdir, $name);
-  open my $fh, ">", $path or die "Cannot write $path: $!";
-  print $fh $content;
-  close $fh or die "Cannot close $path: $!";
-  $path
-}
-
-sub run_under_cover ($script, $label, @criteria) {
-  my $cover_db   = File::Spec->catdir($Tmpdir, "cover_db_$label");
-  my $abs_tmpdir = abs_path($Tmpdir);
-  my $coverage   = @criteria ? "-coverage," . join(",", @criteria) . "," : "";
-  my @cmd        = (
-    $^X, "-Iblib/lib", "-Iblib/arch",
-    "-MDevel::Cover=-db,$cover_db,-silent,1,${coverage}+select,$abs_tmpdir",
-    $script,
-  );
-  system(@cmd) == 0 or die "Failed to run script under Devel::Cover: @cmd";
-
-  my $db = Devel::Cover::DB->new(db => $cover_db);
-  $db->merge_runs;
-  my $real_path = abs_path($script);
-  ($db, $real_path)
 }
 
 sub decision_inputs_for ($db, $file) {
@@ -142,7 +113,8 @@ two(0, 0);
 PERL
 
   my ($db, $path) = run_under_cover(
-    $script, "no_mcdc", qw( statement branch condition subroutine )
+    $script, "no_mcdc",
+    criteria => [qw( statement branch condition subroutine )],
   );
   my $di = decision_inputs_for($db, $path);
   ok !$di, "decision_inputs absent when mcdc not selected";

--- a/t/internal/dor_hijack.t
+++ b/t/internal/dor_hijack.t
@@ -27,52 +27,15 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Cwd        qw( abs_path );
-use File::Spec ();
-use File::Temp qw( tempdir );
-use Test::More import => [ qw( done_testing is ok ) ];
+use Test::More import => [qw( done_testing is ok )];
 
-use Devel::Cover::DB ();
-
-my $Tmpdir = tempdir(CLEANUP => 1);
-
-sub write_script ($name, $content) {
-  my $path = File::Spec->catfile($Tmpdir, $name);
-  open my $fh, ">", $path or die "Cannot write $path: $!";
-  print $fh $content;
-  close $fh or die "Cannot close $path: $!";
-  $path
-}
-
-# Run a script under Devel::Cover with runops_cover (replace_ops off), then
-# return ($cover, $real_path) where $real_path is the absolute symlink-resolved
-# path that Devel::Cover stores for the script.
-sub run_under_cover ($script, $label) {
-  my $cover_db   = File::Spec->catdir($Tmpdir, "cover_db_$label");
-  my $abs_tmpdir = abs_path($Tmpdir);
-  my @cmd        = (
-    $^X,
-    "-Iblib/lib",
-    "-Iblib/arch",
-    "-MDevel::Cover=-db,$cover_db,-silent,1,-replace_ops,0"
-      . ",+select,$abs_tmpdir",
-    $script,
-  );
-  system(@cmd) == 0 or die "Failed to run script under Devel::Cover: @cmd";
-
-  my $db = Devel::Cover::DB->new(db => $cover_db);
-  $db->merge_runs;
-  my $cover = $db->cover;
-
-  # Devel::Cover resolves symlinks (e.g. /tmp -> /private/tmp on macOS)
-  my $real_path = abs_path($script);
-  ($cover, $real_path)
-}
+use Devel::Cover::Test::Internal qw( write_script run_under_cover );
 
 sub check_stmt_count ($label, $code, $line, $expected) {
   my $script = write_script("$label.pl", $code);
-  my ($cover, $path) = run_under_cover($script, $label);
-  my $file = $cover->file($path);
+  my ($db, $path)
+    = run_under_cover($script, $label, options => ["-replace_ops,0"]);
+  my $file = $db->cover->file($path);
   ok $file, "$label: coverage data found";
 
   my $stmts = $file->criterion("statement");

--- a/t/internal/mcdc_context_parity.t
+++ b/t/internal/mcdc_context_parity.t
@@ -31,14 +31,9 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Cwd        qw( abs_path );
-use File::Spec ();
-use File::Temp qw( tempdir );
 use Test::More import => [qw( done_testing is is_deeply subtest )];
 
-use Devel::Cover::DB ();
-
-my $Tmpdir = tempdir(CLEANUP => 1);
+use Devel::Cover::Test::Internal qw( write_script run_under_cover );
 
 # Decisions under test.  Each is a genuine multi-condition decision; D1-D3 have
 # four atomic positions (D3 is coupled, reusing $a), D4 is a three-condition
@@ -57,32 +52,6 @@ my %Context = (
   implicit_return => sub ($expr) { "$expr" },
 );
 
-sub write_script ($name, $content) {
-  my $path = File::Spec->catfile($Tmpdir, $name);
-  open my $fh, ">", $path or die "Cannot write $path: $!";
-  print $fh $content;
-  close $fh or die "Cannot close $path: $!";
-  $path
-}
-
-sub run_under_cover ($script, $label) {
-  my $cover_db   = File::Spec->catdir($Tmpdir, "cover_db_$label");
-  my $abs_tmpdir = abs_path($Tmpdir);
-  my @cmd        = (
-    $^X,
-    "-Iblib/lib",
-    "-Iblib/arch",
-    "-MDevel::Cover=-db,$cover_db,-silent,1,"
-      . "-coverage,condition,-coverage,mcdc,+select,$abs_tmpdir",
-    $script,
-  );
-  system(@cmd) == 0 or die "Failed to run script under Devel::Cover: @cmd";
-
-  my $db = Devel::Cover::DB->new(db => $cover_db);
-  $db->merge_runs;
-  ($db, abs_path($script))
-}
-
 # Drive a single decision in a single context across all 16 input tuples, then
 # return its recorded MC/DC table structure as a sorted list of label counts -
 # one entry per recorded table.  A unified four-condition decision yields [4];
@@ -98,7 +67,11 @@ for my \$v (0 .. 15) {
 PERL
 
   my $label = "${op}_${context}";
-  my ($db, $path) = run_under_cover(write_script("$label.pl", $code), $label);
+  my ($db, $path) = run_under_cover(
+    write_script("$label.pl", $code),
+    $label,
+    criteria => [qw( condition mcdc )],
+  );
   my $mcdc = $db->cover->file($path)->{mcdc} // {};
 
   my @counts;

--- a/t/internal/mcdc_proven.t
+++ b/t/internal/mcdc_proven.t
@@ -29,23 +29,11 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Cwd        qw( abs_path );
-use File::Spec ();
-use File::Temp qw( tempdir );
 use Test::More import => [qw( done_testing is ok subtest )];
 
-use Devel::Cover::DB ();
+use Devel::Cover::Test::Internal qw( write_script run_under_cover );
 
-my $Tmpdir   = tempdir(CLEANUP => 1);
 my $Decision = '($a && $b) || ($c && $d)';
-
-sub write_script ($name, $content) {
-  my $path = File::Spec->catfile($Tmpdir, $name);
-  open my $fh, ">", $path or die "Cannot write $path: $!";
-  print $fh $content;
-  close $fh or die "Cannot close $path: $!";
-  $path
-}
 
 # Drive the decision in $context over the input tuples in @$tuples, $runs times
 # into one coverage database, then return its single MC/DC table's covered and
@@ -63,25 +51,14 @@ my \$sink;
 \$sink = decision(\@\$_) for ($list);
 PERL
 
-  my $label    = "${context}_${runs}_" . $Call++;
-  my $script   = write_script("$label.pl", $code);
-  my $cover_db = File::Spec->catdir($Tmpdir, "db_$label");
-  my $abs      = abs_path($Tmpdir);
+  my $label  = "${context}_${runs}_" . $Call++;
+  my $script = write_script("$label.pl", $code);
+  my ($db, $path);
   for (1 .. $runs) {
-    my @cmd = (
-      $^X,
-      "-Iblib/lib",
-      "-Iblib/arch",
-      "-MDevel::Cover=-db,$cover_db,-silent,1,"
-        . "-coverage,condition,-coverage,mcdc,+select,$abs",
-      $script,
-    );
-    system(@cmd) == 0 or die "Failed to run under Devel::Cover: @cmd";
+    ($db, $path)
+      = run_under_cover($script, $label, criteria => [qw( condition mcdc )]);
   }
-
-  my $db = Devel::Cover::DB->new(db => $cover_db);
-  $db->merge_runs;
-  my $mcdc = $db->cover->file(abs_path($script))->{mcdc} // {};
+  my $mcdc = $db->cover->file($path)->{mcdc} // {};
 
   my @tables = map $_->@*, values %$mcdc;
   is @tables, 1, "$context ($runs run) records a single unified table";

--- a/t/lib/Devel/Cover/Test/Internal.pm
+++ b/t/lib/Devel/Cover/Test/Internal.pm
@@ -1,0 +1,132 @@
+package Devel::Cover::Test::Internal;
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Exporter qw( import );
+our @EXPORT_OK = qw( write_script run_under_cover );
+
+use Cwd        qw( abs_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use Devel::Cover::DB ();
+
+# One tempdir per process; per-call labels keep coverage db paths distinct.
+my $Tmpdir = tempdir(CLEANUP => 1);
+
+sub write_script ($name, $content) {
+  my $path = File::Spec->catfile($Tmpdir, $name);
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $content;
+  close $fh or die "Cannot close $path: $!";
+  $path
+}
+
+sub run_under_cover ($script, $label, %opts) {
+  my $cover_db = File::Spec->catdir($Tmpdir, "cover_db_$label");
+  my @criteria = ($opts{criteria} // [])->@*;
+  my @parts    = ("-db,$cover_db", "-silent,1");
+  push @parts, join ",", "-coverage", @criteria if @criteria;
+  push @parts, ($opts{options} // [])->@*;
+  push @parts, "+select," . abs_path($Tmpdir);
+  my @cmd = (
+    $^X, "-Iblib/lib", "-Iblib/arch", "-MDevel::Cover=" . join(",", @parts),
+    $script,
+  );
+  system(@cmd) == 0 or die "Failed to run script under Devel::Cover: @cmd";
+
+  my $db = Devel::Cover::DB->new(db => $cover_db);
+  $db->merge_runs;
+  ($db, abs_path($script))
+}
+
+"
+Well, the dogs were barking at the new moon
+Whistling a new tune
+Hoping it would come soon
+"
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+Devel::Cover::Test::Internal - run generated scripts under Devel::Cover
+
+=head1 SYNOPSIS
+
+ use Devel::Cover::Test::Internal qw( write_script run_under_cover );
+
+ my $script = write_script("simple_and.pl", $source);
+ my ($db, $path) = run_under_cover(
+   $script, "simple_and",
+   criteria => ["condition", "mcdc"],
+ );
+ my $cover = $db->cover;
+
+=head1 DESCRIPTION
+
+Shared helpers for internal tests that write a small Perl script, run it
+under Devel::Cover in a child process, and inspect the resulting coverage
+database.  The module owns one temporary directory per process; each call
+uses its label to keep coverage db paths distinct, and the directory is
+cleaned up automatically at process exit.
+
+=head1 EXPORTED SUBROUTINES
+
+All functions are exported on request via L<Exporter>.
+
+=head2 write_script ($name, $content)
+
+ my $script = write_script("simple_and.pl", $source);
+
+Write C<$content> to a file called C<$name> in the shared temporary
+directory and return its path.
+
+=head2 run_under_cover ($script, $label, %opts)
+
+ my ($db, $path) = run_under_cover($script, $label, %opts);
+
+Run C<$script> under Devel::Cover with C<-silent,1>, collecting into a
+coverage db named after C<$label>, and die if the child fails.  Options:
+
+=over
+
+=item C<criteria>
+
+Arrayref of coverage criteria, e.g. C<["condition", "mcdc"]>, passed as a
+single C<-coverage> option.  Omit to collect the default set (all criteria).
+
+=item C<options>
+
+Arrayref of extra Devel::Cover option strings, e.g. C<["-replace_ops,0"]>,
+inserted before the C<+select> of the shared temporary directory.
+
+=back
+
+Returns the loaded, run-merged L<Devel::Cover::DB> and the absolute
+symlink-resolved path of C<$script> (the path Devel::Cover stores for it).
+Repeated calls with the same C<$label> accumulate runs in the same
+coverage db.
+
+=head1 LICENCE
+
+Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+This software is free.  It is licensed under the same terms as Perl itself.
+
+The latest version of this software should be available from my homepage:
+https://pjcj.net
+
+=cut


### PR DESCRIPTION
## Summary

The internal tests that run a generated script under Devel::Cover each carried their own near-identical `write_script` and `run_under_cover` helpers. This moves them into a shared test-only package, following the `Devel::Cover::Test::Showcase` precedent in `t/lib`.

## Changes

- Add `Devel::Cover::Test::Internal` exporting `write_script` and `run_under_cover`. The helper takes an optional criteria list (default: all criteria) and extra Devel::Cover options (for `-replace_ops,0`), returns the loaded run-merged `Devel::Cover::DB` for callers to call `->cover` on, and owns one tempdir per process with per-call labels keeping coverage db paths distinct.
- Convert `compound_logop.t`, `decision_inputs.t`, `dor_hijack.t`, `mcdc_context_parity.t`, `mcdc_proven.t` and `condition_chain.t` to use it.
- Test-specific inspection helpers stay in their test files. `complexity.t` and `global_destruction.t` keep their hand-rolled variants: they need the coverage db path and captured stderr respectively.

## Ticket

Closes #482