### PR TITLE
GH-502 Report too-wide decisions as unanalysed

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -1876,7 +1876,8 @@ static void cover_logop(pTHX) {
   } else {
     dSP;
 
-    int leftval_true_ish = (PL_op->op_type == OP_DOR || PL_op->op_type == OP_DORASSIGN)
+    int leftval_true_ish = (PL_op->op_type == OP_DOR ||
+                            PL_op->op_type == OP_DORASSIGN)
       ? SvOK(TOPs) : SvTRUE(TOPs);
     /* We don't count X= as void context because we care about the value
      * of the RHS */

--- a/Cover.xs
+++ b/Cover.xs
@@ -149,9 +149,8 @@ typedef struct {
 #define DC_VECTOR_X     2
 
 /*
- * Matches Devel::Cover::Condition_table::for_line's 16-atomic cap on the Perl
- * side; decisions wider than this are not rendered as truth tables and cannot
- * contribute to MC/DC, so we do not record input vectors for them.
+ * Per-decision analysis limit; matches $Max_width in Condition_table.
+ * Wider decisions record no input vectors - see docs/technical/mcdc.md.
  */
 #define DC_MAX_DECISION_WIDTH 16
 
@@ -1911,6 +1910,9 @@ static void cover_logop(pTHX) {
         int      leaf_left = dc_meta_iv(aTHX_ meta, "leaf_col_left", 13);
         int      is_entry  = dc_meta_iv(aTHX_ meta, "is_entry",      8) == 1;
         dc_dctx *d;
+
+        /* A too-wide decision records nothing - never push a frame */
+        if (width > DC_MAX_DECISION_WIDTH) width = 0;
 
         dc_stack_discard_stale(aTHX);
         d = dc_stack_find_root(aTHX_ root_addr);

--- a/docs/technical/mcdc.md
+++ b/docs/technical/mcdc.md
@@ -108,8 +108,8 @@ articles.
 These four tests achieve:
 
 - 100% statement coverage.
-- 100% branch coverage (the outer decision goes both ways: tests 1-3 → T; test 4
-  → F).
+- 100% branch coverage (the outer decision goes both ways: tests 1-3 → T;
+  test 4 → F).
 - 100% condition coverage. Between them the four tests cover every row of the
   outer `||`'s `or_3` table (`l`, `!l && r`, `!l && !r`) and every row of the
   inner `&&`'s `and_3` table (`l && r`, `l && !r`, `!l`).

--- a/docs/technical/mcdc.md
+++ b/docs/technical/mcdc.md
@@ -411,9 +411,19 @@ USAGE POD in `Devel::Cover::Mcdc`, and a `Changes` entry.
 
 ## Limitations
 
-- Decisions with more than 16 atomic conditions are skipped by
-  `Condition_table::for_line`; MC/DC inherits that limit. The bound exists
-  because the truth table size grows as 2^N and becomes unwieldy.
+- Decisions with more than 16 atomic conditions are not analysed. The limit
+  is per decision, enforced on both sides: `Condition_table::for_line`
+  (`$Max_width`) returns a `too_wide` stub table with labels but no rows, and
+  the XS recorder (`DC_MAX_DECISION_WIDTH`) records no input vectors for such
+  decisions. `DB::_derive_mcdc` reports the decision as 0 of its width with an
+  `unanalysed` flag, warns at report time naming the file and line (silenced
+  by `-silent`), and ignores any `# uncoverable mcdc` markers on it, with a
+  warning of its own. Reporters show "too many conditions" in place of the
+  missing-conditions list, and the JSON report carries `"unanalysed": 1`. The
+  bound exists because the truth table size grows as 2^N and becomes
+  unwieldy. The remedy is to split the decision with an intermediate
+  variable, which needs no extra test cases, preserves short-circuiting, and
+  lets every condition be analysed.
 
 - A statement-level logop whose value is discarded records its outer operator as
   a decision only when its right operand is itself a decision. So

--- a/docs/technical/mcdc.md
+++ b/docs/technical/mcdc.md
@@ -400,9 +400,9 @@ percentage.
 
 `tests/mcdc_basic` covers the standard short-circuit forms (`&&`, `||`, chained,
 leading negation, and the mixed-precedence worked example). `tests/mcdc_xor`,
-`tests/mcdc_constant_right`, `tests/mcdc_demo`, and `tests/mcdc_signatures`
-exercise the distinct code paths. Internal tests live under `t/internal/mcdc_*`
-and `t/internal/decision_*`.
+`tests/mcdc_constant_right`, `tests/mcdc_demo`, `tests/mcdc_signatures`, and
+`tests/mcdc_wide` exercise the distinct code paths. Internal tests live under
+`t/internal/mcdc_*` and `t/internal/decision_*`.
 
 ### Documentation
 
@@ -423,7 +423,8 @@ USAGE POD in `Devel::Cover::Mcdc`, and a `Changes` entry.
   bound exists because the truth table size grows as 2^N and becomes
   unwieldy. The remedy is to split the decision with an intermediate
   variable, which needs no extra test cases, preserves short-circuiting, and
-  lets every condition be analysed.
+  lets every condition be analysed. `tests/mcdc_wide` covers the behaviour
+  end to end.
 
 - A statement-level logop whose value is discarded records its outer operator as
   a decision only when its right operand is itself a decision. So

--- a/lib/Devel/Cover/Condition_table.pm
+++ b/lib/Devel/Cover/Condition_table.pm
@@ -43,6 +43,9 @@ package Devel::Cover::Condition_table::Table {
   # MC/DC nor the truth-table display may treat those rows as covered.  A single
   # logop is exact from its hit counts, and observed vectors are real.
   sub proven ($self) { $self->{proven} }
+
+  # A stub for a decision wider than the analysis limit: labels but no rows
+  sub too_wide ($self) { $self->{too_wide} }
 }
 
 package Devel::Cover::Condition_table;
@@ -62,6 +65,11 @@ my %Primitive = (
 );
 
 my %Is_boolean = (and_2 => 1, or_2 => 1);
+
+# Per-decision analysis limit; matches DC_MAX_DECISION_WIDTH in Cover.xs
+my $Max_width = 16;
+
+sub max_width ($class) { $Max_width }
 
 sub _hits ($condition) {
   map { defined && $_ > 0 ? 1 : 0 } $condition->[0]->@*
@@ -235,8 +243,6 @@ sub apply_observed_vectors ($rows, $obs) {
 }
 
 sub for_line ($class, $conditions, $observed = undef) {
-  return if @$conditions > 16;
-
   my %expr_map;
   $expr_map{ _expr($_) } = $_ for @$conditions;
 
@@ -266,8 +272,20 @@ sub for_line ($class, $conditions, $observed = undef) {
     my $c = $conditions->[$i];
     next if $is_child{ _expr($c) };
 
+    my @labels = _build_labels($c, $find);
+    if (@labels > $Max_width) {
+      push @tables,
+        Devel::Cover::Condition_table::Table->new(
+          expr     => _expr($c),
+          labels   => \@labels,
+          rows     => [],
+          proven   => 0,
+          too_wide => 1,
+        );
+      next;
+    }
+
     my @rows    = _build_rows($c, $find);
-    my @labels  = _build_labels($c, $find);
     my $obs     = $observed && $observed->[$i];
     my $applied = $obs      && %$obs ? 1 : 0;
 
@@ -320,10 +338,15 @@ expected results, and coverage status.
 
 =head1 METHODS
 
-=head2 for_line ($conditions)
+=head2 for_line ($conditions, $observed)
 
-Class method. Takes an arrayref of condition objects for a line.
-Returns a list of Table objects.
+Class method. Takes an arrayref of condition objects for a line and an
+optional arrayref of observed input-vector hashes indexed parallel to the
+conditions. Returns a list of Table objects, one per decision on the line.
+
+A decision with more than 16 atomic conditions is not analysed: its Table
+is a stub with C<too_wide> true, carrying the expression and labels but no
+rows.
 
 =head1 SEE ALSO
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -17,7 +17,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 use Devel::Cover::Criterion ();
 use Devel::Cover::DB::File  ();
 use Devel::Cover::DB::IO    ();
-use Devel::Cover::Log       qw( dcinfo );
+use Devel::Cover::Log       qw( dcinfo dcwarn );
 
 use Carp         qw( carp croak );
 use File::Find   qw( find );
@@ -918,8 +918,8 @@ sub _uncoverable_details ($criterion, $info, $file, $line) {
   if ($info =~ /pair:(\d+)/) {
     if ($1) { $type = $1 - 1 }
     else {
-      warn "Invalid pair:$1 (pairs are numbered from 1) parsing "
-        . "uncoverable $criterion at $file:$line\n";
+      dcwarn "Invalid pair:$1 (pairs are numbered from 1) parsing "
+        . "uncoverable $criterion at $file:$line";
       return;
     }
   }
@@ -1107,9 +1107,9 @@ sub _mcdc_uncoverable ($unc, $file, $line, $n, $total) {
     } elsif ($col >= 0 && $col < $total) {
       $uncov[$col] = $flag;
     } else {
-      warn "Ignoring uncoverable mcdc pair:"
+      dcwarn "Ignoring uncoverable mcdc pair:"
         . ($col + 1)
-        . " out of range (1..$total) at $file:$line\n";
+        . " out of range (1..$total) at $file:$line";
     }
   }
   \@uncov

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -25,11 +25,9 @@ use File::Path   qw( rmtree );
 use List::Util   qw( any );
 use Scalar::Util qw( blessed reftype );
 
-use Devel::Cover::Dumper qw( Dumper );  # For debugging
-
 my $Has_term_size = eval { require Term::Size };
 
-my $DB = "cover.15";                    # Version of the database
+my $DB = "cover.15";  # Version of the database
 
 @Devel::Cover::DB::Criteria
   = (qw( statement branch condition mcdc subroutine pod time ));

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -1051,7 +1051,9 @@ sub _derive_mcdc ($self, $cover, $uncoverable = {}) {
   require Devel::Cover::Condition_table;
   require Devel::Cover::Mcdc::Analyser;
 
-  while (my ($file, $cf) = each %$cover) {
+  # Sorted iteration keeps the too-wide warnings deterministic
+  for my $file (sort keys %$cover) {
+    my $cf = $cover->{$file};
     my $cc = $cf->{condition} or next;
     next if exists $cf->{mcdc};
 
@@ -1059,12 +1061,29 @@ sub _derive_mcdc ($self, $cover, $uncoverable = {}) {
     my $unc    = $digest && $uncoverable->{$digest}{mcdc};
 
     my %mcdc;
-    for my $line (keys %$cc) {
+    for my $line (sort { $a <=> $b } keys %$cc) {
       my @loc      = $cc->{$line}->@* or next;
       my @observed = map observed_vectors($_), @loc;
       my @tables   = Devel::Cover::Condition_table->for_line(\@loc, \@observed);
       for my $n (0 .. $#tables) {
         my $table = $tables[$n];
+
+        # Too wide to analyse: 0 of its width, flagged, warned about here
+        if ($table->too_wide) {
+          my @labels = $table->labels;
+          my $limit  = Devel::Cover::Condition_table->max_width;
+          dcwarn "MC/DC decision at $file:$line has " . @labels
+            . " conditions, exceeding the analysis limit of $limit";
+          dcwarn "Ignoring uncoverable mcdc at $file:$line: "
+            . "the decision exceeds the analysis limit"
+            if $unc && $unc->{$line}[$n];
+          push $mcdc{$line}->@*, [
+              [(0) x @labels],
+              { text => $table->expr, labels => \@labels, unanalysed => 1 },
+            ];
+          next;
+        }
+
         my $r     = Devel::Cover::Mcdc::Analyser->analyse($table);
         my $total = $r->{total};
         my $pairs = $r->{pairs};

--- a/lib/Devel/Cover/Log.pm
+++ b/lib/Devel/Cover/Log.pm
@@ -19,7 +19,7 @@ use Exporter          qw( import );
 
 BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
 
-our @EXPORT_OK = qw( dcinfo dcerror dcprogress );
+our @EXPORT_OK = qw( dcinfo dcerror dcprogress dcwarn );
 our $Prefix    = "cover";
 
 sub dcinfo ($msg) {
@@ -28,6 +28,11 @@ sub dcinfo ($msg) {
 }
 
 sub dcerror ($msg) {
+  print STDERR "$Prefix: $msg\n";
+}
+
+sub dcwarn ($msg) {
+  return if $Devel::Cover::Silent;
   print STDERR "$Prefix: $msg\n";
 }
 
@@ -48,10 +53,11 @@ Devel::Cover::Log - Centralised diagnostic output for Devel::Cover
 
 =head1 SYNOPSIS
 
- use Devel::Cover::Log qw( dcinfo dcerror dcprogress );
+ use Devel::Cover::Log qw( dcinfo dcerror dcprogress dcwarn );
 
  dcinfo "Reading database from $dbname";
  dcerror "Unrecognised output format: $fmt";
+ dcwarn "Ignoring malformed uncoverable comment at $file:$line";
  dcprogress "Rendering $n of $total";
 
  # Tools other than C<cover> can override the prefix:
@@ -79,6 +85,11 @@ C<$Devel::Cover::Silent> is true.
 =item dcerror($msg)
 
 Error message.  Never silenced: errors are always reported.
+
+=item dcwarn($msg)
+
+Warning about a problem in the input or configuration; the requested output
+is still produced.  Silenced when C<$Devel::Cover::Silent> is true.
 
 =item dcprogress($msg)
 

--- a/lib/Devel/Cover/Mcdc.pm
+++ b/lib/Devel/Cover/Mcdc.pm
@@ -22,6 +22,9 @@ sub text      ($self) { $self->[1]{text} }
 sub labels    ($self) { $self->[1]{labels} // [] }
 sub criterion ($self) { "mcdc" }
 
+# True for a decision too wide to analyse; see LIMITATIONS below
+sub unanalysed ($self) { $self->[1]{unanalysed} ? 1 : 0 }
+
 sub covered ($self, $i = undef) {
   defined $i ? $self->[0][$i] : scalar grep $_, $self->[0]->@*
 }
@@ -112,6 +115,25 @@ report.
 Reports show MC/DC in two places: a per-file C<mcdc> percentage column in
 the summary, and a per-decision detail block listing each atomic condition
 whose independence pair was missing.
+
+=head1 LIMITATIONS
+
+A decision with more than 16 conditions exceeds the analysis limit.  Such a
+decision counts as 0 of its width in the percentages and appears in reports
+with an error flag and a "too many conditions" note in place of the
+missing-conditions list.  Generating a report warns, naming the file and
+line; C<-silent> suppresses the warning.  Any C<# uncoverable mcdc> markers
+on such a decision are ignored.
+
+The remedy is to split the decision with an intermediate variable:
+
+ my $r = $c1 || $c2 || ... || $c17 || $c18;          # too wide
+
+ my $left = $c1 || $c2 || ... || $c9;                # analysed
+ my $r    = $left || $c10 || ... || $c18;            # analysed
+
+The split form needs no extra test cases, preserves short-circuiting, and
+lets every condition be analysed.
 
 =head1 SEE ALSO
 

--- a/lib/Devel/Cover/Report/Compilation.pm
+++ b/lib/Devel/Cover/Report/Compilation.pm
@@ -80,6 +80,11 @@ sub print_mcdc ($db, $file, $) {
   for my $location (sort { $a <=> $b } $mcdc->items) {
     for my $m ($mcdc->location($location)->@*) {
       next unless $m->error;
+      if ($m->unanalysed) {
+        print "Unanalysed MC/DC decision (too many conditions) ",
+          "at $file line $location: ", $m->text, "\n";
+        next;
+      }
       print "Uncovered MC/DC pair (", join(", ", $m->missing->@*),
         ") at $file line $location: ", $m->text, "\n";
     }

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -266,7 +266,10 @@ sub print_mcdc () {
           number     => $count == 1 ? $location : "",
           percentage => $m->percentage,
           class      => class($m->percentage, $m->error, "mcdc"),
-          atomics    => [
+          note       => $m->unanalysed ? "too many conditions" : "",
+          atomics    => $m->unanalysed
+          ? []
+          : [
             map +{
               label => encode_entities($labels[$_] // ""),
               class => $vals[$_] ? "c3" : "c0",
@@ -754,8 +757,12 @@ $Templates{mcdc} = <<'HTML';
       </td>
       <td class="[% decision.class %]"> [% decision.percentage %] </td>
       <td>
-        [% FOREACH atom = decision.atomics %]
-          <span class="[% atom.class %]"> [% atom.label %] </span>
+        [% IF decision.note %]
+          <em> [% decision.note %] </em>
+        [% ELSE %]
+          [% FOREACH atom = decision.atomics %]
+            <span class="[% atom.class %]"> [% atom.label %] </span>
+          [% END %]
         [% END %]
       </td>
       <td class="s"> [% decision.text %] </td>

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -536,12 +536,17 @@ sub render_mcdc_detail ($mcdc) {
       . '<div class="head"><span>MC/DC</span>'
       . _summary_text($m->{covered}, $m->{total})
       . qq(</div>\n<div class="body">\n)
-      . qq(<div class="expr">$m->{text}</div>\n)
-      . qq(<div class="mcdc-atomics">\n);
-    for my $a ($m->{atomics}->@*) {
-      $o .= qq(<span class="mcdc-pill $a->{class}">$a->{label}</span>\n);
+      . qq(<div class="expr">$m->{text}</div>\n);
+    if ($m->{unanalysed}) {
+      $o .= qq(<div class="mcdc-note">too many conditions</div>\n);
+    } else {
+      $o .= qq(<div class="mcdc-atomics">\n);
+      for my $a ($m->{atomics}->@*) {
+        $o .= qq(<span class="mcdc-pill $a->{class}">$a->{label}</span>\n);
+      }
+      $o .= "</div>\n";
     }
-    $o .= "</div>\n</div>\n</div>\n";
+    $o .= "</div>\n</div>\n";
   }
   $o
 }
@@ -981,8 +986,11 @@ sub line_mcdc ($f, $n) {
       covered    => $m->covered,
       total      => $m->total,
       error      => $m->error,
+      unanalysed => $m->unanalysed,
       class      => class($m->percentage, $m->error, "mcdc"),
-      atomics    => [
+      atomics    => $m->unanalysed
+      ? []
+      : [
         map { {
           label   => encode_entities($labels[$_] // ""),
           covered => $vals[$_] ? 1    : 0,
@@ -1929,6 +1937,13 @@ td.chevron {
   border-radius: 12px;
   font-family: var(--font-code);
   font-size: var(--font-size-small);
+}
+
+.mcdc-note {
+  margin-top: 6px;
+  font-size: var(--font-size-small);
+  font-style: italic;
+  color: var(--fg-muted);
 }
 
 /* Minimap */

--- a/lib/Devel/Cover/Report/Html_minimal.pm
+++ b/lib/Devel/Cover/Report/Html_minimal.pm
@@ -523,7 +523,7 @@ sub print_mcdc_report ($db, $file, $opt) {
       my @labels = $m->labels->@*;
       my @cls    = bclass(@vals);
       my $pct    = $m->percentage;
-      my $pills  = join " ",
+      my $pills  = $m->unanalysed ? "<em>too many conditions</em>" : join " ",
           map qq(<span class="$cls[$_]">)
         . escape_HTML($labels[$_] // "")
         . "</span>", 0 .. $#vals;

--- a/lib/Devel/Cover/Report/Html_subtle.pm
+++ b/lib/Devel/Cover/Report/Html_subtle.pm
@@ -250,7 +250,7 @@ sub print_mcdc ($db, $file, $options) {
       my @vals   = $m->values;
       my @labels = $m->labels->@*;
 
-      my $atomics = join " ",
+      my $atomics = $m->unanalysed ? "<em>too many conditions</em>" : join " ",
           map qq(<span class="@{[ $vals[$_] ? "covered" : "uncovered" ]}">)
         . encode_entities($labels[$_] // "")
         . "</span>", 0 .. $#vals;

--- a/lib/Devel/Cover/Report/Json.pm
+++ b/lib/Devel/Cover/Report/Json.pm
@@ -134,6 +134,7 @@ sub _mcdc ($f) {
           labels  => $m->labels,
           covered => [map $_ + 0, $m->values],
           error   => $m->error ? 1 : 0,
+          $m->unanalysed ? (unanalysed => 1) : (),
         };
     }
     $out{$line} = \@entries;
@@ -302,6 +303,11 @@ The per-criterion keys are: C<statements>, C<branches>, C<conditions>,
 C<condition_truth_tables>, C<mcdc>, C<subroutines>, C<pod>, C<time>.  Within
 each criterion, keys are source line numbers and values are arrays of coverage
 objects for that line.
+
+An C<mcdc> entry for a decision too wide to analyse (more conditions than the
+per-decision limit) carries C<"unanalysed": 1>; its C<covered> array is all
+zeroes.  The key is absent for analysed decisions, distinguishing "too wide
+to analyse" from "untested".
 
 =back
 

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -354,8 +354,10 @@ sub print_mcdc ($db, $file, $) {
   for my $location (sort { $a <=> $b } $mcdc->items) {
     my $n = 0;
     for my $m ($mcdc->location($location)->@*) {
+      my $missing = $m->unanalysed ? "too many conditions" : join ", ",
+        $m->missing->@*;
       printf $tpl, $n ? "" : $location, $m->error ? "***" : "", $m->percentage,
-        $m->covered, $m->total, join(", ", $m->missing->@*), $m->text;
+        $m->covered, $m->total, $missing, $m->text;
       $n++;
     }
   }

--- a/t/internal/condition_table.t
+++ b/t/internal/condition_table.t
@@ -314,18 +314,90 @@ sub test_independent_conditions () {
   is_deeply \@exprs, ['$a && $b', '$x || $y'], "both expressions present";
 }
 
-# > 16 conditions returns empty list
-sub test_too_many_conditions () {
-  my @conditions = map {
-    mock_condition(
-      "Condition_and_3",
-      [1, 1, 1],
-      { type => "and_3", left => "\$a$_", op => "&&", right => "\$b$_" },
-    )
-  } 1 .. 17;
+# Chain of $n atomics ($x1 && $x2 && ... && $xn): n-1 and_3 records whose
+# left strings accumulate, matching how Devel::Cover records a chain.
+sub chain_conditions ($n, $prefix) {
+  my @atoms = map "\$$prefix$_", 1 .. $n;
+  my @conditions;
+  my $left = $atoms[0];
+  for my $i (1 .. $n - 1) {
+    push @conditions,
+      mock_condition(
+        "Condition_and_3",
+        [1, 1, 1],
+        { type => "and_3", left => $left, op => "&&", right => $atoms[$i] },
+      );
+    $left = "$left && $atoms[$i]";
+  }
+  @conditions
+}
+
+# A decision with more than 16 atomic conditions is too wide to analyse:
+# for_line returns a stub table flagged too_wide, with labels (so consumers
+# know the width) but no rows.
+sub test_too_wide_decision () {
+  my @conditions = chain_conditions(17, "a");
 
   my @tables = Devel::Cover::Condition_table->for_line(\@conditions);
-  is @tables, 0, "> 16 conditions returns empty";
+  is @tables, 1, "too wide: one table";
+
+  my $t = $tables[0];
+  ok $t->too_wide, "too wide: flagged";
+  ok !$t->proven,  "too wide: not proven";
+
+  my @rows = $t->rows;
+  is @rows, 0, "too wide: no rows";
+
+  my @labels = $t->labels;
+  is @labels, 17, "too wide: labels carry the width";
+  is $t->expr, join(" && ", map "\$a$_", 1 .. 17), "too wide: expr text";
+}
+
+# Exactly 16 atomic conditions is within the limit.
+sub test_exactly_16_atomics () {
+  my @conditions = chain_conditions(16, "a");
+
+  my @tables = Devel::Cover::Condition_table->for_line(\@conditions);
+  is @tables, 1, "16 atomics: one table";
+  ok !$tables[0]->too_wide, "16 atomics: not too wide";
+
+  my @labels = $tables[0]->labels;
+  is @labels, 16, "16 atomics: all labels present";
+
+  my @rows = $tables[0]->rows;
+  is @rows, 17, "16 atomics: rows built";
+}
+
+# The cap is per decision, not per line: two 10-atomic decisions sharing a
+# line (18 condition records, more than the old per-line cap) must both be
+# analysed.
+sub test_two_decisions_one_line () {
+  my @conditions = (chain_conditions(10, "a"), chain_conditions(10, "b"));
+
+  my @tables = Devel::Cover::Condition_table->for_line(\@conditions);
+  is @tables, 2, "two decisions on one line: two tables";
+  for my $t (@tables) {
+    ok !$t->too_wide, "decision @{[$t->expr]} not too wide";
+    my @rows = $t->rows;
+    is @rows, 11, "decision @{[$t->expr]} rows built";
+  }
+}
+
+# A too-wide decision and a narrow one on the same line: only the wide one
+# becomes a stub.
+sub test_wide_and_narrow_one_line () {
+  my @conditions = (chain_conditions(17, "a"), chain_conditions(2, "b"));
+
+  my @tables = Devel::Cover::Condition_table->for_line(\@conditions);
+  is @tables, 2, "wide+narrow: two tables";
+
+  my ($wide)   = grep { $_->too_wide } @tables;
+  my ($narrow) = grep { !$_->too_wide } @tables;
+  ok $wide,   "wide+narrow: wide table flagged";
+  ok $narrow, "wide+narrow: narrow table analysed";
+
+  my @rows = $narrow ? $narrow->rows : ();
+  is @rows, 3, "wide+narrow: narrow rows built";
 }
 
 # undef in hit counts (Devel::Cover can produce these)
@@ -1131,7 +1203,10 @@ sub main () {
   test_composite_or_and;
   test_deep_and_chain;
   test_independent_conditions;
-  test_too_many_conditions;
+  test_too_wide_decision;
+  test_exactly_16_atomics;
+  test_two_decisions_one_line;
+  test_wide_and_narrow_one_line;
   test_undef_hits;
   test_unknown_type;
   test_single_input_with_subexpr;

--- a/t/internal/condition_table.t
+++ b/t/internal/condition_table.t
@@ -349,7 +349,7 @@ sub test_too_wide_decision () {
   is @rows, 0, "too wide: no rows";
 
   my @labels = $t->labels;
-  is @labels, 17, "too wide: labels carry the width";
+  is @labels,  17, "too wide: labels carry the width";
   is $t->expr, join(" && ", map "\$a$_", 1 .. 17), "too wide: expr text";
 }
 

--- a/t/internal/decision_inputs.t
+++ b/t/internal/decision_inputs.t
@@ -22,9 +22,9 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 
 use Test::More import => [qw( done_testing is is_deeply ok subtest )];
 
-use Devel::Cover::DB             ();
-use Devel::Cover::Mcdc           ();
-use Devel::Cover::Test::Internal qw( write_script run_under_cover );
+use Devel::Cover::DB             ();  ## no perlimports
+use Devel::Cover::Mcdc           ();  ## no perlimports
+use Devel::Cover::Test::Internal qw( run_under_cover write_script );
 
 # A mock condition entry matching the structure Devel::Cover produces:
 #   [0] hit counts per outcome, [1] {type, left, op, right}, [2] uncoverable
@@ -307,8 +307,8 @@ PERL
 # A decision wider than the analysis limit records no input vectors;
 # a narrow decision alongside it is unaffected.
 sub test_too_wide_decision_records_nothing () {
-  my @vars = map "\$v$_", 1 .. 17;
-  my $args = join ", ", ("1") x 17;
+  my @vars   = map "\$v$_", 1 .. 17;
+  my $args   = join ", ", ("1") x 17;
   my $script = write_script("too_wide.pl", <<PERL);
 sub wide { my (@{[ join ", ", @vars ]}) = \@_; my \$r = @{[
   join " && ", @vars ]}; \$r }

--- a/t/internal/decision_inputs.t
+++ b/t/internal/decision_inputs.t
@@ -304,6 +304,29 @@ PERL
     "array-element chain records a three-level cascaded short-circuit";
 }
 
+# A decision wider than the analysis limit records no input vectors;
+# a narrow decision alongside it is unaffected.
+sub test_too_wide_decision_records_nothing () {
+  my @vars = map "\$v$_", 1 .. 17;
+  my $args = join ", ", ("1") x 17;
+  my $script = write_script("too_wide.pl", <<PERL);
+sub wide { my (@{[ join ", ", @vars ]}) = \@_; my \$r = @{[
+  join " && ", @vars ]}; \$r }
+wide($args);
+sub two { my (\$p, \$q) = \@_; my \$r = \$p && \$q; \$r }
+two(1, 0);
+PERL
+
+  my ($db, $path) = run_under_cover($script, "too_wide");
+  my $di = decision_inputs_for($db, $path);
+  ok $di, "decision_inputs present for too_wide";
+
+  my @recorded = grep defined, @$di;
+  is @recorded, 1, "only the narrow decision records vectors";
+  is_deeply $recorded[0], { "1|0" => 1 },
+    "the narrow decision's vector is unaffected";
+}
+
 sub test_add_condition_cross_run_merge () {
   my $db = bless {}, "Devel::Cover::DB";
   my $cc = {};
@@ -352,6 +375,8 @@ sub main () {
     \&test_sort_block_records_per_invocation;
   subtest "chain cascades record short circuits" =>
     \&test_chain_cascades_record_short_circuits;
+  subtest "too-wide decision records nothing" =>
+    \&test_too_wide_decision_records_nothing;
   subtest "cross-run merge"     => \&test_add_condition_cross_run_merge;
   subtest "xor four-slot merge" => \&test_add_condition_xor_four_slot_merge;
 

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -444,6 +444,51 @@ sub test_truth_tables_unproven_rows_uncovered () {
   ok !(grep $_->{class} eq "c3", @rows), "no covered colour on unproven rows";
 }
 
+# A too-wide decision (more atomics than the analysis limit) produces a stub
+# table with no rows; the truth-table panel must skip it cleanly, without
+# rendering an empty table or warning on its undefined short_expr.
+sub test_truth_tables_skip_too_wide () {
+  my @cond;
+  my $left = '$v1';
+  for my $i (2 .. 17) {
+    push @cond,
+      _mock_cond(
+        "Condition_or_3",
+        [1, 1, 1],
+        { type => "or_3", left => $left, op => "||", right => "\$v$i" },
+      );
+    $left = "$left || \$v$i";
+  }
+  my $f = MockFile->new(MockCriterion->new({ 7 => \@cond }));
+
+  my @warnings;
+  local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+  my @tts = Devel::Cover::Report::Html_crisp::line_truth_tables($f, 7);
+  is @tts,      0, "too-wide decision renders no truth table";
+  is @warnings, 0, "no warnings from the stub table";
+}
+
+sub test_mcdc_detail_unanalysed_note () {
+  my $line = {
+    count => 1,
+    mcdc  => [{
+      text       => "wide decision",
+      percentage => 0,
+      covered    => 0,
+      total      => 18,
+      error      => 1,
+      class      => "c0",
+      unanalysed => 1,
+      atomics    => [],
+    }],
+  };
+
+  my $html = Devel::Cover::Report::Html_crisp::render_line_detail($line);
+  like $html, qr/too many conditions/,
+    "unanalysed: note rendered in place of pills";
+  unlike $html, qr/mcdc-pill/, "unanalysed: no atomic pills";
+}
+
 sub test_truth_tables_pass_observed_vectors () {
   my @cond = (
     _mock_cond(
@@ -721,6 +766,8 @@ sub main () {
   test_dir_header_links;
   test_app_js_hash_filter;
   test_truth_tables_unproven_rows_uncovered;
+  test_truth_tables_skip_too_wide;
+  test_mcdc_detail_unanalysed_note;
   test_truth_tables_pass_observed_vectors;
   test_condition_cells_panel;
   test_condition_cells_panel_merges_conditions;

--- a/t/internal/log.t
+++ b/t/internal/log.t
@@ -18,7 +18,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 
 use Test::More import => [qw( done_testing is )];
 
-use Devel::Cover::Log qw( dcerror dcinfo dcprogress );
+use Devel::Cover::Log qw( dcerror dcinfo dcprogress dcwarn );
 
 {
   no feature "signatures";
@@ -69,6 +69,20 @@ sub test_dcerror_not_silenced () {
   is $err, "cover: oops\n", "dcerror silent: still emitted - not guarded";
 }
 
+sub test_dcwarn_writes_to_stderr () {
+  local $Devel::Cover::Silent = 0;
+  my ($out, $err) = capture { dcwarn "beware" };
+  is $out, "",                "dcwarn: nothing on STDOUT";
+  is $err, "cover: beware\n", "dcwarn: prefixed message on STDERR";
+}
+
+sub test_dcwarn_silenced () {
+  local $Devel::Cover::Silent = 1;
+  my ($out, $err) = capture { dcwarn "beware" };
+  is $out, "", "dcwarn silent: nothing on STDOUT";
+  is $err, "", "dcwarn silent: nothing on STDERR";
+}
+
 sub test_dcprogress_writes_to_stderr () {
   local $Devel::Cover::Silent = 0;
   my ($out, $err) = capture { dcprogress "step 1" };
@@ -109,6 +123,8 @@ test_dcinfo_writes_to_stderr;
 test_dcinfo_silenced;
 test_dcerror_writes_to_stderr;
 test_dcerror_not_silenced;
+test_dcwarn_writes_to_stderr;
+test_dcwarn_silenced;
 test_dcprogress_writes_to_stderr;
 test_dcprogress_silenced;
 test_prefix_override;

--- a/t/internal/mcdc_criterion.t
+++ b/t/internal/mcdc_criterion.t
@@ -110,6 +110,17 @@ sub test_missing_excludes_marked () {
   is_deeply $m->missing, ['$a'], "missing omits columns marked uncoverable";
 }
 
+sub test_unanalysed_flag () {
+  my $m = bless [[0, 0], { text => '$a && $b', unanalysed => 1 }],
+    "Devel::Cover::Mcdc";
+  is $m->unanalysed, 1, "unanalysed true when flagged";
+}
+
+sub test_unanalysed_default () {
+  my $m = mcdc([1, 0]);
+  is $m->unanalysed, 0, "unanalysed false when not flagged";
+}
+
 sub main () {
   test_total_counts_columns;
   test_covered_counts_satisfied_columns;
@@ -126,6 +137,8 @@ sub main () {
   test_error_flags_covered_but_marked;
   test_fully_marked_decision_has_no_error;
   test_missing_excludes_marked;
+  test_unanalysed_flag;
+  test_unanalysed_default;
   done_testing;
 }
 

--- a/t/internal/mcdc_too_wide.t
+++ b/t/internal/mcdc_too_wide.t
@@ -140,19 +140,27 @@ sub pill_re ($report, $var) {
   $re{$report}
 }
 
+my %Needs_template = (html_basic => 1, html_subtle => 1);
+
 sub test_html_reports_note_limit () {
   my ($db, $path) = run_wide("too_wide_html", "$Narrow$Decl\n$Wide\n");
   for my $report (qw( html_basic html_minimal html_subtle html_crisp )) {
-    my $outdir = "$db->{db}/$report";
-    my $out    = `$^X -Iblib/lib -Iblib/arch bin/cover -report $report \\
-      -silent -outputdir $outdir $db->{db} 2>&1`;
-    is $? >> 8, 0, "cover -report $report exits 0";
-    my $all = join "", map slurp($_), glob "$outdir/*.html";
-    like $all, qr/too many conditions/, "$report notes the limit";
-    like $all, pill_re($report, '$x'),
-      "$report renders the narrow decision's pills";
-    unlike $all, pill_re($report, '$v5'),
-      "$report renders no atomic pill for the wide decision";
+    subtest $report => sub {
+      if ($Needs_template{$report} && !eval { require Template; 1 }) {
+        Test::More::plan(skip_all => "Template not available");
+        return;
+      }
+      my $outdir = "$db->{db}/$report";
+      my $out    = `$^X -Iblib/lib -Iblib/arch bin/cover -report $report \\
+        -silent -outputdir $outdir $db->{db} 2>&1`;
+      is $? >> 8, 0, "cover -report $report exits 0";
+      my $all = join "", map slurp($_), glob "$outdir/*.html";
+      like $all, qr/too many conditions/, "$report notes the limit";
+      like $all, pill_re($report, '$x'),
+        "$report renders the narrow decision's pills";
+      unlike $all, pill_re($report, '$v5'),
+        "$report renders no atomic pill for the wide decision";
+    };
   }
 }
 

--- a/t/internal/mcdc_too_wide.t
+++ b/t/internal/mcdc_too_wide.t
@@ -1,0 +1,223 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# A decision with more conditions than the analysis limit must not be
+# silently excluded from MC/DC: it counts as 0 out of its width, carries an
+# unanalysed flag, and report-time derivation warns, naming file and line.
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is like ok subtest unlike )];
+
+use Devel::Cover::Test::Internal qw( write_script run_under_cover );
+
+{
+  no feature "signatures";
+
+  sub capture_stderr (&) {
+    my ($code) = @_;
+    my $err = "";
+    open my $save_err, ">&", \*STDERR or die "Cannot dup STDERR: $!";
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">", \$err or die "Cannot redirect STDERR: $!";
+    my $result = $code->();
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">&", $save_err or die "Cannot restore STDERR: $!";
+    ($err, $result)
+  }
+}
+
+my @Vars = map "\$v$_", 1 .. 18;
+my $Decl = "my (" . join(", ", @Vars) . ") = (0) x 18;";
+my $Wide = "my \$r = " . join(" || ", @Vars) . ";";
+
+# The narrow decision is fully exercised, so without the fix the file-level
+# percentage would read 100 while the wide decision is silently excluded.
+my $Narrow = <<'PERL';
+sub narrow { my ($x, $y) = @_; my $r = $x && $y; $r }
+narrow(0, 0);
+narrow(1, 0);
+narrow(1, 1);
+PERL
+
+# Line numbers in the generated script: narrow block is lines 1-4, the
+# declaration line 5, the wide decision line 6.
+my $Wide_line = 6;
+
+sub run_wide ($label, $source) {
+  my $script = write_script("$label.pl", $source);
+  my ($db, $path)
+    = run_under_cover($script, $label, criteria => [qw( condition mcdc )]);
+  ($db, $path)
+}
+
+sub decisions ($db, $path) {
+  my $mcdc = $db->cover->file($path)->{mcdc} // {};
+  map { ($_->@*) } values %$mcdc
+}
+
+sub test_wide_decision_reported_unanalysed () {
+  my ($db, $path) = run_wide("too_wide", "$Narrow$Decl\n$Wide\n");
+  my ($err) = capture_stderr { $db->cover };
+
+  my ($wide)   = grep { $_->total == 18 } decisions($db, $path);
+  my ($narrow) = grep { $_->total == 2 } decisions($db, $path);
+
+  ok $wide, "wide decision present in mcdc data";
+  is $wide->covered, 0, "wide decision counts 0 of its width";
+  ok $wide->error,       "wide decision carries an error flag";
+  ok $wide->unanalysed,  "wide decision flagged unanalysed";
+  is $wide->text, join(" || ", @Vars), "wide decision text preserved";
+
+  ok $narrow, "narrow decision on the same file still analysed";
+  is $narrow->covered, 2, "narrow decision fully covered";
+  ok !$narrow->error,      "narrow decision has no error";
+  ok !$narrow->unanalysed, "narrow decision not flagged unanalysed";
+
+  like $err, qr/18 conditions.*limit of 16/,
+    "warning names the width and the limit";
+  like $err, qr/\Q$path\E:$Wide_line\b/, "warning names file and line";
+}
+
+sub test_warning_respects_silent () {
+  my ($db, $path) = run_wide("too_wide_silent", "$Narrow$Decl\n$Wide\n");
+  my ($err) = do {
+    local $Devel::Cover::Silent = 1;
+    capture_stderr { $db->cover };
+  };
+  is $err, "", "no warning under -silent";
+
+  my ($wide) = grep { $_->total == 18 } decisions($db, $path);
+  ok $wide && $wide->unanalysed, "decision still flagged unanalysed";
+}
+
+sub test_uncoverable_marker_ignored_with_warning () {
+  my $source = "$Narrow$Decl\n# uncoverable mcdc\n$Wide\n";
+  my ($db, $path) = run_wide("too_wide_unc", $source);
+  my ($err) = capture_stderr { $db->cover };
+
+  my ($wide) = grep { $_->total == 18 } decisions($db, $path);
+  ok $wide, "wide decision present";
+  is $wide->uncoverable, 0, "uncoverable marker not applied";
+  ok $wide->error, "decision still reports an error";
+
+  my $line = $Wide_line + 1;  # the marker comment shifts the decision down
+  like $err, qr/Ignoring uncoverable mcdc at \Q$path\E:$line\b/,
+    "marker on a too-wide decision warns and is ignored";
+}
+
+sub slurp ($path) {
+  open my $fh, "<", $path or die "Cannot read $path: $!";
+  my $content = do { local $/; <$fh> };
+  close $fh or die "Cannot close $path: $!";
+  $content
+}
+
+# Each HTML reporter must render the note in place of the wide decision's
+# atomic pills.  The narrow decision's pills, the wide decision's text and
+# the highlighted source all legitimately mention wide-only variables, so
+# the absence assertion targets each reporter's own pill markup.
+sub pill_re ($report, $var) {
+  my %re = (
+    html_basic   => qr|<span class="c[03]">\s*\Q$var\E\s*</span>|,
+    html_minimal => qr|<span class="c[03]">\Q$var\E</span>|,
+    html_subtle  => qr|<span class="(?:un)?covered">\Q$var\E</span>|,
+    html_crisp   => qr|<span class="mcdc-pill [^"]*">\Q$var\E</span>|,
+  );
+  $re{$report}
+}
+
+sub test_html_reports_note_limit () {
+  my ($db, $path) = run_wide("too_wide_html", "$Narrow$Decl\n$Wide\n");
+  for my $report (qw( html_basic html_minimal html_subtle html_crisp )) {
+    my $outdir = "$db->{db}/$report";
+    my $out    = `$^X -Iblib/lib -Iblib/arch bin/cover -report $report \\
+      -silent -outputdir $outdir $db->{db} 2>&1`;
+    is $? >> 8, 0, "cover -report $report exits 0";
+    my $all = join "", map slurp($_), glob "$outdir/*.html";
+    like $all, qr/too many conditions/, "$report notes the limit";
+    like $all, pill_re($report, '$x'),
+      "$report renders the narrow decision's pills";
+    unlike $all, pill_re($report, '$v5'),
+      "$report renders no atomic pill for the wide decision";
+  }
+}
+
+sub run_report ($db, $report) {
+  my $out = `$^X -Iblib/lib -Iblib/arch bin/cover -report $report -silent \\
+    $db->{db} 2>&1`;
+  is $? >> 8, 0, "cover -report $report exits 0";
+  $out
+}
+
+sub test_text_report_notes_limit () {
+  my ($db, $path) = run_wide("too_wide_text", "$Narrow$Decl\n$Wide\n");
+  my $out = run_report($db, "text");
+  like $out, qr/\Qtoo many conditions\E/,
+    "text report notes the limit in place of the missing list";
+  unlike $out, qr/\$v1, \$v2/,
+    "text report does not list the wide decision's conditions as missing";
+}
+
+sub test_compilation_report_notes_limit () {
+  my ($db, $path) = run_wide("too_wide_comp", "$Narrow$Decl\n$Wide\n");
+  my $out = run_report($db, "compilation");
+  my $re = qr|Unanalysed MC/DC decision \(too many conditions\)|;
+  like $out, qr/$re at .* line $Wide_line:/,
+    "compilation report emits an unanalysed line";
+  unlike $out, qr|Uncovered MC/DC pair \(\$v1|,
+    "compilation report does not claim missing pairs for the wide decision";
+}
+
+# The JSON report carries the flag so consumers can distinguish "too wide
+# to analyse" from "untested".  It is emitted only on unanalysed decisions,
+# keeping existing output unchanged.
+sub test_json_report_carries_flag () {
+  subtest "json report" => sub {
+    eval "require JSON::MaybeXS; 1" or do {
+      Test::More::plan(skip_all => "JSON::MaybeXS not available");
+      return;
+    };
+    my ($db, $path) = run_wide("too_wide_json", "$Narrow$Decl\n$Wide\n");
+    my $outdir = "$db->{db}/json";
+    my $out    = `$^X -Iblib/lib -Iblib/arch bin/cover -report json \\
+      -silent -outputdir $outdir $db->{db} 2>&1`;
+    is $? >> 8, 0, "cover -report json exits 0";
+
+    my $json = JSON::MaybeXS->new(utf8 => 1)
+      ->decode(slurp("$outdir/cover.json"));
+    my ($f)  = grep { $_->{mcdc} } values $json->{files}->%*;
+    ok $f, "json has a file with mcdc data";
+    my @decisions = map { $_->@* } values $f->{mcdc}->%*;
+    my ($wide)    = grep { $_->{covered}->@* == 18 } @decisions;
+    my ($narrow)  = grep { $_->{covered}->@* == 2 } @decisions;
+    ok $wide, "wide decision present in json";
+    ok $wide->{unanalysed}, "wide decision flagged unanalysed in json";
+    ok $narrow, "narrow decision present in json";
+    ok !exists $narrow->{unanalysed},
+      "narrow decision carries no unanalysed key";
+  };
+}
+
+test_wide_decision_reported_unanalysed;
+test_warning_respects_silent;
+test_uncoverable_marker_ignored_with_warning;
+test_text_report_notes_limit;
+test_compilation_report_notes_limit;
+test_html_reports_note_limit;
+test_json_report_carries_flag;
+
+done_testing;

--- a/t/internal/mcdc_too_wide.t
+++ b/t/internal/mcdc_too_wide.t
@@ -42,7 +42,7 @@ use Devel::Cover::Test::Internal qw( write_script run_under_cover );
 
 my @Vars = map "\$v$_", 1 .. 18;
 my $Decl = "my (" . join(", ", @Vars) . ") = (0) x 18;";
-my $Wide = "my \$r = " . join(" || ", @Vars) . ";";
+my $Wide = 'my $r = ' . join(" || ", @Vars) . ";";
 
 # The narrow decision is fully exercised, so without the fix the file-level
 # percentage would read 100 while the wide decision is silently excluded.
@@ -78,8 +78,8 @@ sub test_wide_decision_reported_unanalysed () {
 
   ok $wide, "wide decision present in mcdc data";
   is $wide->covered, 0, "wide decision counts 0 of its width";
-  ok $wide->error,       "wide decision carries an error flag";
-  ok $wide->unanalysed,  "wide decision flagged unanalysed";
+  ok $wide->error,      "wide decision carries an error flag";
+  ok $wide->unanalysed, "wide decision flagged unanalysed";
   is $wide->text, join(" || ", @Vars), "wide decision text preserved";
 
   ok $narrow, "narrow decision on the same file still analysed";
@@ -140,6 +140,12 @@ sub pill_re ($report, $var) {
   $re{$report}
 }
 
+sub run_cover (@args) {
+  my $cmd = join " ", $^X, "-Iblib/lib", "-Iblib/arch", "bin/cover", @args,
+    "2>&1";
+  `$cmd`
+}
+
 my %Needs_template = (html_basic => 1, html_subtle => 1);
 
 sub test_html_reports_note_limit () {
@@ -151,8 +157,9 @@ sub test_html_reports_note_limit () {
         return;
       }
       my $outdir = "$db->{db}/$report";
-      my $out    = `$^X -Iblib/lib -Iblib/arch bin/cover -report $report \\
-        -silent -outputdir $outdir $db->{db} 2>&1`;
+      my $out    = run_cover(
+        "-report", $report, "-silent", "-outputdir", $outdir, $db->{db}
+      );
       is $? >> 8, 0, "cover -report $report exits 0";
       my $all = join "", map slurp($_), glob "$outdir/*.html";
       like $all, qr/too many conditions/, "$report notes the limit";
@@ -165,8 +172,7 @@ sub test_html_reports_note_limit () {
 }
 
 sub run_report ($db, $report) {
-  my $out = `$^X -Iblib/lib -Iblib/arch bin/cover -report $report -silent \\
-    $db->{db} 2>&1`;
+  my $out = run_cover("-report", $report, "-silent", $db->{db});
   is $? >> 8, 0, "cover -report $report exits 0";
   $out
 }
@@ -183,7 +189,7 @@ sub test_text_report_notes_limit () {
 sub test_compilation_report_notes_limit () {
   my ($db, $path) = run_wide("too_wide_comp", "$Narrow$Decl\n$Wide\n");
   my $out = run_report($db, "compilation");
-  my $re = qr|Unanalysed MC/DC decision \(too many conditions\)|;
+  my $re  = qr|Unanalysed MC/DC decision \(too many conditions\)|;
   like $out, qr/$re at .* line $Wide_line:/,
     "compilation report emits an unanalysed line";
   unlike $out, qr|Uncovered MC/DC pair \(\$v1|,
@@ -201,20 +207,20 @@ sub test_json_report_carries_flag () {
     };
     my ($db, $path) = run_wide("too_wide_json", "$Narrow$Decl\n$Wide\n");
     my $outdir = "$db->{db}/json";
-    my $out    = `$^X -Iblib/lib -Iblib/arch bin/cover -report json \\
-      -silent -outputdir $outdir $db->{db} 2>&1`;
+    my $out    = run_cover("-report", "json", "-silent", "-outputdir", $outdir,
+      $db->{db});
     is $? >> 8, 0, "cover -report json exits 0";
 
-    my $json = JSON::MaybeXS->new(utf8 => 1)
-      ->decode(slurp("$outdir/cover.json"));
-    my ($f)  = grep { $_->{mcdc} } values $json->{files}->%*;
+    my $json
+      = JSON::MaybeXS->new(utf8 => 1)->decode(slurp("$outdir/cover.json"));
+    my ($f) = grep { $_->{mcdc} } values $json->{files}->%*;
     ok $f, "json has a file with mcdc data";
-    my @decisions = map { $_->@* } values $f->{mcdc}->%*;
+    my @decisions = map  { $_->@* } values $f->{mcdc}->%*;
     my ($wide)    = grep { $_->{covered}->@* == 18 } @decisions;
     my ($narrow)  = grep { $_->{covered}->@* == 2 } @decisions;
-    ok $wide, "wide decision present in json";
+    ok $wide,               "wide decision present in json";
     ok $wide->{unanalysed}, "wide decision flagged unanalysed in json";
-    ok $narrow, "narrow decision present in json";
+    ok $narrow,             "narrow decision present in json";
     ok !exists $narrow->{unanalysed},
       "narrow decision carries no unanalysed key";
   };

--- a/t/internal/mcdc_too_wide.t
+++ b/t/internal/mcdc_too_wide.t
@@ -22,7 +22,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 
 use Test::More import => [qw( done_testing is like ok subtest unlike )];
 
-use Devel::Cover::Test::Internal qw( write_script run_under_cover );
+use Devel::Cover::Test::Internal qw( run_under_cover write_script );
 
 {
   no feature "signatures";

--- a/t/internal/uncoverable_mcdc_pair.t
+++ b/t/internal/uncoverable_mcdc_pair.t
@@ -9,6 +9,7 @@
 
 # "# uncoverable mcdc pair:N" is 1-based.  pair:0 and columns past the
 # decision's width must warn and be ignored, never abort the report (GH-496).
+# The warnings go through dcwarn, so -silent suppresses them.
 
 use 5.20.0;
 use warnings;
@@ -27,17 +28,34 @@ use Devel::Cover::DB ();
 
 my $Tmpdir = tempdir(CLEANUP => 1);
 
+{
+  no feature "signatures";
+
+  # Warnings go to STDERR via dcwarn, not through perl's warn.
+  sub warnings_from (&) {
+    my ($code) = @_;
+    my $err = "";
+    open my $save_err, ">&", \*STDERR or die "Cannot dup STDERR: $!";
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">", \$err or die "Cannot redirect STDERR: $!";
+    $code->();
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">&", $save_err or die "Cannot restore STDERR: $!";
+    [split /(?<=\n)/, $err]
+  }
+}
+
 sub parse_comments ($source) {
   my $path = File::Spec->catfile($Tmpdir, "source.pl");
   open my $fh, ">", $path or die "Cannot write $path: $!";
   print $fh $source;
   close $fh or die "Cannot close $path: $!";
 
-  my $unc = {};
-  my @warnings;
-  local $SIG{__WARN__} = sub { push @warnings, $_[0] };
-  Devel::Cover::DB->new->uncoverable_comments($unc, $path, "digest");
-  ($unc, \@warnings, $path)
+  my $unc      = {};
+  my $warnings = warnings_from {
+    Devel::Cover::DB->new->uncoverable_comments($unc, $path, "digest");
+  };
+  ($unc, $warnings, $path)
 }
 
 sub test_pair_zero_is_rejected () {
@@ -64,14 +82,15 @@ PERL
 }
 
 sub mcdc_uncoverable ($marks, $total) {
-  my @warnings;
-  local $SIG{__WARN__} = sub { push @warnings, $_[0] };
-  my $uncov = do {
+  my $uncov;
+  my $warnings = warnings_from {
+    $uncov = do {
 
-    package Devel::Cover::DB;
-    _mcdc_uncoverable({ 7 => [$marks] }, "source.pl", 7, 0, $total)
+      package Devel::Cover::DB;
+      _mcdc_uncoverable({ 7 => [$marks] }, "source.pl", 7, 0, $total)
+    };
   };
-  ($uncov, \@warnings)
+  ($uncov, $warnings)
 }
 
 sub test_out_of_range_column_warns () {
@@ -94,10 +113,30 @@ sub test_bare_marker_marks_all_columns () {
   is_deeply $uncov, ["default", "default"], "bare marker: every column marked";
 }
 
+sub test_pair_zero_warning_respects_silent () {
+  local $Devel::Cover::Silent = 1;
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my ($a, $b) = (1, 1);
+# uncoverable mcdc pair:0
+my $r = $a && $b;
+PERL
+  is @$warnings, 0, "pair:0 silent: no warning";
+  ok !exists $unc->{digest}{mcdc}, "pair:0 silent: marker still ignored";
+}
+
+sub test_out_of_range_warning_respects_silent () {
+  local $Devel::Cover::Silent = 1;
+  my ($uncov, $warnings) = mcdc_uncoverable([[5, "default", ""]], 2);
+  is @$warnings, 0, "out of range silent: no warning";
+  ok !(grep defined, @$uncov), "out of range silent: no column marked";
+}
+
 test_pair_zero_is_rejected;
 test_pair_one_is_recorded;
 test_out_of_range_column_warns;
 test_negative_column_warns;
 test_bare_marker_marks_all_columns;
+test_pair_zero_warning_respects_silent;
+test_out_of_range_warning_respects_silent;
 
 done_testing;

--- a/test_output/cover/mcdc_wide.5.020000
+++ b/test_output/cover/mcdc_wide.5.020000
@@ -1,0 +1,209 @@
+cover: Reading database from ...
+cover: MC/DC decision at tests/mcdc_wide:23 has 18 conditions, exceeding the analysis limit of 16
+cover: MC/DC decision at tests/mcdc_wide:41 has 17 conditions, exceeding the analysis limit of 16
+--------------- ------ ------ ------ ------ ------ ------ ------
+File              stmt   bran   cond   mcdc    sub  total   scar
+--------------- ------ ------ ------ ------ ------ ------ ------
+tests/mcdc_wide  100.0    n/a   68.5   10.2  100.0   61.3   40.4
+Total            100.0    n/a   68.5   10.2  100.0   61.3   40.4
+--------------- ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/mcdc_wide
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+36 74.8 56.7 40.4
+
+Worst Subroutines
+-----------------
+
+Subroutine CC SCAR  Location          
+---------- -- ----  ------------------
+wide       18 33.4  tests/mcdc_wide:22
+mixed      18 32.6  tests/mcdc_wide:40
+narrow      2  6.9  tests/mcdc_wide:31
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10             1                           1   use strict;
+               1                               
+               1                               
+11             1                           1   use warnings;
+               1                               
+               1                               
+12                                             
+13                                             # A decision with more than 16 conditions exceeds the MC/DC analysis limit
+14                                             # and must count as 0 of its width with an error flag and note, rather than
+15                                             # being silently excluded and inflating the file percentage.  The narrow
+16                                             # decisions here are fully exercised, so without the limit handling the file
+17                                             # would read mcdc 100.0.
+18                                             
+19                                             # An 18-condition chain: unanalysed, 0/18.  A statement has one COP, so the
+20                                             # wrapped decision's conditions are all keyed to its first line.
+21                                             sub wide {
+22             2                           2     my @v = @_;
+23    ***      2          * 66   *  0            my $r = $v[0] || $v[1] || $v[2] || $v[3] || $v[4] || $v[5] || $v[6]
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+24                                                 || $v[7] || $v[8] || $v[9] || $v[10] || $v[11] || $v[12] || $v[13]
+25                                                 || $v[14] || $v[15] || $v[16] || $v[17];
+26             2                                 $r
+27                                             }
+28                                             
+29                                             # A fully exercised 2-condition decision: MC/DC satisfied.
+30                                             sub narrow {
+31             3                           3     my ($p, $q) = @_;
+32             3           100    100            my $r = $p && $q;
+33             3                                 $r
+34                                             }
+35                                             
+36                                             # A 17-condition decision and a 2-condition decision on the same line: the
+37                                             # limit is per decision, not per line, so only the wide one is unanalysed.
+38                                             # Both statements start on one line so their conditions share a line key.
+39                                             sub mixed {
+40             3                           3     my ($p, $q, @v) = @_;
+41             3           100    100            my $s = $p && $q; my $r = $v[0] || $v[1] || $v[2] || $v[3] || $v[4]
+      ***      3          * 66   *  0          
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+      ***                 * 66                 
+42                                                 || $v[5] || $v[6] || $v[7] || $v[8] || $v[9] || $v[10] || $v[11]
+43                                                 || $v[12] || $v[13] || $v[14] || $v[15] || $v[16];
+44             3                                 ($r, $s)
+45                                             }
+46                                             
+47                                             sub main {
+48             1                           1     my @r;
+49                                             
+50             1                                 push @r, narrow(1, 1);
+51             1                                 push @r, narrow(1, 0);
+52             1                                 push @r, narrow(0, 1);
+53                                             
+54             1                                 push @r, wide((0) x 18);
+55             1                                 push @r, wide(1, (0) x 17);
+56                                             
+57             1                                 push @r, mixed(1, 1, (0) x 17);
+58             1                                 push @r, mixed(1, 0, (0) x 17);
+59             1                                 push @r, mixed(0, 1, 1, (0) x 16);
+60                                             }
+61                                             
+62             1                               main();
+
+
+Conditions
+----------
+
+and 3 conditions
+
+line  err      %     !l  l&&!r   l&&r   expr
+----- --- ------ ------ ------ ------   ----
+32           100      1      1      1   $p && $q
+41           100      1      1      1   $p && $q
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+23    ***     66      1      0      1   $v[0] || $v[1] || $v[2] || $v[3] || $v[4] || $v[5] || $v[6] || $v[7] || $v[8] || $v[9] || $v[10] || $v[11] || $v[12] || $v[13] || $v[14] || $v[15] || $v[16] || $v[17]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10] or $v[11] or $v[12] or $v[13] or $v[14] or $v[15] or $v[16]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10] or $v[11] or $v[12] or $v[13] or $v[14] or $v[15]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10] or $v[11] or $v[12] or $v[13] or $v[14]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10] or $v[11] or $v[12] or $v[13]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10] or $v[11] or $v[12]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10] or $v[11]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3] or $v[4]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2] or $v[3]
+      ***     66      1      0      1   $v[0] or $v[1] or $v[2]
+      ***     66      1      0      1   $v[0] or $v[1]
+41    ***     66      1      0      2   $v[0] || $v[1] || $v[2] || $v[3] || $v[4] || $v[5] || $v[6] || $v[7] || $v[8] || $v[9] || $v[10] || $v[11] || $v[12] || $v[13] || $v[14] || $v[15] || $v[16]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10] or $v[11] or $v[12] or $v[13] or $v[14] or $v[15]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10] or $v[11] or $v[12] or $v[13] or $v[14]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10] or $v[11] or $v[12] or $v[13]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10] or $v[11] or $v[12]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10] or $v[11]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9] or $v[10]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8] or $v[9]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7] or $v[8]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6] or $v[7]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5] or $v[6]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4] or $v[5]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3] or $v[4]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2] or $v[3]
+      ***     66      1      0      2   $v[0] or $v[1] or $v[2]
+      ***     66      1      0      2   $v[0] or $v[1]
+
+
+MC/DC
+-----
+
+line  err      %  cov  tot   missing                expr
+----- --- ------ ---- ----   --------------------   ----
+23    ***      0    0   18   too many conditions    $v[0] || $v[1] || $v[2] || $v[3] || $v[4] || $v[5] || $v[6] || $v[7] || $v[8] || $v[9] || $v[10] || $v[11] || $v[12] || $v[13] || $v[14] || $v[15] || $v[16] || $v[17]
+32           100    2    2                          $p && $q
+41           100    2    2                          $p && $q
+      ***      0    0   17   too many conditions    $v[0] || $v[1] || $v[2] || $v[3] || $v[4] || $v[5] || $v[6] || $v[7] || $v[8] || $v[9] || $v[10] || $v[11] || $v[12] || $v[13] || $v[14] || $v[15] || $v[16]
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location          
+---------- ----- --- ----- ------------------
+BEGIN          1   1   0.0 tests/mcdc_wide:10
+BEGIN          1   1   0.0 tests/mcdc_wide:11
+main           1   1   0.0 tests/mcdc_wide:48
+mixed          3  18  32.6 tests/mcdc_wide:40
+narrow         3   2   6.9 tests/mcdc_wide:31
+wide           2  18  33.4 tests/mcdc_wide:22
+
+

--- a/tests/mcdc_wide
+++ b/tests/mcdc_wide
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use strict;
+use warnings;
+
+# A decision with more than 16 conditions exceeds the MC/DC analysis limit
+# and must count as 0 of its width with an error flag and note, rather than
+# being silently excluded and inflating the file percentage.  The narrow
+# decisions here are fully exercised, so without the limit handling the file
+# would read mcdc 100.0.
+
+# An 18-condition chain: unanalysed, 0/18.  A statement has one COP, so the
+# wrapped decision's conditions are all keyed to its first line.
+sub wide {
+  my @v = @_;
+  my $r = $v[0] || $v[1] || $v[2] || $v[3] || $v[4] || $v[5] || $v[6]
+    || $v[7] || $v[8] || $v[9] || $v[10] || $v[11] || $v[12] || $v[13]
+    || $v[14] || $v[15] || $v[16] || $v[17];
+  $r
+}
+
+# A fully exercised 2-condition decision: MC/DC satisfied.
+sub narrow {
+  my ($p, $q) = @_;
+  my $r = $p && $q;
+  $r
+}
+
+# A 17-condition decision and a 2-condition decision on the same line: the
+# limit is per decision, not per line, so only the wide one is unanalysed.
+# Both statements start on one line so their conditions share a line key.
+sub mixed {
+  my ($p, $q, @v) = @_;
+  my $s = $p && $q; my $r = $v[0] || $v[1] || $v[2] || $v[3] || $v[4]
+    || $v[5] || $v[6] || $v[7] || $v[8] || $v[9] || $v[10] || $v[11]
+    || $v[12] || $v[13] || $v[14] || $v[15] || $v[16];
+  ($r, $s)
+}
+
+sub main {
+  my @r;
+
+  push @r, narrow(1, 1);
+  push @r, narrow(1, 0);
+  push @r, narrow(0, 1);
+
+  push @r, wide((0) x 18);
+  push @r, wide(1, (0) x 17);
+
+  push @r, mixed(1, 1, (0) x 17);
+  push @r, mixed(1, 0, (0) x 17);
+  push @r, mixed(0, 1, 1, (0) x 16);
+}
+
+main();


### PR DESCRIPTION
## Summary

A decision with more than 16 conditions was silently excluded from MC/DC analysis, inflating the file percentage - a file could read mcdc 100.0 precisely because the analysis gave up on its widest decision. The limit was also applied per line rather than per decision, so two 9-condition decisions sharing a line were both skipped while a single 17-condition decision passed, only to report a test gap no amount of testing could close.

## Changes

- One per-decision limit of 16 conditions, enforced at collection (the recorder pushes no frame for wider decisions) and at analysis (`Condition_table::for_line` returns a `too_wide` stub table).
- A too-wide decision counts as 0 of its width with an error flag; reporters show "too many conditions" in place of the missing-conditions list, and the JSON report carries an `unanalysed` flag so consumers can distinguish "too wide to analyse" from "untested".
- Report generation warns, naming file and line, via the new `dcwarn` in `Devel::Cover::Log`, suppressed by `-silent`; collection stays silent. The existing uncoverable mcdc pair warnings now go through `dcwarn` too.
- `# uncoverable mcdc` markers on a too-wide decision are ignored, with a warning.
- The user-facing docs describe the limit and the remedy: split the decision with an intermediate variable, which needs no extra test cases and preserves short-circuiting.
- New end-to-end fixture `tests/mcdc_wide` plus internal tests; derivation visits files and lines in sorted order so the warnings are deterministic.

## Ticket

Fixes #502