### PR TITLE
GH-505 Fix MC/DC coupling docs and add test

### DIFF
--- a/docs/technical/mcdc.md
+++ b/docs/technical/mcdc.md
@@ -49,10 +49,11 @@ like `$a && (!$a || $b)` are tautologies that almost never survive review. So
 for typical Perl code hybrid behaves like unique-cause, while remaining
 well-defined for the unusual cases.
 
-In the current implementation coupling does not reach the analyser at all.
-Decisions are recorded per logop (see Limitations), so repeated atomic
-conditions end up in separate truth tables and the masking fallback is never
-triggered by real code. It remains as defensive code rather than an active path.
+Coupling does reach the analyser. A coupled decision such as
+`($a && $b) || ($a && $c)` is recorded as a single table with a repeated `$a`
+column, and unique-cause can never demonstrate a repeated column, so the
+masking fallback is a live, necessary path for such decisions (see
+Limitations).
 
 Pure masking is over-permissive in a short-circuit language: any execution where
 the left operand short-circuits masks every condition on the right, so under

--- a/lib/Devel/Cover/Tutorial.pod
+++ b/lib/Devel/Cover/Tutorial.pod
@@ -189,13 +189,17 @@ and expression coverage, and they pass against both implementations - so
 the bug is invisible to those metrics.
 
 MC/DC additionally requires a pair of tests that flips C<$unlocked>
-while holding C<$is_owner> and C<$is_admin> compatibly.  The smallest
-such pair is C<(T,T,F)> and C<(T,F,F)>.  Neither is in the four-test
-set above; adding C<(T,T,F)> exposes the bug, because the correct
-implementation returns true (the user owns the unlocked article) while
-the buggy one returns false.
+while holding C<$is_owner> and C<$is_admin> compatibly.  The first
+test, C<(T,T,T)>, already provides the true side: the left operand is
+true, so C<$is_admin> is never evaluated and is masked.  The false side
+needs C<$is_owner> true with a false outcome, forcing C<(T,F,F)>.  That
+test is not in the four-test set above; adding it exposes the bug,
+because the correct implementation returns false (the article is
+locked, no admin override) while the buggy one returns true.
 
 100% MC/DC usually implies 100% expression coverage, but not always.
+The same example is worked through in full, table by table, in
+F<docs/technical/mcdc.md> in the distribution.
 
 =head2 3.0 Other considerations
 

--- a/t/internal/decision_inputs.t
+++ b/t/internal/decision_inputs.t
@@ -86,6 +86,32 @@ PERL
     "four distinct observed vectors, no phantom (1,0,0)";
 }
 
+sub test_coupled_decision_vectors () {
+  my $script = write_script("coupled.pl", <<'PERL');
+my @r;
+sub coupled {
+  my ($a, $b, $c) = @_;
+  push @r, ($a && $b) || ($a && $c);
+}
+coupled(1, 1, 0);
+coupled(1, 0, 1);
+coupled(1, 0, 0);
+coupled(0, 0, 0);
+PERL
+
+  my ($db, $path) = run_under_cover($script, "coupled");
+  my $di = decision_inputs_for($db, $path);
+  ok $di, "decision_inputs present for coupled decision";
+
+  # One root, four columns ($a, $b, $a, $c)
+  my @recorded = grep defined, @$di;
+  is @recorded, 1, "exactly one root recorded (outer ||)";
+
+  is_deeply $recorded[0],
+    { "1|1|X|X" => 1, "1|0|1|1" => 1, "1|0|1|0" => 1, "0|X|0|X" => 1 },
+    "coupled columns agree within every observed vector";
+}
+
 sub test_repeated_observation () {
   my $script = write_script("repeated.pl", <<'PERL');
 my @r;
@@ -359,6 +385,7 @@ sub test_add_condition_xor_four_slot_merge () {
 sub main () {
   subtest "simple two-leaf and"    => \&test_simple_and;
   subtest "worked example"         => \&test_worked_example;
+  subtest "coupled decision"       => \&test_coupled_decision_vectors;
   subtest "repeated observation"   => \&test_repeated_observation;
   subtest "no inputs without mcdc" => \&test_no_inputs_without_mcdc;
   subtest "void compound no false coverage" =>

--- a/t/internal/mcdc_analyser.t
+++ b/t/internal/mcdc_analyser.t
@@ -118,8 +118,8 @@ sub test_or_concrete_only_pair () {
 }
 
 # Build a Condition_table::Table directly from synthetic rows.  Used to test
-# coupled-condition behaviour: real Condition_table construction does not
-# normally produce label collisions, but the analyser must still handle them.
+# coupled-condition behaviour: a coupled decision such as
+# ($a && $b) || ($a && $c) builds one table with a repeated label.
 sub build_synthetic_table ($expr, $labels, $rows) {
   my @row_objects = map {
     Devel::Cover::Condition_table::Row->new(
@@ -343,7 +343,8 @@ sub test_const_right_compound_left_observed_vectors () {
       { type => "or_2", left => '$a && $b', op => "//", right => "{}" },
     ),
   );
-  # Three-element vectors, as a non-skipping perl records for `($a && $b) // {}`:
+  # Three-element vectors, as a non-skipping perl records for
+  # `($a && $b) // {}`:
   #   1|1|X  $a true, $b true  -> left defined, right not evaluated
   #   1|0|X  $a true, $b false -> left defined (false), right not evaluated
   #   0|X|X  $a false          -> left defined (false), right not evaluated

--- a/test_output/cover/mcdc_coupled.5.020000
+++ b/test_output/cover/mcdc_coupled.5.020000
@@ -1,0 +1,129 @@
+cover: Reading database from ...
+------------------ ------ ------ ------ ------ ------ ------ ------
+File                 stmt   bran   cond   mcdc    sub  total   scar
+------------------ ------ ------ ------ ------ ------ ------ ------
+tests/mcdc_coupled  100.0    n/a   88.8   75.0  100.0   92.3   19.5
+Total               100.0    n/a   88.8   75.0  100.0   92.3   19.5
+------------------ ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/mcdc_coupled
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 7 94.9  7.0 19.5
+
+Worst Subroutines
+-----------------
+
+Subroutine      CC SCAR  Location             
+--------------- -- ----  ---------------------
+coupled_partial  4 14.0  tests/mcdc_coupled:27
+coupled          4 13.9  tests/mcdc_coupled:19
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10             1                           1   use strict;
+               1                               
+               1                               
+11             1                           1   use warnings;
+               1                               
+               1                               
+12                                             
+13                                             # A coupled decision - the same atomic condition appearing more than once -
+14                                             # builds a single table whose repeated columns unique-cause can never
+15                                             # demonstrate, so crediting them exercises hybrid's masking fallback.
+16                                             
+17                                             # Fully exercised: the masking fallback finds pairs for both $a columns.
+18                                             sub coupled {
+19             4                           4     my ($a, $b, $c) = @_;
+20             4           100    100            my $r = ($a && $b) || ($a && $c);
+                           100                 
+                           100                 
+21             4                                 $r
+22                                             }
+23                                             
+24                                             # Never called with a false $a: both coupled columns stay missing while
+25                                             # $b and $c are satisfied.
+26                                             sub coupled_partial {
+27             3                           3     my ($a, $b, $c) = @_;
+28    ***      3           100   * 50            my $r = ($a && $b) || ($a && $c);
+      ***                 * 66                 
+      ***                 * 66                 
+29             3                                 $r
+30                                             }
+31                                             
+32                                             sub main {
+33             1                           1     my @r;
+34                                             
+35             1                                 push @r, coupled(1, 1, 0);
+36             1                                 push @r, coupled(1, 0, 1);
+37             1                                 push @r, coupled(1, 0, 0);
+38             1                                 push @r, coupled(0, 0, 0);
+39                                             
+40             1                                 push @r, coupled_partial(1, 1, 0);
+41             1                                 push @r, coupled_partial(1, 0, 1);
+42             1                                 push @r, coupled_partial(1, 0, 0);
+43                                             }
+44                                             
+45             1                               main();
+
+
+Conditions
+----------
+
+and 3 conditions
+
+line  err      %     !l  l&&!r   l&&r   expr
+----- --- ------ ------ ------ ------   ----
+20           100      1      2      1   $a and $b
+             100      1      1      1   $a and $c
+28    ***     66      0      2      1   $a and $b
+      ***     66      0      1      1   $a and $c
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+20           100      1      1      2   $a && $b || $a && $c
+28           100      1      1      1   $a && $b || $a && $c
+
+
+MC/DC
+-----
+
+line  err      %  cov  tot   missing                expr
+----- --- ------ ---- ----   --------------------   ----
+20           100    4    4                          $a && $b || $a && $c
+28    ***     50    2    4   $a, $a                 $a && $b || $a && $c
+
+
+Covered Subroutines
+-------------------
+
+Subroutine      Count  CC  SCAR Location             
+--------------- ----- --- ----- ---------------------
+BEGIN               1   1   0.0 tests/mcdc_coupled:10
+BEGIN               1   1   0.0 tests/mcdc_coupled:11
+coupled             4   4  13.9 tests/mcdc_coupled:19
+coupled_partial     3   4  14.0 tests/mcdc_coupled:27
+main                1   1   0.0 tests/mcdc_coupled:33
+
+

--- a/tests/mcdc_coupled
+++ b/tests/mcdc_coupled
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use strict;
+use warnings;
+
+# A coupled decision - the same atomic condition appearing more than once -
+# builds a single table whose repeated columns unique-cause can never
+# demonstrate, so crediting them exercises hybrid's masking fallback.
+
+# Fully exercised: the masking fallback finds pairs for both $a columns.
+sub coupled {
+  my ($a, $b, $c) = @_;
+  my $r = ($a && $b) || ($a && $c);
+  $r
+}
+
+# Never called with a false $a: both coupled columns stay missing while
+# $b and $c are satisfied.
+sub coupled_partial {
+  my ($a, $b, $c) = @_;
+  my $r = ($a && $b) || ($a && $c);
+  $r
+}
+
+sub main {
+  my @r;
+
+  push @r, coupled(1, 1, 0);
+  push @r, coupled(1, 0, 1);
+  push @r, coupled(1, 0, 0);
+  push @r, coupled(0, 0, 0);
+
+  push @r, coupled_partial(1, 1, 0);
+  push @r, coupled_partial(1, 0, 1);
+  push @r, coupled_partial(1, 0, 0);
+}
+
+main();


### PR DESCRIPTION
## Summary

The Variants section of docs/technical/mcdc.md claimed coupling never reaches the analyser and that the masking fallback is defensive code never triggered by real code. The decomposition limitation that claim rested on was later removed, so the section contradicted the Limitations section and observed behaviour: `($a && $b) || ($a && $c)` builds one four-column table that only the masking fallback can satisfy. The Tutorial's worked example had also diverged from the implemented analyser, recommending a test the tool would not credit.

## Changes

- Rewrite the Variants paragraph to describe the current behaviour and fix the test comment repeating the stale claim.
- Align Tutorial section 2.5 with the analyser: the forced test is (T,F,F), since adding (T,T,F) records a vector identical to an existing test's; point to mcdc.md for the full worked tables.
- Add `tests/mcdc_coupled`, exercising the masking fallback with real recorded vectors (a fully exercised coupled decision reaches 100%; a partial one reports both coupled columns missing), plus an internal test asserting the repeated atomic condition records consistently within each vector.

## Ticket

Closes #505