### PR TITLE
GH-507 Align MC/DC recorder and table widths

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -1466,10 +1466,10 @@ static int dc_enumerate_columns(pTHX_ HV *cache, OP *op, OP *root,
   OP *right_op  = dc_skipped_operand(aTHX_ op, 1);
   int left_col, right_col;
 
+  /* A constant left operand keeps its column: _build_labels always gives the
+   * left operand one, and the widths must agree */
   if (left_op && dc_is_logop_type(left_op->op_type)) {
     next_col = dc_enumerate_columns(aTHX_ cache, left_op, root, next_col);
-    left_col = -1;
-  } else if (left_op && dc_is_const_leaf(aTHX_ left_op)) {
     left_col = -1;
   } else {
     left_col = next_col++;

--- a/lib/Devel/Cover/Condition_table.pm
+++ b/lib/Devel/Cover/Condition_table.pm
@@ -14,6 +14,8 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
+use Devel::Cover::Log qw( dcwarn );
+
 package Devel::Cover::Condition_table::Row {
 
   sub new ($class, %args) {
@@ -226,17 +228,25 @@ sub _build_labels ($condition, $find) {
 # vector can carry more columns than a row.  The collapse always drops the
 # trailing right operand, leaving the left subtree, so project each observed
 # vector onto the surviving leading columns before matching.  When the
-# dimensions already agree the projection is a no-op.
+# dimensions already agree the projection is a no-op.  A vector narrower than
+# the rows means the recorder and the table disagreed about columns; such a
+# key is skipped with a warning rather than matching wrong columns.
 #
 # Operates on the row's `inputs` arrayref and `covered` slots, so it serves both
 # this module's rows and the Truth_Table reporters' rows, which share that
 # layout.
-sub apply_observed_vectors ($rows, $obs) {
+sub apply_observed_vectors ($rows, $obs, $expr = undef) {
   my $width = @$rows ? $rows->[0]{inputs}->@* : 0;
   my %seen;
-  for my $key (keys %$obs) {
+  for my $key (sort keys %$obs) {
     next unless $obs->{$key};
     my @v = split /\|/, $key, -1;
+    if (@v < $width) {
+      # Narrower than the rows: the recorder and the table disagreed
+      dcwarn qq(Ignoring short MC/DC vector "$key")
+        . (defined $expr ? " for $expr" : "");
+      next;
+    }
     $seen{ join "|", @v[0 .. $width - 1] } = 1;
   }
   $_->{covered} = $seen{ join "|", $_->{inputs}->@* } ? 1 : 0 for @$rows;
@@ -289,7 +299,7 @@ sub for_line ($class, $conditions, $observed = undef) {
     my $obs     = $observed && $observed->[$i];
     my $applied = $obs      && %$obs ? 1 : 0;
 
-    apply_observed_vectors(\@rows, $obs) if $applied;
+    apply_observed_vectors(\@rows, $obs, _expr($c)) if $applied;
 
     my $counter = 0;
     push @tables,

--- a/lib/Devel/Cover/Condition_table.pm
+++ b/lib/Devel/Cover/Condition_table.pm
@@ -38,16 +38,8 @@ package Devel::Cover::Condition_table::Table {
   sub short_expr ($self) { $self->{short_expr} }
   sub labels     ($self) { $self->{labels}->@* }
   sub rows       ($self) { $self->{rows}->@* }
-
-  # True unless the rows are an unverified synthesis: a compound decision
-  # (>= 3 atomics, so >= 2 logops) with no observed vectors.  Its row coverage
-  # is a cross-product whose co-occurrence was never demonstrated, so neither
-  # MC/DC nor the truth-table display may treat those rows as covered.  A single
-  # logop is exact from its hit counts, and observed vectors are real.
-  sub proven ($self) { $self->{proven} }
-
-  # A stub for a decision wider than the analysis limit: labels but no rows
-  sub too_wide ($self) { $self->{too_wide} }
+  sub proven     ($self) { $self->{proven} }
+  sub too_wide   ($self) { $self->{too_wide} }
 }
 
 package Devel::Cover::Condition_table;
@@ -90,8 +82,7 @@ sub _make_rows ($spec, $hits, $unc) {
   } @$spec
 }
 
-# Per-spec-row uncoverable flags from the condition's "# uncoverable condition"
-# markers, which align positionally with the outcome (and so spec-row) order.
+# Uncoverable flags align positionally with the outcome (spec-row) order
 sub _uncov ($condition) {
   map $_ ? 1 : 0, ($condition->[2] // [])->@*
 }
@@ -100,9 +91,7 @@ sub _expr ($condition) {
   join " ", $condition->[1]->@{qw( left op right )}
 }
 
-# Each expansion is [inputs, covered, uncoverable].  A leaf operand or a
-# short-circuited (X) operand contributes no sub-decision row, so it is never
-# uncoverable in its own right.
+# Each expansion is [inputs, covered, uncoverable]
 sub _expand_operand ($val, $sub_rows, $negated = 0) {
   unless ($sub_rows) {
     return ([[$val], 1, 0])
@@ -117,11 +106,7 @@ sub _expand_operand ($val, $sub_rows, $negated = 0) {
   } @$sub_rows
 }
 
-# A logop recorded in void context collapses to its boolean 2-count form, but
-# the recorded structure keeps both operands.  Promote a void-collapsed node
-# back to its 3-count form so MC/DC rebuilds the full decision; the rebuilt
-# table has no observed vectors and so is reported unproven (honest 0%, never a
-# false pass).  A const-right collapse is a real boolean and is left alone.
+# Promote a void-collapsed logop back to its 3-count form (see DESCRIPTION)
 sub _effective_type ($condition) {
   my $info = $condition->[1];
   my $type = $info->{type};
@@ -142,8 +127,6 @@ sub _build_rows ($condition, $find) {
 
   my ($info, $left_cond, $right_cond) = _resolve_children($condition, $find);
 
-  # This operator's own per-outcome uncoverable markers map positionally onto
-  # its spec rows, and propagate to the combined rows expanded from them below.
   my @hits = _hits($condition);
   my @prim = _make_rows($spec, \@hits, [_uncov($condition)]);
 
@@ -219,22 +202,6 @@ sub _build_labels ($condition, $find) {
   @labels
 }
 
-# Observed-vector data overrides synthesis: rows are covered iff their input
-# vector matches an observed key.  Synthesised rows not in the observed set stay
-# rendered with covered=0 so the truth table still draws.
-#
-# A constant right operand (e.g. `$x // {}`) collapses the table to fewer inputs
-# than the runtime recorded for the uncollapsed expression, so an observed
-# vector can carry more columns than a row.  The collapse always drops the
-# trailing right operand, leaving the left subtree, so project each observed
-# vector onto the surviving leading columns before matching.  When the
-# dimensions already agree the projection is a no-op.  A vector narrower than
-# the rows means the recorder and the table disagreed about columns; such a
-# key is skipped with a warning rather than matching wrong columns.
-#
-# Operates on the row's `inputs` arrayref and `covered` slots, so it serves both
-# this module's rows and the Truth_Table reporters' rows, which share that
-# layout.
 sub apply_observed_vectors ($rows, $obs, $expr = undef) {
   my $width = @$rows ? $rows->[0]{inputs}->@* : 0;
   my %seen;
@@ -314,7 +281,10 @@ sub for_line ($class, $conditions, $observed = undef) {
   @tables
 }
 
-1
+"
+Flood the world deep in sunlight
+Break into the peaceful wild
+"
 
 __END__
 
@@ -324,8 +294,7 @@ __END__
 
 =head1 NAME
 
-Devel::Cover::Condition_table - Condition truth tables for coverage
-reporting.
+Devel::Cover::Condition_table - Condition truth tables for coverage reporting.
 
 =head1 SYNOPSIS
 
@@ -341,22 +310,126 @@ reporting.
 
 =head1 DESCRIPTION
 
-Generates condition truth tables from Devel::Cover condition data.
-Takes the array of Condition_* objects for a source line and returns
-one Table per expression, each containing rows with input combinations,
-expected results, and coverage status.
+Generates condition truth tables from Devel::Cover condition data. Takes the
+array of Condition_* objects for a source line and returns one Table per
+decision, each containing rows with input combinations, expected results, and
+coverage status.
+
+Rows are synthesised from each operator's recorded hit counts.  A compound
+decision (two or more logops) is synthesised as a cross-product of its operands'
+rows, so a combined row can appear covered although its inputs never occurred
+together in one execution. Two mechanisms keep that honest: observed input
+vectors, recorded at runtime for MC/DC, override synthesis when supplied (see
+L</apply_observed_vectors ($rows, $obs, $expr)>), and a table whose rows remain
+an unverified synthesis is marked unproven (see L</proven>).
+
+A logop executed in void context is recorded collapsed to its boolean 2-count
+form, but the recorded structure keeps both operands.  Such a node is promoted
+back to its 3-count form so MC/DC rebuilds the full decision; the rebuilt table
+has no observed vectors and so is reported unproven - an honest 0%, never a
+false pass.  A constant-right collapse is a real boolean and is left alone.
+
+=head1 ROW OBJECTS
+
+Each table row is a C<Devel::Cover::Condition_table::Row>, constructed by C<new
+(%args)> with read-only accessors:
+
+=over
+
+=item inputs
+
+Arrayref of column values: C<0>, C<1>, or C<"X"> for an operand never evaluated
+because an earlier operand short-circuited.
+
+=item result
+
+The decision's outcome for these inputs.
+
+=item covered
+
+True if this input combination was exercised.
+
+=item uncoverable
+
+True if this row is excused by an C<# uncoverable condition> marker.
+
+=back
+
+=head1 TABLE OBJECTS
+
+L</for_line ($conditions, $observed)> returns
+C<Devel::Cover::Condition_table::Table> objects, constructed by C<new (%args)>
+with read-only accessors:
+
+=over
+
+=item expr
+
+The decision's source text.
+
+=item short_expr
+
+The decision with each atomic condition replaced by a letter (A, B, ...), as
+displayed above rendered truth tables.
+
+=item labels
+
+The atomic condition texts, one per column, in depth-first left-to-right order.
+
+=item rows
+
+The Row objects.
+
+=item proven
+
+True unless the rows are an unverified synthesis: a compound decision (three or
+more atomics, so two or more logops) with no observed vectors.  Its row coverage
+is a cross-product whose co-occurrence was never demonstrated, so neither MC/DC
+nor the truth-table display may treat those rows as covered.  A single logop is
+exact from its hit counts, and observed vectors are real.
+
+=item too_wide
+
+True for the stub table of a decision wider than the analysis limit: it carries
+the expression and labels but no rows.
+
+=back
 
 =head1 METHODS
 
+=head2 max_width
+
+Class method.  The per-decision analysis limit of 16 atomic conditions, matching
+C<DC_MAX_DECISION_WIDTH> in the XS recorder.
+
+=head2 apply_observed_vectors ($rows, $obs, $expr)
+
+Overrides synthesised coverage with observed data: each row in C<$rows> is
+covered iff its input vector matches a key of C<$obs>. Synthesised rows not in
+the observed set stay rendered with C<covered=0> so the truth table still draws.
+
+A constant right operand (e.g. C<$x // {}>) collapses the table to fewer inputs
+than the runtime recorded for the uncollapsed expression, so an observed vector
+can carry more columns than a row.  The collapse always drops the trailing right
+operand, leaving the left subtree, so each observed vector is projected onto the
+surviving leading columns before matching; when the dimensions already agree the
+projection is a no-op.  A vector narrower than the rows means the recorder and
+the table disagreed about columns; such a key is skipped with a warning (named
+with C<$expr> when given, suppressed by C<-silent>) rather than matching wrong
+columns.
+
+Operates on the rows' C<inputs> arrayrefs and C<covered> slots directly, so it
+serves both this module's rows and the Truth_Table reporters' rows, which share
+that layout.
+
 =head2 for_line ($conditions, $observed)
 
-Class method. Takes an arrayref of condition objects for a line and an
-optional arrayref of observed input-vector hashes indexed parallel to the
+Class method. Takes an arrayref of condition objects for a line and an optional
+arrayref of observed input-vector hashes indexed parallel to the
 conditions. Returns a list of Table objects, one per decision on the line.
 
-A decision with more than 16 atomic conditions is not analysed: its Table
-is a stub with C<too_wide> true, carrying the expression and labels but no
-rows.
+A decision with more than 16 atomic conditions is not analysed: its Table is a
+stub with C<too_wide> true, carrying the expression and labels but no rows.
 
 =head1 SEE ALSO
 
@@ -366,7 +439,7 @@ L<Devel::Cover>
 
 Copyright 2026, Paul Johnson (paul@pjcj.net)
 
-This software is free.  It is licensed under the same terms as Perl
-itself. The latest version should be available from: https://pjcj.net
+This software is free.  It is licensed under the same terms as Perl itself. The
+latest version should be available from: https://pjcj.net
 
 =cut

--- a/t/internal/condition_table.t
+++ b/t/internal/condition_table.t
@@ -16,7 +16,7 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Test::More import => [qw( done_testing is is_deeply ok )];
+use Test::More import => [qw( done_testing is is_deeply like ok unlike )];
 
 use Devel::Cover::Condition_table ();
 
@@ -314,8 +314,8 @@ sub test_independent_conditions () {
   is_deeply \@exprs, ['$a && $b', '$x || $y'], "both expressions present";
 }
 
-# Chain of $n atomics ($x1 && $x2 && ... && $xn): n-1 and_3 records whose
-# left strings accumulate, matching how Devel::Cover records a chain.
+# Chain of $n atomics ($x1 && $x2 && ... && $xn): n-1 and_3 records whose left
+# strings accumulate, matching how Devel::Cover records a chain.
 sub chain_conditions ($n, $prefix) {
   my @atoms = map "\$$prefix$_", 1 .. $n;
   my @conditions;
@@ -333,8 +333,8 @@ sub chain_conditions ($n, $prefix) {
 }
 
 # A decision with more than 16 atomic conditions is too wide to analyse:
-# for_line returns a stub table flagged too_wide, with labels (so consumers
-# know the width) but no rows.
+# for_line returns a stub table flagged too_wide, with labels (so consumers know
+# the width) but no rows.
 sub test_too_wide_decision () {
   my @conditions = chain_conditions(17, "a");
 
@@ -368,9 +368,8 @@ sub test_exactly_16_atomics () {
   is @rows, 17, "16 atomics: rows built";
 }
 
-# The cap is per decision, not per line: two 10-atomic decisions sharing a
-# line (18 condition records, more than the old per-line cap) must both be
-# analysed.
+# The cap is per decision, not per line: two 10-atomic decisions sharing a line
+# (18 condition records, more than the old per-line cap) must both be analysed.
 sub test_two_decisions_one_line () {
   my @conditions = (chain_conditions(10, "a"), chain_conditions(10, "b"));
 
@@ -953,6 +952,40 @@ sub test_observed_vectors_xor () {
   is $covered{"1|1"}, 0, "xor: unobserved (1,1) not covered";
 }
 
+# A recorded vector narrower than the rows means the recorder and the table
+# disagreed about columns.  Such a key must be skipped with a warning naming the
+# vector, not wipe the valid keys' coverage or leak uninitialized-value
+# warnings.
+sub test_short_observed_vector_ignored () {
+  my @conditions = (mock_condition(
+    "Condition_and_3",
+    [1, 1, 1],
+    { type => "and_3", left => '$a', op => "&&", right => '$b' },
+  ));
+
+  my @observed = ({ "1|1" => 1, "0|X" => 1, "1" => 1 });
+
+  my $err = "";
+  my ($t) = do {
+    open my $save, ">&", \*STDERR or die "Cannot dup STDERR: $!";
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">", \$err or die "Cannot redirect STDERR: $!";
+    my @r = Devel::Cover::Condition_table->for_line(\@conditions, \@observed);
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">&", $save or die "Cannot restore STDERR: $!";
+    @r
+  };
+
+  my %covered;
+  $covered{ join "|", $_->inputs->@* } = $_->covered ? 1 : 0 for $t->rows;
+
+  is $covered{"1|1"}, 1, "short key: valid observed key still covers its row";
+  is $covered{"0|X"}, 1, "short key: short-circuit key still covers its row";
+  unlike $err, qr/[Uu]ninitialized/, "short key: no uninitialized warnings";
+  like $err, qr|Ignoring short MC/DC vector "1" for \$a && \$b|,
+    "short key: warning names the vector and the expression";
+}
+
 # Deep chain $a && $b && $c && $d: three logops, four atomics, five synthesised
 # rows.  Observe only the all-true and outermost-false vectors; the three
 # intermediate short-circuit rows must read covered=0.
@@ -1162,9 +1195,9 @@ sub test_proven_single_logop () {
   ok $t->proven, "single logop is proven without observed vectors";
 }
 
-# Worked example: $a || ($b && $c).  Without observed vectors the
-# composite rows are a synthesised cross-product whose co-occurrence was never
-# demonstrated, so the table is not proven.
+# Worked example: $a || ($b && $c).  Without observed vectors the composite rows
+# are a synthesised cross-product whose co-occurrence was never demonstrated, so
+# the table is not proven.
 sub _worked_example_conditions () { (
   mock_condition(
     "Condition_and_3",
@@ -1227,6 +1260,7 @@ sub main () {
   test_addr_overrides_string;
   test_observed_vectors_override_synthesis;
   test_observed_vectors_xor;
+  test_short_observed_vector_ignored;
   test_observed_vectors_deep_chain;
   test_observed_vectors_mixed_chain;
   test_observed_vectors_indexed_at_root;

--- a/t/internal/decision_inputs.t
+++ b/t/internal/decision_inputs.t
@@ -20,15 +20,16 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Test::More import => [qw( done_testing is is_deeply ok subtest )];
+use Test::More import => [qw( done_testing is is_deeply ok subtest unlike )];
 
 use Devel::Cover::DB             ();  ## no perlimports
 use Devel::Cover::Mcdc           ();  ## no perlimports
 use Devel::Cover::Test::Internal qw( run_under_cover write_script );
 
 # A mock condition entry matching the structure Devel::Cover produces:
-#   [0] hit counts per outcome, [1] {type, left, op, right}, [2] uncoverable
-#   markers per outcome.
+#   [0] hit counts per outcome
+#   [1] {type, left, op, right}
+#   [2] uncoverable markers per outcome.
 sub mock_condition ($class, $hits, $info, $unc = undef) {
   bless [$hits, $info, $unc], "Devel::Cover::$class"
 }
@@ -76,8 +77,8 @@ PERL
   my $di = decision_inputs_for($db, $path);
   ok $di, "decision_inputs present for worked example";
 
-  # Find the entry recording the outer || root (3 columns; 4 distinct
-  # observed vectors).  Inner && entries have no decision_inputs.
+  # Find the entry recording the outer || root (3 columns; 4 distinct observed
+  # vectors).  Inner && entries have no decision_inputs.
   my @recorded = grep defined, @$di;
   is @recorded, 1, "exactly one root recorded (outer ||)";
 
@@ -110,6 +111,32 @@ PERL
   is_deeply $recorded[0],
     { "1|1|X|X" => 1, "1|0|1|1" => 1, "1|0|1|0" => 1, "0|X|0|X" => 1 },
     "coupled columns agree within every observed vector";
+}
+
+# On perls that do not fold a constant left operand (5.28-era), the recorder
+# must still give it a column: the table always does, and a width disagreement
+# surfaces as a short-vector warning at derivation time.
+sub test_left_constant_width_parity () {
+  my $script = write_script("left_const.pl", <<'PERL');
+sub f { my ($b) = @_; my $r = (undef // $b) && 1; $r }
+f(1);
+f(0);
+PERL
+
+  my ($db, $path) = run_under_cover($script, "left_const");
+
+  my $err = "";
+  {
+    open my $save, ">&", \*STDERR or die "Cannot dup STDERR: $!";
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">", \$err or die "Cannot redirect STDERR: $!";
+    $db->cover;
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">&", $save or die "Cannot restore STDERR: $!";
+  }
+
+  unlike $err, qr|Ignoring short MC/DC vector|,
+    "recorded vectors are as wide as the table";
 }
 
 sub test_repeated_observation () {
@@ -208,10 +235,9 @@ sub test_unproven_ignores_derived_uncoverable () {
     "every atomic of an unproven table is reported missing";
 }
 
-# The recorder must record one accurate vector per completed evaluation
-# and nothing for abandoned ones.  A die out of a decision abandons its
-# frame; the next execution must not inherit the aborted execution's
-# column values.
+# The recorder must record one accurate vector per completed evaluation and
+# nothing for abandoned ones.  A die out of a decision abandons its frame; the
+# next execution must not inherit the aborted execution's column values.
 sub test_die_discards_abandoned_evaluation () {
   my $script = write_script("die_mid_decision.pl", <<'PERL');
 sub f { die "boom" }
@@ -230,8 +256,8 @@ PERL
     "aborted evaluation records nothing; completed one is not contaminated";
 }
 
-# Recursion through the same decision must record one vector per
-# invocation, not merge the inner invocation into the outer's frame.
+# Recursion through the same decision must record one vector per invocation, not
+# merge the inner invocation into the outer's frame.
 sub test_recursion_records_each_invocation () {
   my $script = write_script("recursive_decision.pl", <<'PERL');
 sub r { my ($n) = @_; my $v = ($n <= 0) || r($n - 1); $v }
@@ -248,9 +274,8 @@ PERL
     "outer and inner invocations each record their own vector";
 }
 
-# A decision resolving while an abandoned inner frame is still on the
-# stack must be counted once, and the abandoned frame must record
-# nothing.
+# A decision resolving while an abandoned inner frame is still on the stack must
+# be counted once, and the abandoned frame must record nothing.
 sub test_abandoned_inner_frame_not_double_counted () {
   my $script = write_script("abandoned_inner.pl", <<'PERL');
 sub f { die "x" }
@@ -267,10 +292,10 @@ PERL
   is_deeply $recorded[0], { "0|0" => 1 }, "outer vector counted exactly once";
 }
 
-# A decision ending a sort comparator resolves via the deferred path;
-# each comparator invocation must record its own vector rather than
-# blending values across invocations.  The ternary keeps the || classified
-# as a condition rather than a statement-level branch.
+# A decision ending a sort comparator resolves via the deferred path; each
+# comparator invocation must record its own vector rather than blending values
+# across invocations.  The ternary keeps the || classified as a condition rather
+# than a statement-level branch.
 sub test_sort_block_records_per_invocation () {
   my $script = write_script("sort_block.pl", <<'PERL');
 my $numeric = 1;
@@ -294,10 +319,10 @@ PERL
     "each comparator invocation records its own vector";
 }
 
-# A short-circuit deep in a chain resolves the whole decision in one
-# jump.  The recorder must still snapshot the vector when the chain's
-# operands are element accesses, whose optree roots are nulled ops, and
-# when the cascade spans more than two logops.
+# A short-circuit deep in a chain resolves the whole decision in one jump.  The
+# recorder must still snapshot the vector when the chain's operands are element
+# accesses, whose optree roots are nulled ops, and when the cascade spans more
+# than two logops.
 sub test_chain_cascades_record_short_circuits () {
   my $script = write_script("chain_cascade.pl", <<'PERL');
 sub h3 { my %h = @_; my $r = $h{a} || $h{b} || $h{c}; $r }
@@ -330,8 +355,8 @@ PERL
     "array-element chain records a three-level cascaded short-circuit";
 }
 
-# A decision wider than the analysis limit records no input vectors;
-# a narrow decision alongside it is unaffected.
+# A decision wider than the analysis limit records no input vectors; a narrow
+# decision alongside it is unaffected.
 sub test_too_wide_decision_records_nothing () {
   my @vars   = map "\$v$_", 1 .. 17;
   my $args   = join ", ", ("1") x 17;
@@ -383,11 +408,12 @@ sub test_add_condition_xor_four_slot_merge () {
 }
 
 sub main () {
-  subtest "simple two-leaf and"    => \&test_simple_and;
-  subtest "worked example"         => \&test_worked_example;
-  subtest "coupled decision"       => \&test_coupled_decision_vectors;
-  subtest "repeated observation"   => \&test_repeated_observation;
-  subtest "no inputs without mcdc" => \&test_no_inputs_without_mcdc;
+  subtest "simple two-leaf and"        => \&test_simple_and;
+  subtest "worked example"             => \&test_worked_example;
+  subtest "coupled decision"           => \&test_coupled_decision_vectors;
+  subtest "left constant width parity" => \&test_left_constant_width_parity;
+  subtest "repeated observation"       => \&test_repeated_observation;
+  subtest "no inputs without mcdc"     => \&test_no_inputs_without_mcdc;
   subtest "void compound no false coverage" =>
     \&test_void_compound_no_false_coverage;
   subtest "unproven ignores derived uncoverable" =>


### PR DESCRIPTION
## Summary

An observed MC/DC vector narrower than its decision's truth table silently wiped the decision's coverage, with "uninitialized value in join" warnings at report time. The underlying cause is the recorder and the table disagreeing about columns: on perls that do not fold a constant left operand (5.28-era), the recorder declined the constant's column while the table always labels it, so every vector for such a decision came up short. Verified on dc-5.28.0, where `(undef // $b) && 1` recorded one-column vectors against a two-column table; it now reports honest per-column results.

## Changes

- Skip observed vectors narrower than the rows, warning with the vector and expression (suppressed by `-silent`), instead of letting undef reach the row matching.
- Allocate a recorder column for a constant left operand so the two sides agree by construction; newer perls fold such operands away and never see them.
- Move Condition_table's multi-line commentary into POD and document the Row and Table accessors, max_width, and apply_observed_vectors, which the POD previously omitted.

## Ticket

Closes #507