### PR TITLE
GH-509 Don't excuse achievable MC/DC columns

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1893,6 +1893,16 @@ An invalid position warns and the marker is ignored: C<pair:0> when the
 comment is parsed, and a position greater than the number of atomic conditions
 in the decision when the report is generated.
 
+Condition markers also feed MC/DC: an atomic condition is excused
+automatically when every route to demonstrating its independence needs a truth
+table row built from an outcome marked C<uncoverable condition>.  Use those
+markers when a particular outcome cannot occur, for example an error state
+that cannot be simulated.  If a pair could still be formed from rows not
+marked uncoverable, the atomic condition is reported missing - a test gap, not
+an excuse.  For a decision that can never execute at all, such as code inside
+a branch that can never be taken, mark the whole decision with the bare
+C<uncoverable mcdc> comment.
+
 As for conditions, the "count" value selects between several decisions on one
 line.
 

--- a/lib/Devel/Cover/Mcdc/Analyser.pm
+++ b/lib/Devel/Cover/Mcdc/Analyser.pm
@@ -68,11 +68,13 @@ sub _pair ($col, $rows, $labels, $label_count) {
 }
 
 sub analyse ($class, $table) {
-  my @labels = $table->labels;
-  my @rows   = grep $_->covered, $table->rows;
-  my @avail  = grep { $_->covered || $_->uncoverable } $table->rows;
+  my @labels     = $table->labels;
+  my @rows       = grep $_->covered,      $table->rows;
+  my @achievable = grep !$_->uncoverable, $table->rows;
+  my @avail      = grep { $_->covered || $_->uncoverable } $table->rows;
 
   my %label_count;
+
   $label_count{$_}++ for @labels;
 
   my %pairs;
@@ -85,10 +87,12 @@ sub analyse ($class, $table) {
       next;
     }
 
-    # No pair among covered rows.  If one exists once uncoverable rows are
-    # allowed, the column can never be demonstrated, so it is excused rather
-    # than counted missing.
-    if (_pair($col, \@avail, \@labels, \%label_count)) {
+    # No pair among covered rows.  A pair among achievable rows is a test gap.
+    # Only a column whose sole pairs need uncoverable rows is excused (see
+    # DESCRIPTION).
+    if (_pair($col, \@achievable, \@labels, \%label_count)) {
+      push @missing, $labels[$col];
+    } elsif (_pair($col, \@avail, \@labels, \%label_count)) {
       $uncoverable{$col} = 1;
     } else {
       push @missing, $labels[$col];
@@ -128,13 +132,40 @@ Devel::Cover::Mcdc::Analyser - MC/DC pair analyser
 
 =head1 DESCRIPTION
 
-Given a L<Devel::Cover::Condition_table::Table> for a single decision, computes
-Modified Condition/Decision Coverage (MC/DC) pairs for each atomic condition.
+Given a table from L<Devel::Cover::Condition_table> for a single decision,
+computes Modified Condition/Decision Coverage (MC/DC) pairs for each atomic
+condition.
 
 The analyser implements hybrid MC/DC: a unique-cause first pass followed by a
 masking fallback for coupled conditions (the same atomic condition appearing
 more than once in a decision).  In typical Perl code, where coupling is rare,
 hybrid behaves like unique-cause.
+
+Each atomic condition is classified against the table's rows in tiers:
+
+=over 4
+
+=item 1
+
+A pair among covered rows: satisfied.
+
+=item 2
+
+Otherwise, a pair among achievable rows (those not marked uncoverable):
+missing - a test gap the user can close.
+
+=item 3
+
+Otherwise, a pair once uncoverable rows are admitted: excused - every route to
+demonstrating the condition's independence needs a row the user has asserted
+cannot occur.  This covers a decision that never executed with every outcome
+marked uncoverable, such as code inside a branch that can never be taken.
+
+=item 4
+
+Otherwise: missing - the condition can never flip the decision's result.
+
+=back
 
 C<analyse> returns a hashref with keys:
 
@@ -156,6 +187,10 @@ was found.
 =item C<missing>
 
 Arrayref of atomic conditions whose independence pair was not demonstrated.
+
+=item C<uncoverable>
+
+Hashref keyed by excused column index (tier 3 above).
 
 =back
 

--- a/t/internal/mcdc_analyser.t
+++ b/t/internal/mcdc_analyser.t
@@ -466,6 +466,82 @@ sub test_compound_uncoverable_excuses_column () {
   is_deeply $r->{missing}, [], "compound excuse: nothing missing";
 }
 
+# A column whose independence pair is achievable with more tests must stay
+# missing even when another pair exists through an uncoverable row.  Covered
+# (0,0) plus uncoverable (1,0) would pair $a, but the achievable rows (0,1)
+# and (1,1) also pair it, so it is a test gap, not an excuse.
+sub test_achievable_pair_stays_missing () {
+  my $table = build_synthetic_table(
+    '$a xor $b',
+    ['$a', '$b'],
+    [
+      { inputs => [0, 0], result => 0 },
+      { inputs => [1, 0], result => 1, covered => 0, uncoverable => 1 },
+      { inputs => [0, 1], result => 1, covered => 0 },
+      { inputs => [1, 1], result => 0, covered => 0 },
+    ],
+  );
+  my $r = Devel::Cover::Mcdc::Analyser->analyse($table);
+  is_deeply $r->{missing}, ['$a', '$b'],
+    "achievable pair: both columns are test gaps";
+  is_deeply $r->{uncoverable}, {}, "achievable pair: nothing excused";
+}
+
+# The achievable probe uses the same masking fallback as the covered probe: a
+# coupled column pairable among achievable rows stays missing even though an
+# uncoverable row could also pair it.
+sub test_coupled_achievable_pair_stays_missing () {
+  my $table = build_synthetic_table(
+    '($a && $b) || ($a && $c)',
+    ['$a', '$b', '$a'],
+    [
+      { inputs => [1, 1, 1], result => 1 },
+      { inputs => [0, 1, 0], result => 0, covered => 0 },
+      { inputs => [0, 1, 1], result => 0, covered => 0, uncoverable => 1 },
+    ],
+  );
+  my $r = Devel::Cover::Mcdc::Analyser->analyse($table);
+  is_deeply $r->{missing}, ['$a', '$b', '$a'],
+    "coupled achievable: all columns are test gaps";
+  is_deeply $r->{uncoverable}, {}, "coupled achievable: nothing excused";
+}
+
+# A pair formed from an uncoverable row and an achievable-but-untested row
+# excuses nothing: the achievable row is still a test to write.  Once it is
+# covered the column becomes excused (test_uncoverable_row_excuses_column).
+sub test_uncoverable_pair_needs_covered_row () {
+  my $table = build_synthetic_table(
+    '$a && $b',
+    ['$a', '$b'],
+    [
+      { inputs => [0, "X"], result => 0 },
+      { inputs => [1, 0],   result => 0, covered => 0, uncoverable => 1 },
+      { inputs => [1, 1],   result => 1, covered => 0 },
+    ],
+  );
+  my $r = Devel::Cover::Mcdc::Analyser->analyse($table);
+  is_deeply $r->{missing}, ['$a', '$b'],
+    "mixed pair: both columns still missing";
+  is_deeply $r->{uncoverable}, {}, "mixed pair: nothing excused";
+}
+
+# A decision that never executed with every outcome marked uncoverable - code
+# inside a branch that cannot be taken - is fully excused, not missing.
+sub test_all_uncoverable_never_run_stays_excused () {
+  my @conditions = (mock_condition_unc(
+    "Condition_and_3",
+    [0, 0, 0],
+    { type => "and_3", left => '$a', op => "&&", right => '$b' },
+    [1, 1, 1],
+  ));
+  my ($table) = Devel::Cover::Condition_table->for_line(\@conditions);
+  my $r = Devel::Cover::Mcdc::Analyser->analyse($table);
+  is $r->{satisfied}, 0, "never run: nothing satisfied";
+  is_deeply $r->{missing}, [], "never run: nothing missing";
+  is_deeply [sort keys $r->{uncoverable}->%*], [0, 1],
+    "never run: both columns excused";
+}
+
 sub main () {
   test_api_keys;
   test_uncoverable_row_excuses_column;
@@ -473,6 +549,10 @@ sub main () {
   test_compound_outer_uncoverable_propagates;
   test_compound_uncoverable_excuses_column;
   test_no_pair_even_with_uncoverable_stays_missing;
+  test_achievable_pair_stays_missing;
+  test_coupled_achievable_pair_stays_missing;
+  test_uncoverable_pair_needs_covered_row;
+  test_all_uncoverable_never_run_stays_excused;
   test_const_right_collapsed_observed_vectors;
   test_const_right_or_operator;
   test_const_right_compound_left_observed_vectors;


### PR DESCRIPTION
## Summary

The MC/DC analyser excused an atomic condition as uncoverable whenever its independence pair could be formed once rows marked uncoverable were admitted, without ever consulting rows achievable by simply adding tests. A plain test gap could therefore be silently excused. The analyser now probes achievable rows first and reports such a column as missing, excusing only a column whose every pair needs an uncoverable row. Genuinely untestable code keeps its excuse: an operand value that only occurs in an error state that cannot be simulated, or a decision inside a branch that can never be taken, including the never-executed decision with every outcome marked uncoverable.

## Changes

- `Devel::Cover::Mcdc::Analyser` classifies each column in tiers: satisfied by a covered pair, missing when a pair is achievable with more tests, excused when every pair needs an uncoverable row, otherwise missing. The tiers are documented in the POD along with the previously undocumented `uncoverable` return key.
- The uncoverable MC/DC section in `Devel::Cover`'s POD now explains when condition markers excuse an atomic condition and when to reach for the bare `# uncoverable mcdc` marker instead.
- New tests cover the xor scenario from the review, a coupled variant exercising the masking fallback in the achievable probe, a mixed pair that excuses nothing until its achievable row is covered, and the fully excused never-executed decision.

## Implications

- Columns previously excused despite an achievable pair now appear as missing in reports. That is the intended behaviour change; no golden files changed.

## Ticket

Closes #509