### PR TITLE
GH-511 Fix MC/DC docs and warn on mcdc alone

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ measure of quality.
 Devel::Cover is now quite stable and provides many of the features to be
 expected in a useful coverage tool.
 
-Statement, branch, condition, subroutine, and pod coverage information is
-reported.  Statement and subroutine coverage data should be accurate.  Branch
+Statement, branch, condition, MC/DC, subroutine, and pod coverage information
+is reported.  Statement and subroutine coverage data should be accurate.  Branch
 and condition coverage data should be mostly accurate too, although not always
 what one might initially expect.  Pod coverage comes from Pod::Coverage.  If
 Pod::Coverage::CountParents is available it will be used instead.

--- a/bin/cover
+++ b/bin/cover
@@ -701,8 +701,8 @@ coverage is missing.
 =item json
 
 A detailed JSON report containing per-line, per-criterion coverage data
-(statements, branches, conditions, condition truth tables, subroutines, pod)
-plus per-file metadata.  See L<Devel::Cover::Report::Json>.
+(statements, branches, conditions, condition truth tables, mcdc, subroutines,
+pod) plus per-file metadata.  See L<Devel::Cover::Report::Json>.
 
 =item json_summary
 
@@ -740,14 +740,14 @@ multiple times.
 
 Specify C<-coverage> options to report on specific criteria.  By default all
 available information on all criteria in all files will be reported. Available
-coverage options are statement, branch, condition, mcdc, subroutine, pod, and
-default (which equates to all available options).  The C<mcdc> criterion reports
-Modified Condition/Decision Coverage and is derived from the condition truth
-tables, so collecting C<condition> is a prerequisite. However, if you know you
-only want coverage information for certain criteria it is better to only collect
-data for those criteria in the first place by specifying them at that point.
-This will make the data collection and reporting processes faster and less
-memory intensive.  See the documentation for L<Devel::Cover> for more
+coverage options are statement, branch, condition, mcdc, subroutine, pod, time,
+and default (which equates to all available options).  The C<mcdc> criterion
+reports Modified Condition/Decision Coverage and is derived from the condition
+truth tables, so collecting C<condition> is a prerequisite.  However, if you
+know you only want coverage information for certain criteria it is better to
+only collect data for those criteria in the first place by specifying them at
+that point.  This will make the data collection and reporting processes faster
+and less memory intensive.  See the documentation for L<Devel::Cover> for more
 information.
 
 If you want all *except* some criteria, then you can say something like

--- a/docs/technical/mcdc.md
+++ b/docs/technical/mcdc.md
@@ -256,8 +256,9 @@ condition coverage:
    so `not($a) && $b` and parenthesised forms link correctly to their parent
    decision.
 
-4. **Reporter rendering** of the composite tables in `Html_minimal`,
-   `Html_subtle`, `Html_crisp`, `Text2`, and `Json`.
+4. **Reporter rendering** of the composite tables in `Html_crisp`, the only
+   reporter that consumes `Condition_table`; the other reporters still render
+   per-logop condition tables via the legacy `Truth_Table`.
 
 MC/DC adds the analysis on top of this shared base, a criterion class to compute
 a percentage and flag missing pairs, and the per-execution input-vector recorder
@@ -273,7 +274,9 @@ interface is separate:
 
 - `mcdc` is a distinct entry in `@Devel::Cover::DB::Criteria`.
 - A separate flag bit selects it in `Cover.xs`.
-- `cover -coverage mcdc` enables it independently of `-coverage condition`.
+- `cover -coverage mcdc` selects it by name, although `condition` must also be
+  collected: MC/DC derives from the condition truth tables, and selecting
+  `mcdc` alone warns at startup and collects nothing (see Limitations).
 - Reports show MC/DC as its own column with its own percentage.
 
 The reasoning:
@@ -285,8 +288,8 @@ The reasoning:
   MC/DC opt-in.
 - Existing CI thresholds on condition coverage do not silently change meaning
   when MC/DC is added.
-- Industry tools (gcov `--mcdc`, LDRA, VectorCAST) report MC/DC as a separate
-  metric alongside condition coverage.
+- Industry tools (gcov `--conditions`, llvm-cov `--show-mcdc`, LDRA,
+  VectorCAST) report MC/DC as a separate metric alongside condition coverage.
 
 ## Per-decision input-vector recording
 
@@ -296,11 +299,13 @@ composite decisions. The composite truth table for
 rows and the outer `||`'s rows: every cross-product row is marked covered iff
 each sub-decision's row was hit at least once. But the cross-product mixes rows
 from different test executions. The misplaced-negation bug in the worked example
-survives synthesis-only analysis - the buggy implementation hits the inner `&&`
-row `(1,0)` on Test 2 and the outer `||` row `(0,X,0)` on Test 4, which the
-cross-product synthesises into a phantom `(T,F,F)` row that no test actually
-executed. The analyser, seeing the phantom row as covered, then reports the
-buggy implementation as MC/DC-satisfied.
+survives synthesis-only analysis. In the buggy implementation the inner `&&` is
+`($is_owner && !$unlocked)`: Test 1 hits its `(1,0)` row (`$is_owner` true,
+`!$unlocked` false) and Test 4 hits the outer `||`'s `(0,X,0)` row, and the
+cross-product joins them into a phantom `(T,T,F)` row (in input terms, with
+result F) that no test actually executed. Pairing that phantom with Test 2's
+observed `(T,F,X)` (result T) demonstrates `$unlocked`'s independence, so the
+analyser reports the buggy implementation as MC/DC-satisfied.
 
 Audit-grade MC/DC therefore needs per-execution combined-input data. `Cover.xs`
 records each decision's input vector at runtime: a small stack
@@ -329,6 +334,12 @@ observed-vector hashes; when present, each synthesised row is marked `covered=1`
 iff its input vector matches an observed key. Synthesised rows the runtime never
 executed keep `covered=0` so the truth-table renderer still draws them - users
 see the unobserved combinations as "rendered but not hit" rather than vanishing.
+
+A compound table whose rows remain an unverified synthesis - no observed
+vectors were applied - is marked unproven, and `DB::_derive_mcdc` zeroes its
+MC/DC coverage: an honest 0%, never a false pass. Void-context decisions are
+rebuilt without observed vectors and so always report unproven. The precise
+`proven` rule is specified in the `Devel::Cover::Condition_table` POD.
 
 The runtime recorder requires `Devel::Cover::Mcdc` to be loaded as a criterion
 subclass during Devel::Cover's bootstrap (via `Criterion.pm`'s runtime require
@@ -411,6 +422,10 @@ MC/DC is documented here, with a user-facing section 2.5 in `Tutorial.pod`,
 USAGE POD in `Devel::Cover::Mcdc`, and a `Changes` entry.
 
 ## Limitations
+
+- MC/DC derives from the condition truth tables, so `condition` must be
+  collected for `mcdc` to produce data. Selecting `mcdc` without `condition`
+  warns at startup and produces an empty MC/DC report.
 
 - Decisions with more than 16 atomic conditions are not analysed. The limit
   is per decision, enforced on both sides: `Condition_table::for_line`

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -183,6 +183,11 @@ sub has_select { scalar @Select_re }
     my @coverage = get_coverage();
     %Coverage = map { $_ => 1 } @coverage;
 
+    warn __PACKAGE__
+      . ": mcdc coverage requires condition coverage; "
+      . "no mcdc data will be collected.\n"
+      if $Coverage{mcdc} && !$Coverage{condition} && !$Silent;
+
     my $nopod = "";
     if (!$Pod && exists $Coverage{pod}) {
       delete $Coverage{pod};  # Pod::Coverage unavailable

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1557,8 +1557,8 @@ measure of quality.
 Devel::Cover is now quite stable and provides many of the features to be
 expected in a useful coverage tool.
 
-Statement, branch, condition, subroutine, and pod coverage information is
-reported.  Statement and subroutine coverage data should be accurate.  Branch
+Statement, branch, condition, MC/DC, subroutine, and pod coverage information
+is reported.  Statement and subroutine coverage data should be accurate.  Branch
 and condition coverage data should be mostly accurate too, although not always
 what one might initially expect.  Pod coverage comes from L<Pod::Coverage>. If
 L<Pod::Coverage::CountParents> is available it will be used instead.

--- a/lib/Devel/Cover/Mcdc.pm
+++ b/lib/Devel/Cover/Mcdc.pm
@@ -89,7 +89,8 @@ C<error>) for reporting.
 
 MC/DC is a parallel criterion alongside C<condition>.  It derives from the
 condition truth tables already collected by the existing runtime
-instrumentation, so no new XS data collection is required.
+instrumentation, supplemented by a per-execution input-vector recorder in the
+XS runtime; no condition collection is duplicated.
 
 See L<Devel::Cover::Tutorial/2.5 Modified condition/decision coverage> for an
 introduction to the metric and a worked example, and
@@ -109,8 +110,8 @@ C<mcdc> on the command line:
 
 MC/DC is derived from the condition truth tables collected at runtime.
 C<condition> must therefore be active at collection time; selecting C<mcdc>
-alone leaves no condition data to analyse and produces an empty MC/DC
-report.
+alone warns at startup, leaves no condition data to analyse and produces an
+empty MC/DC report.
 
 Reports show MC/DC in two places: a per-file C<mcdc> percentage column in
 the summary, and a per-decision detail block listing each atomic condition
@@ -134,6 +135,17 @@ The remedy is to split the decision with an intermediate variable:
 
 The split form needs no extra test cases, preserves short-circuiting, and
 lets every condition be analysed.
+
+A decision evaluated in void context records only its boolean outcome, so its
+truth table cannot be verified against observed input vectors and it is
+reported as 0% MC/DC even when the tests exercise every combination.  This
+includes a decision returned as a sub's last expression when every call to
+the sub discards the result.
+
+A statement-level logop whose value is discarded is recorded as a decision
+only when its right operand is itself a decision: C<($a && $b) || ($c && $d)>
+is analysed, but in C<($a && $b) || $c> the outer C<||> stays a branch.  In
+value context the outer operator is always recorded.
 
 =head1 SEE ALSO
 

--- a/t/internal/mcdc_without_condition.t
+++ b/t/internal/mcdc_without_condition.t
@@ -34,9 +34,11 @@ sub run_covered ($label, @parts) {
   my $script  = write_script("$label.pl", 'my $r = 1 && 0;' . "\n");
   my $db      = File::Spec->catdir($Tmpdir, "db_$label");
   my $errfile = File::Spec->catfile($Tmpdir, "err_$label");
+  my $devnull = File::Spec->devnull;
   my $cmd     = join " ", $^X, "-Iblib/lib", "-Iblib/arch",
-    "-MDevel::Cover=" . join(",", "-db,$db", @parts), $script, ">/dev/null",
+    "-MDevel::Cover=" . join(",", "-db,$db", @parts), $script, ">$devnull",
     "2>$errfile";
+
   system($cmd) == 0 or die "Failed to run: $cmd";
   open my $fh, "<", $errfile or die "Cannot read $errfile: $!";
   my $err = do { local $/; <$fh> };

--- a/t/internal/mcdc_without_condition.t
+++ b/t/internal/mcdc_without_condition.t
@@ -1,0 +1,59 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# MC/DC is derived from condition truth tables, so selecting mcdc without
+# condition collects nothing.  Devel::Cover must warn at startup so the
+# empty report is not a mystery.
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing like unlike )];
+
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use Devel::Cover::Test::Internal qw( write_script );
+
+my $Tmpdir  = tempdir(CLEANUP => 1);
+my $Warning = qr/Devel::Cover: mcdc coverage requires condition coverage/;
+
+sub run_covered ($label, @parts) {
+  my $script  = write_script("$label.pl", 'my $r = 1 && 0;' . "\n");
+  my $db      = File::Spec->catdir($Tmpdir, "db_$label");
+  my $errfile = File::Spec->catfile($Tmpdir, "err_$label");
+  my $cmd     = join " ", $^X, "-Iblib/lib", "-Iblib/arch",
+    "-MDevel::Cover=" . join(",", "-db,$db", @parts), $script, ">/dev/null",
+    "2>$errfile";
+  system($cmd) == 0 or die "Failed to run: $cmd";
+  open my $fh, "<", $errfile or die "Cannot read $errfile: $!";
+  my $err = do { local $/; <$fh> };
+  close $fh or die "Cannot close $errfile: $!";
+  $err
+}
+
+like run_covered("mcdc_only", "-coverage,mcdc"), $Warning,
+  "mcdc without condition warns at startup";
+
+unlike run_covered("mcdc_and_condition", "-coverage,condition,mcdc"), $Warning,
+  "mcdc with condition does not warn";
+
+unlike run_covered("default_set"), $Warning,
+  "the default coverage set does not warn";
+
+unlike run_covered("mcdc_only_silent", "-coverage,mcdc", "-silent,1"),
+  $Warning, "-silent suppresses the warning";
+
+done_testing;


### PR DESCRIPTION
## Summary

The MC/DC documentation contained several factual errors, and selecting `mcdc` coverage without `condition` silently collected nothing. This fixes the documentation and makes the mcdc-without-condition case visible.

## Changes

- Warn at startup when `mcdc` is selected without `condition`, since MC/DC derives from the condition truth tables and collects nothing alone. The warning is suppressed by `-silent` and tested in `t/internal/mcdc_without_condition.t`.
- Rewrite the phantom-row explanation in `docs/technical/mcdc.md` with the rows the buggy implementation actually hits; as written it was only coherent for the correct implementation.
- Correct false claims: only Html_crisp renders the composite truth tables, gcov's option is `--conditions` (llvm-cov has `--show-mcdc`), mcdc cannot be collected independently of condition, and the input-vector recorder is new XS collection.
- Describe the proven/unproven rule and the condition prerequisite in mcdc.md, and document the void-context 0% and statement-level right-operand limitations in the Mcdc POD.
- Add MC/DC to the headline criteria lists in README.md and the Devel::Cover POD, add mcdc to `cover`'s json report description and `time` to its `-coverage` list.

## Ticket

Closes #511