### PR TITLE
GH-516 Fix and_2 cells and or_2 truth-table rows

### DIFF
--- a/docs/technical/branches_and_conditions.md
+++ b/docs/technical/branches_and_conditions.md
@@ -280,7 +280,7 @@ false):
 control flow op like `next`, `die`, `return`):
 
 ```perl
-# Columns: l, !l
+# Columns: short-circuit count first: !l, l for and; l, !l for or
 $c = [ $c->[3], $c->[1] + $c->[2] ];
 ```
 
@@ -307,7 +307,7 @@ class in `lib/Devel/Cover/`:
 
 | Class             | Operator | Outcomes | Headers                |
 | ----------------- | -------- | -------- | ---------------------- |
-| `Condition_and_2` | and/&&   | 2        | `l`, `!l`              |
+| `Condition_and_2` | and/&&   | 2        | `!l`, `l`              |
 | `Condition_and_3` | and/&&   | 3        | `!l`, `l&&!r`, `l&&r`  |
 | `Condition_or_2`  | or/\|\|  | 2        | `l`, `!l`              |
 | `Condition_or_3`  | or/\|\|  | 3        | `l`, `!l&&r`, `!l&&!r` |

--- a/lib/Devel/Cover/Condition_and_2.pm
+++ b/lib/Devel/Cover/Condition_and_2.pm
@@ -15,7 +15,7 @@ use warnings;
 use base "Devel::Cover::Condition";
 
 sub count   { 2 }
-sub headers { [qw( l !l )] }
+sub headers { [qw( !l l )] }
 
 1
 

--- a/lib/Devel/Cover/Condition_table.pm
+++ b/lib/Devel/Cover/Condition_table.pm
@@ -46,15 +46,16 @@ package Devel::Cover::Condition_table;
 
 # Truth table specs: each entry is [inputs, result], in stored hit order
 # (the Condition_*::headers order).
-my @Boolean_spec = ([[0], 0], [[1], 1]);
-my @And3_spec    = ([[0, "X"], 0], [[1, 0], 0], [[1, 1], 1]);
-my @Or3_spec     = ([[1, "X"], 1], [[0, 1], 1], [[0, 0], 0]);
-my @Xor4_spec    = ([[1, 1], 0], [[1, 0], 1], [[0, 1], 1], [[0, 0], 0]);
+my @And2_spec = ([[0], 0], [[1], 1]);
+my @Or2_spec  = ([[1], 1], [[0], 0]);
+my @And3_spec = ([[0, "X"], 0], [[1, 0], 0], [[1, 1], 1]);
+my @Or3_spec  = ([[1, "X"], 1], [[0, 1], 1], [[0, 0], 0]);
+my @Xor4_spec = ([[1, 1], 0], [[1, 0], 1], [[0, 1], 1], [[0, 0], 0]);
 
 my %Primitive = (
-  and_2 => \@Boolean_spec,
+  and_2 => \@And2_spec,
   and_3 => \@And3_spec,
-  or_2  => \@Boolean_spec,
+  or_2  => \@Or2_spec,
   or_3  => \@Or3_spec,
   xor_4 => \@Xor4_spec,
 );

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -914,21 +914,33 @@ sub line_branches ($f, $n) {
   } @$loc
 }
 
+sub _cond_fragment ($s) {
+  if ($Have_highlighter) {
+    my ($h) = highlight($R{options}{option}, $s);
+    return $h if defined $h;
+  }
+  encode_entities($s)
+}
+
+# Mark the decision's own operator, distinguishing it from those in operands
+sub _cond_expr ($c) {
+  my ($left, $op, $right) = $c->[1]->@{qw( left op right )};
+  _cond_fragment($left)
+    . ' <span class="cond-op">'
+    . encode_entities($op)
+    . "</span> "
+    . _cond_fragment($right)
+}
+
 sub line_condition_cells ($f, $n) {
   my $conditions = $f->condition or return;
   my $loc        = $conditions->location($n);
   return unless $loc && @$loc;
   map {
-    my $c    = $_;
-    my $text = $c->text;
-    if ($Have_highlighter) {
-      ($text) = highlight($R{options}{option}, $text);
-    } else {
-      $text = encode_entities($text);
-    }
+    my $c = $_;
     {
       type    => $c->type,
-      text    => $text,
+      text    => _cond_expr($c),
       headers => [map encode_entities($_), ($c->headers // [])->@*],
       parts   => [
         map { {
@@ -1893,6 +1905,14 @@ td.chevron {
 .detail .body .expr {
   margin-bottom: 4px;
   color: var(--fg);
+}
+
+.detail .body .expr .cond-op {
+  font-weight: 700;
+  color: var(--cond-op-fg);
+  background: var(--cond-op-bg);
+  padding: 1px 5px;
+  border-radius: 4px;
 }
 
 .detail .body table { margin-top: 4px; }

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -263,6 +263,8 @@ our $Crisp_base_css = <<'CSS';
   --fg-muted: #6c757d;
   --border: #dee2e6;
   --link: #1565c0;
+  --cond-op-bg: #c2dcf7;
+  --cond-op-fg: #0d47a1;
   --link-visited: #4a148c;
   --header-bg: #f5f5f5;
 
@@ -316,6 +318,8 @@ our $Crisp_base_css = <<'CSS';
     --fg-muted: #9e9e9e;
     --border: #424242;
     --link: #64b5f6;
+    --cond-op-bg: #2a4a72;
+    --cond-op-fg: #90caf9;
     --link-visited: #ce93d8;
     --header-bg: #2a2a2a;
 
@@ -361,6 +365,8 @@ html[data-theme="dark"] {
   --fg-muted: #9e9e9e;
   --border: #424242;
   --link: #64b5f6;
+  --cond-op-bg: #2a4a72;
+  --cond-op-fg: #90caf9;
   --link-visited: #ce93d8;
   --header-bg: #2a2a2a;
 
@@ -405,6 +411,8 @@ html[data-theme="light"] {
   --fg-muted: #6c757d;
   --border: #dee2e6;
   --link: #1565c0;
+  --cond-op-bg: #c2dcf7;
+  --cond-op-fg: #0d47a1;
   --link-visited: #4a148c;
   --header-bg: #f5f5f5;
 

--- a/t/internal/condition_table.t
+++ b/t/internal/condition_table.t
@@ -18,6 +18,8 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 
 use Test::More import => [qw( done_testing is is_deeply like ok unlike )];
 
+use Devel::Cover::Condition_and_2 ();
+use Devel::Cover::Condition_or_2  ();
 use Devel::Cover::Condition_table ();
 
 # Build a mock condition object: blessed arrayref matching the structure that
@@ -153,6 +155,28 @@ sub test_single_or2_asymmetric () {
   is_deeply $rows[1]->inputs, [1], "or_2 asym: row (1) inputs";
   is $rows[1]->result, 1, "or_2 asym: row (1) result";
   ok $rows[1]->covered, "or_2 asym: row (1) covered";
+}
+
+# The 2-count types store hits short-circuit first, rows come back in
+# stored hit order, and headers claim that same order, so row $i's input
+# must match header $i: !l is input 0, l is input 1.
+sub test_boolean_headers_match_row_order () {
+  my %ops       = (and_2 => "&&", or_2 => "||");
+  my %input_for = ("!l"  => 0,    "l"  => 1);
+  for my $type (sort keys %ops) {
+    my $class      = "Condition_$type";
+    my @conditions = (mock_condition(
+      $class, [1, 0],
+      { type => $type, left => '$a', op => $ops{$type}, right => "1" },
+    ));
+    my ($t)     = Devel::Cover::Condition_table->for_line(\@conditions);
+    my @rows    = $t->rows;
+    my $headers = "Devel::Cover::$class"->headers;
+    for my $i (0, 1) {
+      is $rows[$i]->inputs->[0], $input_for{ $headers->[$i] },
+        qq($type row $i matches header "$headers->[$i]");
+    }
+  }
 }
 
 # xor_4: $a xor $b (4 paths)
@@ -1274,6 +1298,7 @@ sub main () {
   test_single_and2;
   test_single_or2;
   test_single_or2_asymmetric;
+  test_boolean_headers_match_row_order;
   test_single_xor4;
   test_single_xor4_asymmetric;
   test_composite_or_and;

--- a/t/internal/condition_table.t
+++ b/t/internal/condition_table.t
@@ -134,6 +134,27 @@ sub test_single_or2 () {
   ok $rows[1]->covered, "or_2 row 1 covered";
 }
 
+# or_2 with asymmetric hits: stored order is short-circuit first (l, !l),
+# so hits [1, 0] mean only l was exercised and only row (1) is covered.
+# The symmetric hits above cannot detect a reversed row mapping; these can.
+sub test_single_or2_asymmetric () {
+  my @conditions = (mock_condition(
+    "Condition_or_2", [1, 0],
+    { type => "or_2", left => '$a', op => "||", right => "0" },
+  ));
+
+  my ($t) = Devel::Cover::Condition_table->for_line(\@conditions);
+  my @rows = sort { "@{$a->inputs}" cmp "@{$b->inputs}" } $t->rows;
+
+  is_deeply $rows[0]->inputs, [0], "or_2 asym: row (0) inputs";
+  is $rows[0]->result, 0, "or_2 asym: row (0) result";
+  ok !$rows[0]->covered, "or_2 asym: row (0) not covered";
+
+  is_deeply $rows[1]->inputs, [1], "or_2 asym: row (1) inputs";
+  is $rows[1]->result, 1, "or_2 asym: row (1) result";
+  ok $rows[1]->covered, "or_2 asym: row (1) covered";
+}
+
 # xor_4: $a xor $b (4 paths)
 sub test_single_xor4 () {
   my @conditions = (mock_condition(
@@ -1252,6 +1273,7 @@ sub main () {
   test_single_or3;
   test_single_and2;
   test_single_or2;
+  test_single_or2_asymmetric;
   test_single_xor4;
   test_single_xor4_asymmetric;
   test_composite_or_and;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -552,6 +552,26 @@ sub test_truth_tables_pass_observed_vectors () {
   is $covered{"1|0|0"}, 0, "phantom (1,0,0) not covered";
 }
 
+# or_2 stores its hits short-circuit first (l, !l), so with only the l
+# outcome exercised the truth-table view must colour row (1), not its
+# complement.  Symmetric hits cannot catch a reversed row mapping.
+sub test_truth_tables_or2_asymmetric () {
+  my @cond = (_mock_cond(
+    "Condition_or_2", [1, 0],
+    { type => "or_2", left => '$x', op => "||", right => "0" },
+  ));
+  my $f = MockFile->new(MockCriterion->new({ 7 => \@cond }));
+
+  my @tts = Devel::Cover::Report::Html_crisp::line_truth_tables($f, 7);
+  is @tts, 1, "or_2 asym: single truth table";
+
+  my %row = map { $_->{inputs}[0] => $_ } $tts[0]{rows}->@*;
+  ok $row{1}{covered}, "or_2 asym: row (1) covered";
+  is $row{1}{class}, "c3", "or_2 asym: row (1) class c3";
+  ok !$row{0}{covered}, "or_2 asym: row (0) not covered";
+  is $row{0}{class}, "c0", "or_2 asym: row (0) class c0";
+}
+
 # Panel 1 of the per-line detail block: per-logop cells aligned with the
 # headline cond % (one cell per truth-value slot, classes from the condition's
 # value/error pair).  Covers line_condition_cells data layout and the rendered
@@ -801,6 +821,7 @@ sub main () {
   test_mcdc_detail_unanalysed_note;
   test_mcdc_detail_excused_badge;
   test_truth_tables_pass_observed_vectors;
+  test_truth_tables_or2_asymmetric;
   test_condition_cells_panel;
   test_condition_cells_panel_merges_conditions;
   test_decision_vectors_panel_heading;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -572,6 +572,24 @@ sub test_truth_tables_or2_asymmetric () {
   is $row{0}{class}, "c0", "or_2 asym: row (0) class c0";
 }
 
+# and_2 stores its hits short-circuit first (!l, l) and the cells pair each
+# stored count with its header positionally, so with only the !l outcome
+# exercised the covered count must sit under the "!l" header.
+sub test_condition_cells_and2_headers () {
+  my @cond = (_mock_cond(
+    "Condition_and_2", [1, 0],
+    { type => "and_2", left => '$x', op => "&&", right => "1" },
+  ));
+  my $f = MockFile->new(MockCriterion->new({ 7 => \@cond }));
+
+  my @cells = Devel::Cover::Report::Html_crisp::line_condition_cells($f, 7);
+  is @cells,                     1,    "and_2 asym: single cells entry";
+  is $cells[0]{headers}[0],      "!l", "and_2 asym: header 0 is !l";
+  is $cells[0]{headers}[1],      "l",  "and_2 asym: header 1 is l";
+  is $cells[0]{parts}[0]{count}, 1,    "and_2 asym: count 1 under !l";
+  is $cells[0]{parts}[1]{count}, 0,    "and_2 asym: count 0 under l";
+}
+
 # Panel 1 of the per-line detail block: per-logop cells aligned with the
 # headline cond % (one cell per truth-value slot, classes from the condition's
 # value/error pair).  Covers line_condition_cells data layout and the rendered
@@ -822,6 +840,7 @@ sub main () {
   test_mcdc_detail_excused_badge;
   test_truth_tables_pass_observed_vectors;
   test_truth_tables_or2_asymmetric;
+  test_condition_cells_and2_headers;
   test_condition_cells_panel;
   test_condition_cells_panel_merges_conditions;
   test_decision_vectors_panel_heading;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -590,6 +590,24 @@ sub test_condition_cells_and2_headers () {
   is $cells[0]{parts}[1]{count}, 0,    "and_2 asym: count 0 under l";
 }
 
+# A compound line's outer cells table is captioned with the whole expression,
+# so which operator its columns describe is not obvious.  The decision's own
+# operator is marked; operators inside compound operands are not.
+sub test_condition_cells_op_marked () {
+  my @cond = (_mock_cond(
+    "Condition_or_3",
+    [1, 1, 0],
+    { type => "or_3", left => '$x && $y', op => "||", right => '$z' },
+  ));
+  my $f = MockFile->new(MockCriterion->new({ 7 => \@cond }));
+
+  my @cells = Devel::Cover::Report::Html_crisp::line_condition_cells($f, 7);
+  like $cells[0]{text}, qr{\$x.*<span class="cond-op">\|\|</span>.*\$z}s,
+    "cells: the decision's own operator is marked";
+  unlike $cells[0]{text}, qr{cond-op">(?:&amp;&amp;|&&)<}s,
+    "cells: the operator inside the left operand is not marked";
+}
+
 # Panel 1 of the per-line detail block: per-logop cells aligned with the
 # headline cond % (one cell per truth-value slot, classes from the condition's
 # value/error pair).  Covers line_condition_cells data layout and the rendered
@@ -841,6 +859,7 @@ sub main () {
   test_truth_tables_pass_observed_vectors;
   test_truth_tables_or2_asymmetric;
   test_condition_cells_and2_headers;
+  test_condition_cells_op_marked;
   test_condition_cells_panel;
   test_condition_cells_panel_merges_conditions;
   test_decision_vectors_panel_heading;

--- a/test_output/cover/cond_branch.5.020000
+++ b/test_output/cover/cond_branch.5.020000
@@ -431,7 +431,7 @@ Conditions
 
 and 2 conditions
 
-line  err      %      l     !l   expr
+line  err      %     !l      l   expr
 ----- --- ------ ------ ------   ----
 240          100      2      2   shift() && (return)
 

--- a/test_output/cover/cond_branch.5.043008
+++ b/test_output/cover/cond_branch.5.043008
@@ -431,7 +431,7 @@ Conditions
 
 and 2 conditions
 
-line  err      %      l     !l   expr
+line  err      %     !l      l   expr
 ----- --- ------ ------ ------   ----
 240          100      2      2   shift() && (return)
 

--- a/test_output/cover/mcdc_constant_right.5.020000
+++ b/test_output/cover/mcdc_constant_right.5.020000
@@ -92,7 +92,7 @@ Conditions
 
 and 2 conditions
 
-line  err      %      l     !l   expr
+line  err      %     !l      l   expr
 ----- --- ------ ------ ------   ----
 15           100      1      1   $p && 1
 


### PR DESCRIPTION
## Summary

A condition that collapses to two outcomes displays its counts under `l`/`!l` headers. `and_2` stores its counts short-circuit first but its headers claimed the opposite order, so every reporter pairing them by position showed each count under the wrong header, claiming the untested outcome ran. `or_2` had the mirror fault in the truth-table synthesis, colouring each row with its complement's coverage. Both are display faults - percentages were never affected. On top of the fixes, each condition cells table now names its own operator, since with short-circuit-first ordering an `and` and an `or` table on the same line lead with opposite columns.

## Changes

- `Condition_and_2::headers` is now `(!l, l)`, matching the stored order and the `and_3` short-circuit-first convention; golden files and the technical docs updated to match.
- `Condition_table` gives `and_2` and `or_2` separate truth-table specs, since their stored hit orders differ.
- The crisp report's condition cell captions render the decision's own operator as a highlighted pill, distinguishing it from operators inside compound operands.
- New regression tests use asymmetric hits at both the analyser and the crisp reporter surface; symmetric hits cannot catch a reversed mapping.

## Implications

- The `or_2` row fault cannot appear in text reports (observed vectors override compound synthesis, and a lone boolean's MC/DC numbers are symmetric under row reversal), so its regression protection lives in unit tests rather than golden files.

## Ticket

Closes #516