### PR TITLE
GH-521 Update default HTML report docs

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -685,7 +685,7 @@ configurable.
 =item html_basic
 
 HTML reporting with syntax highlighting if L<PPI::HTML> or L<Perl::Tidy>
-module is detected. Like html|html_minimal reporting, percentage thresholds
+module is detected. Like the other HTML reports, percentage thresholds
 are colour-coded and configurable.
 
 =item text

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -61,24 +61,24 @@ report is generated:
 
 HTML report formats are:
 
-- html|html_minimal (default)
+- html|html_crisp (default)
 - html_basic
-- html_crisp
+- html_minimal
 - html_subtle
 
 They are implemented in:
 
 - Devel::Cover::Report::Html
-  - which is an empty subclass of Devel::Cover::Report::Html_minimal
+  - which is an empty subclass of Devel::Cover::Report::Html_crisp
 - Devel::Cover::Report::Html_basic
 - Devel::Cover::Report::Html_crisp
+- Devel::Cover::Report::Html_minimal
 - Devel::Cover::Report::Html_subtle
 
 **Minimal** was written by Michael Carman. One of the goals was to keep the
 output as small as possible and he decided not to use templates. Unfortunately,
 minimal does not handle uncovered code correctly and, whilst the truth tables
-are nice, they are not always correct when there are many variables. This is
-currently the default HTML report.
+are nice, they are not always correct when there are many variables.
 
 **Basic** handles uncovered code correctly and the conditions are displayed
 correctly, if not as nicely as in minimal. It also allows for coloured code.
@@ -89,7 +89,8 @@ is the format used for cpancover.
 templates are embedded in a single module. It features dark mode,
 sortable/filterable file tables, directory grouping, inline branch and condition
 truth tables, a scroll minimap, and keyboard navigation. Requires
-[Template Toolkit](https://metacpan.org/pod/Template).
+[Template Toolkit](https://metacpan.org/pod/Template). This is the default HTML
+report.
 
 ## cpancover
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1765,11 +1765,6 @@ your code and determined that you are not going to be able to exercise it, it
 may be better to record that fact in some formal fashion and stop Devel::Cover
 complaining about it, so that real problems are not lost in the noise.
 
-If you have uncoverable criteria I suggest not using the default HTML report
-(with uses html_minimal at the moment) because this sometimes shows uncoverable
-points as uncovered.  Instead, you should use the html_basic report for HTML
-output which should behave correctly in this regard.
-
 There are two ways to specify a construct as uncoverable, one invasive and one
 non-invasive.
 


### PR DESCRIPTION
## Summary

Several documents still described `html_minimal` as the default HTML report, but the default is now `Html_crisp`.

## Ticket

Closes #521