### PR TITLE
Fix coverage of installed AutoLoader modules

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -529,9 +529,7 @@ sub use_file ($file) {
   $file = autosplit_parent($file);
 
   return $Files{$file} if exists $Files{$file};
-  return 0
-    if $file =~ /\(eval \d+\)/
-    || $file =~ /^\.\.[\/\\]\.\.[\/\\]lib[\/\\](?:Storable|POSIX).pm$/;
+  return 0             if $file =~ /\(eval \d+\)/;
 
   my $f = normalised_file($file);
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -420,6 +420,20 @@ sub get_coverage {
   return wantarray ? @names : "@names";
 }
 
+# strip AutoSplit's #line suffix and resolve stale blib paths via %INC
+sub autosplit_parent ($file) {
+  return $file unless $file =~ s/ \(autosplit into (.*)\)$//;
+  my $al = $1;
+  return $file if -e $file;
+  my ($key) = $file =~ m{^blib/(?:lib|arch)/(.*)};
+  return $file unless defined $key;
+  my $pm = $INC{$key};
+  return $file unless defined $pm && !ref $pm && $pm =~ /\Q$key\E$/;
+  my $root = substr $pm, 0, length($pm) - length $key;
+  $al =~ s{^blib/(?:lib|arch)/}{};
+  -e "$root$al" ? $pm : $file
+}
+
 {
 
   my %File_cache;
@@ -435,7 +449,7 @@ sub get_coverage {
     $Normalising = 1;
 
     my $f = $file;
-    $file =~ s/ \(autosplit into .*\)$//;
+    $file = autosplit_parent($file);
     $file =~ s/^\(eval in .*\) //;
     if (
          exists coverage(0)->{module}
@@ -512,7 +526,7 @@ sub use_file ($file) {
 
   # just don't call your filenames 0
   while ($file =~ $find_filename) { $file = $1 || $2 || $3 || $4 }
-  $file =~ s/ \(autosplit into .*\)$//;
+  $file = autosplit_parent($file);
 
   return $Files{$file} if exists $Files{$file};
   return 0

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -33,8 +33,7 @@ my $DB = "cover.15";  # Version of the database
   = (qw( statement branch condition mcdc subroutine pod time ));
 @Devel::Cover::DB::Criteria_short   = (qw( stmt bran cond mcdc sub pod time ));
 $Devel::Cover::DB::Ignore_filenames = qr/   # Used by Devel::Cover
-  (?: [\/\\]lib[\/\\](?:Storable|POSIX).pm$ )
-  | # Moose
+  # Moose
   (?:
     (?:
       reader | writer | constructor | destructor | accessor |

--- a/t/internal/autosplit_parent.t
+++ b/t/internal/autosplit_parent.t
@@ -1,0 +1,96 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use lib qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is )];
+
+my $Pm    = "Autoloader_stale.pm";
+my $Al    = "auto/Autoloader_stale/stale.al";
+my $Stale = "blib/lib/$Pm (autosplit into blib/lib/$Al)";
+
+sub parent ($file) { Devel::Cover::autosplit_parent($file) }
+
+sub test_no_suffix () {
+  is parent("tests/$Pm"), "tests/$Pm", "name without suffix is unchanged";
+}
+
+sub test_existing_path () {
+  is parent("tests/$Pm (autosplit into tests/$Al)"), "tests/$Pm",
+    "suffix stripped when the path still exists";
+}
+
+sub test_stale_blib_lib () {
+  local $INC{$Pm} = "tests/$Pm";
+  is parent($Stale), "tests/$Pm", "stale blib/lib path recovered from %INC";
+}
+
+sub test_stale_blib_arch () {
+  local $INC{$Pm} = "tests/$Pm";
+  is parent("blib/arch/$Pm (autosplit into blib/arch/$Al)"), "tests/$Pm",
+    "stale blib/arch path recovered from %INC";
+}
+
+sub test_mixed_prefixes () {
+  local $INC{$Pm} = "tests/$Pm";
+  is parent("blib/arch/$Pm (autosplit into blib/lib/$Al)"), "tests/$Pm",
+    ".pm and .al under different blib prefixes";
+}
+
+sub test_inc_miss () {
+  local %INC = %INC;
+  delete $INC{$Pm};
+  is parent($Stale), "blib/lib/$Pm", "no %INC entry degrades to stripped name";
+}
+
+sub test_inc_ref () {
+  local $INC{$Pm} = sub { };
+  is parent($Stale), "blib/lib/$Pm", "%INC hook ref degrades to stripped name";
+}
+
+sub test_inc_odd_value () {
+  local $INC{$Pm} = "/somewhere/else.pm";
+  is parent($Stale), "blib/lib/$Pm",
+    "%INC value not ending in the key degrades to stripped name";
+}
+
+sub test_al_missing () {
+  local $INC{$Pm} = "t/internal/$Pm";
+  is parent($Stale), "blib/lib/$Pm",
+    "no .al under the %INC root degrades to stripped name";
+}
+
+sub test_non_blib_stale () {
+  is parent("../../lib/POSIX.pm (autosplit into ../../lib/auto/POSIX/f.al)"),
+    "../../lib/POSIX.pm", "non-blib stale path is only stripped";
+}
+
+sub main () {
+  # a compile-time use would run CHECK blocks needing the unbootstrapped XS
+  require Devel::Cover;
+
+  test_no_suffix;
+  test_existing_path;
+  test_stale_blib_lib;
+  test_stale_blib_arch;
+  test_mixed_prefixes;
+  test_inc_miss;
+  test_inc_ref;
+  test_inc_odd_value;
+  test_al_missing;
+  test_non_blib_stale;
+  done_testing;
+}
+
+main;

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -133,7 +133,7 @@ sub test_write_read () {
   my $st = Devel::Cover::DB::Structure->new(base => $base);
   $st->add_criteria("statement");
   $st->set_file($file);
-  $st->{f}{$file}{statement} = [ [ $file, 1 ] ];
+  $st->{f}{$file}{statement} = [[$file, 1]];
   $st->write($base);
 
   # Read it back into a fresh object
@@ -142,7 +142,7 @@ sub test_write_read () {
 
   ok exists $st2->{f}{$file}, "write/read: file entry present";
   is $st2->{f}{$file}{digest}, $digest, "write/read: digest preserved";
-  is_deeply $st2->{f}{$file}{statement}, [ [ $file, 1 ] ],
+  is_deeply $st2->{f}{$file}{statement}, [[$file, 1]],
     "write/read: data preserved";
 }
 
@@ -216,10 +216,10 @@ sub test_read_all_no_dir () {
 
 sub test_merge () {
   my $st1 = Devel::Cover::DB::Structure->new;
-  $st1->{f}{"/a.pm"} = { digest => "aaa", statement => [ [ "/a.pm", 1 ] ] };
+  $st1->{f}{"/a.pm"} = { digest => "aaa", statement => [["/a.pm", 1]] };
 
   my $st2 = Devel::Cover::DB::Structure->new;
-  $st2->{f}{"/b.pm"} = { digest => "bbb", statement => [ [ "/b.pm", 2 ] ] };
+  $st2->{f}{"/b.pm"} = { digest => "bbb", statement => [["/b.pm", 2]] };
 
   $st1->merge($st2);
   ok exists $st1->{f}{"/a.pm"}, "merge: original entry retained";
@@ -234,17 +234,17 @@ sub test_autoload_add_get () {
   $st->add_criteria("statement", "branch", "subroutine");
 
   # add_statement should push data into {f}{$file}{statement}
-  $st->add_statement($file, [ $file, 10 ]);
-  $st->add_statement($file, [ $file, 20 ]);
-  is_deeply $st->{f}{$file}{statement}, [ [ $file, 10 ], [ $file, 20 ] ],
+  $st->add_statement($file, [$file, 10]);
+  $st->add_statement($file, [$file, 20]);
+  is_deeply $st->{f}{$file}{statement}, [[$file, 10], [$file, 20]],
     "autoload add: add_statement pushes entries";
 
-  $st->add_branch($file, [ $file, 15, { text => "if block" } ]);
-  is_deeply $st->{f}{$file}{branch}, [ [ $file, 15, { text => "if block" } ] ],
+  $st->add_branch($file, [$file, 15, { text => "if block" }]);
+  is_deeply $st->{f}{$file}{branch}, [[$file, 15, { text => "if block" }]],
     "autoload add: add_branch pushes entry";
 
-  $st->add_subroutine($file, [ $file, 5 ]);
-  is_deeply $st->{f}{$file}{subroutine}, [ [ $file, 5 ] ],
+  $st->add_subroutine($file, [$file, 5]);
+  is_deeply $st->{f}{$file}{subroutine}, [[$file, 5]],
     "autoload add: add_subroutine pushes entry";
 }
 
@@ -255,10 +255,10 @@ sub test_autoload_get_by_digest () {
   $st->set_file($file);
   $st->add_criteria("statement");
 
-  $st->add_statement($file, [ $file, 1 ]);
+  $st->add_statement($file, [$file, 1]);
 
   my $got = $st->get_statement($digest);
-  is_deeply $got, [ [ $file, 1 ] ],
+  is_deeply $got, [[$file, 1]],
     "autoload get: get_statement retrieves by digest";
 
   my $miss = $st->get_statement("nonexistent_digest");
@@ -326,7 +326,7 @@ sub test_reuse () {
 
   ok !$st->reuse("/new.pm"), "reuse: false for unknown file";
 
-  $st->{f}{"/old.pm"}{start}{-1}{__COVER__} = [ { statement => 5 } ];
+  $st->{f}{"/old.pm"}{start}{-1}{__COVER__} = [{ statement => 5 }];
   ok $st->reuse("/old.pm"), "reuse: true when __COVER__ start exists";
 }
 
@@ -428,10 +428,10 @@ sub test_autoload_get_time () {
   $st->set_file($file);
 
   # time criterion maps to statement internally
-  $st->{f}{$file}{statement} = [ [ $file, 1 ] ];
+  $st->{f}{$file}{statement} = [[$file, 1]];
 
   my $got = $st->get_time($digest);
-  is_deeply $got, [ [ $file, 1 ] ], "autoload get_time: maps to statement data";
+  is_deeply $got, [[$file, 1]], "autoload get_time: maps to statement data";
 }
 
 sub test_set_file_missing () {
@@ -481,8 +481,8 @@ sub test_set_subroutine_reuse_existing () {
   $st->add_criteria("statement");
 
   # Set up a reusable structure with __COVER__ and an existing sub
-  $st->{f}{$file}{start}{-1}{__COVER__} = [ { statement => 0 } ];
-  $st->{f}{$file}{start}{10}{oldsub}    = [ { statement => 5 } ];
+  $st->{f}{$file}{start}{-1}{__COVER__} = [{ statement => 0 }];
+  $st->{f}{$file}{start}{10}{oldsub}    = [{ statement => 5 }];
 
   $st->set_subroutine("oldsub", $file, 10, 0);
 
@@ -498,7 +498,7 @@ sub test_set_subroutine_reuse_additional_first () {
   $st->add_criteria("statement");
 
   # Set up reusable structure but without the sub we'll request
-  $st->{f}{$file}{start}{-1}{__COVER__} = [ { statement => 10 } ];
+  $st->{f}{$file}{start}{-1}{__COVER__} = [{ statement => 10 }];
 
   $st->set_subroutine("newsub", $file, 20, 0);
 
@@ -515,7 +515,7 @@ sub test_set_subroutine_reuse_additional_repeat () {
   $st->add_criteria("statement");
 
   # Set up reusable structure without the sub
-  $st->{f}{$file}{start}{-1}{__COVER__} = [ { statement => 10 } ];
+  $st->{f}{$file}{start}{-1}{__COVER__} = [{ statement => 10 }];
   # Simulate that we've already seen an additional sub in this file
   $st->{additional_count}{statement}{$file} = 1;
 
@@ -548,7 +548,7 @@ sub test_add_count_reuse_not_additional () {
   $st->add_criteria("statement");
 
   # Set up reuse so the || branch in add_count is tested
-  $st->{f}{$file}{start}{-1}{__COVER__} = [ { statement => 0 } ];
+  $st->{f}{$file}{start}{-1}{__COVER__} = [{ statement => 0 }];
   $st->{additional} = 0;
 
   my ($n, $new) = $st->add_count("statement");
@@ -661,7 +661,7 @@ sub test_set_complexity () {
   my $st   = Devel::Cover::DB::Structure->new;
   $st->set_file($file);
 
-  my $sub_id = [ $file, 10, "mysub", 0 ];
+  my $sub_id = [$file, 10, "mysub", 0];
   $st->set_complexity($sub_id, 5);
 
   is $st->{f}{$file}{complexity}{10}{mysub}[0], 5,
@@ -674,8 +674,8 @@ sub test_set_complexity_multiple_subs () {
   my $st = Devel::Cover::DB::Structure->new;
   $st->set_file($file);
 
-  $st->set_complexity([ $file, 10, "sub_a", 0 ], 3);
-  $st->set_complexity([ $file, 20, "sub_b", 0 ], 7);
+  $st->set_complexity([$file, 10, "sub_a", 0], 3);
+  $st->set_complexity([$file, 20, "sub_b", 0], 7);
 
   is $st->{f}{$file}{complexity}{10}{sub_a}[0], 3,
     "set_complexity multi: first sub has correct CC";
@@ -689,7 +689,7 @@ sub test_complexity_write_read () {
 
   my $st = Devel::Cover::DB::Structure->new(base => $base);
   $st->set_file($file);
-  $st->set_complexity([ $file, 5, "f", 0 ], 4);
+  $st->set_complexity([$file, 5, "f", 0], 4);
   $st->write($base);
 
   my $st2 = Devel::Cover::DB::Structure->new(base => $base);
@@ -704,7 +704,7 @@ sub test_get_complexity () {
   my $digest = md5_file($file);
   my $st     = Devel::Cover::DB::Structure->new;
   $st->set_file($file);
-  $st->set_complexity([ $file, 8, "g", 0 ], 6);
+  $st->set_complexity([$file, 8, "g", 0], 6);
 
   my $got = $st->get_complexity($digest);
   is_deeply $got, { 8 => { g => [6] } }, "get_complexity: retrieves by digest";
@@ -718,7 +718,7 @@ sub test_set_end_line () {
   my $st   = Devel::Cover::DB::Structure->new;
   $st->set_file($file);
 
-  my $sub_id = [ $file, 10, "f", 0 ];
+  my $sub_id = [$file, 10, "f", 0];
   $st->set_end_line($sub_id, 25);
 
   is $st->{f}{$file}{end_line}{10}{f}[0], 25,
@@ -730,7 +730,7 @@ sub test_get_end_lines () {
   my $digest = md5_file($file);
   my $st     = Devel::Cover::DB::Structure->new;
   $st->set_file($file);
-  $st->set_end_line([ $file, 8, "g", 0 ], 20);
+  $st->set_end_line([$file, 8, "g", 0], 20);
 
   my $got = $st->get_end_lines($digest);
   is_deeply $got, { 8 => { g => [20] } }, "get_end_lines: retrieves by digest";
@@ -745,7 +745,7 @@ sub test_end_line_write_read () {
 
   my $st = Devel::Cover::DB::Structure->new(base => $base);
   $st->set_file($file);
-  $st->set_end_line([ $file, 5, "f", 0 ], 15);
+  $st->set_end_line([$file, 5, "f", 0], 15);
   $st->write($base);
 
   my $st2 = Devel::Cover::DB::Structure->new(base => $base);
@@ -763,7 +763,7 @@ sub test_set_subroutine_returns_sub_id () {
   $st->add_count("statement");
 
   my $sub_id = $st->set_subroutine("h", $file, 15, 0);
-  is_deeply $sub_id, [ $file, 15, "h", 0 ], "set_subroutine: returns sub_id";
+  is_deeply $sub_id, [$file, 15, "h", 0], "set_subroutine: returns sub_id";
 
   $st->set_complexity($sub_id, 9);
   is $st->{f}{$file}{complexity}{15}{h}[0], 9,

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -596,7 +596,7 @@ sub test_destroy () {
 
 sub test_digest_ignored_file () {
   my $st     = Devel::Cover::DB::Structure->new;
-  my $ignore = "/some/lib/Storable.pm";
+  my $ignore = "/loader/0x123abc/Some/Module.pm";
   my $stderr = capture_stderr {
     my $d = $st->digest($ignore);
     ok !defined $d, "digest ignored: returns undef"
@@ -619,7 +619,7 @@ sub test_write_no_digest_ignored () {
   my $base = fresh_base("no_digest_ign");
 
   my $st = Devel::Cover::DB::Structure->new(base => $base);
-  $st->{f}{"/some/lib/POSIX.pm"} = { data => 1 };
+  $st->{f}{"/loader/0x123abc/Some/Module.pm"} = { data => 1 };
 
   my $stderr = capture_stderr { $st->write($base) };
   is $stderr, "", "write no digest ignored: no warning for ignored file";

--- a/test_output/cover/autoloader_stale.5.020000
+++ b/test_output/cover/autoloader_stale.5.020000
@@ -1,0 +1,132 @@
+cover: Reading database from ...
+
+Common prefix: tests/
+
+------------------- ------ ------ ------ ------ ------ ------ ------
+File                  stmt   bran   cond   mcdc    sub  total   scar
+------------------- ------ ------ ------ ------ ------ ------ ------
+Autoloader_stale.pm  100.0    n/a    n/a    n/a  100.0  100.0    0.0
+autoloader_stale     100.0    n/a    n/a    n/a  100.0  100.0    0.0
+Total                100.0    n/a    n/a    n/a  100.0  100.0    0.0
+------------------- ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+Module Summary
+--------------
+
+Files CC   Cov CRAP SCAR
+----- -- ----- ---- ----
+    2  1 100.0  1.0  0.0
+
+
+Autoloader_stale.pm
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+ 1 100.0  1.0  0.0
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+2                                              
+3                                              # This software is free.  It is licensed under the same terms as Perl itself.
+4                                              
+5                                              # The latest version of this software should be available from my homepage:
+6                                              # https://pjcj.net
+7                                              
+8                                              # Simulates an installed AutoLoader module with stale blib #line paths.
+9                                              
+10                                             package Autoloader_stale;
+11                                             
+12             1                           1   use strict;
+               1                               
+               1                               
+13             1                           1   use warnings;
+               1                               
+               1                               
+14                                             
+15             1                           1   use AutoLoader qw( AUTOLOAD );
+               1                               
+               1                               
+16                                             
+17             1                           1   sub loaded { 42 }
+18                                             
+19                                             1;
+20                                             
+21                                             __END__
+22                                             
+23             1                           1   sub stale { 18 }
+24                                             
+25                                             1;
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location              
+---------- ----- --- ----- ----------------------
+BEGIN          1   1   0.0 Autoloader_stale.pm:12
+BEGIN          1   1   0.0 Autoloader_stale.pm:13
+BEGIN          1   1   0.0 Autoloader_stale.pm:15
+loaded         1   1   0.0 Autoloader_stale.pm:17
+stale          1   1   0.0 Autoloader_stale.pm:23
+
+
+autoloader_stale
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+ 1 100.0  1.0  0.0
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10             1                           1   use strict;
+               1                               
+               1                               
+11             1                           1   use warnings;
+               1                               
+               1                               
+12                                             
+13             1                           1   use lib "tests";
+               1                               
+               1                               
+14                                             
+15             1                           1   use Autoloader_stale;
+               1                               
+               1                               
+16                                             
+17             1                               my $Sum = Autoloader_stale::loaded();
+18                                             
+19             1                               $Sum += Autoloader_stale::stale();
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location           
+---------- ----- --- ----- -------------------
+BEGIN          1   1   0.0 autoloader_stale:10
+BEGIN          1   1   0.0 autoloader_stale:11
+BEGIN          1   1   0.0 autoloader_stale:13
+BEGIN          1   1   0.0 autoloader_stale:15
+
+

--- a/tests/Autoloader_stale.pm
+++ b/tests/Autoloader_stale.pm
@@ -1,0 +1,25 @@
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Simulates an installed AutoLoader module with stale blib #line paths.
+
+package Autoloader_stale;
+
+use strict;
+use warnings;
+
+use AutoLoader qw( AUTOLOAD );
+
+sub loaded { 42 }
+
+1;
+
+__END__
+
+sub stale { 18 }
+
+1;

--- a/tests/auto/Autoloader_stale/autosplit.ix
+++ b/tests/auto/Autoloader_stale/autosplit.ix
@@ -1,0 +1,5 @@
+# Index created by AutoSplit for blib/lib/Autoloader_stale.pm
+#    (file acts as timestamp)
+package Autoloader_stale;
+sub stale ;
+1;

--- a/tests/auto/Autoloader_stale/stale.al
+++ b/tests/auto/Autoloader_stale/stale.al
@@ -1,0 +1,9 @@
+# NOTE: Derived from blib/lib/Autoloader_stale.pm.
+# Changes made here will be lost when autosplit is run again.
+# See AutoSplit.pm.
+package Autoloader_stale;
+
+#line 23 "blib/lib/Autoloader_stale.pm (autosplit into blib/lib/auto/Autoloader_stale/stale.al)"
+sub stale { 18 }
+
+1;

--- a/tests/autoloader_stale
+++ b/tests/autoloader_stale
@@ -1,0 +1,19 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use strict;
+use warnings;
+
+use lib "tests";
+
+use Autoloader_stale;
+
+my $Sum = Autoloader_stale::loaded();
+
+$Sum += Autoloader_stale::stale();


### PR DESCRIPTION
Fixes #522

## Summary

- AutoSplit bakes the build-time path into each `.al` file's `#line`
  directive, so coverage of autoloaded subs from an installed module was
  recorded under a stale `blib/` path and discarded at report time with a
  pair of warnings per test process.
- Recover the parent `.pm`'s real path from `%INC` when the baked path no
  longer exists, checking the `.al` resolves from the same root to guard
  against shadowed installations.  A miss keeps the old behaviour.
- Remove the `Storable`/`POSIX` special cases, dead since core stopped
  autosplitting them before 5.20.

## Test plan

- [x] New end-to-end test with a hand-written stale `.al` fixture
- [x] Unit tests for `autosplit_parent`
- [x] Full suite passes on all configured Perl versions
- [x] Verified against installed `Net::SSLeay` under 5.24.0