### PR TITLE
GH-527 Fix crisp legend threshold ranges

### DIFF
--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -202,6 +202,15 @@ HTML
   $o
 }
 
+sub dist_range ($cl) {
+  my $t = $Threshold;
+      $cl eq "c0"    ? "&lt; $t->{c0}%"
+    : $cl eq "c1"    ? "$t->{c0}-$t->{c1}%"
+    : $cl eq "c2"    ? "$t->{c1}-$t->{c2}%"
+    : $t->{c2} < 100 ? "$t->{c2}-100%"
+    :                  "100%"
+}
+
 sub render_dist_bar ($dist) {
   my $dt = $dist->{dist_total} // 0;
   return "" unless $dt > 0;
@@ -222,17 +231,17 @@ sub render_dist_bar ($dist) {
 HTML
   }
   $o .= "</div>\n";
-  my $t = $R{threshold};
+  my $c3 = $Threshold->{c2} < 100 ? dist_range("c3") : "at 100%";
   my $untested
     = $dist->{untested}
     ? qq(<span class="leg-untested">$dist->{untested} untested</span>\n)
     : "";
   $o .= <<HTML;
 <div class="dist-legend">
-<span class="leg-c0">$dist->{c0} &lt; $t->{c0}%</span>
-<span class="leg-c1">$dist->{c1} $t->{c0}-$t->{c1}%</span>
-<span class="leg-c2">$dist->{c2} $t->{c1}-100%</span>
-<span class="leg-c3">$dist->{c3} at 100%</span>
+<span class="leg-c0">$dist->{c0} @{[ dist_range("c0") ]}</span>
+<span class="leg-c1">$dist->{c1} @{[ dist_range("c1") ]}</span>
+<span class="leg-c2">$dist->{c2} @{[ dist_range("c2") ]}</span>
+<span class="leg-c3">$dist->{c3} $c3</span>
 $untested</div>
 HTML
   $o
@@ -1174,11 +1183,8 @@ sub coverage_distribution ($file_data) {
   $dist{dist_total} = @$file_data || 1;
 
   my $pl = sub ($n) { $n == 1 ? "file" : "files" };
-  my $t  = $Threshold;
-  $dist{tip_c0} = "$dist{c0} ${\$pl->($dist{c0})}" . " &lt; $t->{c0}%";
-  $dist{tip_c1} = "$dist{c1} ${\$pl->($dist{c1})}" . " $t->{c0}-$t->{c1}%";
-  $dist{tip_c2} = "$dist{c2} ${\$pl->($dist{c2})}" . " $t->{c1}-100%";
-  $dist{tip_c3} = "$dist{c3} ${\$pl->($dist{c3})}" . " 100%";
+  $dist{"tip_$_"} = "$dist{$_} ${\$pl->($dist{$_})} ${\dist_range($_)}"
+    for qw( c0 c1 c2 c3 );
   $dist{tip_untested} = "$dist{untested} untested ${\$pl->($dist{untested})}";
   %dist
 }
@@ -1247,7 +1253,6 @@ sub report ($pkg, $db, $options) {
     filenames => {
       map { $_ => do { (my $f = $_) =~ s/\W/-/g; $f } } $options->{file}->@*
     },
-    threshold      => $Threshold,
     have_ppi       => eval { require PPI; 1 } ? 1 : 0,
     favicon_colour => favicon("c3"),
     report_id      => $options->{outputdir},

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -17,7 +17,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
 use File::Spec ();
-use Test::More import => [qw( done_testing is like ok plan unlike )];
+use Test::More import => [qw( diag done_testing is like ok plan unlike )];
 use Devel::Cover::Mcdc               ();  ## no perlimports
 use Devel::Cover::Report::Html_crisp ();
 use Devel::Cover::Test::Showcase     qw(
@@ -33,19 +33,19 @@ eval "require HTML::Entities; 1" or do {
 };
 
 # Shared state populated by _setup
-my ($Tmpdir, $Libdir, $Outdir);
+my ($Tmpdir, $Libdir, $Outdir, $Cover_db);
 my %Golden;
 
 # Generate golden report output via run_cover (external process).
 sub _setup () {
   return if $Tmpdir;
   ($Tmpdir, $Libdir) = setup_lib_dir;
-  my $cover_db = create_cover_db($Tmpdir, $Libdir);
-  $Outdir = File::Spec->catdir($Tmpdir, "html");
+  $Cover_db = create_cover_db($Tmpdir, $Libdir);
+  $Outdir   = File::Spec->catdir($Tmpdir, "html");
 
   my ($out, $exit) = run_cover(
     "--select_dir", $Libdir, "--report", "html_crisp",
-    "--outputdir",  $Outdir, "--silent", $cover_db,
+    "--outputdir",  $Outdir, "--silent", $Cover_db,
   );
   die "Report generation failed (exit $exit):\n$out\n" if $exit;
 
@@ -126,6 +126,29 @@ sub test_render_index () {
   like $got,   qr/class="help-overlay"/,    "has help overlay";
   like $got,   qr/class="footer"/,          "has footer";
   like $got,   qr/Devel::Cover/,            "footer mentions Devel::Cover";
+}
+
+sub test_dist_legend_custom_thresholds () {
+  like $Golden{"coverage.html"}, qr/at 100%/,
+    "default thresholds: legend shows at 100%";
+
+  my $outdir = File::Spec->catdir($Tmpdir, "html_thresholds");
+  my ($out, $exit) = run_cover(
+    "--select_dir", $Libdir,       "--report", "html_crisp",
+    "--outputdir",  $outdir,       "--silent", "--report_c0",
+    25,             "--report_c1", 50,         "--report_c2",
+    75,             $Cover_db,
+  );
+  is $exit, 0, "custom threshold report generated" or diag $out;
+
+  my $html = slurp("$outdir/coverage.html");
+  like $html,   qr/leg-c0">\d+ &lt; 25%/, "legend c0 below c0 threshold";
+  like $html,   qr/leg-c1">\d+ 25-50%/,   "legend c1 range c0 to c1";
+  like $html,   qr/leg-c2">\d+ 50-75%/,   "legend c2 range c1 to c2";
+  like $html,   qr/leg-c3">\d+ 75-100%/,  "legend c3 range c2 to 100";
+  unlike $html, qr/at 100%/,        "no 'at 100%' label when c2 is below 100";
+  like $html,   qr/files? 50-75%/,  "bar tooltip c2 range c1 to c2";
+  like $html,   qr/files? 75-100%/, "bar tooltip c3 range c2 to 100";
 }
 
 sub test_render_file_page () {
@@ -863,6 +886,7 @@ sub main () {
   test_crit_name;
   test_render_layout;
   test_render_index;
+  test_dist_legend_custom_thresholds;
   test_render_file_page;
   test_tooltip_structure;
   test_glass_tooltips;


### PR DESCRIPTION
## Summary

The crisp report's coverage distribution legend and bar-segment tooltips assumed the `report_c2` threshold was always 100, so custom thresholds such as `-report_c0 25 -report_c1 50 -report_c2 75` labelled the last two buckets as `50-100%` and `at 100%` instead of `50-75%` and `75-100%`. The range labels are now built by a single helper from the configured thresholds, used by both the legend and the tooltips. Output with default thresholds is unchanged.

## Ticket

Closes #527