### PR TITLE
GH-528 Fix crisp report directory rows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,5 +86,7 @@ jobs:
           cpanm --notest --installdeps --with-develop .
 
       - name: Run tests
+        env:
+          HARNESS_OPTIONS: j4
         run:
           cpanm --verbose --test-only .

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -395,7 +395,13 @@ sub _summarise_dir_complexity ($self, $s, $dir_files, $dir_stats) {
   my $ds_hash = $self->{dir_summary} = {};
   for my $dir (keys %$dir_files) {
     my $d = $ds_hash->{$dir} = {};
-    for my $criterion (qw( statement branch condition total )) {
+    my %criteria;
+    for my $f ($dir_files->{$dir}->@*) {
+      my $fs = $s->{$f} or next;
+      $criteria{$_}++ for keys %$fs;
+    }
+    delete @criteria{qw( complexity scar time )};
+    for my $criterion (sort keys %criteria) {
       my ($covered, $total, $error) = (0, 0, 0);
       for my $f ($dir_files->{$dir}->@*) {
         my $c = $s->{$f}{$criterion} or next;

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -31,7 +31,7 @@ use Devel::Cover::Path            qw( common_prefix );
 use File::Path     qw( mkpath );
 use Getopt::Long   qw( GetOptions );
 use HTML::Entities qw( encode_entities );
-use List::Util     qw( any first );
+use List::Util     qw( any );
 use POSIX          qw( strftime );
 our %R;
 my %Assets;
@@ -380,18 +380,11 @@ HTML
 HTML
 
   for my $g (@groups) {
-    my $t = first { $_->{exists} && !$_->{uncompiled} } $g->{files}->@*;
     $o .= qq(<tr class="dir-header" data-dir="$g->{dir}">\n)
       . "<td>$g->{dir}</td>\n";
-    for my $c ($R{criteria}->@*) {
-      $o .= cov_cell(
-        $g->{criteria}{$c},
-        0, undef, $t ? "$t->{link}#filter=$c" : undef,
-      );
-    }
-    $o .= cov_cell($g->{total}, 0, undef,
-      $t ? "$t->{link}#filter=total" : undef);
-    $o .= scar_cell($g, $t ? $t->{link} : undef);
+    $o .= cov_cell($g->{criteria}{$_}, 0) for $R{criteria}->@*;
+    $o .= cov_cell($g->{total},        0);
+    $o .= scar_cell($g);
     $o .= "</tr>\n";
     $o .= file_row($_, $g->{dir}) for $g->{files}->@*;
   }
@@ -784,6 +777,11 @@ sub get_summary ($file, $criterion) {
   _format_criterion($R{db}->summary($file), $criterion)
 }
 
+sub _na_scar ($f) {
+  $f->{$_} = "-" for qw( file_crap file_scar file_cc file_cov );
+  $f->{worst_subs} = [];
+}
+
 sub _apply_scar ($f, $scar_data) {
   if ($scar_data && defined $scar_data->{file_crap}) {
     $f->{file_crap} = sprintf "%.1f", $scar_data->{file_crap};
@@ -800,11 +798,7 @@ sub _apply_scar ($f, $scar_data) {
       } } @sorted[0 .. ($#sorted > 2 ? 2 : $#sorted)]
     ];
   } elsif ($f->{uncompiled}) {
-    $f->{file_crap}  = "-";
-    $f->{file_scar}  = "-";
-    $f->{file_cc}    = "-";
-    $f->{file_cov}   = "-";
-    $f->{worst_subs} = [];
+    _na_scar($f);
   } else {
     $f->{file_crap}  = 0;
     $f->{file_scar}  = 0;
@@ -825,6 +819,7 @@ sub build_one_file ($file) {
     name       => $file,
     basename   => $basename,
     dir        => $dir,
+    db_dir     => $dir,
     link       => "$R{filenames}{$file}.html",
     exists     => -e $file,
     uncompiled => $uncompiled,
@@ -867,18 +862,20 @@ sub build_dir_groups ($file_data) {
   my %dirs;
   push $dirs{ $_->{dir} }->@*, $_ for @$file_data;
   map {
-    my $dir = $_;
-    my $g   = {
+    my $dir    = $_;
+    my $db_dir = $dirs{$dir}[0]{db_dir};
+    my $g      = {
       dir      => $dir || "(root)",
       dir_key  => $dir,
-      total    => get_dir_summary($dir, "total"),
+      total    => get_dir_summary($db_dir, "total"),
       criteria =>
-        { map { $_ => get_dir_summary($dir, $_) } $R{criteria}->@* },
+        { map { $_ => get_dir_summary($db_dir, $_) } $R{criteria}->@* },
       files => $dirs{$dir},
     };
     $g->{pc}    = $g->{total}{pc};
     $g->{class} = $g->{total}{class};
-    _apply_scar($g, $R{db}->dir_summary($dir, "scar"));
+    my $scar = $R{db}->dir_summary($db_dir, "scar");
+    $scar ? _apply_scar($g, $scar) : _na_scar($g);
     $g;
   } sort keys %dirs
 }
@@ -2295,7 +2292,6 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
 
     /* Directory collapse/expand */
     tbody.addEventListener("click", function(e) {
-      if (e.target.closest(".cell-link")) return;
       var dh = e.target.closest(".dir-header");
       if (!dh) return;
       var collapsed = dh.classList.toggle("collapsed");

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -466,11 +466,14 @@ sub test_dir_level_scar () {
   ok defined $ds, "dirscar: dir summary exists";
 
   # Per-criterion aggregation
-  for my $c (qw( statement branch condition total )) {
+  for my $c (qw( statement branch subroutine total )) {
     ok exists $ds->{$c},           "dirscar: has $c";
     ok defined $ds->{$c}{covered}, "dirscar: $c has covered";
     ok defined $ds->{$c}{total},   "dirscar: $c has total";
   }
+
+  # No entry is fabricated for criteria with no data
+  ok !exists $ds->{condition}, "dirscar: no condition entry without data";
 
   # SCAR entry
   my $scar = $ds->{scar};
@@ -685,8 +688,7 @@ sub test_print_summary_scar () {
   my ($file_row) = $output =~ /^(\S*ps_scar\.pl\s.+)$/m;
   ok defined $file_row, "summary: file row found";
   my @file_cols = split " ", $file_row // "";
-  is @file_cols, 7,
-    "summary: file row has name + 5 criteria + scar (7 cols)";
+  is @file_cols, 7, "summary: file row has name + 5 criteria + scar (7 cols)";
   like $file_cols[-1], qr/^\d+\.\d$/,
     "summary: file row scar column is numeric";
 

--- a/t/internal/dir_summary.t
+++ b/t/internal/dir_summary.t
@@ -1,0 +1,74 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is ok )];
+
+use Devel::Cover::DB ();
+
+sub crit ($covered, $total) {
+  { covered => $covered, total => $total, error => $total - $covered }
+}
+
+sub test_all_criteria_aggregated () {
+  my $db = bless {}, "Devel::Cover::DB";
+  my $s  = {
+    "lib/A/Foo.pm" => {
+      statement  => crit(5, 10),
+      branch     => crit(1, 4),
+      condition  => crit(2, 6),
+      mcdc       => crit(1, 3),
+      subroutine => crit(2, 2),
+      pod        => crit(1, 2),
+      time       => { covered => 0, total => 123, error => 0 },
+      total      => crit(12, 27),
+      complexity => { max     => 3, mean     => 2, count => 2 },
+      scar       => { file_cc => 4, file_cov => 50 },
+    },
+    "lib/A/Bar.pm" => {
+      statement  => crit(10, 10),
+      subroutine => crit(1,  2),
+      total      => crit(11, 12),
+    },
+  };
+  my $dir_files = { "lib/A" => ["lib/A/Foo.pm", "lib/A/Bar.pm"] };
+  my $dir_stats = { "lib/A" => { cc_sum => 6, cc_count => 3 } };
+
+  $db->_summarise_dir_complexity($s, $dir_files, $dir_stats);
+
+  my $d = $db->dir_summary("lib/A");
+  ok $d, "directory summary created";
+  is $d->{statement}{covered},    15, "statement covered summed";
+  is $d->{statement}{total},      20, "statement total summed";
+  is $d->{statement}{percentage}, 75, "statement percentage computed";
+  is $d->{branch}{total},         4,  "branch aggregated";
+  is $d->{condition}{total},      6,  "condition aggregated";
+  is $d->{mcdc}{total},           3,  "mcdc aggregated";
+  is $d->{subroutine}{covered},   3,  "subroutine aggregated";
+  is $d->{pod}{covered},          1,  "pod aggregated";
+  is $d->{total}{covered},        23, "total aggregated";
+  ok !exists $d->{time},       "time not aggregated";
+  ok !exists $d->{complexity}, "complexity not treated as a criterion";
+  is $d->{scar}{file_cc}, 4, "dir SCAR computed from dir stats";
+}
+
+sub main () {
+  test_all_criteria_aggregated;
+  done_testing;
+}
+
+main;

--- a/t/internal/html_crisp.t
+++ b/t/internal/html_crisp.t
@@ -30,6 +30,26 @@ eval "require HTML::Entities; 1" or do {
   exit;
 };
 
+# Directory header rows show real aggregates and no links to files.
+sub test_dir_header_rows ($content) {
+  my @rows = $content =~ m{(<tr class="dir-header".*?</tr>)}gs;
+  is @rows, 2, "index has two dir-header rows";
+
+  for my $row (@rows) {
+    my ($dir) = $row =~ m{data-dir="([^"]+)"};
+    unlike $row, qr/cell-link/, "$dir dir-header row has no links";
+  }
+
+  my ($covered) = grep m{data-dir="Covered"}, @rows;
+  ok $covered, "Covered dir-header row present";
+  unlike $covered, qr/class="na"/,
+    "Covered dir row has aggregates for all criteria";
+  like $covered, qr{<dt>CC</dt><dd>[1-9]},
+    "Covered dir row SCAR tooltip has non-zero CC";
+  unlike $covered, qr/data-value="0" class="scar-val/,
+    "Covered dir row SCAR is not a bare 0";
+}
+
 # Html_crisp report for a db with --select_dir:
 # - All four modules appear in the summary index
 # - Uncovered modules have no per-file detail pages
@@ -51,6 +71,8 @@ sub test_html_crisp_report () {
   ok -e $index, "coverage.html was generated";
 
   my $content = slurp($index);
+
+  test_dir_header_rows($content);
 
   # All eight modules appear in the index
   like $content, qr/Covered\/Calc\.pm/,      "Covered/Calc.pm in index";

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -399,14 +399,55 @@ sub test_index_filter_links () {
     "index: SCAR cell links to file without #filter";
 }
 
-sub test_dir_header_links () {
+sub test_dir_header_no_links () {
   my $got = $Golden{"coverage.html"};
   my ($dir_block) = $got =~ m{(<tr class="dir-header".*?</tr>)}s;
   ok defined $dir_block, "dir-header row found in golden index";
-  like $dir_block, qr/cell-link/,
-    "dir-header: cells wrapped in cell-link anchors";
-  like $dir_block, qr/#filter=/,
-    "dir-header: cell-link hrefs include filter hash";
+  unlike $dir_block, qr/cell-link/, "dir-header: cells have no links";
+  unlike $dir_block, qr/<a /,       "dir-header: no anchors at all";
+}
+
+sub test_build_dir_groups () {
+  no warnings "once";
+
+  my $db = bless {
+    dir_summary => {
+      "/full/lib/Covered" => {
+        statement =>
+          { covered => 5, total => 10, error => 5, percentage => 50 },
+        total => { covered => 5, total => 10, error => 5, percentage => 50 },
+        scar  => {
+          file_cc   => 3,
+          file_cov  => 50,
+          file_crap => 6.4,
+          file_scar => 18.5,
+          subs      => [],
+        },
+      },
+    },
+    },
+    "Devel::Cover::DB";
+
+  local %Devel::Cover::Report::Html_crisp::R
+    = (db => $db, criteria => ["statement"]);
+
+  my $files = [
+    { dir => "Covered",   db_dir => "/full/lib/Covered",   name => "a" },
+    { dir => "Uncovered", db_dir => "/full/lib/Uncovered", name => "b" },
+  ];
+  my @groups = Devel::Cover::Report::Html_crisp::build_dir_groups($files);
+  is @groups, 2, "two directory groups built";
+
+  my ($cov, $uncov) = @groups;
+  is $cov->{dir}, "Covered", "groups sorted by display dir";
+  is $cov->{criteria}{statement}{pc}, "50.0",
+    "aggregate looked up by full directory, not shortened dir";
+  is $cov->{pc},        "50.0", "group total aggregated";
+  is $cov->{file_scar}, "18.5", "group SCAR aggregated";
+
+  is $uncov->{total}{pc}, "n/a", "no data: total shows n/a";
+  is $uncov->{file_scar}, "-",   "no data: SCAR shows n/a, not 0";
+  is $uncov->{file_crap}, "-",   "no data: CRAP shows n/a";
 }
 
 # The index header and badges must name the criterion "MC/DC", matching the
@@ -425,7 +466,6 @@ sub test_app_js_hash_filter () {
   like $app_js, qr/history\.replaceState/, "app.js: uses replaceState";
   like $app_js, qr/#filter=/,              "app.js: filter hash referenced";
   like $app_js, qr/location\.hash/,        "app.js: reads location.hash";
-  like $app_js, qr/cell-link/, "app.js: index click handler aware of cell-link";
 }
 
 {
@@ -902,7 +942,8 @@ sub main () {
   test_render_worst_files_untested_colour;
   test_stat_badge_no_tip_when_empty;
   test_index_filter_links;
-  test_dir_header_links;
+  test_dir_header_no_links;
+  test_build_dir_groups;
   test_app_js_hash_filter;
   test_mcdc_full_name;
   test_truth_tables_unproven_rows_uncovered;


### PR DESCRIPTION
## Summary

With "Group by directory" enabled, directory rows in the crisp HTML report always showed n/a for every criterion and a green SCAR of 0. The report looked up aggregates by the prefix-shortened directory whilst the database keys the full path, so the lookup never matched, and the database only aggregated statement, branch, condition and total in any case. Directory summaries now aggregate every criterion the files actually have, the report looks them up by the full directory, and SCAR shows n/a rather than 0 when there really is no data.

The metric cells on directory rows no longer link to the first file under the directory; the whole row now toggles collapse instead.

The branch also switches CI to run tests in parallel (`HARNESS_OPTIONS=j4`), matching the 4 vCPUs on the standard GitHub runners.

## Ticket

Closes #528