### PR TITLE
GH-531 Use relative links in collection HTML

### DIFF
--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -307,7 +307,10 @@ class Devel::Cover::Collection {
       LOAD_TEMPLATES =>
         [Devel::Cover::Collection::Template::Provider->new({})],
     });
+    $vars->{root} = "";
     $template->process("summary", $vars, $f) or die $template->error;
+    $vars->{root} = "../";
+
     for my $start (sort keys $vars->{modules}->%*) {
       $vars->{module_start} = $start;
       my $dist = "$d/dist/$start.html";
@@ -318,7 +321,7 @@ class Devel::Cover::Collection {
     my $about_f = "$d/about.html";
     say "\nWriting about page to $about_f ...";
 
-    $template->process("about", { subdir => "latest/" }, $about_f)
+    $template->process("about", { root => "" }, $about_f)
       or die $template->error;
 
     # print Dumper $vars;
@@ -372,7 +375,6 @@ class Devel::Cover::Collection {
       title       => "Coverage report",
       modules     => {},
       vals        => {},
-      subdir      => "latest/",
       headers     => [grep !/time/, @Devel::Cover::DB::Criteria_short, "total"],
       criteria    => [grep !/time/, @Devel::Cover::DB::Criteria,       "total"],
       col_headers => do {
@@ -410,7 +412,7 @@ class Devel::Cover::Collection {
 
       my $m = $vars->{vals}{$module} = {};
       $m->{module} = $mod;
-      $m->{link}   = "/$module/index.html"
+      $m->{link}   = "$module/index.html"
         if $json->{summary}{Total}{total}{total};
 
       for my $criterion ($vars->{criteria}->@*) {
@@ -760,7 +762,7 @@ https://pjcj.net
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="/[% subdir %]collection.css">
+<link rel="stylesheet" href="[% root %]collection.css">
 <link rel="icon" href="data:image/svg+xml,
   <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'>
   <circle cx='8' cy='8' r='7' fill='%232e7d32'/>
@@ -785,11 +787,11 @@ Coverage information from
 by <a href="https://pjcj.net">Paul Johnson</a>.
 Please report problems to the
 <a href="https://github.com/pjcj/Devel--Cover/issues">bug tracker</a>.
-<a href="/[% subdir %]about.html">About</a> the project.
+<a href="[% root %]about.html">About</a> the project.
 This server generously donated by
 <a href="https://www.bytemark.co.uk">Bytemark</a>.
 </footer>
-<script src="/[% subdir %]collection.js" defer></script>
+<script src="[% root %]collection.js" defer></script>
 </body>
 </html>
 EOT
@@ -913,7 +915,7 @@ $Templates{module_by_start} = <<'EOT';
     <tr>
       <td>
         [% IF vals.$m.link %]
-          <a href="/[% subdir %][%- vals.$m.link -%]">
+          <a href="[% root %][%- vals.$m.link -%]">
             [% module.name || module.module %]
           </a>
         [% ELSE %]
@@ -923,7 +925,7 @@ $Templates{module_by_start} = <<'EOT';
       <td>[% module.version %]</td>
       <td>
         [% IF vals.$m.log %]
-          <a href="/[% subdir %][% vals.$m.log %]">&para;</a>
+          <a href="[% root %][% vals.$m.log %]">&para;</a>
         [% END %]
       </td>
       [% FOREACH criterion = criteria %]

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -1,0 +1,103 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( getcwd );
+use File::Path qw( make_path );
+use File::Temp ();
+use JSON::PP   ();
+use Test::More import => [qw( done_testing like plan unlike )];
+
+BEGIN {
+  plan skip_all => "Devel::Cover::Collection requires Perl 5.42" if $] < 5.042;
+  for my $module (qw( Template Parallel::Iterator JSON::MaybeXS )) {
+    plan skip_all => "$module required for this test"
+      unless eval "require $module; 1";
+  }
+}
+
+require Devel::Cover::Collection;
+
+my $Dist = "Foo-Bar-1.00";
+my $Log  = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--1234567890.123456.out.gz";
+
+sub write_file ($path, $content) {
+  open my $fh, ">", $path or die "Can't open $path: $!";
+  print $fh $content;
+  close $fh or die "Can't close $path: $!";
+}
+
+sub slurp ($path) {
+  open my $fh, "<", $path or die "Can't open $path: $!";
+  local $/;
+  my $content = <$fh>;
+  close $fh or die "Can't close $path: $!";
+  $content
+}
+
+sub setup_results_dir {
+  my $dir = File::Temp->newdir;
+  make_path("$dir/$Dist");
+
+  my $criterion = { percentage => 85.5, covered => 10, total => 12 };
+  my $cover     = {
+    runs    => [{ name => "Foo-Bar", version => "1.00", dir => "/tmp/x" }],
+    summary => { Total => { total => $criterion, statement => $criterion } },
+  };
+  write_file("$dir/$Dist/cover.json", JSON::PP->new->encode($cover));
+  write_file("$dir/$Log",             "log\n");
+
+  $dir
+}
+
+my $Cwd = getcwd;
+my $Dir = setup_results_dir;
+
+my $Collection = Devel::Cover::Collection->new(results_dir => "$Dir");
+$Collection->generate_html;
+chdir $Cwd or die "Can't chdir $Cwd: $!";
+
+my %Page = (
+  index => slurp("$Dir/index.html"),
+  dist  => slurp("$Dir/dist/F.html"),
+  about => slurp("$Dir/about.html"),
+);
+
+for my $name (sort keys %Page) {
+  unlike $Page{$name}, qr{/latest/},        "$name page has no /latest/ links";
+  unlike $Page{$name}, qr{(?:href|src)="/}, "$name page has no absolute links";
+}
+
+for my $name (qw( index about )) {
+  like $Page{$name}, qr{href="collection\.css"},
+    "$name page links stylesheet relatively";
+  like $Page{$name}, qr{src="collection\.js"},
+    "$name page links script relatively";
+  like $Page{$name}, qr{href="about\.html"},
+    "$name page links about page relatively";
+}
+
+like $Page{index}, qr{href="dist/F\.html"}, "index links dist page";
+
+like $Page{dist}, qr{href="\.\./collection\.css"}, "dist page links stylesheet";
+like $Page{dist}, qr{src="\.\./collection\.js"},   "dist page links script";
+like $Page{dist}, qr{href="\.\./about\.html"},     "dist page links about page";
+like $Page{dist}, qr{href="\.\./\Q$Dist\E/index\.html"},
+  "dist page links module report";
+like $Page{dist}, qr{href="\.\./\Q$Log\E"}, "dist page links build log";
+
+done_testing;

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -24,6 +24,8 @@ use Test::More import => [qw( done_testing like plan unlike )];
 
 BEGIN {
   plan skip_all => "Devel::Cover::Collection requires Perl 5.42" if $] < 5.042;
+  plan skip_all => "Devel::Cover::Collection is not portable to Windows"
+    if $^O eq "MSWin32";
   for my $module (qw( Template Parallel::Iterator JSON::MaybeXS )) {
     plan skip_all => "$module required for this test"
       unless eval "require $module; 1";


### PR DESCRIPTION
## Summary

The collection pages (index, per-letter distribution pages, about) hard-coded the `/latest/` URL prefix in their links, so a results tree could only ever be served at that path. Each page now gets a root prefix matching its own depth and every link is relative, making any results tree servable at any URL. This is groundwork for regenerating cpancover into a separate tree served alongside production.

## Ticket

Part of #531