### PR TITLE
GH-531 Isolate docker stacks by environment

### DIFF
--- a/utils/dc
+++ b/utils/dc
@@ -404,8 +404,8 @@ recipe_cpancover() {
 }
 
 cpancover_docker_ps() {
-  local name="${docker_image//[^a-zA-Z0-9_.]/-}"
-  $docker ps -a | tail -n +2 | grep "$name-" | grep -vw "$(hostname)"
+  $docker ps -a --filter "label=cpancover.env=$env" |
+    tail -n +2 | grep -vw "$(hostname)"
 }
 
 recipe_cpancover-docker-ps() {
@@ -607,6 +607,7 @@ cpancover_controller_command() {
     --mount "type=bind,source=$sock,target=$sock" \
     --mount "type=bind,source=$results_dir,target=/remote_staging" \
     ${env_flags[@]:+"${env_flags[@]}"} \
+    --label "cpancover.env=$env" \
     --rm=false --memory=1g --name="$(docker_name "$name")" \
     "$docker_image" "${cmd[@]}"
 }
@@ -620,6 +621,7 @@ recipe_cpancover-docker-shell() {
   mkdir -p "$staging"
   $docker run -it \
     --mount type=bind,source="$staging",target=/remote_staging \
+    --label "cpancover.env=$env" \
     --rm=false --memory=1g --name="$(docker_name docker)" \
     "$docker_image" /bin/bash
 }
@@ -637,6 +639,7 @@ recipe_cpancover-docker-module() {
   local v=
   ((verbose)) && v=--verbose
   container=$($docker run -d \
+    --label "cpancover.env=$env" \
     --rm=false --memory=1g --name="$name" \
     "$docker_image" \
     dc $v cpancover-build-module "$module")

--- a/utils/dc
+++ b/utils/dc
@@ -133,9 +133,11 @@ cpancover (Docker):
   cpancover-docker-kill                Kill running cpancover containers.
   cpancover-docker-module <mod> <name> Build coverage for a module in Docker
                                        (called by Collection.pm).
+  cpancover-docker-prune               Prune unused Docker data (manual
+                                       maintenance).
   cpancover-docker-ps                  List running cpancover containers.
   cpancover-docker-pull                Pull the latest cpancover Docker image.
-  cpancover-docker-rm                  Remove cpancover containers and prune.
+  cpancover-docker-rm                  Remove cpancover containers.
   cpancover-docker-rm-image            Stop containers and remove the Docker
                                        image.
   cpancover-docker-shell               Open a shell in a cpancover container.
@@ -422,11 +424,14 @@ recipe_cpancover-docker-kill() {
 
 cpancover_docker_rm() {
   cpancover_docker_ps_ids | xargs -r "$docker" rm -f
-  $docker system prune --force
 }
 
 recipe_cpancover-docker-rm() {
   cpancover_docker_rm
+}
+
+recipe_cpancover-docker-prune() {
+  $docker system prune --force
 }
 
 recipe_cpancover-docker-rm-image() {


### PR DESCRIPTION
## Summary

Parallel cpancover stacks (prod and dev) could interfere with each other: containers were identified by a grep on names derived from the image name, and every build pass ran a global `docker system prune --force`, which could remove another stack's exited but not yet copied worker containers.

Every `docker run` now carries a `cpancover.env` label and the ps/kill/rm recipes filter on it, so each stack only ever touches its own containers. The global prune moves to a new manual maintenance recipe, `cpancover-docker-prune`.

## Ticket

Part of #531