### PR TITLE
GH-531 Make cpancover compression switchable

### DIFF
--- a/docs/technical/cpancover-rebuild.md
+++ b/docs/technical/cpancover-rebuild.md
@@ -95,11 +95,12 @@ At the end of the rebuild cycle the recipe:
   normal loop. Rebuilt distdirs replace the previous contents at the same path,
   so version compression still kicks in when the new version supersedes enough
   old versions.
-- **Log retention**: every rebuild run produces a fresh `<log_name>.out.gz` in
-  `$results_dir`. Failed rebuilds refresh the existing `<distdir>/.log_ref` to
-  point at the new log, so users clicking "log" on a failing distribution see
-  the most recent failure rather than a stale one from months ago. Old `.out.gz`
-  files accumulate until the normal log-retention policy reaps them.
+- **Log retention**: every rebuild run produces a fresh `<log_name>.out` in
+  `$results_dir`, compressed to `.out.gz` only when `CPANCOVER_COMPRESS` is
+  set. Failed rebuilds refresh the existing `<distdir>/.log_ref` to point at
+  the new log, so users clicking "log" on a failing distribution see the most
+  recent failure rather than a stale one from months ago. Old log files
+  accumulate until the normal log-retention policy reaps them.
 - **`is_covered` / `is_failed` semantics change in rebuild mode**: a distdir
   counts as "done" only if it has both been processed and flagged rebuilt this
   cycle. Outside rebuild mode the methods behave as before.

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -331,11 +331,11 @@ class Devel::Cover::Collection {
   }
 
   method resolve_log_links ($d, $mods, $vars) {
-    # Match top-level .out.gz log files to modules
+    # Match top-level .out/.out.gz log files to modules
     my $n   = 0;
     my $re  = qr/^\w-\w\w-\w+-(.*)/;
     my $ext = qr/($Dist_ext_re)/;
-    my $ts  = qr/--\d{10,11}\.\d{6}\.out\.gz$/;
+    my $ts  = qr/--\d{10,11}\.\d{6}\.out(?:\.gz)?$/;
     for my $f (@$mods) {
       my ($module) = $f =~ /${re}${ext}${ts}/ or next;
       next if $vars->{vals}{$module}{log};
@@ -568,7 +568,7 @@ class Devel::Cover::Collection {
 
   method cpan_path_for ($distdir) {
     # The log filename format records the CPAN path directly:
-    # "A-AU-AUTHOR-Dist-Name-1.23.tar.gz--<timestamp>.out.gz". Parse it
+    # "A-AU-AUTHOR-Dist-Name-1.23.tar.gz--<timestamp>.out[.gz]". Parse it
     # instead of asking cpanm, which wants module names (Foo::Bar) not
     # distribution names (Foo-Bar) and so fails for most real distdirs.
     #
@@ -595,13 +595,14 @@ class Devel::Cover::Collection {
 
   method _log_index {
     # Index log filenames by distdir so per-distdir lookups are O(1).
-    # Filename format: A-AU-AUTHOR-Distdir-Name-1.23.tar.gz--<ts>.out.gz
+    # Filename format: A-AU-AUTHOR-Distdir-Name-1.23.tar.gz--<ts>.out[.gz]
     $_log_index_cache //= do {
       opendir my $dh, $results_dir or die "Can't opendir $results_dir: $!";
       my %by_distdir;
       for my $name (readdir $dh) {
         next
-          unless $name =~ /\A\w-\w\w-\w+-(.+?)${Dist_ext_re}--.*\.out\.gz\z/;
+          unless $name
+          =~ /\A\w-\w\w-\w+-(.+?)${Dist_ext_re}--.*\.out(?:\.gz)?\z/;
         push $by_distdir{$1}->@*, $name;
       }
       closedir $dh or warn "Can't closedir $results_dir: $!";

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -579,14 +579,14 @@ class Devel::Cover::Collection {
     my $log = $self->_log_name_for($distdir);
     if (
       defined $log
-      && $log =~ m{\A(.)-(..)-([^-]+)-(\Q$distdir\E${Dist_ext_re})--}
+      && $log =~ m{^(.)-(..)-([^-]+)-(\Q$distdir\E${Dist_ext_re})--}
     ) {
       return "$1/$2/$3/$4";
     }
 
     # Fall back to cpanm with the module name, stripping any trailing
     # version (including "-v1.2.3" forms).
-    my $bare   = $distdir =~ s/-v?\d[\d.]*\z//r;
+    my $bare   = $distdir =~ s/-v?\d[\d.]*$//r;
     my $module = $bare    =~ s/-/::/gr;
     my $out    = $self->bsys("cpanm", "--info", $module);
     chomp $out;
@@ -601,8 +601,7 @@ class Devel::Cover::Collection {
       my %by_distdir;
       for my $name (readdir $dh) {
         next
-          unless $name
-          =~ /\A\w-\w\w-\w+-(.+?)${Dist_ext_re}--.*\.out(?:\.gz)?\z/;
+          unless $name =~ /^\w-\w\w-\w+-(.+?)${Dist_ext_re}--.*\.out(?:\.gz)?$/;
         push $by_distdir{$1}->@*, $name;
       }
       closedir $dh or warn "Can't closedir $results_dir: $!";

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -34,8 +34,10 @@ BEGIN {
 
 require Devel::Cover::Collection;
 
-my $Dist = "Foo-Bar-1.00";
-my $Log  = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--1234567890.123456.out.gz";
+my $Dist  = "Foo-Bar-1.00";
+my $Log   = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--1234567890.123456.out.gz";
+my $Dist2 = "Baz-Qux-2.00";
+my $Log2  = "P-PJ-PJCJ-Baz-Qux-2.00.tar.gz--1234567891.123456.out";
 
 sub write_file ($path, $content) {
   open my $fh, ">", $path or die "Can't open $path: $!";
@@ -51,17 +53,22 @@ sub slurp ($path) {
   $content
 }
 
-sub setup_results_dir {
-  my $dir = File::Temp->newdir;
-  make_path("$dir/$Dist");
+sub write_dist ($dir, $dist, $name, $version, $log) {
+  make_path("$dir/$dist");
 
   my $criterion = { percentage => 85.5, covered => 10, total => 12 };
   my $cover     = {
-    runs    => [{ name => "Foo-Bar", version => "1.00", dir => "/tmp/x" }],
+    runs    => [{ name => $name, version => $version, dir => "/tmp/x" }],
     summary => { Total => { total => $criterion, statement => $criterion } },
   };
-  write_file("$dir/$Dist/cover.json", JSON::PP->new->encode($cover));
-  write_file("$dir/$Log",             "log\n");
+  write_file("$dir/$dist/cover.json", JSON::PP->new->encode($cover));
+  write_file("$dir/$log",             "log\n");
+}
+
+sub setup_results_dir {
+  my $dir = File::Temp->newdir;
+  write_dist($dir, $Dist,  "Foo-Bar", "1.00", $Log);
+  write_dist($dir, $Dist2, "Baz-Qux", "2.00", $Log2);
 
   $dir
 }
@@ -74,9 +81,10 @@ $Collection->generate_html;
 chdir $Cwd or die "Can't chdir $Cwd: $!";
 
 my %Page = (
-  index => slurp("$Dir/index.html"),
-  dist  => slurp("$Dir/dist/F.html"),
-  about => slurp("$Dir/about.html"),
+  index  => slurp("$Dir/index.html"),
+  dist   => slurp("$Dir/dist/F.html"),
+  dist_b => slurp("$Dir/dist/B.html"),
+  about  => slurp("$Dir/about.html"),
 );
 
 for my $name (sort keys %Page) {
@@ -101,5 +109,7 @@ like $Page{dist}, qr{href="\.\./about\.html"},     "dist page links about page";
 like $Page{dist}, qr{href="\.\./\Q$Dist\E/index\.html"},
   "dist page links module report";
 like $Page{dist}, qr{href="\.\./\Q$Log\E"}, "dist page links build log";
+like $Page{dist_b}, qr{href="\.\./\Q$Log2\E"},
+  "dist page links uncompressed build log";
 
 done_testing;

--- a/utils/dc
+++ b/utils/dc
@@ -840,6 +840,8 @@ cpancover_serve() {
 :${port} {
   root * $www_dir
   redir / /latest/ 301
+  @logs path *.out
+  header @logs Content-Type "text/plain; charset=utf-8"
   file_server {
     precompressed gzip
   }
@@ -861,6 +863,8 @@ cpancover.com, www.cpancover.com {
   root * $www_dir
   redir / /latest/ 301
   encode zstd gzip
+  @logs path *.out
+  header @logs Content-Type "text/plain; charset=utf-8"
   file_server {
     precompressed gzip
   }

--- a/utils/dc
+++ b/utils/dc
@@ -95,8 +95,9 @@ cpancover:
   cpancover-compress-new               Compress only new results directories.
   cpancover-compress-old-versions [n]  Compress old dist versions, keeping n
                                        latest (default 3).
-  cpancover-generate-html              Generate HTML reports, compress results,
-                                       and update JSON.
+  cpancover-generate-html              Generate HTML reports and update JSON;
+                                       compress results only when CPANCOVER_
+                                       COMPRESS is set.
   cpancover-latest                     List the latest CPAN modules to process.
   cpancover-run-loop                   Run build cycles in a loop (10 min
                                        interval).
@@ -631,11 +632,24 @@ recipe_cpancover-docker-shell() {
     "$docker_image" /bin/bash
 }
 
+cpancover_compression_enabled() {
+  [[ -n "${CPANCOVER_COMPRESS:-}" ]]
+}
+
+cpancover_clean_dir() {
+  local dir="$1"
+  rm -rf "$dir/runs" "$dir/structure"
+  rm -f "$dir"/digests "$dir"/digests.gz "$dir"/cover.[0-9]* \
+    "$dir"/cover.[0-9]*.gz "$dir"/*.lock "$dir"/*.lock.gz
+}
+
 recipe_cpancover-docker-module() {
   local module="${1:?No module specified}"
   local name="${2:?No name specified}"
   local staging="${3:-$results_dir}"
   local module_timeout="${CPANCOVER_TIMEOUT:-1800}" # half an hour
+  local log_ext=out
+  cpancover_compression_enabled && log_ext=out.gz
 
   local log_name="$name"
   name=$(docker_name "$name")
@@ -700,7 +714,8 @@ recipe_cpancover-docker-module() {
       elif [[ -d "$staging/$base" ]]; then
         continue
       fi
-      echo "$log_name.out.gz" >"$f/.log_ref"
+      cpancover_clean_dir "$f"
+      echo "$log_name.$log_ext" >"$f/.log_ref"
       mv "$f" "$staging"
     done
 
@@ -718,7 +733,7 @@ recipe_cpancover-docker-module() {
       local bare
       bare=$(cpan_distdir "${module##*/}")
       if [[ -d "$staging/$bare" ]]; then
-        echo "$log_name.out.gz" >"$staging/$bare/.log_ref"
+        echo "$log_name.$log_ext" >"$staging/$bare/.log_ref"
       fi
     fi
   fi
@@ -730,9 +745,7 @@ cpancover_compress_dir() {
   shift 3 2>/dev/null || shift $#
   local exclude=("$@")
 
-  rm -rf "$dir/runs" "$dir/structure"
-  rm -f "$dir"/digests "$dir"/digests.gz "$dir"/cover.[0-9]* \
-    "$dir"/cover.[0-9]*.gz "$dir"/*.lock "$dir"/*.lock.gz
+  cpancover_clean_dir "$dir"
 
   local find_args=("$dir" -maxdepth 1
     -type f -not -name '*.gz' -not -name '*.xz' -not -name '*.json'
@@ -763,20 +776,22 @@ cpancover_compress_dir() {
   fi
 }
 
+cpancover_remove_stale_gz() {
+  # stale .gz files would shadow freshly generated files via precompressed gzip
+  rm -f "$results_dir"/about.html.gz "$results_dir"/index.html.gz \
+    "$results_dir"/collection.css.gz "$results_dir"/collection.js.gz \
+    "$results_dir"/cpancover.json.gz \
+    "$results_dir"/dist/*.gz
+}
+
 cpancover_compress_dirs() {
   local only_new="$1"
   local max_jobs="${CPANCOVER_COMPRESS_JOBS:-$(nice_cpus)}"
   local jobs=0 dir name prefix
 
-  rm -f "$results_dir"/about.html.gz "$results_dir"/index.html.gz \
-    "$results_dir"/collection.css.gz "$results_dir"/collection.js.gz \
-    "$results_dir"/cpancover.json.gz
+  cpancover_remove_stale_gz
   cpancover_compress_dir "$results_dir" "" "top-level: " \
     about.html index.html collection.css collection.js
-
-  # dist/ contains generated HTML that must be served uncompressed;
-  # delete stale .gz files so Caddy serves the fresh versions.
-  rm -f "$results_dir"/dist/*.gz
 
   for dir in "$results_dir"/*/; do
     [[ -d "$dir" ]] || continue
@@ -927,11 +942,17 @@ cpancover_generate_html() {
   pi "Generating HTML at $(date)"
   cpancover_compress_old_versions
   run_cpancover --generate_html
-  cpancover_compress_new
-  local json=$results_dir/cpancover.json
-  local tmp=$json-tmp-$$.gz
-  pi "Compressing $json"
-  pigz <"$json" >"$tmp" && mv "$tmp" "$json.gz"
+  if cpancover_compression_enabled; then
+    cpancover_compress_new
+    local json=$results_dir/cpancover.json
+    local tmp=$json-tmp-$$.gz
+    pi "Compressing $json"
+    pigz <"$json" >"$tmp" && mv "$tmp" "$json.gz"
+  else
+    cpancover_remove_stale_gz
+    # DB::IO leaves .lock sidecars; the compress walk used to strip them
+    find "$results_dir" -maxdepth 2 -name '*.lock' -delete
+  fi
   pi "Done"
 }
 

--- a/xt/collection.t
+++ b/xt/collection.t
@@ -783,6 +783,19 @@ sub cpan_path_for_method () {
   is $cm->cpan_path_for("Multi-1.0"), "A/AU/NEWAUTH/Multi-1.0.tar.gz",
     "cpan_path_for picks newest log when multiple match distdir";
 
+  # Logs are only compressed when CPANCOVER_COMPRESS is set, so plain
+  # .out names must be indexed and parsed just like .out.gz ones.
+  my $udir = tempdir(CLEANUP => 1);
+  my $uc   = Devel::Cover::Collection->new(results_dir => $udir);
+  touch_empty_file("$udir/U-UN-UNZIP-Plain-Log-3.00.tar.gz--444.555.out");
+  is $uc->cpan_path_for("Plain-Log-3.00"), "U/UN/UNZIP/Plain-Log-3.00.tar.gz",
+    "cpan_path_for parses uncompressed top-level log filename";
+  write_log_ref(
+    "$udir/Plain-Ref-4.00", "P-PL-PLAIN-Plain-Ref-4.00.tar.gz--666.777.out\n"
+  );
+  is $uc->cpan_path_for("Plain-Ref-4.00"), "P/PL/PLAIN/Plain-Ref-4.00.tar.gz",
+    "cpan_path_for parses uncompressed log name from .log_ref";
+
   # Legacy bug: a dep distdir may carry the target's .log_ref. Don't
   # trust a .log_ref whose dist name does not match the distdir -
   # otherwise we would reinstall the wrong distribution. Fall through

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -1,0 +1,159 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.42.0;
+
+use Test2::V0  qw( done_testing is ok skip_all subtest );
+use File::Temp qw( tempdir );
+
+skip_all "dc recipes are not portable to Windows" if $^O eq "MSWin32";
+skip_all "utils/dc not found" unless -x "utils/dc";
+skip_all "pigz required" if system "pigz --version >/dev/null 2>&1";
+
+my $Dc  = "utils/dc";
+my $Log = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--1234567890.123456.out";
+
+sub dc (@args) {
+  my $cmd = join " ", $Dc, @args;
+  system("$cmd >/dev/null 2>&1") == 0 or die "$cmd failed";
+}
+
+sub write_file ($path, $content) {
+  open my $fh, ">", $path or die "Can't open $path: $!";
+  print $fh $content;
+  close $fh or die "Can't close $path: $!";
+}
+
+sub slurp ($path) {
+  open my $fh, "<", $path or die "Can't open $path: $!";
+  local $/;
+  my $content = <$fh>;
+  close $fh or die "Can't close $path: $!";
+  $content
+}
+
+sub make_results_tree () {
+  my $dir = tempdir(CLEANUP => 1);
+  for my $d ("Foo-Bar-1.00", "Foo-Bar-1.00/runs", "dist") {
+    mkdir "$dir/$d" or die "Can't mkdir $dir/$d: $!";
+  }
+  write_file("$dir/Foo-Bar-1.00/cover.json", "{}");
+  write_file("$dir/Foo-Bar-1.00/index.html", "html\n");
+  write_file("$dir/Foo-Bar-1.00/cover.14",   "db\n");
+  write_file("$dir/$Log",                    "log\n");
+  write_file("$dir/$_",                      "x\n")
+    for qw( index.html about.html collection.css collection.js );
+  write_file("$dir/cpancover.json", "{}");
+  write_file("$dir/dist/F.html",    "html\n");
+  write_file("$dir/index.html.gz",  "stale\n");
+  write_file("$dir/dist/F.html.gz", "stale\n");
+  $dir
+}
+
+sub compress_recipe () {
+  my $dir = make_results_tree;
+  dc("-r", $dir, "cpancover-compress");
+
+  ok !-e "$dir/index.html.gz",                "stale top-level .gz removed";
+  ok !-e "$dir/dist/F.html.gz",               "stale dist .gz removed";
+  ok -e "$dir/$Log.gz",                       "top-level log compressed";
+  ok !-e "$dir/$Log",                         "uncompressed top-level log gone";
+  ok -e "$dir/Foo-Bar-1.00/index.html.gz",    "distdir html compressed";
+  ok -e "$dir/Foo-Bar-1.00/index.html",       "sidecar created";
+  ok !-s "$dir/Foo-Bar-1.00/index.html",      "sidecar is empty";
+  ok -e "$dir/Foo-Bar-1.00/virtual_unzipped", "marker created";
+  ok !-e "$dir/Foo-Bar-1.00/runs",            "runs stripped";
+  ok !-e "$dir/Foo-Bar-1.00/cover.14",        "cover DB stripped";
+  ok -s "$dir/index.html",  "top-level index left uncompressed";
+  ok -s "$dir/dist/F.html", "dist page left uncompressed";
+}
+
+sub uncompress_recipe () {
+  my $dir = make_results_tree;
+  dc("-r", $dir, "cpancover-compress");
+
+  dc("-r", $dir, "cpancover-uncompress-dir", "Foo-Bar-1.00");
+  is slurp("$dir/Foo-Bar-1.00/index.html"), "html\n",
+    "uncompress restores content";
+  ok !-e "$dir/Foo-Bar-1.00/index.html.gz", "uncompress removes .gz";
+
+  dc("-r", $dir, "cpancover-uncompress-dir", "Foo-Bar-1.00");
+  is slurp("$dir/Foo-Bar-1.00/index.html"), "html\n",
+    "uncompress is a no-op on an uncompressed dir";
+}
+
+sub make_docker_stub ($bin) {
+  write_file("$bin/docker", <<~'BASH');
+    #!/bin/sh
+    cmd="$1"
+    shift
+    case "$cmd" in
+      run) echo fake-container ;;
+      logs) echo "fake build log" ;;
+      cp)
+        dest="$2"
+        dist="$STUB_DISTDIR"
+        mkdir -p "$dest/staging/$dist/runs" "$dest/staging/$dist/structure"
+        echo db >"$dest/staging/$dist/cover.14"
+        echo x >"$dest/staging/$dist/digests"
+        echo x >"$dest/staging/$dist/x.lock"
+        echo '{}' >"$dest/staging/$dist/cover.json"
+        echo html >"$dest/staging/$dist/index.html"
+        ;;
+    esac
+    exit 0
+    BASH
+  chmod 0755, "$bin/docker" or die "Can't chmod docker stub: $!";
+}
+
+sub docker_module_log_ref () {
+  skip_all "timeout required" if system "command -v timeout >/dev/null 2>&1";
+  my $bin = tempdir(CLEANUP => 1);
+  make_docker_stub($bin);
+  local $ENV{PATH}         = "$bin:$ENV{PATH}";
+  local $ENV{STUB_DISTDIR} = "Foo-Bar-1.00";
+
+  my $log = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--123.456";
+
+  my $off = tempdir(CLEANUP => 1);
+  {
+    delete local $ENV{CPANCOVER_COMPRESS};
+    dc("-r", $off, "cpancover-docker-module", "Foo::Bar", $log, $off);
+  }
+  is slurp("$off/Foo-Bar-1.00/.log_ref"), "$log.out\n",
+    ".log_ref records .out when compression is off";
+  ok !-e "$off/Foo-Bar-1.00/runs",      "runs stripped at ingest";
+  ok !-e "$off/Foo-Bar-1.00/cover.14",  "cover DB stripped at ingest";
+  ok !-e "$off/Foo-Bar-1.00/x.lock",    "lock stripped at ingest";
+  ok -e "$off/Foo-Bar-1.00/index.html", "report survives ingest";
+  ok -e "$off/Foo-Bar-1.00/cover.json", "cover.json survives ingest";
+
+  my $on = tempdir(CLEANUP => 1);
+  {
+    local $ENV{CPANCOVER_COMPRESS} = 1;
+    dc("-r", $on, "cpancover-docker-module", "Foo::Bar", $log, $on);
+  }
+  is slurp("$on/Foo-Bar-1.00/.log_ref"), "$log.out.gz\n",
+    ".log_ref records .out.gz when compression is on";
+}
+
+sub main () {
+  my @tests = qw(
+    compress_recipe
+    uncompress_recipe
+    docker_module_log_ref
+  );
+  for my $test (@tests) {
+    no strict qw( refs );
+    subtest $test => \&$test;
+  }
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

Results compression becomes opt-in: the pipeline compresses only when `CPANCOVER_COMPRESS` is set, and it defaults to off, so regenerated trees are served uncompressed. The housekeeping the compression pass used to do - stripping coverage DB internals, removing stale `.gz` files that would shadow freshly generated pages, cleaning up `.lock` sidecars - now happens without it. The read side accepts both `.out` and `.out.gz` log names, and Caddy serves plain `.out` logs inline as `text/plain` instead of offering them as downloads.

## Implications

- Existing compressed trees keep rendering as before, and their logs stay reachable since both log suffixes are accepted.
- The manual `cpancover-compress`, `cpancover-compress-new` and `cpancover-uncompress-dir` recipes work regardless of the flag; only the automatic loop consults it.
- The production Caddyfile changes, so `dc cpancover-configure-caddy` is needed on deployment.

## Ticket

Part of #531