### PR TITLE
GH-531 Atomic writes and seed recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 ._*
 .DS_Store
 tmp/
-llm/
+llm
 
 tags*
 .perl-version

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -297,6 +297,15 @@ class Devel::Cover::Collection {
       : "c3"
   }
 
+  method _process_template ($template, $name, $vars, $file) {
+    my $tmp = "$file.tmp.$$";
+    $template->process($name, $vars, $tmp) or die $template->error;
+    rename $tmp, $file or do {
+      unlink $tmp;
+      die "Can't rename $tmp to $file: $!\n";
+    };
+  }
+
   method write_summary ($vars) {
     my $d = $self->dir;
     my $f = $self->file;
@@ -308,21 +317,19 @@ class Devel::Cover::Collection {
         [Devel::Cover::Collection::Template::Provider->new({})],
     });
     $vars->{root} = "";
-    $template->process("summary", $vars, $f) or die $template->error;
+    $self->_process_template($template, "summary", $vars, $f);
     $vars->{root} = "../";
 
     for my $start (sort keys $vars->{modules}->%*) {
       $vars->{module_start} = $start;
       my $dist = "$d/dist/$start.html";
-      $template->process("module_by_start", $vars, $dist)
-        or die $template->error;
+      $self->_process_template($template, "module_by_start", $vars, $dist);
     }
 
     my $about_f = "$d/about.html";
     say "\nWriting about page to $about_f ...";
 
-    $template->process("about", { root => "" }, $about_f)
-      or die $template->error;
+    $self->_process_template($template, "about", { root => "" }, $about_f);
 
     # print Dumper $vars;
     $self->write_json($vars);

--- a/lib/Devel/Cover/DB/IO/Base.pm
+++ b/lib/Devel/Cover/DB/IO/Base.pm
@@ -34,8 +34,12 @@ sub _read ($self, $file, $reader) {
 
 sub _write ($self, $file, $writer) {
   my $lock_fh = $self->_lock($file, LOCK_EX);
-  unlink $file;
-  $writer->();
+  my $tmp     = "$file.tmp.$$";
+  eval { $writer->($tmp); 1 } or do { my $e = $@; unlink $tmp; die $e };
+  rename $tmp, $file or do {
+    unlink $tmp;
+    die "Can't rename $tmp to $file: $!\n";
+  };
   $self
 }
 
@@ -54,10 +58,10 @@ sub read_fh ($self, $file, $reader) {
 sub write_fh ($self, $file, $writer) {
   $self->_write(
     $file,
-    sub {
-      open my $fh, ">", $file or die "Can't open $file: $!\n";
+    sub ($tmp) {
+      open my $fh, ">", $tmp or die "Can't open $tmp: $!\n";
       $writer->($fh);
-      close $fh or die "Can't close $file: $!\n";
+      close $fh or die "Can't close $tmp: $!\n";
     },
   )
 }

--- a/lib/Devel/Cover/DB/IO/Base.pm
+++ b/lib/Devel/Cover/DB/IO/Base.pm
@@ -7,46 +7,39 @@
 
 package Devel::Cover::DB::IO::Base;
 
-use strict;
+use 5.20.0;
 use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
 
-use Fcntl ":flock";
+use Fcntl qw( LOCK_EX LOCK_SH );
 
 # VERSION
 
-sub new {
-  my $class = shift;
-  bless {@_}, $class
+sub new ($class, @args) {
+  bless {@args}, $class
 }
 
-sub _lock {
-  my $self = shift;
-  my ($file, $type) = @_;
+sub _lock ($self, $file, $type) {
   my $lock = "$file.lock";
   open my $fh, "+>>", $lock or die "Can't open $lock: $!\n";
   flock $fh, $type or die "Can't lock $lock: $!\n";
   $fh
 }
 
-sub _read {
-  my $self = shift;
-  my ($file, $reader) = @_;
+sub _read ($self, $file, $reader) {
   my $lock_fh = $self->_lock($file, LOCK_SH);
   $reader->()
 }
 
-sub _write {
-  my $self = shift;
-  my ($file, $writer) = @_;
+sub _write ($self, $file, $writer) {
   my $lock_fh = $self->_lock($file, LOCK_EX);
   unlink $file;
   $writer->();
   $self
 }
 
-sub _read_fh {
-  my $self = shift;
-  my ($file, $reader) = @_;
+sub read_fh ($self, $file, $reader) {
   $self->_read(
     $file,
     sub {
@@ -54,20 +47,18 @@ sub _read_fh {
       my $data = $reader->($fh);
       close $fh or die "Can't close $file: $!\n";
       $data
-    }
+    },
   )
 }
 
-sub _write_fh {
-  my $self = shift;
-  my ($file, $writer) = @_;
+sub write_fh ($self, $file, $writer) {
   $self->_write(
     $file,
     sub {
       open my $fh, ">", $file or die "Can't open $file: $!\n";
       $writer->($fh);
       close $fh or die "Can't close $file: $!\n";
-    }
+    },
   )
 }
 
@@ -97,6 +88,16 @@ This module is a base class for IO routines for Devel::Cover::DB.
 L<Devel::Cover>
 
 =head1 METHODS
+
+=head2 read_fh ($file, $reader)
+
+Call C<$reader> with a filehandle open for reading C<$file>, holding a shared
+lock, and return its result.
+
+=head2 write_fh ($file, $writer)
+
+Call C<$writer> with a filehandle to write the data for C<$file>, holding an
+exclusive lock.
 
 =head1 LICENCE
 

--- a/lib/Devel/Cover/DB/IO/JSON.pm
+++ b/lib/Devel/Cover/DB/IO/JSON.pm
@@ -7,8 +7,10 @@
 
 package Devel::Cover::DB::IO::JSON;
 
-use strict;
+use 5.20.0;
 use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
 
 use base "Devel::Cover::DB::IO::Base";
 
@@ -16,44 +18,40 @@ use JSON::MaybeXS ();
 
 # VERSION
 
-sub new {
-  my $class = shift;
-  my %args  = @_;
-  my $json  = JSON::MaybeXS->new(utf8 => 1, allow_blessed => 1);
+sub new ($class, %args) {
+  my $json = JSON::MaybeXS->new(utf8 => 1, allow_blessed => 1);
   $json->ascii->pretty->canonical
     if exists $args{options} && $args{options} =~ /\bpretty\b/i;
   my $self = $class->SUPER::new(%args, json => $json);
   bless $self, $class
 }
 
-sub read {
-  my $self = shift;
-  my ($file) = @_;
-  $self->_read_fh(
+sub read ($self, $file) {
+  $self->read_fh(
     $file,
-    sub {
-      my ($fh) = @_;
+    sub ($fh) {
       local $/;
       my $data = eval { $self->{json}->decode(<$fh>) };
       die "Can't read $file with ", (ref $self->{json}), ": $@" if $@;
       $data
-    }
+    },
   )
 }
 
-sub write {
-  my $self = shift;
-  my ($data, $file) = @_;
-  $self->_write_fh(
+sub write ($self, $data, $file) {
+  $self->write_fh(
     $file,
-    sub {
-      my ($fh) = @_;
+    sub ($fh) {
       print $fh $self->{json}->encode($data);
-    }
+    },
   )
 }
 
-1
+"
+Oh, and that's all I heard about Brenda and Eddie
+Can't tell you more 'cause I told you already
+And here we are waving Brenda and Eddie goodbye
+"
 
 __END__
 

--- a/lib/Devel/Cover/DB/IO/Sereal.pm
+++ b/lib/Devel/Cover/DB/IO/Sereal.pm
@@ -7,53 +7,57 @@
 
 package Devel::Cover::DB::IO::Sereal;
 
-use strict;
+use 5.20.0;
 use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
 
 use base "Devel::Cover::DB::IO::Base";
 
-use Sereal::Decoder;
-use Sereal::Encoder;
+use Sereal::Decoder ();
+use Sereal::Encoder ();
 
 # VERSION
 
 my ($Decoder, $Encoder);
 
-sub new {
-  my $class = shift;
-  my $self  = $class->SUPER::new(@_);
+sub new ($class, @args) {
+  my $self = $class->SUPER::new(@args);
   bless $self, $class
 }
 
-sub read {
-  my $self = shift;
-  my ($file) = @_;
-  $self->_read_fh(
+sub read ($self, $file) {
+  $self->read_fh(
     $file,
-    sub {
-      my ($fh) = @_;
+    sub ($fh) {
       local $/;
       my $data
         = eval { ($Decoder ||= Sereal::Decoder->new({}))->decode(<$fh>) };
       die "Can't read $file with Sereal: $@" if $@;
       $data
-    }
+    },
   )
 }
 
-sub write {
-  my $self = shift;
-  my ($data, $file) = @_;
-  $self->_write_fh(
+sub write ($self, $data, $file) {
+  $self->write_fh(
     $file,
-    sub {
-      my ($fh) = @_;
+    sub ($fh) {
       print $fh ($Encoder ||= Sereal::Encoder->new({}))->encode($data);
-    }
+    },
   )
 }
 
-1
+"
+Norman and Norma had three lovely daughters
+Nadia, Nora and Neive
+The firm Norma worked at wouldn't take her back
+After maternity leave
+They dreamt of Majorca, but couldn't afford to go
+On Norman's salary
+So they went to Cromer, got double pneumonia
+And Norma remembered when she used to say
+"
 
 __END__
 

--- a/lib/Devel/Cover/DB/IO/Storable.pm
+++ b/lib/Devel/Cover/DB/IO/Storable.pm
@@ -7,34 +7,48 @@
 
 package Devel::Cover::DB::IO::Storable;
 
-use strict;
+use 5.20.0;
 use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
 
 use base "Devel::Cover::DB::IO::Base";
 
-use Storable;
+use Storable ();
 
 # VERSION
 
-sub new {
-  my $class = shift;
-  my $self  = $class->SUPER::new(@_);
+sub new ($class, @args) {
+  my $self = $class->SUPER::new(@args);
   bless $self, $class
 }
 
-sub read {
-  my $self = shift;
-  my ($file) = @_;
-  $self->_read($file, sub { Storable::retrieve($file) })
+sub read ($self, $file) {
+  $self->read_fh(
+    $file,
+    sub ($fh) {
+      binmode $fh;
+      Storable::fd_retrieve($fh)
+    },
+  )
 }
 
-sub write {
-  my $self = shift;
-  my ($data, $file) = @_;
-  $self->_write($file, sub { Storable::nstore($data, $file) })
+sub write ($self, $data, $file) {
+  $self->write_fh(
+    $file,
+    sub ($fh) {
+      binmode $fh;
+      Storable::nstore_fd($data, $fh);
+    },
+  )
 }
 
-1
+"
+Oh I, I believe in magic and I believe in dreams
+Until I heard the thunder rumble
+I saw the mountains crumble
+Then came the circus, so I followed its parade
+"
 
 __END__
 

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -72,9 +72,14 @@ sub write_file ($directory, $file) {
   for my $f (@files) {
     my $contents = $Files{$f} // next;
     my $path     = "$directory/$f";
-    open my $fh, ">", $path or die "Can't open $path: $!\n";
+    my $tmp      = "$path.tmp.$$";
+    open my $fh, ">", $tmp or die "Can't open $tmp: $!\n";
     print $fh $contents;
-    close $fh or die "Can't close $path: $!\n";
+    close $fh or die "Can't close $tmp: $!\n";
+    rename $tmp, $path or do {
+      unlink $tmp;
+      die "Can't rename $tmp to $path: $!\n";
+    };
   }
 }
 
@@ -1483,7 +1488,14 @@ function standardistaTableSortingInit() {
 addEvent(window, 'load', standardistaTableSortingInit)
 EOF
 
-1
+"
+Every day, every night
+In that all old familiar light
+You hang up when I call you at home
+And I try to get through
+And I try to talk to you
+But there's something stopping me from getting through
+"
 
 __END__
 

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -12,7 +12,7 @@ use warnings;
 use feature qw( postderef signatures );
 no warnings qw( experimental::postderef experimental::signatures );
 
-use FindBin ();
+use FindBin ();  ## no perlimports
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
@@ -20,7 +20,7 @@ use Cwd        qw( getcwd );
 use File::Path qw( make_path );
 use File::Temp ();
 use JSON::PP   ();
-use Test::More import => [qw( done_testing like plan unlike )];
+use Test::More import => [qw( done_testing is like plan unlike )];
 
 BEGIN {
   plan skip_all => "Devel::Cover::Collection requires Perl 5.42" if $] < 5.042;
@@ -32,7 +32,7 @@ BEGIN {
   }
 }
 
-require Devel::Cover::Collection;
+use Devel::Cover::Collection ();
 
 my $Dist  = "Foo-Bar-1.00";
 my $Log   = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--1234567890.123456.out.gz";
@@ -65,10 +65,19 @@ sub write_dist ($dir, $dist, $name, $version, $log) {
   write_file("$dir/$log",             "log\n");
 }
 
+sub seed_page ($dir, $file) {
+  write_file("$dir/$file", "old");
+  link "$dir/$file", "$dir/$file.seeded"
+    or plan skip_all => "hardlinks not supported";
+}
+
 sub setup_results_dir {
   my $dir = File::Temp->newdir;
   write_dist($dir, $Dist,  "Foo-Bar", "1.00", $Log);
   write_dist($dir, $Dist2, "Baz-Qux", "2.00", $Log2);
+
+  make_path("$dir/dist");
+  seed_page($dir, $_) for qw( index.html dist/F.html about.html );
 
   $dir
 }
@@ -111,5 +120,11 @@ like $Page{dist}, qr{href="\.\./\Q$Dist\E/index\.html"},
 like $Page{dist}, qr{href="\.\./\Q$Log\E"}, "dist page links build log";
 like $Page{dist_b}, qr{href="\.\./\Q$Log2\E"},
   "dist page links uncompressed build log";
+
+for my $f (qw( index.html dist/F.html about.html )) {
+  is slurp("$Dir/$f.seeded"), "old", "$f is written atomically";
+}
+my @Tmp = map glob, "$Dir/*.tmp.*", "$Dir/dist/*.tmp.*";
+is @Tmp, 0, "no tmp files remain";
 
 done_testing;

--- a/t/internal/io_atomic.t
+++ b/t/internal/io_atomic.t
@@ -1,0 +1,99 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();  ## no perlimports
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Temp ();
+use Test::More import => [qw( done_testing is plan )];
+
+use Devel::Cover::DB::IO::Base     ();
+use Devel::Cover::DB::IO::Storable ();
+
+sub write_file ($path, $content) {
+  open my $fh, ">", $path or die "Can't open $path: $!";
+  print $fh $content;
+  close $fh or die "Can't close $path: $!";
+}
+
+sub slurp ($path) {
+  open my $fh, "<", $path or die "Can't open $path: $!";
+  local $/;
+  my $content = <$fh>;
+  close $fh or die "Can't close $path: $!";
+  $content
+}
+
+my $Dir = File::Temp->newdir;
+
+write_file("$Dir/probe", "x");
+plan skip_all => "hardlinks not supported"
+  unless eval { link "$Dir/probe", "$Dir/probe2" };
+
+# write_fh contract: the data goes to a tmp file and the target stays
+# intact until the rename
+{
+  my $file = "$Dir/data";
+  write_file($file, "old");
+  link $file, "$Dir/seeded" or die "Can't link $file: $!";
+
+  my $io = Devel::Cover::DB::IO::Base->new;
+  $io->write_fh(
+    $file,
+    sub ($fh) {
+      my @writing = glob "$file.tmp*";
+      is @writing,     1,     "writer writes to a tmp file";
+      is slurp($file), "old", "target is untouched while writing";
+      print $fh "new";
+    },
+  );
+
+  is slurp($file),         "new", "target has the new content";
+  is slurp("$Dir/seeded"), "old", "hardlinked copy keeps the old content";
+  my $nlink = (stat $file)[3];
+  is $nlink, 1, "target no longer shares its inode";
+  my @tmp = glob "$Dir/data.tmp*";
+  is @tmp, 0, "no tmp files remain";
+}
+
+# IO::Storable's public interface
+{
+  my $file = "$Dir/db";
+  my $io   = Devel::Cover::DB::IO::Storable->new;
+  $io->write({ key => "first" }, $file);
+  link $file, "$Dir/db.seeded" or die "Can't link $file: $!";
+  $io->write({ key => "second" }, $file);
+
+  is $io->read($file)->{key}, "second", "storable file has the new data";
+  is $io->read("$Dir/db.seeded")->{key}, "first",
+    "seeded storable copy keeps the old data";
+}
+
+SKIP: {
+  Test::More::skip "JSON::MaybeXS required for this test", 2
+    unless eval { require Devel::Cover::DB::IO::JSON; 1 };
+
+  my $file = "$Dir/cover.json";
+  my $io   = Devel::Cover::DB::IO::JSON->new;
+  $io->write({ key => "first" }, $file);
+  link $file, "$Dir/cover.json.seeded" or die "Can't link $file: $!";
+  $io->write({ key => "second" }, $file);
+
+  is $io->read($file)->{key}, "second", "json file has the new data";
+  is $io->read("$Dir/cover.json.seeded")->{key}, "first",
+    "seeded json copy keeps the old data";
+}
+
+done_testing;

--- a/t/internal/web_atomic.t
+++ b/t/internal/web_atomic.t
@@ -1,0 +1,57 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();  ## no perlimports
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Temp ();
+use Test::More import => [qw( done_testing is like plan )];
+
+use Devel::Cover::Web qw( write_file );
+
+sub spew ($path, $content) {
+  open my $fh, ">", $path or die "Can't open $path: $!";
+  print $fh $content;
+  close $fh or die "Can't close $path: $!";
+}
+
+sub slurp ($path) {
+  open my $fh, "<", $path or die "Can't open $path: $!";
+  local $/;
+  my $content = <$fh>;
+  close $fh or die "Can't close $path: $!";
+  $content
+}
+
+my $Dir = File::Temp->newdir;
+
+spew("$Dir/probe", "x");
+plan skip_all => "hardlinks not supported"
+  unless eval { link "$Dir/probe", "$Dir/probe2" };
+
+my $File = "$Dir/collection.css";
+spew($File, "old");
+link $File, "$Dir/seeded" or die "Can't link $File: $!";
+
+write_file("$Dir", "collection.css");
+
+like slurp($File), qr/Devel::Cover/, "target has the asset content";
+is slurp("$Dir/seeded"), "old", "hardlinked copy keeps the old content";
+my $Nlink = (stat $File)[3];
+is $Nlink, 1, "target no longer shares its inode";
+my @Tmp = glob "$Dir/collection.css.tmp*";
+is @Tmp, 0, "no tmp files remain";
+
+done_testing;

--- a/utils/dc
+++ b/utils/dc
@@ -110,6 +110,9 @@ cpancover:
                                        fall through to the normal run loop.
   cpancover-run-once                   Fetch latest modules and run one build
                                        cycle.
+  cpancover-seed <src> <dest>          Seed a new results tree from an existing
+                                       one using hardlinks (dist dirs, failed
+                                       markers, and build logs only).
   cpancover-serve [port]               Serve results locally via Caddy (default
                                        port 8080).
   cpancover-test                       Run a test module through the full build
@@ -932,6 +935,23 @@ recipe_cpancover-uncompress-dir() {
   find "$results_dir/$subdir/" -name __failed__ -prune -o \
     -type f -name '*.gz' \
     -exec gzip -df {} \;
+}
+
+recipe_cpancover-seed() {
+  local src="${1:?No source directory specified}"
+  local dest="${2:?No destination directory specified}"
+  [[ -d $src ]] || pf "No such directory: $src"
+  [[ -e $dest ]] && pf "Destination already exists: $dest"
+
+  pi "Seeding $dest from $src"
+  mkdir -p "$dest"
+  cp -al "$src/." "$dest"
+  rm -rf "$dest/dist" "$dest/__rebuilt__"
+  # keep only the build logs at the top level
+  find "$dest" -maxdepth 1 -type f \
+    ! -name '*.out' ! -name '*.out.gz' -delete
+  find "$dest" -name '*.lock' -delete
+  pi "Done"
 }
 
 cpancover_compress_old_versions() {

--- a/utils/dc
+++ b/utils/dc
@@ -733,7 +733,8 @@ recipe_cpancover-docker-module() {
       local bare
       bare=$(cpan_distdir "${module##*/}")
       if [[ -d "$staging/$bare" ]]; then
-        echo "$log_name.$log_ext" >"$staging/$bare/.log_ref"
+        echo "$log_name.$log_ext" >"$staging/$bare/.log_ref.tmp.$$"
+        mv "$staging/$bare/.log_ref.tmp.$$" "$staging/$bare/.log_ref"
       fi
     fi
   fi

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -96,6 +96,7 @@ sub make_docker_stub ($bin) {
     case "$cmd" in
       run) echo fake-container ;;
       logs) echo "fake build log" ;;
+      wait) sleep "${STUB_WAIT_SLEEP:-0}" ;;
       cp)
         dest="$2"
         dist="$STUB_DISTDIR"
@@ -143,11 +144,42 @@ sub docker_module_log_ref () {
     ".log_ref records .out.gz when compression is on";
 }
 
+sub docker_module_timeout_log_ref () {
+  skip_all "timeout required" if system "command -v timeout >/dev/null 2>&1";
+  my $bin = tempdir(CLEANUP => 1);
+  make_docker_stub($bin);
+  local $ENV{PATH}              = "$bin:$ENV{PATH}";
+  local $ENV{STUB_WAIT_SLEEP}   = 3;
+  local $ENV{CPANCOVER_TIMEOUT} = 1;
+  local $ENV{CPANCOVER_REBUILD} = 1;
+
+  my $log     = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--123.456";
+  my $staging = tempdir(CLEANUP => 1);
+  my $distdir = "$staging/Foo-Bar-1.00";
+
+  mkdir $distdir or die "Can't mkdir $distdir: $!";
+  write_file("$distdir/.log_ref", "old\n");
+  link "$distdir/.log_ref", "$distdir/.log_ref.seeded"
+    or skip_all "hardlinks not supported";
+
+  dc(
+    "-r", $staging, "cpancover-docker-module", "Foo-Bar-1.00.tar.gz", $log,
+    $staging,
+  );
+
+  is slurp("$distdir/.log_ref"), "$log.out\n", "timeout path rewrites .log_ref";
+  is slurp("$distdir/.log_ref.seeded"), "old\n",
+    "hardlinked copy keeps the old content";
+  my @tmp = glob "$distdir/.log_ref.tmp.*";
+  is @tmp, 0, "no tmp files remain";
+}
+
 sub main () {
   my @tests = qw(
     compress_recipe
     uncompress_recipe
     docker_module_log_ref
+    docker_module_timeout_log_ref
   );
   for my $test (@tests) {
     no strict qw( refs );

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -16,8 +16,9 @@ skip_all "dc recipes are not portable to Windows" if $^O eq "MSWin32";
 skip_all "utils/dc not found" unless -x "utils/dc";
 skip_all "pigz required" if system "pigz --version >/dev/null 2>&1";
 
-my $Dc  = "utils/dc";
-my $Log = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--1234567890.123456.out";
+my $Dc     = "utils/dc";
+my $Log    = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--1234567890.123456.out";
+my $Log_gz = "P-PJ-PJCJ-Baz-Qux-2.00.tar.gz--1234567891.123456.out";
 
 sub dc (@args) {
   my $cmd = join " ", $Dc, @args;
@@ -174,12 +175,65 @@ sub docker_module_timeout_log_ref () {
   is @tmp, 0, "no tmp files remain";
 }
 
+sub make_seed_source ($src) {
+  mkdir "$src/$_"
+    or die "Can't mkdir $src/$_: $!"
+    for "Foo-Bar-1.00", "__failed__", "__rebuilt__", "dist";
+  write_file("$src/Foo-Bar-1.00/cover.json",  "{}\n");
+  write_file("$src/Foo-Bar-1.00/index.html",  "html\n");
+  write_file("$src/Foo-Bar-1.00/.log_ref",    "$Log\n");
+  write_file("$src/Foo-Bar-1.00/x.lock",      "lock\n");
+  write_file("$src/__failed__/Bad-Dist-0.01", "1234567890\n");
+  write_file("$src/__rebuilt__/Foo-Bar-1.00", "1234567890\n");
+  write_file("$src/$Log",                     "log\n");
+  write_file("$src/$Log_gz.gz",               "gzlog\n");
+  write_file("$src/index.html",               "top\n");
+  write_file("$src/index.html.gz",            "stale\n");
+  write_file("$src/cpancover.json",           "{}\n");
+  write_file("$src/.cpancover_status",        "modules=1\n");
+  write_file("$src/dist/F.html",              "html\n");
+  write_file("$src/dist/F.html.gz",           "stale\n");
+}
+
+sub inode ($path) { (stat $path)[1] }
+
+sub seed_recipe () {
+  my $base = tempdir(CLEANUP => 1);
+  my $src  = "$base/src";
+  my $dest = "$base/dest";
+  mkdir $src or die "Can't mkdir $src: $!";
+  make_seed_source($src);
+
+  dc("cpancover-seed", $src, $dest);
+
+  is slurp("$dest/Foo-Bar-1.00/index.html"), "html\n", "dist dir seeded";
+  is inode("$dest/Foo-Bar-1.00/index.html"),
+    inode("$src/Foo-Bar-1.00/index.html"), "dist files are hardlinked";
+  is slurp("$dest/Foo-Bar-1.00/.log_ref"), "$Log\n", ".log_ref seeded";
+  ok -e "$dest/__failed__/Bad-Dist-0.01", "failed markers seeded";
+  is slurp("$dest/$Log"),       "log\n",            "top-level log seeded";
+  is inode("$dest/$Log"),       inode("$src/$Log"), "logs are hardlinked";
+  is slurp("$dest/$Log_gz.gz"), "gzlog\n",          "compressed log seeded";
+
+  ok !-e "$dest/__rebuilt__",         "rebuilt markers excluded";
+  ok !-e "$dest/dist",                "dist pages excluded";
+  ok !-e "$dest/index.html",          "top-level index excluded";
+  ok !-e "$dest/index.html.gz",       "stale top-level .gz excluded";
+  ok !-e "$dest/cpancover.json",      "top-level json excluded";
+  ok !-e "$dest/.cpancover_status",   "status file excluded";
+  ok !-e "$dest/Foo-Bar-1.00/x.lock", "lock files excluded";
+
+  my $rc = system "$Dc cpancover-seed $src $dest >/dev/null 2>&1";
+  ok $rc != 0, "seeding over an existing destination fails";
+}
+
 sub main () {
   my @tests = qw(
     compress_recipe
     uncompress_recipe
     docker_module_log_ref
     docker_module_timeout_log_ref
+    seed_recipe
   );
   for my $test (@tests) {
     no strict qw( refs );


### PR DESCRIPTION
## Summary

Every write into a results tree now goes to a tmp file which is renamed into place: the coverage DB backends, the web assets, the collection pages, and the `dc` rebuild-timeout `.log_ref`. A reader never sees a partial file, and a tree seeded from production with `cp -al` hardlinks keeps its own copies instead of corrupting the source through shared inodes.

The new `cpancover-seed <src> <dest>` recipe creates such a tree, hardlinking dist directories, failed markers, and build logs, and excluding everything that is regenerated or stale. Along the way the `DB::IO` modules are modernised and Storable moves to the shared filehandle API, so the private helpers really are private.

## Ticket

Part of #531