### PR TITLE
Fix problems found during seeded-tree validation

### DIFF
--- a/bin/cpancover
+++ b/bin/cpancover
@@ -208,7 +208,7 @@ The following command line options are supported:
   --compress_old_versions - compress data older than n versions (3)
   --directory             - location of the modules             ($cwd)
   --dryrun                - don't execute (for some commands)   (off)
-  --force                 - recollect coverage                  (off)
+  --force                 - retry failed builds                 (off)
   --generate_html         - generate html                       (off)
   --local                 - use local (uninstalled) code        (off)
   --local_build           - build coveraage for all the modules (off)

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -681,9 +681,10 @@ class Devel::Cover::Collection {
         my (undef, $module) = @_;
         my $d = $module =~ s|.*/||r =~ s/${Dist_ext_re}$//r;
         if ($self->is_covered($d)) {
+          # replacing an existing distdir is the rebuild machinery's job
           $self->set_covered($d);
           say "$module already covered" if $verbose;
-          return unless $force;
+          return;
         } elsif ($self->is_failed($d)) {
           say "$module already failed" if $verbose;
           return unless $force;
@@ -1060,8 +1061,10 @@ Environment identifier (e.g., 'prod', 'dev'). Default: 'prod'.
 
 =head3 force
 
-Boolean. If true, re-run coverage even for already-covered modules.
-Default: 0.
+Boolean. If true, retry modules which previously failed to build, and
+re-run coverage for build directories which have already been analysed.
+Covered modules are never rebuilt this way; that is the job of the
+rebuild machinery. Default: 0.
 
 =head3 output_file
 

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -338,8 +338,17 @@ class Devel::Cover::Collection {
   }
 
   method resolve_log_links ($d, $mods, $vars) {
-    # Match top-level .out/.out.gz log files to modules
-    my $n   = 0;
+    # Prefer .log_ref: it names the log of the build that produced the
+    # current distdir contents, and covers modules built as dependencies
+    my $n = 0;
+    for my $module (keys $vars->{vals}->%*) {
+      my $log = $self->_read_log_ref($d, $module) // next;
+      $vars->{vals}{$module}{log} = $log if -e "$d/$log";
+      print "-" if !($n++ % 1000) && !$verbose;
+    }
+
+    # Fallback: match top-level .out/.out.gz log files by name
+    $n = 0;
     my $re  = qr/^\w-\w\w-\w+-(.*)/;
     my $ext = qr/($Dist_ext_re)/;
     my $ts  = qr/--\d{10,11}\.\d{6}\.out(?:\.gz)?$/;
@@ -347,15 +356,6 @@ class Devel::Cover::Collection {
       my ($module) = $f =~ /${re}${ext}${ts}/ or next;
       next if $vars->{vals}{$module}{log};
       $vars->{vals}{$module}{log} = $f;
-      print "-" if !($n++ % 1000) && !$verbose;
-    }
-
-    # Fallback: .log_ref for modules built as dependencies
-    $n = 0;
-    for my $module (keys $vars->{vals}->%*) {
-      next if $vars->{vals}{$module}{log};
-      my $log = $self->_read_log_ref($d, $module) // next;
-      $vars->{vals}{$module}{log} = $log;
       print "-" if !($n++ % 1000) && !$verbose;
     }
     say "";

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -34,10 +34,15 @@ BEGIN {
 
 use Devel::Cover::Collection ();
 
-my $Dist  = "Foo-Bar-1.00";
-my $Log   = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--1234567890.123456.out.gz";
-my $Dist2 = "Baz-Qux-2.00";
-my $Log2  = "P-PJ-PJCJ-Baz-Qux-2.00.tar.gz--1234567891.123456.out";
+my $Dist    = "Foo-Bar-1.00";
+my $Log     = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--1234567890.123456.out.gz";
+my $Log_new = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--1234567899.123456.out.gz";
+my $Dist2   = "Baz-Qux-2.00";
+my $Log2    = "P-PJ-PJCJ-Baz-Qux-2.00.tar.gz--1234567891.123456.out";
+my $Dist3   = "Dangle-Ref-3.00";
+my $Log3    = "P-PJ-PJCJ-Dangle-Ref-3.00.tar.gz--1234567892.123456.out";
+my $Ref3    = "P-PJ-PJCJ-Dangle-Ref-3.00.tar.gz--9999999999.123456.out";
+my $Dist4   = "Dep-Only-4.00";
 
 sub write_file ($path, $content) {
   open my $fh, ">", $path or die "Can't open $path: $!";
@@ -53,7 +58,7 @@ sub slurp ($path) {
   $content
 }
 
-sub write_dist ($dir, $dist, $name, $version, $log) {
+sub write_dist ($dir, $dist, $name, $version, $log = undef) {
   make_path("$dir/$dist");
 
   my $criterion = { percentage => 85.5, covered => 10, total => 12 };
@@ -62,7 +67,7 @@ sub write_dist ($dir, $dist, $name, $version, $log) {
     summary => { Total => { total => $criterion, statement => $criterion } },
   };
   write_file("$dir/$dist/cover.json", JSON::PP->new->encode($cover));
-  write_file("$dir/$log",             "log\n");
+  write_file("$dir/$log",             "log\n") if defined $log;
 }
 
 sub seed_page ($dir, $file) {
@@ -75,6 +80,19 @@ sub setup_results_dir {
   my $dir = File::Temp->newdir;
   write_dist($dir, $Dist,  "Foo-Bar", "1.00", $Log);
   write_dist($dir, $Dist2, "Baz-Qux", "2.00", $Log2);
+
+  # $Dist was rebuilt: .log_ref names the newer log, both logs remain
+  write_file("$dir/$Log_new",       "log\n");
+  write_file("$dir/$Dist/.log_ref", "$Log_new\n");
+
+  # $Dist3 has a dangling .log_ref but a name-matching log
+  write_dist($dir, $Dist3, "Dangle-Ref", "3.00", $Log3);
+  write_file("$dir/$Dist3/.log_ref", "$Ref3\n");
+
+  # $Dist4 was built as a dependency: no own log, .log_ref names the
+  # target's log
+  write_dist($dir, $Dist4, "Dep-Only", "4.00");
+  write_file("$dir/$Dist4/.log_ref", "$Log_new\n");
 
   make_path("$dir/dist");
   seed_page($dir, $_) for qw( index.html dist/F.html about.html );
@@ -93,6 +111,7 @@ my %Page = (
   index  => slurp("$Dir/index.html"),
   dist   => slurp("$Dir/dist/F.html"),
   dist_b => slurp("$Dir/dist/B.html"),
+  dist_d => slurp("$Dir/dist/D.html"),
   about  => slurp("$Dir/about.html"),
 );
 
@@ -117,9 +136,18 @@ like $Page{dist}, qr{src="\.\./collection\.js"},   "dist page links script";
 like $Page{dist}, qr{href="\.\./about\.html"},     "dist page links about page";
 like $Page{dist}, qr{href="\.\./\Q$Dist\E/index\.html"},
   "dist page links module report";
-like $Page{dist}, qr{href="\.\./\Q$Log\E"}, "dist page links build log";
+like $Page{dist}, qr{href="\.\./\Q$Log_new\E"},
+  "dist page links the log named in .log_ref";
+unlike $Page{dist}, qr{href="\.\./\Q$Log\E"},
+  "dist page does not link the older log";
 like $Page{dist_b}, qr{href="\.\./\Q$Log2\E"},
   "dist page links uncompressed build log";
+like $Page{dist_d}, qr{href="\.\./\Q$Log3\E"},
+  "dangling .log_ref falls back to the name-matched log";
+unlike $Page{dist_d}, qr{href="\.\./\Q$Ref3\E"},
+  "dangling .log_ref target is not linked";
+like $Page{dist_d}, qr{href="\.\./\Q$Log_new\E"},
+  "dependency dist links its target's log via .log_ref";
 
 for my $f (qw( index.html dist/F.html about.html )) {
   is slurp("$Dir/$f.seeded"), "old", "$f is written atomically";

--- a/utils/dc
+++ b/utils/dc
@@ -1049,7 +1049,7 @@ cpancover_run_loop_rebuild() {
   local batch="${CPANCOVER_REBUILD_BATCH:-100}"
   pi "Starting cpancover rebuild loop at $(date), batch=$batch"
 
-  run_cpancover --nobuild --generate_html
+  cpancover_generate_html
 
   while true; do
     cpancover_docker_rm
@@ -1057,12 +1057,12 @@ cpancover_run_loop_rebuild() {
     cpancover_latest | run_cpancover --build --rebuild --rebuild_batch 0
     local new
     new=$(cpancover_status_value new_count)
-    ((new > 0)) && run_cpancover --nobuild --generate_html
+    ((new > 0)) && cpancover_generate_html
 
     run_cpancover --nobuild --rebuild --rebuild_batch "$batch"
     local rebuilt
     rebuilt=$(cpancover_status_value rebuilt_count)
-    ((rebuilt > 0)) && run_cpancover --nobuild --generate_html
+    ((rebuilt > 0)) && cpancover_generate_html
 
     if [[ $(cpancover_status_value all_rebuilt) == 1 ]]; then
       pi "Rebuild complete; clearing __rebuilt__ markers"
@@ -1086,7 +1086,8 @@ recipe_cpancover-rebuild-batch() {
   local v=
   ((verbose)) && v=--verbose
   run_cpancover $v --nobuild --rebuild \
-    --rebuild_batch "${CPANCOVER_REBUILD_BATCH:-100}" --generate_html
+    --rebuild_batch "${CPANCOVER_REBUILD_BATCH:-100}"
+  cpancover_generate_html
 }
 
 recipe_cpancover-controller-run() {

--- a/utils/dc
+++ b/utils/dc
@@ -104,6 +104,9 @@ cpancover:
   cpancover-rebuild-batch              Run one rebuild pass at CPANCOVER_
                                        REBUILD_BATCH and regenerate HTML
                                        (smoke test before run-loop-rebuild).
+  cpancover-rebuild-module <module>    Rebuild one module (CPAN path, e.g.
+                                       P/PJ/PJCJ/Foo-1.00.tar.gz) and
+                                       regenerate HTML.
   cpancover-run-loop-rebuild           Regenerate every already-covered
                                        distribution in batches (CPANCOVER_
                                        REBUILD_BATCH, default 100), then
@@ -1087,6 +1090,22 @@ recipe_cpancover-rebuild-batch() {
   ((verbose)) && v=--verbose
   run_cpancover $v --nobuild --rebuild \
     --rebuild_batch "${CPANCOVER_REBUILD_BATCH:-100}"
+  cpancover_generate_html
+}
+
+# Rebuild a single named module and regenerate HTML. Removing the
+# __rebuilt__ marker first lets rebuild mode pick the module up even
+# mid-cycle; --force retries it if it previously failed. Dependency
+# distdirs built in the same container are replaced too, but only the
+# named module gets a fresh __rebuilt__ marker.
+recipe_cpancover-rebuild-module() {
+  local module="${1:?No module specified}"
+  local v=
+  ((verbose)) && v=--verbose
+  local bare
+  bare=$(cpan_distdir "${module##*/}")
+  rm -f "$results_dir/__rebuilt__/$bare"
+  echo "$module" | run_cpancover $v --build --rebuild --rebuild_batch 0 --force
   cpancover_generate_html
 }
 

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -9,7 +9,7 @@
 
 use 5.42.0;
 
-use Test2::V0  qw( done_testing is like ok skip_all subtest );
+use Test2::V0  qw( done_testing is isnt like ok skip_all subtest );
 use File::Temp qw( tempdir );
 
 skip_all "dc recipes are not portable to Windows" if $^O eq "MSWin32";
@@ -106,7 +106,10 @@ sub make_docker_stub ($bin) {
         echo db >"$dest/staging/$dist/cover.14"
         echo x >"$dest/staging/$dist/digests"
         echo x >"$dest/staging/$dist/x.lock"
-        echo '{}' >"$dest/staging/$dist/cover.json"
+        printf '%s%s\n' \
+          '{"runs":[{"name":"Foo-Bar","version":"1.00","dir":"/tmp/x"}],' \
+          '"summary":{"Total":{"total":{"percentage":85.5,"covered":10,"total":12}}}}' \
+          >"$dest/staging/$dist/cover.json"
         echo html >"$dest/staging/$dist/index.html"
         ;;
     esac
@@ -230,6 +233,40 @@ sub rebuild_batch_cleanup () {
   is \@locks, [], "no lock sidecars remain";
 }
 
+sub rebuild_module_recipe () {
+  skip_all "timeout required" if system "command -v timeout >/dev/null 2>&1";
+  my $bin = tempdir(CLEANUP => 1);
+  make_docker_stub($bin);
+  local $ENV{PATH}         = "$bin:$ENV{PATH}";
+  local $ENV{STUB_DISTDIR} = "Foo-Bar-1.00";
+  my $module = "P/PJ/PJCJ/Foo-Bar-1.00.tar.gz";
+  my $work   = tempdir(CLEANUP => 1);
+
+  my $dir = tempdir(CLEANUP => 1);
+
+  mkdir "$dir/$_"
+    or die "Can't mkdir $dir/$_: $!"
+    for "Foo-Bar-1.00", "__rebuilt__";
+  write_file("$dir/Foo-Bar-1.00/cover.json",  "{}\n");
+  write_file("$dir/Foo-Bar-1.00/index.html",  "old\n");
+  write_file("$dir/__rebuilt__/Foo-Bar-1.00", "1234567890\n");
+  write_file("$dir/$Log",                     "log\n");
+
+  delete local $ENV{CPANCOVER_COMPRESS};
+  {
+    local $ENV{STUB_CALLS} = "$work/calls";
+    dc("-r", $dir, "cpancover-rebuild-module", $module);
+  }
+
+  like slurp("$work/calls"), qr/\brun\b/, "rebuild launches a docker build";
+  is slurp("$dir/Foo-Bar-1.00/index.html"), "html\n", "distdir is replaced";
+  isnt slurp("$dir/__rebuilt__/Foo-Bar-1.00"), "1234567890\n",
+    "rebuilt marker is rewritten";
+  ok -s "$dir/index.html", "HTML is regenerated";
+  my @locks = (glob("$dir/*.lock"), glob("$dir/*/*.lock"));
+  is \@locks, [], "no lock sidecars remain";
+}
+
 sub make_seed_source ($src) {
   mkdir "$src/$_"
     or die "Can't mkdir $src/$_: $!"
@@ -290,6 +327,7 @@ sub main () {
     docker_module_timeout_log_ref
     force_retries_failed_only
     rebuild_batch_cleanup
+    rebuild_module_recipe
     seed_recipe
   );
   for my $test (@tests) {

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -175,6 +175,29 @@ sub docker_module_timeout_log_ref () {
   is @tmp, 0, "no tmp files remain";
 }
 
+sub rebuild_batch_cleanup () {
+  my $dir = tempdir(CLEANUP => 1);
+  mkdir "$dir/$_"
+    or die "Can't mkdir $dir/$_: $!"
+    for "Foo-Bar-1.00", "__rebuilt__";
+  my $criterion = '{"percentage":85.5,"covered":10,"total":12}';
+  write_file("$dir/Foo-Bar-1.00/cover.json",
+        qq({"runs":[{"name":"Foo-Bar","version":"1.00","dir":"/tmp/x"}],)
+      . qq("summary":{"Total":{"total":$criterion,"statement":$criterion}}}));
+  write_file("$dir/Foo-Bar-1.00/index.html",  "html\n");
+  write_file("$dir/__rebuilt__/Foo-Bar-1.00", "1234567890\n");
+  write_file("$dir/$Log",                     "log\n");
+  write_file("$dir/index.html.gz",            "stale\n");
+
+  delete local $ENV{CPANCOVER_COMPRESS};
+  dc("-r", $dir, "cpancover-rebuild-batch");
+
+  ok -s "$dir/index.html",     "rebuild batch regenerates the index";
+  ok !-e "$dir/index.html.gz", "stale top-level .gz removed";
+  my @locks = (glob("$dir/*.lock"), glob("$dir/*/*.lock"));
+  is \@locks, [], "no lock sidecars remain";
+}
+
 sub make_seed_source ($src) {
   mkdir "$src/$_"
     or die "Can't mkdir $src/$_: $!"
@@ -233,6 +256,7 @@ sub main () {
     uncompress_recipe
     docker_module_log_ref
     docker_module_timeout_log_ref
+    rebuild_batch_cleanup
     seed_recipe
   );
   for my $test (@tests) {

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-LONG
 
 # Copyright 2026, Paul Johnson (paul@pjcj.net)
 
@@ -106,9 +107,10 @@ sub make_docker_stub ($bin) {
         echo db >"$dest/staging/$dist/cover.14"
         echo x >"$dest/staging/$dist/digests"
         echo x >"$dest/staging/$dist/x.lock"
-        printf '%s%s\n' \
+        printf '%s%s%s\n' \
           '{"runs":[{"name":"Foo-Bar","version":"1.00","dir":"/tmp/x"}],' \
-          '"summary":{"Total":{"total":{"percentage":85.5,"covered":10,"total":12}}}}' \
+          '"summary":{"Total":' \
+          '{"total":{"percentage":85.5,"covered":10,"total":12}}}}' \
           >"$dest/staging/$dist/cover.json"
         echo html >"$dest/staging/$dist/index.html"
         ;;
@@ -217,7 +219,7 @@ sub rebuild_batch_cleanup () {
     for "Foo-Bar-1.00", "__rebuilt__";
   my $criterion = '{"percentage":85.5,"covered":10,"total":12}';
   write_file("$dir/Foo-Bar-1.00/cover.json",
-        qq({"runs":[{"name":"Foo-Bar","version":"1.00","dir":"/tmp/x"}],)
+        '{"runs":[{"name":"Foo-Bar","version":"1.00","dir":"/tmp/x"}],'
       . qq("summary":{"Total":{"total":$criterion,"statement":$criterion}}}));
   write_file("$dir/Foo-Bar-1.00/index.html",  "html\n");
   write_file("$dir/__rebuilt__/Foo-Bar-1.00", "1234567890\n");
@@ -229,7 +231,7 @@ sub rebuild_batch_cleanup () {
 
   ok -s "$dir/index.html",     "rebuild batch regenerates the index";
   ok !-e "$dir/index.html.gz", "stale top-level .gz removed";
-  my @locks = (glob("$dir/*.lock"), glob("$dir/*/*.lock"));
+  my @locks = map glob, "$dir/*.lock", "$dir/*/*.lock";
   is \@locks, [], "no lock sidecars remain";
 }
 
@@ -263,7 +265,7 @@ sub rebuild_module_recipe () {
   isnt slurp("$dir/__rebuilt__/Foo-Bar-1.00"), "1234567890\n",
     "rebuilt marker is rewritten";
   ok -s "$dir/index.html", "HTML is regenerated";
-  my @locks = (glob("$dir/*.lock"), glob("$dir/*/*.lock"));
+  my @locks = map glob, "$dir/*.lock", "$dir/*/*.lock";
   is \@locks, [], "no lock sidecars remain";
 }
 

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -9,7 +9,7 @@
 
 use 5.42.0;
 
-use Test2::V0  qw( done_testing is ok skip_all subtest );
+use Test2::V0  qw( done_testing is like ok skip_all subtest );
 use File::Temp qw( tempdir );
 
 skip_all "dc recipes are not portable to Windows" if $^O eq "MSWin32";
@@ -94,6 +94,7 @@ sub make_docker_stub ($bin) {
     #!/bin/sh
     cmd="$1"
     shift
+    echo "$cmd" >>"${STUB_CALLS:-/dev/null}"
     case "$cmd" in
       run) echo fake-container ;;
       logs) echo "fake build log" ;;
@@ -173,6 +174,37 @@ sub docker_module_timeout_log_ref () {
     "hardlinked copy keeps the old content";
   my @tmp = glob "$distdir/.log_ref.tmp.*";
   is @tmp, 0, "no tmp files remain";
+}
+
+sub force_retries_failed_only () {
+  skip_all "timeout required" if system "command -v timeout >/dev/null 2>&1";
+  my $bin = tempdir(CLEANUP => 1);
+  make_docker_stub($bin);
+  local $ENV{PATH}         = "$bin:$ENV{PATH}";
+  local $ENV{STUB_DISTDIR} = "Foo-Bar-1.00";
+  my $module = "P/PJ/PJCJ/Foo-Bar-1.00.tar.gz";
+  my $work   = tempdir(CLEANUP => 1);
+
+  my $covered = tempdir(CLEANUP => 1);
+
+  mkdir "$covered/Foo-Bar-1.00" or die "Can't mkdir $covered/Foo-Bar-1.00: $!";
+  write_file("$covered/Foo-Bar-1.00/cover.json", "{}\n");
+  {
+    local $ENV{STUB_CALLS} = "$work/covered.calls";
+    dc("-f", "-r", $covered, "cpancover", "--build", $module);
+  }
+  ok !-e "$work/covered.calls", "no docker build for a covered dist";
+
+  my $failed = tempdir(CLEANUP => 1);
+  mkdir "$failed/__failed__" or die "Can't mkdir $failed/__failed__: $!";
+  write_file("$failed/__failed__/Foo-Bar-1.00", "1234567890\n");
+  {
+    local $ENV{STUB_CALLS} = "$work/failed.calls";
+    dc("-f", "-r", $failed, "cpancover", "--build", $module);
+  }
+  like slurp("$work/failed.calls"), qr/\brun\b/,
+    "forced build retries a failed dist";
+  ok -e "$failed/Foo-Bar-1.00/cover.json", "retried dist is ingested";
 }
 
 sub rebuild_batch_cleanup () {
@@ -256,6 +288,7 @@ sub main () {
     uncompress_recipe
     docker_module_log_ref
     docker_module_timeout_log_ref
+    force_retries_failed_only
     rebuild_batch_cleanup
     seed_recipe
   );


### PR DESCRIPTION
Part of #531

## Summary
- Prefer `.log_ref` when resolving build log links, so pages link the
  log of the build that produced the current distdir rather than the
  oldest accumulated log.
- Route the rebuild loop and batch recipes through the
  `cpancover_generate_html` wrapper so lock sidecars, stale `.gz` files,
  and old-version compression are handled during a rebuild cycle.
- Restrict `--force` to retrying failed builds; a forced build of a
  covered dist was discarded at ingest.
- Add a `cpancover-rebuild-module` recipe to rebuild one named dist and
  regenerate HTML.

## Test plan
- [x] Full test suite passes
- [x] `xt/dc.t` covers the new recipe, the force semantics, and the
      rebuild-batch cleanup
- [x] Verified end-to-end with real docker against a seeded tree