### PR TITLE
GH-531 Add controller rebuild-module recipe

### DIFF
--- a/utils/dc
+++ b/utils/dc
@@ -126,6 +126,9 @@ cpancover (Docker):
   cpancover-controller-rebuild-batch   Start a controller container running one
                                        rebuild pass (CPANCOVER_REBUILD_BATCH,
                                        default 100) and regenerate HTML.
+  cpancover-controller-rebuild-module <module>
+                                       Rebuild one module via a controller
+                                       container and regenerate HTML.
   cpancover-controller-run             Start a controller container running the
                                        build loop.
   cpancover-controller-run-once        Start a controller container for one
@@ -1131,6 +1134,14 @@ recipe_cpancover-controller-rebuild-batch() {
   local o=(--env "$env")
   ((verbose)) && o+=("--verbose")
   cpancover_controller_command controller dc "${o[@]}" cpancover-rebuild-batch
+}
+
+recipe_cpancover-controller-rebuild-module() {
+  local module="${1:?No module specified}"
+  local o=(--env "$env")
+  ((verbose)) && o+=("--verbose")
+  cpancover_controller_command controller \
+    dc "${o[@]}" cpancover-rebuild-module "$module"
 }
 
 # Default test module - small, stable, predictable

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -95,7 +95,7 @@ sub make_docker_stub ($bin) {
     #!/bin/sh
     cmd="$1"
     shift
-    echo "$cmd" >>"${STUB_CALLS:-/dev/null}"
+    echo "$cmd $*" >>"${STUB_CALLS:-/dev/null}"
     case "$cmd" in
       run) echo fake-container ;;
       logs) echo "fake build log" ;;
@@ -269,6 +269,29 @@ sub rebuild_module_recipe () {
   is \@locks, [], "no lock sidecars remain";
 }
 
+sub controller_rebuild_module_recipe () {
+  my $bin = tempdir(CLEANUP => 1);
+  make_docker_stub($bin);
+  local $ENV{PATH} = "$bin:$ENV{PATH}";
+  my $module = "P/PJ/PJCJ/Foo-Bar-1.00.tar.gz";
+  my $work   = tempdir(CLEANUP => 1);
+  my $dir    = tempdir(CLEANUP => 1);
+
+  {
+    local $ENV{STUB_CALLS} = "$work/calls";
+    dc("-e", "dev", "-r", $dir, "cpancover-controller-rebuild-module", $module,
+    );
+  }
+
+  my $calls = slurp("$work/calls");
+  like $calls, qr{\brun\b.* pjcj/cpancover_dev }, "runs the dev image";
+  like $calls, qr{--label cpancover\.env=dev},    "container is labelled";
+  like $calls, qr{source=\Q$dir\E,target=/remote_staging},
+    "results dir is mounted";
+  like $calls, qr{ dc --env dev cpancover-rebuild-module \Q$module\E},
+    "runs the inner rebuild-module recipe";
+}
+
 sub make_seed_source ($src) {
   mkdir "$src/$_"
     or die "Can't mkdir $src/$_: $!"
@@ -330,6 +353,7 @@ sub main () {
     force_retries_failed_only
     rebuild_batch_cleanup
     rebuild_module_recipe
+    controller_rebuild_module_recipe
     seed_recipe
   );
   for my $test (@tests) {


### PR DESCRIPTION
## Summary

Wrap `cpancover-rebuild-module` in a controller container, matching the other controller recipes, so a named module can be rebuilt on a host without a suitable perl. This is the intended smoke test on the server before starting the full seeded-tree rebuild.

## Ticket

Part of #531