### PR TITLE
GH-540 Reformat documentation to 80 columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,10 +118,9 @@ make dist
 
 ### Core Modules
 
-Modules loaded at bootstrap (before instrumentation activates) cannot be
-covered without `DEVEL_COVER_SELF`. Late-loaded modules (reports, Path,
-Static, etc.) can be covered using `-select` - see
-`docs/technical/self-coverage.md`.
+Modules loaded at bootstrap (before instrumentation activates) cannot be covered
+without `DEVEL_COVER_SELF`. Late-loaded modules (reports, Path, Static, etc.)
+can be covered using `-select` - see `docs/technical/self-coverage.md`.
 
 **Coverage Collection**:
 
@@ -215,11 +214,11 @@ plenv shell dc-5.38.0
 PLENV_VERSION=dc-5.38.0 make out TEST=empty_else
 ```
 
-**IMPORTANT - rebuild before testing under another version**:
-`perl Makefile.PL` bakes the running Perl's path into the generated Makefile.
-A bare `PLENV_VERSION=X make` (or `make gold`, or a test run) then builds and
-runs against whatever Perl the *last* `perl Makefile.PL` used, not `X`. This
-silently produces results for the wrong version, which can look like a genuine
+**IMPORTANT - rebuild before testing under another version**: `perl Makefile.PL`
+bakes the running Perl's path into the generated Makefile. A bare
+`PLENV_VERSION=X make` (or `make gold`, or a test run) then builds and runs
+against whatever Perl the *last* `perl Makefile.PL` used, not `X`. This silently
+produces results for the wrong version, which can look like a genuine
 version-dependent difference. Always regenerate the Makefile for the target
 version first:
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,11 +2,11 @@
 
 ## Source Code
 
-The source code can be found in the [primary
-repository](https://github.com/pjcj/Devel--Cover). This is also the place to
-file bug reports and send pull requests. There are still some old bug reports in
-RT which are described in [a
-ticket](https://github.com/pjcj/Devel--Cover/issues/35).
+The source code can be found in the
+[primary repository](https://github.com/pjcj/Devel--Cover). This is also the
+place to file bug reports and send pull requests. There are still some old bug
+reports in RT which are described in
+[a ticket](https://github.com/pjcj/Devel--Cover/issues/35).
 
 I welcome all contributions, be they in the form of code, bug reports,
 suggestions, documentation, discussion or anything else. In general, and as with
@@ -51,8 +51,8 @@ The `e2e` files get generated from `tests` by `perl Makefile.PL`.
 
 ## HTML report generation
 
-Devel::Cover::Web contains a number of static files that are saved when a
-report is generated:
+Devel::Cover::Web contains a number of static files that are saved when a report
+is generated:
 
 - cover.css
 - common.js

--- a/docs/cpancover.md
+++ b/docs/cpancover.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-Cpancover requires a bourne shell, plenv, and docker, as well as a recent
-perl. The code requires Perl 5.42.0.
+Cpancover requires a bourne shell, plenv, and docker, as well as a recent perl.
+The code requires Perl 5.42.0.
 
 ## Docker
 

--- a/docs/technical/adjust.md
+++ b/docs/technical/adjust.md
@@ -1,14 +1,14 @@
 # Coverage for ADJUST Blocks
 
-ADJUST blocks are a construct introduced by Perl's `class` feature (5.38+).
-This document describes how Devel::Cover discovers and collects coverage for
-them, and how their storage differs from named method CVs.
+ADJUST blocks are a construct introduced by Perl's `class` feature (5.38+). This
+document describes how Devel::Cover discovers and collects coverage for them,
+and how their storage differs from named method CVs.
 
 ## What ADJUST Blocks Are
 
-An `ADJUST` block runs during object construction, after field initialisers
-have executed. It is syntactically similar to `BEGIN` or `END`, but unlike
-those phase blocks it runs once per object created:
+An `ADJUST` block runs during object construction, after field initialisers have
+executed. It is syntactically similar to `BEGIN` or `END`, but unlike those
+phase blocks it runs once per object created:
 
 ```perl
 class Point {
@@ -27,26 +27,26 @@ constructed.
 
 ## How ADJUST CVs Are Stored
 
-Named `method` CVs are found by walking the symbol table: each method is a
-GV (glob value) in the class stash, and `B::walksymtable` visits every GV.
-ADJUST CVs are anonymous and are not stored as GVs anywhere.
+Named `method` CVs are found by walking the symbol table: each method is a GV
+(glob value) in the class stash, and `B::walksymtable` visits every GV. ADJUST
+CVs are anonymous and are not stored as GVs anywhere.
 
 Instead they are held in a dedicated array attached to the stash's auxiliary
 structure. Every package stash (`HV*`) may carry an `xpvhv_aux` extension
-accessed via `HvAUX(stash)`. For class stashes, Perl sets the
-`HvAUXf_IS_CLASS` flag and populates the `xhv_class_adjust_blocks` field, an
-`AV*` of `CV*` pointers - one per `ADJUST` block in declaration order.
+accessed via `HvAUX(stash)`. For class stashes, Perl sets the `HvAUXf_IS_CLASS`
+flag and populates the `xhv_class_adjust_blocks` field, an `AV*` of `CV*`
+pointers - one per `ADJUST` block in declaration order.
 
 `B::HV` does not expose `xhv_class_adjust_blocks`. This field is part of the
 internal `xpvhv_aux` struct added for the `class` feature and has no
-corresponding `B` API. A small XS shim inside `Cover.xs` provides access
-without a dependency on any particular Perl release of `B`.
+corresponding `B` API. A small XS shim inside `Cover.xs` provides access without
+a dependency on any particular Perl release of `B`.
 
 ## The XS Shim
 
-`adjust_blocks(stash)` in `Cover.xs` takes a stash as a hash reference,
-checks for the `HvAUXf_IS_CLASS` flag, and returns code references to each
-ADJUST block CV:
+`adjust_blocks(stash)` in `Cover.xs` takes a stash as a hash reference, checks
+for the `HvAUXf_IS_CLASS` flag, and returns code references to each ADJUST block
+CV:
 
 ```c
 void
@@ -77,9 +77,9 @@ can call it unconditionally.
 
 `adjust_blocks` is called from the `walksymtable` callback in `check_files`
 (`lib/Devel/Cover.pm`). Each time `walksymtable` is about to recurse into a
-sub-stash, the callback calls `adjust_blocks` on that stash, wraps the
-returned code references as `B::CV` objects via `B::svref_2object`, filters
-them with `check_file`, and adds any that pass to `%Cvs`:
+sub-stash, the callback calls `adjust_blocks` on that stash, wraps the returned
+code references as `B::CV` objects via `B::svref_2object`, filters them with
+`check_file`, and adds any that pass to `%Cvs`:
 
 ```perl
 walksymtable(\%main::, "find_cv", sub {
@@ -93,14 +93,14 @@ walksymtable(\%main::, "find_cv", sub {
 });
 ```
 
-Once in `%Cvs`, the existing `get_cover` pipeline processes ADJUST CVs
-without further modification.
+Once in `%Cvs`, the existing `get_cover` pipeline processes ADJUST CVs without
+further modification.
 
 ## ADJUST Block Optree
 
-Unlike `method` CVs, ADJUST CVs do not begin with `methstart`. They compile
-as plain anonymous subroutines, so `check_file` and `sub_info` handle them
-without special casing:
+Unlike `method` CVs, ADJUST CVs do not begin with `methstart`. They compile as
+plain anonymous subroutines, so `check_file` and `sub_info` handle them without
+special casing:
 
 ```text
 leavesub
@@ -111,17 +111,17 @@ leavesub
 
 ## Inherited ADJUST Blocks
 
-When a subclass is declared with `:isa(Parent)`, Perl copies references to
-the parent's ADJUST CVs into the subclass's `xhv_class_adjust_blocks` array.
-The same `CV*` pointer appears in both:
+When a subclass is declared with `:isa(Parent)`, Perl copies references to the
+parent's ADJUST CVs into the subclass's `xhv_class_adjust_blocks` array. The
+same `CV*` pointer appears in both:
 
 ```text
 Animal::xhv_class_adjust_blocks -> [ ADJUST_CV ]
 Dog::xhv_class_adjust_blocks    -> [ ADJUST_CV ]   (same pointer, inherited)
 ```
 
-`adjust_blocks` is called for both stashes during the `walksymtable` pass,
-but `$Cvs{$cv} ||= $cv` ensures the CV enters `%Cvs` only once and `get_cover`
-processes it only once. The execution count, however, reflects all
-constructions - constructing one `Animal` and one `Dog` yields a count of 2
-for the inherited ADJUST block.
+`adjust_blocks` is called for both stashes during the `walksymtable` pass, but
+`$Cvs{$cv} ||= $cv` ensures the CV enters `%Cvs` only once and `get_cover`
+processes it only once. The execution count, however, reflects all constructions
+\- constructing one `Animal` and one `Dog` yields a count of 2 for the inherited
+ADJUST block.

--- a/docs/technical/branches_and_conditions.md
+++ b/docs/technical/branches_and_conditions.md
@@ -1,39 +1,36 @@
 # Branch and Condition Coverage
 
-Devel::Cover tracks two related but distinct coverage criteria for
-logical operators: **branch** coverage and **condition** coverage. This
-document explains what each measures, how the classification is
-determined, and how the runtime data flows from the XS layer through to
-the Perl-level reporting.
+Devel::Cover tracks two related but distinct coverage criteria for logical
+operators: **branch** coverage and **condition** coverage. This document
+explains what each measures, how the classification is determined, and how the
+runtime data flows from the XS layer through to the Perl-level reporting.
 
 ## Overview
 
-Branch and condition coverage both deal with logical operators (`&&`,
-`||`, `and`, `or`, `?:`, `xor`, `^^`, `//`), but they answer different
-questions:
+Branch and condition coverage both deal with logical operators (`&&`, `||`,
+`and`, `or`, `?:`, `xor`, `^^`, `//`), but they answer different questions:
 
-- **Branch coverage** asks: "Was each path through this decision taken?"
-  A branch has two outcomes (true/false) and is 100% covered when both
-  paths have been exercised.
+- **Branch coverage** asks: "Was each path through this decision taken?" A
+  branch has two outcomes (true/false) and is 100% covered when both paths have
+  been exercised.
 
-- **Condition coverage** asks: "What combinations of operand truth
-  values were observed?" A two-operand condition has 2 or 3 possible
-  outcomes depending on the operator and context; a four-operand `xor`
-  has 4.
+- **Condition coverage** asks: "What combinations of operand truth values were
+  observed?" A two-operand condition has 2 or 3 possible outcomes depending on
+  the operator and context; a four-operand `xor` has 4.
 
-The same underlying runtime data (collected in `Cover.xs`) feeds both
-metrics. The Perl-level code in `lib/Devel/Cover.pm` determines which
-metric to register for each op based on how the op is used.
+The same underlying runtime data (collected in `Cover.xs`) feeds both metrics.
+The Perl-level code in `lib/Devel/Cover.pm` determines which metric to register
+for each op based on how the op is used.
 
 ## The Classification Rule
 
-The central question is: does a logical op represent a **control flow
-decision** (branch) or a **value computation** (condition)?
+The central question is: does a logical op represent a **control flow decision**
+(branch) or a **value computation** (condition)?
 
 ### Branches
 
-A logical op is classified as a branch when it controls which code path
-executes and its return value is not used. This includes:
+A logical op is classified as a branch when it controls which code path executes
+and its return value is not used. This includes:
 
 | Source form                | Deparse           | Why branch      |
 | -------------------------- | ----------------- | --------------- |
@@ -46,18 +43,18 @@ executes and its return value is not used. This includes:
 | `if ($x) { } elsif { }`    | `if ($x) { }`     | Chain           |
 
 \*On Perl 5.43.8+, expression-form logops at statement level keep their
-expression-form labels (`$x and ++$y`, `$x or next`). On older Perls,
-they get statement-modifier labels (`if $x`, `unless $x`) because the
-optree cannot distinguish the two forms.
+expression-form labels (`$x and ++$y`, `$x or next`). On older Perls, they get
+statement-modifier labels (`if $x`, `unless $x`) because the optree cannot
+distinguish the two forms.
 
-The ternary (`?:` / `cond_expr`) is always branch coverage regardless
-of context, because it always has two distinct code paths (true block
-and false block).
+The ternary (`?:` / `cond_expr`) is always branch coverage regardless of
+context, because it always has two distinct code paths (true block and false
+block).
 
 ### Conditions
 
-A logical op is classified as a condition when its return value is used
-as part of a larger expression:
+A logical op is classified as a condition when its return value is used as part
+of a larger expression:
 
 | Source form              | Deparse          | Why condition     |
 | ------------------------ | ---------------- | ----------------- |
@@ -69,31 +66,29 @@ as part of a larger expression:
 
 ### Compound assignment operators
 
-`&&=`, `||=`, and `//=` are always condition coverage. They are handled
-by `_walk_logassignop`, which unconditionally calls
-`add_condition_cover`.
+`&&=`, `||=`, and `//=` are always condition coverage. They are handled by
+`_walk_logassignop`, which unconditionally calls `add_condition_cover`.
 
 ### The `xor` operator
 
-`xor` (and `^^` from 5.42+) is always condition coverage with 4
-outcomes: `l&&r`, `l&&!r`, `!l&&r`, `!l&&!r`.
+`xor` (and `^^` from 5.42+) is always condition coverage with 4 outcomes:
+`l&&r`, `l&&!r`, `!l&&r`, `!l&&!r`.
 
 ## How Classification Works in Code
 
-The XS op walker (`walk_ops` in `Cover.xs`, driven from
-`_get_cover_walk`) visits every op in a sub and dispatches each logical
-op to a handler in `lib/Devel/Cover.pm` by type: `logop`,
-`logassignop`, `xor`, and `cond_expr`. The handlers below decide which
-metric to register. They use `B::Deparse` only to render the text label
-for the report (`_deparse_expr`), not to drive the walk.
+The XS op walker (`walk_ops` in `Cover.xs`, driven from `_get_cover_walk`)
+visits every op in a sub and dispatches each logical op to a handler in
+`lib/Devel/Cover.pm` by type: `logop`, `logassignop`, `xor`, and `cond_expr`.
+The handlers below decide which metric to register. They use `B::Deparse` only
+to render the text label for the report (`_deparse_expr`), not to drive the
+walk.
 
 ### `_walk_logop` - the `&&`/`||`/`and`/`or` handler
 
-`_walk_logop` looks up the op's parameters from `%Logop_params` (the
-operator strings, their precedences, and the `$blockname` keyword:
-`"if"` for `and` ops, `"unless"` for `or` ops). It derives the context
-`$cx` from the parent chain (`_logop_parent_cx`) rather than from a
-deparsing call stack.
+`_walk_logop` looks up the op's parameters from `%Logop_params` (the operator
+strings, their precedences, and the `$blockname` keyword: `"if"` for `and` ops,
+`"unless"` for `or` ops). It derives the context `$cx` from the parent chain
+(`_logop_parent_cx`) rather than from a deparsing call stack.
 
 It has four arms that determine both the label and the coverage type:
 
@@ -117,13 +112,13 @@ Arm 4: else
 
 `_classify_op` computes the two control variables:
 
-- **`$is_statement`** selects the label format (statement modifier vs
-  expression form). On 5.43.8+ it reflects `OPpSTATEMENT` only. On
-  older Perls it uses B::Deparse's heuristic.
+- **`$is_statement`** selects the label format (statement modifier vs expression
+  form). On 5.43.8+ it reflects `OPpSTATEMENT` only. On older Perls it uses
+  B::Deparse's heuristic.
 
-- **`$is_branch`** selects the coverage classification. It is true
-  whenever `$is_statement` is true, and also for statement-level
-  expression-form logops (`$cx < 1 && $blockname`).
+- **`$is_branch`** selects the coverage classification. It is true whenever
+  `$is_statement` is true, and also for statement-level expression-form logops
+  (`$cx < 1 && $blockname`).
 
 ```perl
 my $is_statement
@@ -134,61 +129,58 @@ my $is_statement
 my $is_branch = $is_statement || ($cx < 1 && $blockname);
 ```
 
-On 5.43.8+, this separation means expression-form logops at statement
-level (e.g. `$y && $x++`) take arm 3, where they get expression-form
-labels (`$y and ++$x[5]`) but are still classified as branch coverage
-because `$is_branch` is true. On older Perls, `$is_statement` and
-`$is_branch` are always equal (both use the same heuristic), so arm 1
-handles all statement-level logops with statement-modifier labels
-(`if $y`).
+On 5.43.8+, this separation means expression-form logops at statement level
+(e.g. `$y && $x++`) take arm 3, where they get expression-form labels
+(`$y and ++$x[5]`) but are still classified as branch coverage because
+`$is_branch` is true. On older Perls, `$is_statement` and `$is_branch` are
+always equal (both use the same heuristic), so arm 1 handles all statement-level
+logops with statement-modifier labels (`if $y`).
 
-The `$cx < 1` test means we are at statement level (the return value
-is discarded). `$blockname` being set means the op has a
-statement-form keyword (`if`/`unless`). Together they identify logops
-that are semantically branches. Both branch arms also record a
-compound-join condition when the right operand is itself a decision
-(`_record_compound_join`); see the `Compound decision roots` section of
-`Devel::Cover::DB`.
+The `$cx < 1` test means we are at statement level (the return value is
+discarded). `$blockname` being set means the op has a statement-form keyword
+(`if`/`unless`). Together they identify logops that are semantically branches.
+Both branch arms also record a compound-join condition when the right operand is
+itself a decision (`_record_compound_join`); see the `Compound decision roots`
+section of `Devel::Cover::DB`.
 
-Loop conditions (`while`/`until`/C-style `for`) are forced to branch
-coverage regardless of `OPpSTATEMENT`, detected by `_is_loop_condition`
-walking up to a `leaveloop` parent.
+Loop conditions (`while`/`until`/C-style `for`) are forced to branch coverage
+regardless of `OPpSTATEMENT`, detected by `_is_loop_condition` walking up to a
+`leaveloop` parent.
 
 ### `_walk_cond_expr` - the `?:` / `if-else` handler
 
-The `cond_expr` op covers both ternary expressions and if/else
-statements. Both forms always get **branch** coverage - the
-`$is_statement` flag only determines the label format:
+The `cond_expr` op covers both ternary expressions and if/else statements. Both
+forms always get **branch** coverage - the `$is_statement` flag only determines
+the label format:
 
 - Statement form: `"if ($cond) { }"` with elsif chain walking
 - Expression form: `"$cond ? :"`
 
-On 5.43.8+, `OPpSTATEMENT` determines the label. On older Perls, the
-heuristic examines the structure of the true and false blocks.
+On 5.43.8+, `OPpSTATEMENT` determines the label. On older Perls, the heuristic
+examines the structure of the true and false blocks.
 
 ### `_walk_logassignop` - the `&&=`/`||=`/`//=` handler
 
-Always calls `add_condition_cover`. These are value-producing
-operations (they assign the result), so condition coverage is
-appropriate.
+Always calls `add_condition_cover`. These are value-producing operations (they
+assign the result), so condition coverage is appropriate.
 
 ### `_walk_xor` - the `xor`/`^^` handler (5.42+)
 
-`xor` and its high-precedence form `^^` (5.42+) both compile to
-`OP_XOR`. The walker dispatches both to `_walk_xor`, which calls
-`add_condition_cover`. The label is rendered as `^^` when the op is
-used at high precedence (`$cx > 2`) and `xor` otherwise. The raw
-4-outcome counts come from the runtime (`dc_xor` / `cover_logop`).
+`xor` and its high-precedence form `^^` (5.42+) both compile to `OP_XOR`. The
+walker dispatches both to `_walk_xor`, which calls `add_condition_cover`. The
+label is rendered as `^^` when the op is used at high precedence (`$cx > 2`) and
+`xor` otherwise. The raw 4-outcome counts come from the runtime (`dc_xor` /
+`cover_logop`).
 
 ## Runtime Data Collection (Cover.xs)
 
-The XS layer collects raw counts for every logical op at runtime. This
-data feeds both branch and condition coverage at the Perl level.
+The XS layer collects raw counts for every logical op at runtime. This data
+feeds both branch and condition coverage at the Perl level.
 
 ### The condition array
 
-Each logical op has a 6-element array stored in `$Coverage->{condition}`
-keyed by op address. The indices track different outcomes:
+Each logical op has a 6-element array stored in `$Coverage->{condition}` keyed
+by op address. The indices track different outcomes:
 
 ```text
 Index   Meaning
@@ -203,48 +195,45 @@ Index   Meaning
 
 ### How the XS code collects data
 
-1. **`cover_logop`** runs when a logical op (`OP_AND`, `OP_OR`,
-   `OP_XOR`, `OP_DOR`, and their assign variants) is about to execute.
-   It checks the truth value of the left operand on the stack.
+1. **`cover_logop`** runs when a logical op (`OP_AND`, `OP_OR`, `OP_XOR`,
+   `OP_DOR`, and their assign variants) is about to execute. It checks the truth
+   value of the left operand on the stack.
 
 2. If the op short-circuits (left is false for `and`, true for `or`),
-   `add_conditional` immediately records the outcome at index 3
-   (left determined the result).
+   `add_conditional` immediately records the outcome at index 3 (left determined
+   the result).
 
-3. If the op does not short-circuit, `cover_logop` needs to see the
-   right operand's value too. It installs a temporary hook
-   (`get_condition`) at the op that follows the right operand. When
-   execution reaches that op, `get_condition` examines the stack and
-   records the outcome at index 1 (right was false) or 2 (right was
-   true).
+3. If the op does not short-circuit, `cover_logop` needs to see the right
+   operand's value too. It installs a temporary hook (`get_condition`) at the op
+   that follows the right operand. When execution reaches that op,
+   `get_condition` examines the stack and records the outcome at index 1 (right
+   was false) or 2 (right was true).
 
-4. **Void context shortcut**: if the op is in void context, or the
-   right operand is a control flow op (`next`, `last`, `redo`, `goto`,
-   `return`, `die`), the right operand's truth value is irrelevant. The
-   XS code records a 2-outcome result immediately instead of waiting
-   for `get_condition`.
+4. **Void context shortcut**: if the op is in void context, or the right operand
+   is a control flow op (`next`, `last`, `redo`, `goto`, `return`, `die`), the
+   right operand's truth value is irrelevant. The XS code records a 2-outcome
+   result immediately instead of waiting for `get_condition`.
 
-5. **`finalise_conditions`** runs after the programme finishes. Any
-   pending conditions that were never resolved (e.g., because of an
-   early `return` before the right operand's follow-on op was reached)
-   are collected here.
+5. **`finalise_conditions`** runs after the programme finishes. Any pending
+   conditions that were never resolved (e.g., because of an early `return`
+   before the right operand's follow-on op was reached) are collected here.
 
 ### `cover_cond` - branch data from `cond_expr`
 
-The `cond_expr` op (`?:` / `if-else`) uses a simpler mechanism.
-`cover_cond` runs at the `cond_expr` op and records which branch
-(true or false) was taken, using `add_branch` directly.
+The `cond_expr` op (`?:` / `if-else`) uses a simpler mechanism. `cover_cond`
+runs at the `cond_expr` op and records which branch (true or false) was taken,
+using `add_branch` directly.
 
 ## How the Perl Layer Interprets Raw Data
 
-The raw condition array from the XS layer is reinterpreted by
-`add_branch_cover` and `add_condition_cover` in `lib/Devel/Cover.pm`.
+The raw condition array from the XS layer is reinterpreted by `add_branch_cover`
+and `add_condition_cover` in `lib/Devel/Cover.pm`.
 
 ### `add_branch_cover`
 
-For `and`/`or` type branches (where branch coverage is derived from
-condition data), the function reads from `$Coverage->{condition}{$key}`
-and collapses the 6-element array into 2 values:
+For `and`/`or` type branches (where branch coverage is derived from condition
+data), the function reads from `$Coverage->{condition}{$key}` and collapses the
+6-element array into 2 values:
 
 ```perl
 # True path = left true and right evaluated (indices 1 + 2)
@@ -253,16 +242,15 @@ $c = [ $c->[1] + $c->[2], $c->[3] ];
 ```
 
 For `if`/`elsif` type branches, the function reads from
-`$Coverage->{branch}{$key}`, which is populated directly by
-`cover_cond` in the XS layer with a simple `[true_count, false_count]`.
+`$Coverage->{branch}{$key}`, which is populated directly by `cover_cond` in the
+XS layer with a simple `[true_count, false_count]`.
 
 ### `add_condition_cover`
 
-Reorders the raw array into human-readable columns depending on the
-operator and the number of outcomes:
+Reorders the raw array into human-readable columns depending on the operator and
+the number of outcomes:
 
-**`and` with 3 outcomes** (both operands can be independently true or
-false):
+**`and` with 3 outcomes** (both operands can be independently true or false):
 
 ```perl
 # Columns: !l, l&&!r, l&&r
@@ -276,16 +264,16 @@ false):
 @$c = @{$c}[3, 2, 1];
 ```
 
-**`and`/`or` with 2 outcomes** (when the right operand is a constant or
-control flow op like `next`, `die`, `return`):
+**`and`/`or` with 2 outcomes** (when the right operand is a constant or control
+flow op like `next`, `die`, `return`):
 
 ```perl
 # Columns: short-circuit count first: !l, l for and; l, !l for or
 $c = [ $c->[3], $c->[1] + $c->[2] ];
 ```
 
-The right operand's truth value does not matter in this case, so only
-two outcomes are tracked. The `$Const_right` pattern determines this:
+The right operand's truth value does not matter in this case, so only two
+outcomes are tracked. The `$Const_right` pattern determines this:
 
 ```perl
 my $Const_right = qr/^(?:const|s?refgen|gelem|die|undef|
@@ -302,8 +290,8 @@ my $Const_right = qr/^(?:const|s?refgen|gelem|die|undef|
 
 ## The Condition Criterion Classes
 
-Each combination of operator and outcome count has a corresponding
-class in `lib/Devel/Cover/`:
+Each combination of operator and outcome count has a corresponding class in
+`lib/Devel/Cover/`:
 
 | Class             | Operator | Outcomes | Headers                |
 | ----------------- | -------- | -------- | ---------------------- |
@@ -313,15 +301,15 @@ class in `lib/Devel/Cover/`:
 | `Condition_or_3`  | or/\|\|  | 3        | `l`, `!l&&r`, `!l&&!r` |
 | `Condition_xor_4` | xor/^^   | 4        | `l&&r`, `l&&!r`, etc.  |
 
-The `type` field in the condition structure (e.g. `"and_3"`, `"or_2"`)
-selects the class at report time.
+The `type` field in the condition structure (e.g. `"and_3"`, `"or_2"`) selects
+the class at report time.
 
 ## OPpSTATEMENT (Perl 5.43.8+)
 
-Perl 5.43.8 added the `OPpSTATEMENT` private flag to logical ops. When
-set, it means the op was written in statement form (`$x++ if $y`,
-`if ($x) { ... }`, `next unless $y`). When not set, it was written in
-expression form (`$x && $y`, `$x and $y`).
+Perl 5.43.8 added the `OPpSTATEMENT` private flag to logical ops. When set, it
+means the op was written in statement form (`$x++ if $y`, `if ($x) { ... }`,
+`next unless $y`). When not set, it was written in expression form (`$x && $y`,
+`$x and $y`).
 
 Devel::Cover imports this flag conditionally:
 
@@ -333,58 +321,54 @@ BEGIN {
 }
 ```
 
-The constant sub `Has_op_statement` is a compile-time-foldable boolean
-that guards all OPpSTATEMENT checks. It must be called with explicit
-parentheses (`Has_op_statement()`) because on Perl 5.20 the bare form
-`Has_op_statement ?` is parsed as the deprecated match-once `?PATTERN?`
-operator.
+The constant sub `Has_op_statement` is a compile-time-foldable boolean that
+guards all OPpSTATEMENT checks. It must be called with explicit parentheses
+(`Has_op_statement()`) because on Perl 5.20 the bare form `Has_op_statement ?`
+is parsed as the deprecated match-once `?PATTERN?` operator.
 
 ### Where OPpSTATEMENT is used
 
-1. **`_classify_op`** (used by `_walk_logop`): selects the label
-   format (statement modifier vs expression). A separate `$is_branch`
-   variable combines `$is_statement` with `$cx < 1 && $blockname` to
-   also classify statement-level expression-form logops as branches.
+1. **`_classify_op`** (used by `_walk_logop`): selects the label format
+   (statement modifier vs expression). A separate `$is_branch` variable combines
+   `$is_statement` with `$cx < 1 && $blockname` to also classify statement-level
+   expression-form logops as branches.
 
-2. **`_walk_cond_expr`**: determines whether to label as
-   `"if ($cond) { }"` (with elsif walking) or `"$cond ? :"`. Both
-   forms are always branch coverage.
+2. **`_walk_cond_expr`**: determines whether to label as `"if ($cond) { }"`
+   (with elsif walking) or `"$cond ? :"`. Both forms are always branch coverage.
 
 ### Why statement-level expression logops are branches
 
-Consider `$y && $x++` at statement level. Perl 5.43.8 does not set
-OPpSTATEMENT on this op because the programmer wrote it in expression
-form. But the return value is discarded (void context). Semantically
-this is identical to `$x++ if $y` - we care about whether the path was
-taken, not about the combined truth value of `$y && $x++`.
+Consider `$y && $x++` at statement level. Perl 5.43.8 does not set OPpSTATEMENT
+on this op because the programmer wrote it in expression form. But the return
+value is discarded (void context). Semantically this is identical to
+`$x++ if $y` - we care about whether the path was taken, not about the combined
+truth value of `$y && $x++`.
 
-If classified as condition coverage, the report would show 2 or 3
-condition outcomes for `$y and ++$x`, which is misleading - the truth
-value of `$x++` is irrelevant. Branch coverage with a simple
-true/false outcome is the appropriate metric.
+If classified as condition coverage, the report would show 2 or 3 condition
+outcomes for `$y and ++$x`, which is misleading - the truth value of `$x++` is
+irrelevant. Branch coverage with a simple true/false outcome is the appropriate
+metric.
 
 On 5.43.8+, because `$is_statement` only reflects `OPpSTATEMENT`, the
-expression-form logop takes arm 3 of `_walk_logop` and gets an
-expression-form label (`$y and ++$x[5]`). The `$is_branch` variable
-ensures it is still classified as branch coverage despite not being in
-statement form.
+expression-form logop takes arm 3 of `_walk_logop` and gets an expression-form
+label (`$y and ++$x[5]`). The `$is_branch` variable ensures it is still
+classified as branch coverage despite not being in statement form.
 
-On older Perls, both forms are indistinguishable in the optree, so
-both get the statement-modifier label (`if $y`).
+On older Perls, both forms are indistinguishable in the optree, so both get the
+statement-modifier label (`if $y`).
 
-The XS layer's void-context detection already handles this at the data
-level (recording only 2 outcomes when in void context), so the Perl
-layer's classification aligns with what the runtime actually measured.
+The XS layer's void-context detection already handles this at the data level
+(recording only 2 outcomes when in void context), so the Perl layer's
+classification aligns with what the runtime actually measured.
 
 ### Statement-level compound joins
 
-A statement-level logop stays a branch, but when its right operand is
-itself a decision, the outer operator is additionally recorded as a
-condition, so the join is visible to condition and MC/DC coverage. An
-example is a sub's last statement `($a && $b) || ($c && $d)`. See the
-`Compound decision roots` section of `Devel::Cover::DB` and
-`docs/technical/mcdc.md` for the details and the left-only-compound
-exception.
+A statement-level logop stays a branch, but when its right operand is itself a
+decision, the outer operator is additionally recorded as a condition, so the
+join is visible to condition and MC/DC coverage. An example is a sub's last
+statement `($a && $b) || ($c && $d)`. See the `Compound decision roots` section
+of `Devel::Cover::DB` and `docs/technical/mcdc.md` for the details and the
+left-only-compound exception.
 
 ## Examples
 
@@ -410,8 +394,8 @@ line  err      %   true  false   branch
 28    ***     50      0      4   if $y
 ```
 
-Two outcomes: `$y` was true (path taken) or false (short-circuited).
-The label format differs but the coverage data is identical.
+Two outcomes: `$y` was true (path taken) or false (short-circuited). The label
+format differs but the coverage data is identical.
 
 ### Branch: `if ($x) { } elsif ($y) { } else { }`
 
@@ -434,8 +418,8 @@ if ($x && $y) { ... }
 ```
 
 The `if` itself is a `cond_expr` op and gets **branch** coverage
-(`if ($x && $y) { }`). The `&&` inside the condition is a nested logop
-with `$cx > 0`, so it gets **condition** coverage with 3 outcomes:
+(`if ($x && $y) { }`). The `&&` inside the condition is a nested logop with
+`$cx > 0`, so it gets **condition** coverage with 3 outcomes:
 
 ```text
 Conditions
@@ -465,9 +449,9 @@ line  err      %     !l  l&&!r   l&&r   expr
 $y || die "oops";   # void context, but die is a const-right op
 ```
 
-When the right operand matches `$Const_right` (which includes `die`),
-condition coverage uses 2 outcomes because the right operand's truth
-value is not meaningful:
+When the right operand matches `$Const_right` (which includes `die`), condition
+coverage uses 2 outcomes because the right operand's truth value is not
+meaningful:
 
 ```text
 Conditions
@@ -480,11 +464,10 @@ line  err      %      l     !l   expr
 
 The primary test files for branch and condition coverage are:
 
-- `tests/cond_branch` - exercises the branch/condition boundary:
-  `$y && $x++` vs `$x++ if $y`, `$y || next`, loop control operators,
-  `goto`, `redo`, ternary, if/elsif chains, and compound conditions.
-- `tests/cond_and` - focuses on `&&`/`and` in various contexts
-  including `&&=`.
+- `tests/cond_branch` - exercises the branch/condition boundary: `$y && $x++` vs
+  `$x++ if $y`, `$y || next`, loop control operators, `goto`, `redo`, ternary,
+  if/elsif chains, and compound conditions.
+- `tests/cond_and` - focuses on `&&`/`and` in various contexts including `&&=`.
 - `tests/cond_or` - focuses on `||`/`or`/`//` and `||=`/`//=`.
 
 Golden output files in `test_output/cover/` serve as regression tests.

--- a/docs/technical/class.md
+++ b/docs/technical/class.md
@@ -99,15 +99,15 @@ produce independent coverage entries.
 
 ## Test Cases
 
-Three test files cover the class feature, one per Perl release that added
-new constructs:
+Three test files cover the class feature, one per Perl release that added new
+constructs:
 
-- `tests/class38` (5.38+): `class`, `field :param`, `method`, `ADJUST`,
-  `:isa`, anonymous methods, methods with signatures, branch coverage.
-- `tests/class40` (5.40+): extends class38 with `:reader` field attributes
-  and their auto-generated accessors.
+- `tests/class38` (5.38+): `class`, `field :param`, `method`, `ADJUST`, `:isa`,
+  anonymous methods, methods with signatures, branch coverage.
+- `tests/class40` (5.40+): extends class38 with `:reader` field attributes and
+  their auto-generated accessors.
 - `tests/class42` (5.42+): extends class40 with `:writer` field attributes,
   `my method` (lexical/private methods), and `method call_private`.
 
-The golden output files in `test_output/cover/` serve as regression tests
-for all three.
+The golden output files in `test_output/cover/` serve as regression tests for
+all three.

--- a/docs/technical/cpancover-rebuild.md
+++ b/docs/technical/cpancover-rebuild.md
@@ -96,11 +96,11 @@ At the end of the rebuild cycle the recipe:
   so version compression still kicks in when the new version supersedes enough
   old versions.
 - **Log retention**: every rebuild run produces a fresh `<log_name>.out` in
-  `$results_dir`, compressed to `.out.gz` only when `CPANCOVER_COMPRESS` is
-  set. Failed rebuilds refresh the existing `<distdir>/.log_ref` to point at
-  the new log, so users clicking "log" on a failing distribution see the most
-  recent failure rather than a stale one from months ago. Old log files
-  accumulate until the normal log-retention policy reaps them.
+  `$results_dir`, compressed to `.out.gz` only when `CPANCOVER_COMPRESS` is set.
+  Failed rebuilds refresh the existing `<distdir>/.log_ref` to point at the new
+  log, so users clicking "log" on a failing distribution see the most recent
+  failure rather than a stale one from months ago. Old log files accumulate
+  until the normal log-retention policy reaps them.
 - **`is_covered` / `is_failed` semantics change in rebuild mode**: a distdir
   counts as "done" only if it has both been processed and flagged rebuilt this
   cycle. Outside rebuild mode the methods behave as before.

--- a/docs/technical/mcdc.md
+++ b/docs/technical/mcdc.md
@@ -51,9 +51,8 @@ well-defined for the unusual cases.
 
 Coupling does reach the analyser. A coupled decision such as
 `($a && $b) || ($a && $c)` is recorded as a single table with a repeated `$a`
-column, and unique-cause can never demonstrate a repeated column, so the
-masking fallback is a live, necessary path for such decisions (see
-Limitations).
+column, and unique-cause can never demonstrate a repeated column, so the masking
+fallback is a live, necessary path for such decisions (see Limitations).
 
 Pure masking is over-permissive in a short-circuit language: any execution where
 the left operand short-circuits masks every condition on the right, so under
@@ -109,8 +108,8 @@ articles.
 These four tests achieve:
 
 - 100% statement coverage.
-- 100% branch coverage (the outer decision goes both ways: tests 1-3 → T;
-  test 4 → F).
+- 100% branch coverage (the outer decision goes both ways: tests 1-3 → T; test 4
+  → F).
 - 100% condition coverage. Between them the four tests cover every row of the
   outer `||`'s `or_3` table (`l`, `!l && r`, `!l && !r`) and every row of the
   inner `&&`'s `and_3` table (`l && r`, `l && !r`, `!l`).
@@ -275,8 +274,8 @@ interface is separate:
 - `mcdc` is a distinct entry in `@Devel::Cover::DB::Criteria`.
 - A separate flag bit selects it in `Cover.xs`.
 - `cover -coverage mcdc` selects it by name, although `condition` must also be
-  collected: MC/DC derives from the condition truth tables, and selecting
-  `mcdc` alone warns at startup and collects nothing (see Limitations).
+  collected: MC/DC derives from the condition truth tables, and selecting `mcdc`
+  alone warns at startup and collects nothing (see Limitations).
 - Reports show MC/DC as its own column with its own percentage.
 
 The reasoning:
@@ -288,8 +287,8 @@ The reasoning:
   MC/DC opt-in.
 - Existing CI thresholds on condition coverage do not silently change meaning
   when MC/DC is added.
-- Industry tools (gcov `--conditions`, llvm-cov `--show-mcdc`, LDRA,
-  VectorCAST) report MC/DC as a separate metric alongside condition coverage.
+- Industry tools (gcov `--conditions`, llvm-cov `--show-mcdc`, LDRA, VectorCAST)
+  report MC/DC as a separate metric alongside condition coverage.
 
 ## Per-decision input-vector recording
 
@@ -313,31 +312,31 @@ records each decision's input vector at runtime: a small stack
 `add_condition` write each leaf's observed truth value into the current vector,
 and snapshot it into `MY_CXT.decision_inputs` on short-circuit-at-root, on the
 same-type chain reaching the root, or - for decisions ending a sort comparator -
-per invocation from `resolve_deferred_conditionals`. The chain walk follows
-each right operand's `op_next`, stepping through nulled ops (the tree roots of
+per invocation from `resolve_deferred_conditionals`. The chain walk follows each
+right operand's `op_next`, stepping through nulled ops (the tree roots of
 element accesses, which are not executed but whose `op_next` still leads on) to
-reach the enclosing logop. Each evaluation of a
-decision gets its own frame: the decision's entry logop (the first to fire on
-every evaluation) always pushes a fresh one, so recursive invocations record
-separately. Frames record `cxstack_ix` at push; a frame abandoned by a
-non-local exit (`die`, `goto`, `last`) is detected by its now-too-deep context
-depth and discarded without recording - an abandoned evaluation must record
-nothing, since a partial vector would fabricate an observation no execution
-produced. Column metadata (which logop is a decision root, which leaf
-maps to which column index) is computed lazily on first encounter of each CV by
-walking the optree from `CvROOT`. The walk uses `op_first` / `OpSIBLING` chains
-rather than `op_sibparent` to preserve the 5.20 minimum (`op_sibparent`
-requires `PERL_OP_PARENT`, added in 5.22 and made default in 5.26).
+reach the enclosing logop. Each evaluation of a decision gets its own frame: the
+decision's entry logop (the first to fire on every evaluation) always pushes a
+fresh one, so recursive invocations record separately. Frames record
+`cxstack_ix` at push; a frame abandoned by a non-local exit (`die`, `goto`,
+`last`) is detected by its now-too-deep context depth and discarded without
+recording - an abandoned evaluation must record nothing, since a partial vector
+would fabricate an observation no execution produced. Column metadata (which
+logop is a decision root, which leaf maps to which column index) is computed
+lazily on first encounter of each CV by walking the optree from `CvROOT`. The
+walk uses `op_first` / `OpSIBLING` chains rather than `op_sibparent` to preserve
+the 5.20 minimum (`op_sibparent` requires `PERL_OP_PARENT`, added in 5.22 and
+made default in 5.26).
 
 Root identification must agree with condition coverage on what "the decision"
 is. The joining logop of an `if`, `unless` or `while` statement or statement
 modifier - a statically void `and`/`or` whose right operand is not itself a
 decision - is treated as a branch by condition coverage, so the walk
 (`dc_is_branch_logop`) excludes it: it is not a decision root and does not
-de-root the condition chain on its left, which is the real decision and
-records vectors under its own root. Without this exclusion the vectors would
-be keyed by an op that is never finalised as a condition and would be lost,
-leaving statement-context compound decisions permanently unproven.
+de-root the condition chain on its left, which is the real decision and records
+vectors under its own root. Without this exclusion the vectors would be keyed by
+an op that is never finalised as a condition and would be lost, leaving
+statement-context compound decisions permanently unproven.
 
 `Condition_table::for_line` accepts an optional parallel array of
 observed-vector hashes; when present, each synthesised row is marked `covered=1`
@@ -345,11 +344,11 @@ iff its input vector matches an observed key. Synthesised rows the runtime never
 executed keep `covered=0` so the truth-table renderer still draws them - users
 see the unobserved combinations as "rendered but not hit" rather than vanishing.
 
-A compound table whose rows remain an unverified synthesis - no observed
-vectors were applied - is marked unproven, and `DB::_derive_mcdc` zeroes its
-MC/DC coverage: an honest 0%, never a false pass. Void-context decisions are
-rebuilt without observed vectors and so always report unproven. The precise
-`proven` rule is specified in the `Devel::Cover::Condition_table` POD.
+A compound table whose rows remain an unverified synthesis - no observed vectors
+were applied - is marked unproven, and `DB::_derive_mcdc` zeroes its MC/DC
+coverage: an honest 0%, never a false pass. Void-context decisions are rebuilt
+without observed vectors and so always report unproven. The precise `proven`
+rule is specified in the `Devel::Cover::Condition_table` POD.
 
 The runtime recorder requires `Devel::Cover::Mcdc` to be loaded as a criterion
 subclass during Devel::Cover's bootstrap (via `Criterion.pm`'s runtime require
@@ -437,20 +436,19 @@ USAGE POD in `Devel::Cover::Mcdc`, and a `Changes` entry.
   collected for `mcdc` to produce data. Selecting `mcdc` without `condition`
   warns at startup and produces an empty MC/DC report.
 
-- Decisions with more than 16 atomic conditions are not analysed. The limit
-  is per decision, enforced on both sides: `Condition_table::for_line`
+- Decisions with more than 16 atomic conditions are not analysed. The limit is
+  per decision, enforced on both sides: `Condition_table::for_line`
   (`$Max_width`) returns a `too_wide` stub table with labels but no rows, and
   the XS recorder (`DC_MAX_DECISION_WIDTH`) records no input vectors for such
   decisions. `DB::_derive_mcdc` reports the decision as 0 of its width with an
-  `unanalysed` flag, warns at report time naming the file and line (silenced
-  by `-silent`), and ignores any `# uncoverable mcdc` markers on it, with a
-  warning of its own. Reporters show "too many conditions" in place of the
+  `unanalysed` flag, warns at report time naming the file and line (silenced by
+  `-silent`), and ignores any `# uncoverable mcdc` markers on it, with a warning
+  of its own. Reporters show "too many conditions" in place of the
   missing-conditions list, and the JSON report carries `"unanalysed": 1`. The
-  bound exists because the truth table size grows as 2^N and becomes
-  unwieldy. The remedy is to split the decision with an intermediate
-  variable, which needs no extra test cases, preserves short-circuiting, and
-  lets every condition be analysed. `tests/mcdc_wide` covers the behaviour
-  end to end.
+  bound exists because the truth table size grows as 2^N and becomes unwieldy.
+  The remedy is to split the decision with an intermediate variable, which needs
+  no extra test cases, preserves short-circuiting, and lets every condition be
+  analysed. `tests/mcdc_wide` covers the behaviour end to end.
 
 - A statement-level logop whose value is discarded records its outer operator as
   a decision only when its right operand is itself a decision. So

--- a/docs/technical/package.md
+++ b/docs/technical/package.md
@@ -53,11 +53,11 @@ is therefore never visited at runtime.
 
 ## The Phantom Statement
 
-The XS op walker (`dc_walk_ops_r` in `Cover.xs`) visits the optree
-structurally, so it reaches optimised-away `ex-nextstate` ops as children of
-their `lineseq`. An `ex-nextstate` is an `OP_NULL` whose `op_targ` records the
-original `OP_NEXTSTATE`/`OP_DBSTATE`. The most common one sits on the line of a
-closing `}` whose `nextstate` the optimiser nullified.
+The XS op walker (`dc_walk_ops_r` in `Cover.xs`) visits the optree structurally,
+so it reaches optimised-away `ex-nextstate` ops as children of their `lineseq`.
+An `ex-nextstate` is an `OP_NULL` whose `op_targ` records the original
+`OP_NEXTSTATE`/`OP_DBSTATE`. The most common one sits on the line of a closing
+`}` whose `nextstate` the optimiser nullified.
 
 If such an op were registered as a statement, `add_statement_cover` would record
 a statement at the `}` line that the runtime `dc_nextstate` hook can never

--- a/docs/technical/scar.md
+++ b/docs/technical/scar.md
@@ -461,26 +461,25 @@ reducing complexity both lower the score.
 
 ### Summary (`cover -summary`)
 
-An always-on `scar` column appears after the `total` column, showing
-per-file `file_scar` and, for the Total row, `module_scar`. Formatting:
-`%5.1f` for numeric values; `-` when the file is uncompiled without PPI
-(data unknown); `n/a` when the file has no coverable subs.
+An always-on `scar` column appears after the `total` column, showing per-file
+`file_scar` and, for the Total row, `module_scar`. Formatting: `%5.1f` for
+numeric values; `-` when the file is uncompiled without PPI (data unknown);
+`n/a` when the file has no coverable subs.
 
 ### Text report
 
-CC and SCAR columns appear in the covered/uncovered subroutine tables
-alongside call counts and source location.
+CC and SCAR columns appear in the covered/uncovered subroutine tables alongside
+call counts and source location.
 
-Each file section opens with a `File Summary` one-row table of
-`CC`, `Cov`, `CRAP`, and `SCAR`, followed by a `Worst Subroutines`
-digest listing the top three subroutines by CRAP (subs with zero SCAR are
-omitted). The banner is suppressed when the file has no SCAR data.
+Each file section opens with a `File Summary` one-row table of `CC`, `Cov`,
+`CRAP`, and `SCAR`, followed by a `Worst Subroutines` digest listing the top
+three subroutines by CRAP (subs with zero SCAR are omitted). The banner is
+suppressed when the file has no SCAR data.
 
-When the report spans more than one file, a `Module Summary` one-row
-table at the top shows `Files`, `CC`, `Cov`, `CRAP`, and `SCAR`. When the
-report spans more than one directory, a `Directory Summary` table at the
-end lists each directory's CC, coverage, CRAP and SCAR, sorted by SCAR
-descending.
+When the report spans more than one file, a `Module Summary` one-row table at
+the top shows `Files`, `CC`, `Cov`, `CRAP`, and `SCAR`. When the report spans
+more than one directory, a `Directory Summary` table at the end lists each
+directory's CC, coverage, CRAP and SCAR, sorted by SCAR descending.
 
 ### Html_crisp report
 


### PR DESCRIPTION
## Summary

Reflow CLAUDE.md and the files under docs/ to the 80-column wrap standard introduced in #539, so future edits produce diffs containing only genuine content changes rather than whole-file rewrapping. The changes are purely formatting; no wording changes.

## Ticket

Closes #540