### PR TITLE
GH-542 Keep Makefile.PL lines within 80 characters

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -492,8 +492,9 @@ only_in_void_context = 1
 # maximum_violations_per_document    = no_limit
 
 
+# Joining readline is clear and fine for the small files we deal with.
 # Use `local $/ = undef' or Path::Tiny instead of joined readline.
-[InputOutput::ProhibitJoinedReadline]
+[-InputOutput::ProhibitJoinedReadline]
 # set_themes                         = core pbp performance
 # add_themes                         =
 # severity                           = 3

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,4 @@
 #!/usr/bin/perl
-## no critic (ProhibitLongLines)
 
 # Copyright 2001-2026, Paul Johnson (paul@pjcj.net)
 
@@ -409,10 +408,14 @@ TAINT =
 COVER_OPTIONS =
 PERL5OPT =
 
-_run : pure_all
-\t \$(PERL) \$(TAINT) -Iblib/lib -Iblib/arch -MDevel::Cover=-merge,0,`\$(PERL) -e '\$\$l = qx|grep __COVER__ \$\$ARGV[0]|; \$\$l =~ /__COVER__\\s+criteria\\s+(.*)/; (\$\$c = \$\$1 || "all") =~ s/\\s+/,/g; \$\$p = "\$\$1," if \$\$l =~ /__COVER__\\s+test_parameters\\s+(.*)/; print "\$\$p-coverage,\$\$c"' tests/\$(TEST)`,\$(COVER_OPTIONS) tests/\$(TEST)
+TEST_OPTIONS = \$(PERL) utils/makeh test_options tests/\$(TEST)
 
-COVER_PARAMETERS = \$(PERL) -e '\$\$l = qx|grep __COVER__ \$\$ARGV[0]|; \$\$u = "-uncoverable_file \$\$1" if \$\$l =~ /__COVER__\\s+uncoverable_file\\s+(.*)/; (\$\$p) = \$\$l =~ /__COVER__\\s+cover_parameters\\s+(.*)/; print "\$\$u \$\$p"' tests/\$(TEST)
+_run : pure_all
+\t \$(PERL) \$(TAINT) -Iblib/lib -Iblib/arch \\
+\t   -MDevel::Cover=-merge,0,`\$(TEST_OPTIONS)`,\$(COVER_OPTIONS) \\
+\t   tests/\$(TEST)
+
+COVER_PARAMETERS = \$(PERL) utils/makeh cover_parameters tests/\$(TEST)
 
 html : _run
 \t \$(PERL) -Mblib bin/cover `\$(COVER_PARAMETERS)` -report html
@@ -430,14 +433,19 @@ text : out
 \t \$(PAGER) \$(TEST).out
 
 wrun : pure_all
-\t \$(PERL) \$(TAINT) -Iblib/lib -Iblib/arch -MDevel::Cover=-ignore,blib,-merge,0 tests/\$(TEST)
+\t \$(PERL) \$(TAINT) -Iblib/lib -Iblib/arch \\
+\t   -MDevel::Cover=-ignore,blib,-merge,0 tests/\$(TEST)
 
 prove : pure_all
-\t \$(PERL) -Iutils -MDevel::Cover::BuildUtils=prove_command -le '\$\$c = prove_command and print \$\$c and system \$\$c'
+\t \$(PERL) -Iutils -MDevel::Cover::BuildUtils=prove_command \\
+\t   -le '\$\$c = prove_command and print \$\$c and system \$\$c'
+
+NICE_CPUS = \$(PERL) -Iutils -MDevel::Cover::BuildUtils=nice_cpus \\
+\t -e 'print nice_cpus'
 
 t : pure_all
 \t \$(PERL) -Mblib bin/cover -delete
-\t exec make test HARNESS_OPTIONS=j`\$(PERL) -Iutils -MDevel::Cover::BuildUtils=nice_cpus -e 'print nice_cpus'`:c HARNESS_TIMER=1
+\t exec make test HARNESS_OPTIONS=j`\$(NICE_CPUS)`:c HARNESS_TIMER=1
 
 no_replace_ops_t : pure_all
 \t DEVEL_COVER_OPTIONS=-replace_ops,0 exec make t

--- a/t/internal/makeh.t
+++ b/t/internal/makeh.t
@@ -1,0 +1,103 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# The test_options and cover_parameters subcommands build option strings for
+# the Makefile _run and cover targets from __COVER__ directives in test files.
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is like )];
+
+my $Dir = tempdir(CLEANUP => 1);
+my $N   = 0;
+
+sub write_test ($content) {
+  my $path = "$Dir/test" . $N++;
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $content;
+  close $fh or die "Cannot close $path: $!";
+  $path
+}
+
+sub read_file ($file) {
+  open my $fh, "<", $file or die "Cannot open $file: $!";
+  local $/;
+  <$fh>
+}
+
+sub makeh (@args) {
+  qx($^X utils/makeh @args 2>&1)
+}
+
+my $Plain = write_test("print 1;\n");
+is makeh(test_options     => $Plain), "-coverage,all", "no directives";
+is makeh(cover_parameters => $Plain), " ",             "no directives";
+
+my $Criteria
+  = write_test("# __COVER__ criteria statement branch condition subroutine\n");
+is makeh(test_options => $Criteria),
+  "-coverage,statement,branch,condition,subroutine",
+  "criteria words become a comma-separated list";
+
+my $Pod = write_test("# __COVER__ criteria pod-also_private-xx\n");
+is makeh(test_options => $Pod), "-coverage,pod-also_private-xx",
+  "single criteria word";
+
+my $Params = write_test("# __COVER__ test_parameters -subs_only,1\n");
+is makeh(test_options => $Params), "-subs_only,1,-coverage,all",
+  "test_parameters precede coverage";
+
+my $Uncoverable = write_test("# __COVER__ uncoverable_file tests/.unc\n");
+is makeh(cover_parameters => $Uncoverable), "-uncoverable_file tests/.unc ",
+  "uncoverable_file";
+
+my $Ignore = write_test("# __COVER__ cover_parameters -ignore_covered_err\n");
+is makeh(cover_parameters => $Ignore), " -ignore_covered_err",
+  "cover_parameters";
+
+my $Both
+  = write_test("# __COVER__ uncoverable_file tests/.unc\n"
+    . "# __COVER__ cover_parameters -ignore_covered_err\n"
+    . "# __COVER__ test_parameters -subs_only,1\n"
+    . "# __COVER__ criteria statement branch\n");
+is makeh(test_options => $Both), "-subs_only,1,-coverage,statement,branch",
+  "combined directives, test_options";
+is makeh(cover_parameters => $Both),
+  "-uncoverable_file tests/.unc -ignore_covered_err",
+  "combined directives, cover_parameters";
+
+my $Out
+  = "before\n"
+  . "line  err   stmt   time   code\n"
+  . "1           4    0.01  print 1;\n"
+  . "--------\n"
+  . "after\n";
+my $Report = write_test($Out);
+is makeh(strip_criterion => "time", $Report), "", "strip_criterion is silent";
+is read_file($Report),
+    "before\n"
+  . "line  err   stmt   code\n"
+  . "1           4   print 1;\n"
+  . "--------\n"
+  . "after\n", "time column stripped between header and separator only";
+is read_file("$Report.bak"), $Out, "original kept in .bak";
+
+my $Absent = write_test($Out);
+is makeh(strip_criterion => "pod", $Absent), "", "absent criterion is silent";
+is read_file($Absent), $Out, "absent criterion leaves file unchanged";
+
+like makeh(test_options => "$Dir/missing"), qr/^Cannot open /,
+  "unreadable file is reported";
+like makeh(bogus => $Plain), qr/^No such command: bogus/, "unknown command";
+
+done_testing

--- a/utils/makeh
+++ b/utils/makeh
@@ -7,12 +7,34 @@
 # The latest version of this software should be available from my homepage:
 # https://pjcj.net
 
-use strict;
+use 5.20.0;
 use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+sub cover_lines ($file) {
+  open my $fh, "<", $file or die "Cannot open $file: $!";
+  join "", grep /__COVER__/, <$fh>
+}
 
 my $Command = {
-  strip_criterion => sub {
-    my ($command, $criterion, $file) = @_;
+  test_options => sub ($command, $file) {
+    my $l   = cover_lines($file);
+    my ($c) = $l =~ /__COVER__\s+criteria\s+(.*)/;
+    ($c ||= "all") =~ s/\s+/,/g;
+    my $p = $l =~ /__COVER__\s+test_parameters\s+(.*)/ ? "$1," : "";
+    print "$p-coverage,$c";
+  },
+  cover_parameters => sub ($command, $file) {
+    my $l = cover_lines($file);
+    my $u
+      = $l =~ /__COVER__\s+uncoverable_file\s+(.*)/
+      ? "-uncoverable_file $1"
+      : "";
+    my $p = $l =~ /__COVER__\s+cover_parameters\s+(.*)/ ? $1 : "";
+    print "$u $p";
+  },
+  strip_criterion => sub ($command, $criterion, $file) {
     my $t;
     local ($^I, @ARGV) = (".bak", $file);
     while (<>) {
@@ -23,10 +45,10 @@ my $Command = {
         and length > $t;
       print;
     }
-  }
+  },
 };
 
-sub main {
+sub main () {
   my ($command) = @ARGV;
   die "No such command: $command" unless $Command->{$command};
   $Command->{$command}->(@ARGV)


### PR DESCRIPTION
## Summary

Makefile.PL carried a file-wide `## no critic (ProhibitLongLines)` exemption because its postamble embedded two very long Perl one-liners parsing `__COVER__` directives from test files, plus a few over-length recipes. The one-liners now live in `utils/makeh` as `test_options` and `cover_parameters` subcommands, with tests covering the new subcommands and the pre-existing `strip_criterion`. The remaining recipes are wrapped with continuation lines and the exemption is gone.

Along the way `InputOutput::ProhibitJoinedReadline` is disabled repo-wide, since joining readline is clear and fine for the small files we deal with.

## Ticket

Closes #542