### PR TITLE
GH-549 Fix MC/DC for chains as implicit returns

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -958,7 +958,7 @@ static AV *get_conds(pTHX_ AV *conds) {
 #endif
 
 static HV      *dc_lookup_or_build_decision_meta(pTHX_ OP *op, CV *cv);
-static int      dc_is_branch_logop(pTHX_ OP *op);
+static int      dc_is_branch_logop(pTHX_ OP *op, int expr_ctx);
 static IV       dc_meta_iv(pTHX_ HV *meta, const char *key, I32 keylen);
 static dc_dctx *dc_stack_find_root(pTHX_ OP *root_addr);
 static dc_dctx *dc_stack_top(pTHX);
@@ -1396,33 +1396,60 @@ static int dc_is_multiconcat_truthy(pTHX_ OP *op) {
 }
 
 /*
+ * Compute the expression-context flag passed to op's kids, mirroring the
+ * Perl-side _logop_parent_cx classification.  A kid is in expression
+ * position under return, cond_expr, or another logop.  A plain null is
+ * transparent, and everything else is statement position.
+ */
+static int dc_kid_expr_ctx(OP *op, int expr_ctx) {
+  switch (op->op_type) {
+  case OP_RETURN:
+  case OP_COND_EXPR:
+  case OP_AND:
+  case OP_OR:
+  case OP_DOR:
+    return 1;
+  case OP_NULL:
+    if (op->op_targ == OP_RETURN) return 1;
+    if (op->op_targ == OP_SCOPE || op->op_targ == OP_LEAVE) return 0;
+    return expr_ctx;
+  default:
+    return 0;
+  }
+}
+
+/*
  * Recursively collect every logop reachable under op into the AV.  Skips an
  * OP_AND that wraps OP_ITER (foreach loop conditional, not a decision).
+ * expr_ctx is true when op is in expression position.
  */
-static void dc_collect_logops_r(pTHX_ OP *op, AV *logops) {
+static void dc_collect_logops_r(pTHX_ OP *op, AV *logops, int expr_ctx) {
   OP *kid;
+  int kid_ctx;
 
   if (!op) return;
 
   if (dc_is_logop_type(op->op_type)) {
     OP *first = cLOGOPx(op)->op_first;
     if (!(op->op_type == OP_AND && first && first->op_type == OP_ITER)
-        && !dc_is_branch_logop(aTHX_ op))
+        && !dc_is_branch_logop(aTHX_ op, expr_ctx))
       av_push(logops, newSViv(PTR2IV(op)));
   }
 
+  kid_ctx = dc_kid_expr_ctx(op, expr_ctx);
   if (op->op_flags & OPf_KIDS)
     for (kid = cUNOPx(op)->op_first; kid; kid = OpSIBLING(kid))
-      dc_collect_logops_r(aTHX_ kid, logops);
+      dc_collect_logops_r(aTHX_ kid, logops, kid_ctx);
 
   if (op->op_type == OP_SUBST) {
     PMOP *pm = cPMOPx(op);
 #ifdef USE_ITHREADS
     if (pm->op_pmstashstartu.op_pmreplstart)
-      dc_collect_logops_r(aTHX_ pm->op_pmstashstartu.op_pmreplstart, logops);
+      dc_collect_logops_r(aTHX_ pm->op_pmstashstartu.op_pmreplstart, logops,
+                          0);
 #else
     if (pm->op_pmreplrootu.op_pmreplroot)
-      dc_collect_logops_r(aTHX_ pm->op_pmreplrootu.op_pmreplroot, logops);
+      dc_collect_logops_r(aTHX_ pm->op_pmreplrootu.op_pmreplroot, logops, 0);
 #endif
   }
 }
@@ -1516,16 +1543,20 @@ static int dc_enumerate_columns(pTHX_ HV *cache, OP *op, OP *root,
 }
 
 /*
- * A statically void and/or whose right operand is not itself a decision is
+ * A statement-level and/or whose right operand is not itself a decision is
  * the joining logop of an if/unless/while statement or statement modifier.
  * Condition coverage treats it as a branch, so it is not a decision root
  * and must not de-root the condition chain on its left, which is the real
- * decision.
+ * decision.  Statement level means compile-time void context, or unknown
+ * context (a block-final expression) outside expression position - the
+ * Perl-side walk classifies those as branches too.
  */
-static int dc_is_branch_logop(pTHX_ OP *op) {
+static int dc_is_branch_logop(pTHX_ OP *op, int expr_ctx) {
   OP *right;
+  int want;
   if (op->op_type != OP_AND && op->op_type != OP_OR) return 0;
-  if ((op->op_flags & OPf_WANT) != OPf_WANT_VOID) return 0;
+  want = op->op_flags & OPf_WANT;
+  if (want != OPf_WANT_VOID && (want != 0 || expr_ctx)) return 0;
   right = dc_skipped_operand(aTHX_ op, 1);
   return !(right && dc_is_logop_type(right->op_type));
 }
@@ -1567,7 +1598,7 @@ static void dc_walk_cv_decisions(pTHX_ CV *cv) {
   hv_store(walked, (const char *)&cv, sizeof(CV *), newSViv(cv_root_iv), 0);
 
   logops = (AV *)sv_2mortal((SV *)newAV());
-  dc_collect_logops_r(aTHX_ CvROOT(cv), logops);
+  dc_collect_logops_r(aTHX_ CvROOT(cv), logops, 0);
 
   n = av_len(logops) + 1;
   for (i = 0; i < n; i++) {

--- a/docs/technical/mcdc.md
+++ b/docs/technical/mcdc.md
@@ -330,13 +330,20 @@ made default in 5.26).
 
 Root identification must agree with condition coverage on what "the decision"
 is. The joining logop of an `if`, `unless` or `while` statement or statement
-modifier - a statically void `and`/`or` whose right operand is not itself a
+modifier - a statement-level `and`/`or` whose right operand is not itself a
 decision - is treated as a branch by condition coverage, so the walk
 (`dc_is_branch_logop`) excludes it: it is not a decision root and does not
 de-root the condition chain on its left, which is the real decision and records
 vectors under its own root. Without this exclusion the vectors would be keyed by
 an op that is never finalised as a condition and would be lost, leaving
-statement-context compound decisions permanently unproven.
+statement-context compound decisions permanently unproven. Statement level means
+compile-time void context, or unknown context outside expression position.
+Unknown context arises where the context depends on the caller - a sub's bare
+final expression and the operands of a `return` compile identically - so the
+collection walk tracks expression position down the tree (`dc_kid_expr_ctx`).
+Under `return`, `cond_expr` or another logop the Perl-side walk classifies the
+join as an expression, and everywhere else a context-unknown join is a branch
+(GH-549).
 
 `Condition_table::for_line` accepts an optional parallel array of
 observed-vector hashes; when present, each synthesised row is marked `covered=1`

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -172,46 +172,45 @@ BEGIN {
 sub version    { $VERSION }
 sub has_select { scalar @Select_re }
 
-{
+sub check {
+  return unless $Initialised;
 
-  sub check {
-    return unless $Initialised;
+  check_files();
 
-    check_files();
+  set_coverage(keys %Coverage);
+  my @coverage = get_coverage();
+  %Coverage = map { $_ => 1 } @coverage;
 
-    set_coverage(keys %Coverage);
-    my @coverage = get_coverage();
-    %Coverage = map { $_ => 1 } @coverage;
+  warn __PACKAGE__
+    . ": mcdc coverage requires condition coverage; "
+    . "no mcdc data will be collected.\n"
+    if $Coverage{mcdc} && !$Coverage{condition} && !$Silent;
 
-    warn __PACKAGE__
-      . ": mcdc coverage requires condition coverage; "
-      . "no mcdc data will be collected.\n"
-      if $Coverage{mcdc} && !$Coverage{condition} && !$Silent;
-
-    my $nopod = "";
-    if (!$Pod && exists $Coverage{pod}) {
-      delete $Coverage{pod};  # Pod::Coverage unavailable
-      $nopod = <<EOM;
+  my $nopod = "";
+  if (!$Pod && exists $Coverage{pod}) {
+    delete $Coverage{pod};  # Pod::Coverage unavailable
+    $nopod = <<EOM;
     Pod coverage is unavailable.  Please install Pod::Coverage from CPAN.
 EOM
-    }
-
-    set_coverage(keys %Coverage);
-    @coverage = get_coverage();
-    my $last = pop @coverage || "";
-
-    print OUT __PACKAGE__, " $VERSION: Collecting coverage data for ",
-      join(", ", @coverage), @coverage ? " and " : "", "$last.\n", $nopod,
-      $Subs_only     ? "    Collecting for subroutines only.\n" : "",
-      $ENV{MOD_PERL} ? "    Collecting under $ENV{MOD_PERL}\n"  : "",
-      "Selecting packages matching:", join("\n    ", "", @Select), "\n",
-      "Ignoring packages matching:",  join("\n    ", "", @Ignore), "\n",
-      "Ignoring packages in:",        join("\n    ", "", @Inc),    "\n"
-      unless $Silent;
-
-    populate_run();
   }
 
+  set_coverage(keys %Coverage);
+  @coverage = get_coverage();
+  my $last = pop @coverage || "";
+
+  print OUT __PACKAGE__, " $VERSION: Collecting coverage data for ",
+    join(", ", @coverage), @coverage ? " and " : "", "$last.\n", $nopod,
+    $Subs_only     ? "    Collecting for subroutines only.\n" : "",
+    $ENV{MOD_PERL} ? "    Collecting under $ENV{MOD_PERL}\n"  : "",
+    "Selecting packages matching:", join("\n    ", "", @Select), "\n",
+    "Ignoring packages matching:",  join("\n    ", "", @Ignore), "\n",
+    "Ignoring packages in:",        join("\n    ", "", @Inc),    "\n"
+    unless $Silent;
+
+  populate_run();
+}
+
+{
   no warnings "void";  # avoid "Too late to run CHECK block" warning
   CHECK { check }
 }

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -216,23 +216,17 @@ EOM
   CHECK { check }
 }
 
-{
-  my $run_end = 0;
-
-  sub first_end {
-    set_last_end() unless $run_end++
-  }
-
-  my $run_init = 0;
-
-  sub first_init {
-    collect_inits() unless $run_init++
-  }
+sub first_end {
+  state $run_end = 0;
+  set_last_end() unless $run_end++
 }
 
-sub last_end {
-  report() if $Initialised;
+sub first_init {
+  state $run_init = 0;
+  collect_inits() unless $run_init++
 }
+
+sub last_end { report() if $Initialised }
 
 {
   no warnings "void";  # avoid "Too late to run ... block" warning

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -259,7 +259,7 @@ sub _parse_options ($o, $blib) {
     "-subs_only"   => \$Subs_only,
     "-replace_ops" => \$Replace_ops,
   );
-  my %list_opt = ("ignore" => \@Ignore, "inc" => \@Inc, "select" => \@Select);
+  my %list_opt = (ignore => \@Ignore, inc => \@Inc, select => \@Select);
 
   @Inc    = () if "@$o" =~ /-inc /;
   @Ignore = () if "@$o" =~ /-ignore /;

--- a/test_output/cover/mcdc_final_chain.5.020000
+++ b/test_output/cover/mcdc_final_chain.5.020000
@@ -1,0 +1,208 @@
+cover: Reading database from ...
+---------------------- ------ ------ ------ ------ ------ ------ ------
+File                     stmt   bran   cond   mcdc    sub  total   scar
+---------------------- ------ ------ ------ ------ ------ ------ ------
+tests/mcdc_final_chain  100.0  100.0  100.0  100.0  100.0  100.0   26.4
+Total                   100.0  100.0  100.0  100.0  100.0  100.0   26.4
+---------------------- ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/mcdc_final_chain
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+14 100.0 14.0 26.4
+
+Worst Subroutines
+-----------------
+
+Subroutine CC SCAR  Location                 
+---------- -- ----  -------------------------
+bare_dor3   4 13.9  tests/mcdc_final_chain:33
+ret_dor3    4 13.9  tests/mcdc_final_chain:43
+bare_and    3 11.0  tests/mcdc_final_chain:23
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10             1                           1   use strict;
+               1                               
+               1                               
+11             1                           1   use warnings;
+               1                               
+               1                               
+12                                             
+13                                             # A logop chain as a sub's bare final expression under a ||/&& join
+14                                             # registered an MC/DC decision the runtime keyed elsewhere, so it could
+15                                             # never collect.  See GH-549.
+16                                             
+17                                             sub bare_or {
+18             3                           3     my ($p, $q) = @_;
+19             3    100                          $p || $q;
+20                                             }
+21                                             
+22                                             sub bare_and {
+23             4                           4     my ($p, $q, $r) = @_;
+24             4    100    100    100            $p && $q && $r;
+25                                             }
+26                                             
+27                                             sub bare_dor2 {
+28             6                           6     my ($p, $q, $r) = @_;
+29             6    100    100    100            $p // $q || $r;
+30                                             }
+31                                             
+32                                             sub bare_dor3 {
+33             8                           8     my ($p, $q, $s, $r) = @_;
+34             8    100    100    100            $p // $q // $s || $r;
+                           100                 
+35                                             }
+36                                             
+37                                             sub ret_dor2 {
+38             6                           6     my ($p, $q, $r) = @_;
+39             6           100    100            return $p // $q || $r;
+                           100                 
+40                                             }
+41                                             
+42                                             sub ret_dor3 {
+43             8                           8     my ($p, $q, $s, $r) = @_;
+44             8           100    100            return $p // $q // $s || $r;
+                           100                 
+                           100                 
+45                                             }
+46                                             
+47                                             sub main {
+48                                               # Calls are pushed into @r so each decision is exercised in non-void
+49                                               # context.
+50             1                           1     my @r;
+51                                             
+52                                               # Bare final || - a branch on both sides, no MC/DC entry.
+53             1                                 push @r, bare_or(1, 0);
+54             1                                 push @r, bare_or(0, 1);
+55             1                                 push @r, bare_or(0, 0);
+56                                             
+57                                               # Bare final && chain - the top join is a branch; the inner $p && $q
+58                                               # is the registered decision.
+59             1                                 push @r, bare_and(1, 1, 1);
+60             1                                 push @r, bare_and(1, 1, 0);
+61             1                                 push @r, bare_and(1, 0, 0);
+62             1                                 push @r, bare_and(0, 0, 0);
+63                                             
+64                                               # Width-2 inner chain under a bare final || join.
+65             1                                 push @r, bare_dor2(1,     undef, 0);
+66             1                                 push @r, bare_dor2(0,     undef, 1);
+67             1                                 push @r, bare_dor2(undef, 1,     0);
+68             1                                 push @r, bare_dor2(undef, 0,     1);
+69             1                                 push @r, bare_dor2(undef, undef, 1);
+70             1                                 push @r, bare_dor2(undef, undef, 0);
+71                                             
+72                                               # Width-3 inner chain under a bare final || join - the unearnable
+73                                               # 0/3 before the fix.
+74             1                                 push @r, bare_dor3(1,     undef, undef, 0);
+75             1                                 push @r, bare_dor3(0,     undef, undef, 1);
+76             1                                 push @r, bare_dor3(undef, 1,     undef, 0);
+77             1                                 push @r, bare_dor3(undef, 0,     undef, 1);
+78             1                                 push @r, bare_dor3(undef, undef, 1,     0);
+79             1                                 push @r, bare_dor3(undef, undef, 0,     1);
+80             1                                 push @r, bare_dor3(undef, undef, undef, 1);
+81             1                                 push @r, bare_dor3(undef, undef, undef, 0);
+82                                             
+83                                               # Explicit return controls - expression context, where the walk and
+84                                               # the runtime already agreed.
+85             1                                 push @r, ret_dor2(1,     undef, 0);
+86             1                                 push @r, ret_dor2(0,     undef, 1);
+87             1                                 push @r, ret_dor2(undef, 1,     0);
+88             1                                 push @r, ret_dor2(undef, 0,     1);
+89             1                                 push @r, ret_dor2(undef, undef, 1);
+90             1                                 push @r, ret_dor2(undef, undef, 0);
+91                                             
+92             1                                 push @r, ret_dor3(1,     undef, undef, 0);
+93             1                                 push @r, ret_dor3(0,     undef, undef, 1);
+94             1                                 push @r, ret_dor3(undef, 1,     undef, 0);
+95             1                                 push @r, ret_dor3(undef, 0,     undef, 1);
+96             1                                 push @r, ret_dor3(undef, undef, 1,     0);
+97             1                                 push @r, ret_dor3(undef, undef, 0,     1);
+98             1                                 push @r, ret_dor3(undef, undef, undef, 1);
+99             1                                 push @r, ret_dor3(undef, undef, undef, 0);
+100                                            }
+101                                            
+102            1                               main();
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+19           100      2      1   unless $p
+24           100      2      2   if $p and $q
+29           100      4      2   unless $p // $q
+34           100      5      3   unless ($p // $q) // $s
+
+
+Conditions
+----------
+
+and 3 conditions
+
+line  err      %     !l  l&&!r   l&&r   expr
+----- --- ------ ------ ------ ------   ----
+24           100      1      1      2   $p and $q
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+29           100      2      1      3   $p // $q
+34           100      4      1      3   ($p // $q) // $s
+             100      2      2      4   $p // $q
+39           100      2      3      1   ($p // $q) || $r
+             100      2      1      3   $p // $q
+44           100      3      4      1   (($p // $q) // $s) || $r
+             100      4      1      3   ($p // $q) // $s
+             100      2      2      4   $p // $q
+
+
+MC/DC
+-----
+
+line  err      %  cov  tot   missing                expr
+----- --- ------ ---- ----   --------------------   ----
+24           100    2    2                          $p and $q
+29           100    2    2                          $p // $q
+34           100    3    3                          ($p // $q) // $s
+39           100    3    3                          ($p // $q) || $r
+44           100    4    4                          (($p // $q) // $s) || $r
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location                 
+---------- ----- --- ----- -------------------------
+BEGIN          1   1   0.0 tests/mcdc_final_chain:10
+BEGIN          1   1   0.0 tests/mcdc_final_chain:11
+bare_and       4   3  11.0 tests/mcdc_final_chain:23
+bare_dor2      6   3  11.0 tests/mcdc_final_chain:28
+bare_dor3      8   4  13.9 tests/mcdc_final_chain:33
+bare_or        3   2   6.9 tests/mcdc_final_chain:18
+main           1   1   0.0 tests/mcdc_final_chain:50
+ret_dor2       6   3  11.0 tests/mcdc_final_chain:38
+ret_dor3       8   4  13.9 tests/mcdc_final_chain:43
+
+

--- a/test_output/cover/mcdc_final_chain.5.043008
+++ b/test_output/cover/mcdc_final_chain.5.043008
@@ -1,0 +1,208 @@
+cover: Reading database from ...
+---------------------- ------ ------ ------ ------ ------ ------ ------
+File                     stmt   bran   cond   mcdc    sub  total   scar
+---------------------- ------ ------ ------ ------ ------ ------ ------
+tests/mcdc_final_chain  100.0  100.0  100.0  100.0  100.0  100.0   26.4
+Total                   100.0  100.0  100.0  100.0  100.0  100.0   26.4
+---------------------- ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/mcdc_final_chain
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+14 100.0 14.0 26.4
+
+Worst Subroutines
+-----------------
+
+Subroutine CC SCAR  Location                 
+---------- -- ----  -------------------------
+bare_dor3   4 13.9  tests/mcdc_final_chain:33
+ret_dor3    4 13.9  tests/mcdc_final_chain:43
+bare_and    3 11.0  tests/mcdc_final_chain:23
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10             1                           1   use strict;
+               1                               
+               1                               
+11             1                           1   use warnings;
+               1                               
+               1                               
+12                                             
+13                                             # A logop chain as a sub's bare final expression under a ||/&& join
+14                                             # registered an MC/DC decision the runtime keyed elsewhere, so it could
+15                                             # never collect.  See GH-549.
+16                                             
+17                                             sub bare_or {
+18             3                           3     my ($p, $q) = @_;
+19             3    100                          $p || $q;
+20                                             }
+21                                             
+22                                             sub bare_and {
+23             4                           4     my ($p, $q, $r) = @_;
+24             4    100    100    100            $p && $q && $r;
+25                                             }
+26                                             
+27                                             sub bare_dor2 {
+28             6                           6     my ($p, $q, $r) = @_;
+29             6    100    100    100            $p // $q || $r;
+30                                             }
+31                                             
+32                                             sub bare_dor3 {
+33             8                           8     my ($p, $q, $s, $r) = @_;
+34             8    100    100    100            $p // $q // $s || $r;
+                           100                 
+35                                             }
+36                                             
+37                                             sub ret_dor2 {
+38             6                           6     my ($p, $q, $r) = @_;
+39             6           100    100            return $p // $q || $r;
+                           100                 
+40                                             }
+41                                             
+42                                             sub ret_dor3 {
+43             8                           8     my ($p, $q, $s, $r) = @_;
+44             8           100    100            return $p // $q // $s || $r;
+                           100                 
+                           100                 
+45                                             }
+46                                             
+47                                             sub main {
+48                                               # Calls are pushed into @r so each decision is exercised in non-void
+49                                               # context.
+50             1                           1     my @r;
+51                                             
+52                                               # Bare final || - a branch on both sides, no MC/DC entry.
+53             1                                 push @r, bare_or(1, 0);
+54             1                                 push @r, bare_or(0, 1);
+55             1                                 push @r, bare_or(0, 0);
+56                                             
+57                                               # Bare final && chain - the top join is a branch; the inner $p && $q
+58                                               # is the registered decision.
+59             1                                 push @r, bare_and(1, 1, 1);
+60             1                                 push @r, bare_and(1, 1, 0);
+61             1                                 push @r, bare_and(1, 0, 0);
+62             1                                 push @r, bare_and(0, 0, 0);
+63                                             
+64                                               # Width-2 inner chain under a bare final || join.
+65             1                                 push @r, bare_dor2(1,     undef, 0);
+66             1                                 push @r, bare_dor2(0,     undef, 1);
+67             1                                 push @r, bare_dor2(undef, 1,     0);
+68             1                                 push @r, bare_dor2(undef, 0,     1);
+69             1                                 push @r, bare_dor2(undef, undef, 1);
+70             1                                 push @r, bare_dor2(undef, undef, 0);
+71                                             
+72                                               # Width-3 inner chain under a bare final || join - the unearnable
+73                                               # 0/3 before the fix.
+74             1                                 push @r, bare_dor3(1,     undef, undef, 0);
+75             1                                 push @r, bare_dor3(0,     undef, undef, 1);
+76             1                                 push @r, bare_dor3(undef, 1,     undef, 0);
+77             1                                 push @r, bare_dor3(undef, 0,     undef, 1);
+78             1                                 push @r, bare_dor3(undef, undef, 1,     0);
+79             1                                 push @r, bare_dor3(undef, undef, 0,     1);
+80             1                                 push @r, bare_dor3(undef, undef, undef, 1);
+81             1                                 push @r, bare_dor3(undef, undef, undef, 0);
+82                                             
+83                                               # Explicit return controls - expression context, where the walk and
+84                                               # the runtime already agreed.
+85             1                                 push @r, ret_dor2(1,     undef, 0);
+86             1                                 push @r, ret_dor2(0,     undef, 1);
+87             1                                 push @r, ret_dor2(undef, 1,     0);
+88             1                                 push @r, ret_dor2(undef, 0,     1);
+89             1                                 push @r, ret_dor2(undef, undef, 1);
+90             1                                 push @r, ret_dor2(undef, undef, 0);
+91                                             
+92             1                                 push @r, ret_dor3(1,     undef, undef, 0);
+93             1                                 push @r, ret_dor3(0,     undef, undef, 1);
+94             1                                 push @r, ret_dor3(undef, 1,     undef, 0);
+95             1                                 push @r, ret_dor3(undef, 0,     undef, 1);
+96             1                                 push @r, ret_dor3(undef, undef, 1,     0);
+97             1                                 push @r, ret_dor3(undef, undef, 0,     1);
+98             1                                 push @r, ret_dor3(undef, undef, undef, 1);
+99             1                                 push @r, ret_dor3(undef, undef, undef, 0);
+100                                            }
+101                                            
+102            1                               main();
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+19           100      2      1   $p or $q
+24           100      2      2   $p and $q and $r
+29           100      4      2   $p // $q or $r
+34           100      5      3   ($p // $q) // $s or $r
+
+
+Conditions
+----------
+
+and 3 conditions
+
+line  err      %     !l  l&&!r   l&&r   expr
+----- --- ------ ------ ------ ------   ----
+24           100      1      1      2   $p and $q
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+29           100      2      1      3   $p // $q
+34           100      4      1      3   ($p // $q) // $s
+             100      2      2      4   $p // $q
+39           100      2      3      1   ($p // $q) || $r
+             100      2      1      3   $p // $q
+44           100      3      4      1   (($p // $q) // $s) || $r
+             100      4      1      3   ($p // $q) // $s
+             100      2      2      4   $p // $q
+
+
+MC/DC
+-----
+
+line  err      %  cov  tot   missing                expr
+----- --- ------ ---- ----   --------------------   ----
+24           100    2    2                          $p and $q
+29           100    2    2                          $p // $q
+34           100    3    3                          ($p // $q) // $s
+39           100    3    3                          ($p // $q) || $r
+44           100    4    4                          (($p // $q) // $s) || $r
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location                 
+---------- ----- --- ----- -------------------------
+BEGIN          1   1   0.0 tests/mcdc_final_chain:10
+BEGIN          1   1   0.0 tests/mcdc_final_chain:11
+bare_and       4   3  11.0 tests/mcdc_final_chain:23
+bare_dor2      6   3  11.0 tests/mcdc_final_chain:28
+bare_dor3      8   4  13.9 tests/mcdc_final_chain:33
+bare_or        3   2   6.9 tests/mcdc_final_chain:18
+main           1   1   0.0 tests/mcdc_final_chain:50
+ret_dor2       6   3  11.0 tests/mcdc_final_chain:38
+ret_dor3       8   4  13.9 tests/mcdc_final_chain:43
+
+

--- a/tests/mcdc_final_chain
+++ b/tests/mcdc_final_chain
@@ -1,0 +1,102 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use strict;
+use warnings;
+
+# A logop chain as a sub's bare final expression under a ||/&& join
+# registered an MC/DC decision the runtime keyed elsewhere, so it could
+# never collect.  See GH-549.
+
+sub bare_or {
+  my ($p, $q) = @_;
+  $p || $q;
+}
+
+sub bare_and {
+  my ($p, $q, $r) = @_;
+  $p && $q && $r;
+}
+
+sub bare_dor2 {
+  my ($p, $q, $r) = @_;
+  $p // $q || $r;
+}
+
+sub bare_dor3 {
+  my ($p, $q, $s, $r) = @_;
+  $p // $q // $s || $r;
+}
+
+sub ret_dor2 {
+  my ($p, $q, $r) = @_;
+  return $p // $q || $r;
+}
+
+sub ret_dor3 {
+  my ($p, $q, $s, $r) = @_;
+  return $p // $q // $s || $r;
+}
+
+sub main {
+  # Calls are pushed into @r so each decision is exercised in non-void
+  # context.
+  my @r;
+
+  # Bare final || - a branch on both sides, no MC/DC entry.
+  push @r, bare_or(1, 0);
+  push @r, bare_or(0, 1);
+  push @r, bare_or(0, 0);
+
+  # Bare final && chain - the top join is a branch; the inner $p && $q
+  # is the registered decision.
+  push @r, bare_and(1, 1, 1);
+  push @r, bare_and(1, 1, 0);
+  push @r, bare_and(1, 0, 0);
+  push @r, bare_and(0, 0, 0);
+
+  # Width-2 inner chain under a bare final || join.
+  push @r, bare_dor2(1,     undef, 0);
+  push @r, bare_dor2(0,     undef, 1);
+  push @r, bare_dor2(undef, 1,     0);
+  push @r, bare_dor2(undef, 0,     1);
+  push @r, bare_dor2(undef, undef, 1);
+  push @r, bare_dor2(undef, undef, 0);
+
+  # Width-3 inner chain under a bare final || join - the unearnable
+  # 0/3 before the fix.
+  push @r, bare_dor3(1,     undef, undef, 0);
+  push @r, bare_dor3(0,     undef, undef, 1);
+  push @r, bare_dor3(undef, 1,     undef, 0);
+  push @r, bare_dor3(undef, 0,     undef, 1);
+  push @r, bare_dor3(undef, undef, 1,     0);
+  push @r, bare_dor3(undef, undef, 0,     1);
+  push @r, bare_dor3(undef, undef, undef, 1);
+  push @r, bare_dor3(undef, undef, undef, 0);
+
+  # Explicit return controls - expression context, where the walk and
+  # the runtime already agreed.
+  push @r, ret_dor2(1,     undef, 0);
+  push @r, ret_dor2(0,     undef, 1);
+  push @r, ret_dor2(undef, 1,     0);
+  push @r, ret_dor2(undef, 0,     1);
+  push @r, ret_dor2(undef, undef, 1);
+  push @r, ret_dor2(undef, undef, 0);
+
+  push @r, ret_dor3(1,     undef, undef, 0);
+  push @r, ret_dor3(0,     undef, undef, 1);
+  push @r, ret_dor3(undef, 1,     undef, 0);
+  push @r, ret_dor3(undef, 0,     undef, 1);
+  push @r, ret_dor3(undef, undef, 1,     0);
+  push @r, ret_dor3(undef, undef, 0,     1);
+  push @r, ret_dor3(undef, undef, undef, 1);
+  push @r, ret_dor3(undef, undef, undef, 0);
+}
+
+main();


### PR DESCRIPTION
## Summary

A logop chain written as a sub's bare final expression, with `||` or `&&` as the top-level join and an inner chain on the left, registered an MC/DC decision keyed by the inner chain while the XS runtime rooted it at the outer join and snapshotted vectors there. The lookup at report time found nothing, so the truth table sat at an unearnable 0% no matter which inputs were exercised.

The XS collection walk now tracks expression position, mirroring the Perl-side classification, so both sides root the decision at the same op. Explicit `return` chains already worked and are unchanged.

The branch also carries a few trivial tidy-ups in `Cover.pm`.

## Ticket

Closes #549