### PR TITLE
GH-553 Refuse to delete non-database directories

### DIFF
--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -122,6 +122,10 @@ sub delete ($self, $db = undef) {
 
   return $self unless -d $db;
 
+  my $dbo = ref $self ? $self : bless { db => $db }, $self;
+  croak "Devel::Cover: $db is not a coverage database - not deleting"
+    unless $dbo->is_valid;
+
   # TODO - just delete the directory?
   opendir my $dir, $db or die "Can't opendir $db: $!";
   my @files = map "$db/$_", map /(.*)/ && $1, grep !/^\.\.?/, readdir $dir;
@@ -1372,7 +1376,8 @@ C<db> attribute. Also writes the structure if one is attached. Returns C<$self>.
 
   $db->delete; $db->delete($db_path);
 
-Remove all contents of the database directory. Returns C<$self>.
+Remove all contents of the database directory. Croaks if the directory does
+not look like a coverage database. Returns C<$self>.
 
 =head2 clean
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -190,10 +190,13 @@ sub is_valid ($self) {
   return 1 if !-e $self->{db};
   return 1 if -e "$self->{db}/$DB";
   opendir my $dir, $self->{db} or return 0;
-  my $ignore = join "|", qw( runs structure debuglog digests .AppleDouble );
+  my $ignore = join "|", map quotemeta,
+    qw( runs structure digests .AppleDouble );
   for my $file (readdir $dir) {
     next if $file eq "." || $file eq "..";
-    next if $file =~ /(?:$ignore)|(?:\.lock)$/ && -e "$self->{db}/$file";
+    next
+      if $file =~ /^(?:$ignore)$|\.lock$|^(?:$ignore|cover\.\d+)\.tmp\.\d+$/
+      && -e "$self->{db}/$file";
     warn "found $file in $self->{db}";
     return 0;
   }

--- a/t/internal/db_delete.t
+++ b/t/internal/db_delete.t
@@ -1,0 +1,126 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# delete removes the contents of a coverage database. It must refuse to
+# touch a directory that does not look like a coverage database - it is
+# called unguarded from coverage start-up when -merge,0 is given, so a
+# mistyped -db path must not destroy unrelated data.
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Path qw( make_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is isnt like ok )];
+
+use Devel::Cover::DB ();
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+my $N      = 0;
+
+sub dir_with (@entries) {
+  my $path = File::Spec->catdir($Tmpdir, "dir" . ++$N);
+  make_path($path);
+  for my $entry (@entries) {
+    if ($entry =~ s|/$||) {
+      make_path(File::Spec->catdir($path, $entry));
+    } else {
+      my $file = File::Spec->catfile($path, $entry);
+      open my $fh, ">", $file or die "Cannot write $file: $!";
+      print $fh "data\n";
+      close $fh or die "Cannot close $file: $!";
+    }
+  }
+  $path
+}
+
+sub entries ($path) {
+  opendir my $dir, $path or die "Cannot opendir $path: $!";
+  my @entries = grep !/^\.\.?$/, readdir $dir;
+  closedir $dir or die "Cannot closedir $path: $!";
+  @entries
+}
+
+sub test_class_method_refuses_foreign_directory () {
+  my $path = dir_with("precious.txt");
+  eval { Devel::Cover::DB->delete($path) };
+  like $@, qr/not a coverage database/,
+    "delete: class method refuses a foreign directory";
+  ok -s File::Spec->catfile($path, "precious.txt"),
+    "delete: class method leaves the contents alone";
+}
+
+sub test_instance_method_refuses_foreign_directory () {
+  my $path = dir_with("precious.txt");
+  my $db   = Devel::Cover::DB->new;
+  $db->{db} = $path;
+  eval { $db->delete };
+  like $@, qr/not a coverage database/,
+    "delete: instance method refuses a foreign directory";
+  ok -s File::Spec->catfile($path, "precious.txt"),
+    "delete: instance method leaves the contents alone";
+}
+
+sub test_substring_names_also_refused () {
+  my $path = dir_with(qw( test_runs/ test_runs/file.txt ));
+  eval { Devel::Cover::DB->delete($path) };
+  like $@, qr/not a coverage database/,
+    "delete: refuses a directory whose entries merely contain 'runs'";
+  ok -s File::Spec->catfile($path, "test_runs", "file.txt"),
+    "delete: the substring-named contents survive";
+}
+
+sub test_valid_database_is_deleted () {
+  my $path = dir_with(qw( cover.15 runs/ runs/run.file digests ));
+  eval { Devel::Cover::DB->delete($path) };
+  is $@,             "", "delete: a valid database raises no exception";
+  is entries($path), 0,  "delete: a valid database is emptied";
+}
+
+sub test_missing_directory_is_a_noop () {
+  my $path = File::Spec->catdir($Tmpdir, "missing");
+  my $ret  = eval { Devel::Cover::DB->delete($path) };
+  is $@,     "",    "delete: a missing directory raises no exception";
+  isnt $ret, undef, "delete: a missing directory returns the invocant";
+}
+
+sub test_no_db_croaks () {
+  eval { Devel::Cover::DB->delete };
+  like $@, qr/No db specified/, "delete: no db still croaks";
+}
+
+sub test_init_db_call_site () {
+  my $path = dir_with("precious.txt");
+  my @inc  = map "-I$_", qw( lib blib/lib blib/arch );
+  my $exit = system $^X, @inc, "-MDevel::Cover=-db,$path,-merge,0,-silent,1",
+    "-e1";
+  isnt $exit, 0, "delete: -merge,0 against a foreign directory aborts";
+  ok -s File::Spec->catfile($path, "precious.txt"),
+    "delete: -merge,0 leaves the foreign directory alone";
+}
+
+sub main () {
+  test_class_method_refuses_foreign_directory;
+  test_instance_method_refuses_foreign_directory;
+  test_substring_names_also_refused;
+  test_valid_database_is_deleted;
+  test_missing_directory_is_a_noop;
+  test_no_db_croaks;
+  test_init_db_call_site;
+}
+
+main;
+done_testing;

--- a/t/internal/db_is_valid.t
+++ b/t/internal/db_is_valid.t
@@ -1,0 +1,87 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# is_valid decides whether a directory is a coverage database. It is the only
+# guard before `cover -delete` destroys the directory, so housekeeping names
+# must match entry names in full - substring matches let foreign directories
+# pass and be deleted.
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Path qw( make_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing ok )];
+
+use Devel::Cover::DB ();
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+my $N      = 0;
+
+sub db_with (@entries) {
+  my $path = File::Spec->catdir($Tmpdir, "db" . ++$N);
+  make_path($path);
+  for my $entry (@entries) {
+    if ($entry =~ s|/$||) {
+      make_path(File::Spec->catdir($path, $entry));
+    } else {
+      my $file = File::Spec->catfile($path, $entry);
+      open my $fh, ">", $file or die "Cannot write $file: $!";
+      close $fh or die "Cannot close $file: $!";
+    }
+  }
+  $path
+}
+
+sub is_valid ($path) {
+  my $db = Devel::Cover::DB->new;
+  $db->{db} = $path;
+  local $SIG{__WARN__} = sub { };
+  $db->is_valid
+}
+
+sub test_foreign_directories_are_invalid () {
+  ok !is_valid(db_with(qw( test_runs/ infrastructure/ debuglog.txt ))),
+    "is_valid: housekeeping names must not match as substrings";
+  ok !is_valid(db_with("xAppleDouble")),
+    "is_valid: the dot in .AppleDouble is not a wildcard";
+  ok !is_valid(db_with("runs.old/")),
+    "is_valid: housekeeping names must not match as prefixes";
+  ok !is_valid(db_with("stranger.txt")), "is_valid: unknown entry is invalid";
+  ok !is_valid(db_with("debuglog/")),
+    "is_valid: debuglog is no longer housekeeping";
+}
+
+sub test_real_databases_are_valid () {
+  ok is_valid(File::Spec->catdir($Tmpdir, "missing")),
+    "is_valid: a missing path is valid";
+  ok is_valid(db_with()), "is_valid: an empty directory is valid";
+  ok is_valid(db_with(qw( cover.15 anything_at_all ))),
+    "is_valid: cover.15 marks a database regardless of other entries";
+  ok is_valid(
+    db_with(qw( runs/ structure/ digests .AppleDouble cover.15.lock ))),
+    "is_valid: all housekeeping entries are accepted";
+  ok is_valid(db_with(qw( runs/ digests.tmp.12345 ))),
+    "is_valid: a leaked atomic-write temp file is accepted";
+}
+
+sub main () {
+  test_foreign_directories_are_invalid;
+  test_real_databases_are_valid;
+}
+
+main;
+done_testing;


### PR DESCRIPTION
## Summary

`cover -delete` treated a directory as a valid coverage database if its entries merely contained the housekeeping names as substrings, so a directory holding only entries such as `test_runs/` or `debuglog.txt` was recursively deleted without a prompt. Coverage start-up with `-merge,0` was worse, deleting the contents of the `-db` directory with no validity check at all, so a mistyped path destroyed unrelated data.

Anchor the housekeeping names in `is_valid` so each must match an entry name in full, and put the validity guard inside `DB::delete` itself, croaking before any damage is done. `debuglog` is also dropped from the housekeeping names since its writer was removed earlier in this release cycle and the DB version bump orphans any database old enough to contain one.

## Ticket

Closes #553