### PR TITLE
GH-555 Load Digest::MD5 in DB.pm

### DIFF
--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -20,6 +20,7 @@ use Devel::Cover::DB::IO    ();
 use Devel::Cover::Log       qw( dcinfo dcwarn );
 
 use Carp         qw( carp croak );
+use Digest::MD5  ();
 use File::Find   qw( find );
 use File::Path   qw( rmtree );
 use List::Util   qw( any );

--- a/t/internal/add_uncoverable.t
+++ b/t/internal/add_uncoverable.t
@@ -20,9 +20,9 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Digest::MD5 ();
-use File::Spec  ();
-use File::Temp  qw( tempdir );
+# Digest::MD5 is deliberately not loaded here - DB.pm must load it itself
+use File::Spec ();
+use File::Temp qw( tempdir );
 use Test::More import => [qw( done_testing is ok )];
 
 use Devel::Cover::DB ();
@@ -43,11 +43,18 @@ sub test_records_specs () {
   my $src = write_source("source.pl", "line one\nline two\nline three\n");
   my $unc = File::Spec->catfile($Tmpdir, ".uncoverable");
 
-  my $db = Devel::Cover::DB->new(uncoverable_file => [$unc]);
-  $db->add_uncoverable([
-    "$src branch 2 0 0 default note-two",
-    "$src statement 3 0 0 default note-three",
-  ]);
+  my $db  = Devel::Cover::DB->new(uncoverable_file => [$unc]);
+  my $err = do {
+    local $@;
+    eval {
+      $db->add_uncoverable([
+        "$src branch 2 0 0 default note-two",
+        "$src statement 3 0 0 default note-three",
+      ]);
+      1
+    } ? "" : $@
+  };
+  is $err, "", "add_uncoverable: works without caller loading Digest::MD5";
 
   ok -e $unc, "add_uncoverable: writes the .uncoverable file";
 
@@ -55,6 +62,7 @@ sub test_records_specs () {
   my @lines = <$fh>;
   close $fh or die "Cannot close $unc: $!";
 
+  require Digest::MD5;
   my $md5_two   = Digest::MD5->new->add("line two\n")->hexdigest;
   my $md5_three = Digest::MD5->new->add("line three\n")->hexdigest;
 
@@ -64,8 +72,36 @@ sub test_records_specs () {
     "add_uncoverable: second spec parsed independently";
 }
 
+# uncoverable() is the other Digest::MD5 call site in DB.pm. Round-trip a spec
+# through add_uncoverable and confirm it comes back keyed by the file digest
+# with the line digest translated back to a line number.
+sub test_uncoverable_round_trip () {
+  my $src = write_source("round_trip.pl", "line one\nline two\n");
+  my $unc = File::Spec->catfile($Tmpdir, ".uncoverable_round_trip");
+
+  my $db = Devel::Cover::DB->new(uncoverable_file => [$unc]);
+  $db->add_uncoverable(["$src branch 2 0 0 default note-two"]);
+
+  my $u;
+  my $err = do {
+    local $@;
+    eval { $u = $db->uncoverable; 1 } ? "" : $@
+  };
+  is $err, "", "uncoverable: works without caller loading Digest::MD5";
+
+  my $file_digest = do {
+    open my $fh, "<", $src or die "Cannot open $src: $!";
+    binmode $fh;
+    require Digest::MD5;
+    Digest::MD5->new->addfile($fh)->hexdigest
+  };
+  ok exists $u->{$file_digest}{branch}{2},
+    "uncoverable: entry keyed by file digest and line number";
+}
+
 sub main () {
   test_records_specs;
+  test_uncoverable_round_trip;
 }
 
 main;

--- a/t/internal/add_uncoverable.t
+++ b/t/internal/add_uncoverable.t
@@ -89,11 +89,13 @@ sub test_uncoverable_round_trip () {
   };
   is $err, "", "uncoverable: works without caller loading Digest::MD5";
 
+  # Read in text mode, matching how uncoverable() digests the file
   my $file_digest = do {
     open my $fh, "<", $src or die "Cannot open $src: $!";
-    binmode $fh;
     require Digest::MD5;
-    Digest::MD5->new->addfile($fh)->hexdigest
+    my $md5 = Digest::MD5->new;
+    while (my $l = <$fh>) { $md5->add($l) }
+    $md5->hexdigest
   };
   ok exists $u->{$file_digest}{branch}{2},
     "uncoverable: entry keyed by file digest and line number";


### PR DESCRIPTION
## Summary

`cover -add_uncoverable_point` died with `Can't locate object method "new" via package "Digest::MD5"` because `DB.pm` calls `Digest::MD5` without loading it. The load used to arrive transitively through the compile-time `use` of `DB::Structure`, which GH-329 deferred to runtime. `DB.pm` now loads `Digest::MD5` itself.

The existing test masked the bug by loading `Digest::MD5` at the top of the file. It now defers that load and round-trips a spec through `uncoverable` to protect the read side as well.

## Ticket

Closes #555