### PR TITLE
GH-559 Don't unlink lock files held by writers

### DIFF
--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -142,10 +142,11 @@ sub clean ($self) {
   my $rm_lock = sub {
     return unless /\.lock$/;
     open my $fh, "+<", $_ or return;
-    if (flock $fh, LOCK_EX | LOCK_NB) {
-      unlink or dcinfo "Can't unlink lock file $_: $!";
-    }
+    # Windows can't unlink an open file, so end the probe before unlinking
+    my $free = flock $fh, LOCK_EX | LOCK_NB;
     close $fh or dcinfo "Can't close lock file $_: $!";
+    return unless $free;
+    unlink or dcinfo "Can't unlink lock file $_: $!";
   };
   find($rm_lock, $self->{db});
 }

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -21,6 +21,7 @@ use Devel::Cover::Log       qw( dcinfo dcwarn );
 
 use Carp         qw( carp croak );
 use Digest::MD5  ();
+use Fcntl        qw( :flock );
 use File::Find   qw( find );
 use File::Path   qw( rmtree );
 use List::Util   qw( any );
@@ -137,8 +138,15 @@ sub delete ($self, $db = undef) {
 }
 
 sub clean ($self) {
-  # remove all lock files
-  my $rm_lock = sub { unlink if /\.lock$/ };
+  # remove lock files nobody currently holds
+  my $rm_lock = sub {
+    return unless /\.lock$/;
+    open my $fh, "+<", $_ or return;
+    if (flock $fh, LOCK_EX | LOCK_NB) {
+      unlink or dcinfo "Can't unlink lock file $_: $!";
+    }
+    close $fh or dcinfo "Can't close lock file $_: $!";
+  };
   find($rm_lock, $self->{db});
 }
 
@@ -1384,7 +1392,8 @@ not look like a coverage database. Returns C<$self>.
 
   $db->clean;
 
-Remove stale C<.lock> files from the database directory.
+Remove stale C<.lock> files from the database directory. Lock files
+currently held by live processes are left in place.
 
 =head2 merge_runs
 

--- a/t/internal/db_clean.t
+++ b/t/internal/db_clean.t
@@ -1,0 +1,96 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# clean sweeps stale .lock files from the database directory. Locking is
+# flock on the lock file's path, so a held lock must never be unlinked -
+# doing so hands the next writer a fresh inode and two processes then hold
+# "exclusive" locks on the same data file.
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Fcntl      qw( :flock );
+use File::Path qw( make_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing ok )];
+
+use Devel::Cover::DB ();
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+
+sub fresh_db ($label) {
+  my $dir = File::Spec->catdir($Tmpdir, $label);
+  make_path($dir);
+  my $db = Devel::Cover::DB->new;
+  $db->{db} = $dir;
+  ($db, $dir)
+}
+
+sub touch ($path) {
+  open my $fh, ">", $path or die "Cannot create $path: $!";
+  close $fh or die "Cannot close $path: $!";
+  $path
+}
+
+sub test_held_lock_survives () {
+  my ($db, $dir) = fresh_db("held");
+  my $held = touch("$dir/digests.lock");
+  open my $fh, "+<", $held or die "Cannot open $held: $!";
+  flock $fh, LOCK_EX or die "Cannot lock $held: $!";
+
+  $db->clean;
+
+  ok -e $held, "clean: leaves a held lock file in place";
+  close $fh or die "Cannot close $held: $!";
+}
+
+sub test_stale_lock_removed () {
+  my ($db, $dir) = fresh_db("stale");
+  my $stale = touch("$dir/cover.15.lock");
+
+  $db->clean;
+
+  ok !-e $stale, "clean: removes an unheld lock file";
+}
+
+sub test_non_lock_file_untouched () {
+  my ($db, $dir) = fresh_db("data");
+  my $data = touch("$dir/cover.15");
+
+  $db->clean;
+
+  ok -e $data, "clean: leaves non-lock files alone";
+}
+
+sub test_subdirectory_lock_removed () {
+  my ($db, $dir) = fresh_db("subdir");
+  make_path("$dir/structure");
+  my $stale = touch("$dir/structure/0123456789abcdef.lock");
+
+  $db->clean;
+
+  ok !-e $stale, "clean: removes unheld lock files in subdirectories";
+}
+
+sub main () {
+  test_held_lock_survives;
+  test_stale_lock_removed;
+  test_non_lock_file_untouched;
+  test_subdirectory_lock_removed;
+}
+
+main;
+done_testing;


### PR DESCRIPTION
## Summary

`DB::clean` removed every `.lock` file under the database directory, whether or not a process still held the lock. Since locking is flock on the lock file's path, unlinking a held lock detached the path from the held inode and the next writer created a fresh lock file and acquired it immediately, so two writers could interleave their rewrites of the same data file. `clean` now probes each lock file with a non-blocking flock and only unlinks the ones nobody holds, so genuinely stale locks (including those from crashed runs, whose flocks are released automatically) are still swept.

A residual window remains between the probe and the unlink. It cannot be closed with path-based flock, but it shrinks the exposure from the whole lifetime of a held lock to a few instructions.

## Ticket

Closes #559