### PR TITLE
Stop merge_runs double-counting runs

### DIFF
--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -151,12 +151,34 @@ sub clean ($self) {
   find($rm_lock, $self->{db});
 }
 
+sub _lock_db ($self) {
+  my $lock = "$self->{db}/merge.lock";
+  open my $fh, "+>>", $lock or die "Can't open $lock: $!\n";
+  flock $fh, LOCK_EX or die "Can't lock $lock: $!\n";
+  $fh
+}
+
 sub merge_runs ($self) {
   my $db = $self->{db};
   return $self unless length $db;
+  return $self unless -d "$db/runs";
+
+  # released when the handle goes out of scope, swept later by clean
+  my $lock_fh = $self->_lock_db;
+
+  # another process may have merged and written since we were constructed
+  my $file = "$db/$DB";
+  $self->read($file) if -e $file;
+
   opendir my $dir, "$db/runs" or return $self;
-  my @runs = map "$db/runs/$_", grep !/^\.\.?/, readdir $dir;
+  my @entries = grep { $_ ne "." && $_ ne ".." } readdir $dir;
   closedir $dir or die "Can't closedir $db/runs: $!";
+
+  # leftovers from an interrupted merge are already in the db - just remove
+  my @stale = map "$db/runs/$_", grep /^\.merged\./, @entries;
+  rmtree(\@stale) if @stale;
+
+  my @runs = map "$db/runs/$_", grep !/^\./, @entries;
 
   $self->{changed_files} = {};
 
@@ -169,8 +191,24 @@ sub merge_runs ($self) {
     $self->merge($r);
   }
 
-  $self->write($db) if @runs;
-  rmtree(\@runs);
+  if (@runs) {
+    my @aside;
+    for my $run (@runs) {
+      (my $to = $run) =~ s|([^/]+)$|.merged.$$.$1|;
+      if (rename $run, $to) {
+        push @aside, $to;
+      } else {
+        dcwarn "Can't rename $run to $to: $!";
+        push @aside, $run;
+      }
+    }
+    $self->write($db);
+    my $err;
+    rmtree(@aside, { error => \$err });
+    dcwarn "Can't remove merged runs: " . join ", ",
+      map { join ": ", %$_ } @$err
+      if $err && @$err;
+  }
 
   if (keys $self->{changed_files}->%*) {
     require Devel::Cover::DB::Structure;
@@ -1404,6 +1442,13 @@ Merge individual run files from C<< $db/runs/ >> into the main database, write
 the merged result, and delete the run files. Handles changed-file detection: if
 a file's digest differs between runs the old coverage is discarded. Returns
 C<$self>.
+
+The whole sequence is serialised via an exclusive flock on C<merge.lock> in
+the database directory, so concurrent merges cannot double-count runs. The
+lock file persists after release and is swept by C<clean> once free. Before
+being written, merged runs are renamed to hidden C<.merged.*> siblings, so a
+merge interrupted between the write and the removal of its runs cannot merge
+them again. Such leftovers are removed on the next call.
 
 =head2 validate_db
 

--- a/t/internal/db_merge_runs.t
+++ b/t/internal/db_merge_runs.t
@@ -1,0 +1,103 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Cwd     ();
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is like ok )];
+
+my $Root = Cwd::cwd();
+
+use Devel::Cover::DB ();
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+
+my $Script = <<'PERL';
+my $x = 1;
+my $y = 2;
+my $z = $x + $y;
+PERL
+
+# Run a script under Devel::Cover and return the db path.
+sub run_cover ($label) {
+  my $script = File::Spec->catfile($Tmpdir, "$label.pl");
+  my $db     = File::Spec->catdir($Tmpdir, "${label}_db");
+
+  open my $fh, ">", $script or die "Cannot write $script: $!";
+  print $fh $Script;
+  close $fh or die "Cannot close $script: $!";
+
+  my @inc = map { "-I$_" } "$Root/blib/arch", "$Root/blib/lib", "$Root/lib";
+
+  system($^X, @inc, "-MDevel::Cover=-db,$db,-silent,1", $script) == 0
+    or die "Failed to run $label under Devel::Cover: $?";
+
+  $db
+}
+
+sub statement_counts ($db, $label) {
+  my ($run)  = values $db->{runs}->%*;
+  my ($file) = grep /$label\.pl$/, keys $run->{count}->%*;
+  $run->{count}{$file}{statement}->@*
+}
+
+sub runs_entries ($db_path) {
+  opendir my $dir, "$db_path/runs" or return;
+  my @entries = grep { $_ ne "." && $_ ne ".." } readdir $dir;
+  closedir $dir or die "Can't closedir $db_path/runs: $!";
+  @entries
+}
+
+sub test_interrupted_merge () {
+  my $db_path = run_cover("crash");
+
+  my $db   = Devel::Cover::DB->new(db => $db_path);
+  my $orig = \&Devel::Cover::DB::write;
+  {
+    no warnings "redefine";
+    local *Devel::Cover::DB::write = sub {
+      $orig->(@_);
+      die "simulated crash\n";
+    };
+    eval { $db->merge_runs };
+  }
+  like $@, qr/simulated crash/, "merge interrupted after write";
+
+  my $db2    = Devel::Cover::DB->new(db => $db_path)->merge_runs;
+  my @counts = statement_counts($db2, "crash");
+  is @counts, 3, "crash: three statements";
+  is $_,      1, "crash: statement executed once" for @counts;
+
+  is runs_entries($db_path), 0, "crash: runs directory is empty";
+}
+
+sub test_normal_merge () {
+  my $db_path = run_cover("normal");
+
+  my $db     = Devel::Cover::DB->new(db => $db_path)->merge_runs;
+  my @counts = statement_counts($db, "normal");
+  is @counts, 3, "normal: three statements";
+  is $_,      1, "normal: statement executed once" for @counts;
+
+  is runs_entries($db_path), 0, "normal: runs directory is empty";
+  ok -e "$db_path/merge.lock", "normal: merge lock file exists";
+}
+
+test_interrupted_merge;
+test_normal_merge;
+done_testing;


### PR DESCRIPTION
Fixes #561

## Summary

- Serialise `merge_runs` with an exclusive flock on `merge.lock` in the
  database directory, so concurrent `cover` invocations can no longer
  merge the same runs twice.
- Rename runs to hidden `.merged.*` siblings before writing the merged
  database, so a merge interrupted between the write and the removal of
  its runs cannot double every count on the next merge. Leftovers are
  swept, not re-merged.
- Report run removal failures, which previously inflated counts
  silently on every subsequent merge.

## Ticket

Fixes #561