### PR TITLE
Match file keys literally in the editor reports

### DIFF
--- a/lib/Devel/Cover/Report/Nvim.pm
+++ b/lib/Devel/Cover/Report/Nvim.pm
@@ -262,11 +262,9 @@ local cov_time = [% cov_time %]
 
 -- Find coverage data for a given filename
 local function coverage_for(filename)
-  local fn_len = string.len(filename)
   for cf, _ in pairs(coverage) do
     local f = string.gsub(cf, "^blib/", "")
-    local match_pos = string.find(filename, f .. "$")
-    if match_pos and match_pos <= fn_len then
+    if #f > 0 and string.sub(filename, -#f) == f then
       return coverage[cf]
     end
   end

--- a/lib/Devel/Cover/Report/Vim.pm
+++ b/lib/Devel/Cover/Report/Vim.pm
@@ -181,7 +181,7 @@ function! s:coverage_for(filename)
   let s:fn_len = strlen(a:filename)
   for s:cf in keys(s:coverage)
     let s:f = substitute(s:cf, "^blib/", "", "")
-    let s:match_pos = match(a:filename, s:f . "$")
+    let s:match_pos = match(a:filename, '\V' . escape(s:f, '\') . '\$')
     if s:match_pos >= 0 && s:match_pos < s:fn_len
       return s:coverage[s:cf]
     endif

--- a/t/internal/nvim_report.t
+++ b/t/internal/nvim_report.t
@@ -1,0 +1,51 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( diag done_testing is like unlike )];
+use Devel::Cover::Test::Showcase qw(
+  create_cover_db
+  run_cover
+  setup_lib_dir
+  slurp
+);
+
+# Stored file keys must be matched as literal text, not as Lua patterns
+sub test_nvim_report_literal_matching () {
+  my ($tmpdir, $libdir) = setup_lib_dir;
+  my $cover_db = create_cover_db($tmpdir, $libdir);
+
+  my ($out, $exit) = run_cover(
+    "--select_dir", $libdir, "--report", "nvim", "--silent", $cover_db,
+  );
+
+  is $exit, 0, "cover --report nvim exits 0" or diag $out;
+
+  my $lua     = slurp("$cover_db/coverage.lua");
+  my $pattern = 'string.find(filename, f .. "$")';
+  my $literal = "string.sub(filename, -#f) == f";
+  unlike $lua, qr/\Q$pattern\E/,
+    "file matching does not build a Lua pattern from the path";
+  like $lua, qr/\Q$literal\E/, "file matching uses a literal suffix comparison";
+}
+
+sub main () {
+  test_nvim_report_literal_matching;
+  done_testing;
+}
+
+main;

--- a/t/internal/vim_report.t
+++ b/t/internal/vim_report.t
@@ -1,0 +1,52 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( diag done_testing is like unlike )];
+use Devel::Cover::Test::Showcase qw(
+  create_cover_db
+  run_cover
+  setup_lib_dir
+  slurp
+);
+
+# Stored file keys must be matched as literal text, not as Vim regexes
+sub test_vim_report_literal_matching () {
+  my ($tmpdir, $libdir) = setup_lib_dir;
+  my $cover_db = create_cover_db($tmpdir, $libdir);
+
+  my ($out, $exit) = run_cover(
+    "--select_dir", $libdir, "--report", "vim", "--silent", $cover_db,
+  );
+
+  is $exit, 0, "cover --report vim exits 0" or diag $out;
+
+  my $vim     = slurp("$cover_db/coverage.vim");
+  my $regex   = 'match(a:filename, s:f . "$")';
+  my $literal = q[match(a:filename, '\V' . escape(s:f, '\') . '\$')];
+  unlike $vim, qr/\Q$regex\E/,
+    "file matching does not build a regex from the raw path";
+  like $vim, qr/\Q$literal\E/,
+    "file matching uses a very-nomagic literal pattern";
+}
+
+sub main () {
+  test_vim_report_literal_matching;
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
Fixes #563

## Summary

- The vim and nvim reports located coverage for the current buffer by
  matching its path against each stored file key as a Vim regex or Lua
  pattern. Special characters in paths (hyphens, dots, brackets,
  parentheses, `~`) made the match fail silently, pick the wrong file,
  or abort with a malformed pattern error.
- The nvim report now compares the tail of the path directly, and the
  vim report uses a `\V` very-nomagic pattern with escaped backslashes,
  so keys are matched as literal text.
- Both templates interpolate paths in other places too (the nvim
  autocmd glob patterns, the vim `:sign place`/`BufReadPost` commands
  via `exe`). Paths with spaces or glob characters can misbehave there
  as well - that is a separate class of problem, left as a possible
  follow-up.

## Ticket

Fixes #563