### PR TITLE
Correct the documented nvim sign priority

### DIFF
--- a/lib/Devel/Cover/Report/Nvim.pm
+++ b/lib/Devel/Cover/Report/Nvim.pm
@@ -479,7 +479,7 @@ Available configuration variables:
  vim.g.devel_cover_linehl_error  -- Error line highlight (default: "err")
  vim.g.devel_cover_signs         -- Custom sign text table
  vim.g.devel_cover_sign_group    -- Sign group name (default: "DevelCover")
- vim.g.devel_cover_sign_priority -- Sign priority (default: 10)
+ vim.g.devel_cover_sign_priority -- Sign priority (default: 1)
 
 Example configuration for solarized theme in init.lua:
 

--- a/t/internal/nvim_report.t
+++ b/t/internal/nvim_report.t
@@ -16,7 +16,7 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Test::More import => [qw( diag done_testing is like unlike )];
+use Test::More import => [qw( diag done_testing is like ok unlike )];
 use Devel::Cover::Test::Showcase qw(
   create_cover_db
   run_cover
@@ -43,8 +43,22 @@ sub test_nvim_report_literal_matching () {
   like $lua, qr/\Q$literal\E/, "file matching uses a literal suffix comparison";
 }
 
+# The template's sign_priority default and the POD's documented one must agree
+sub test_sign_priority_default_documented () {
+  require Devel::Cover::Report::Nvim;
+  my $src = slurp($INC{"Devel/Cover/Report/Nvim.pm"});
+  my ($code_default)
+    = $src =~ /sign_priority = vim\.g\.devel_cover_sign_priority or (\d+),/;
+  my ($pod_default)
+    = $src =~ /devel_cover_sign_priority -- Sign priority \(default: (\d+)\)/;
+  ok defined $code_default, "template sign_priority default found";
+  ok defined $pod_default,  "POD sign_priority default found";
+  is $pod_default, $code_default, "POD documents the template default";
+}
+
 sub main () {
   test_nvim_report_literal_matching;
+  test_sign_priority_default_documented;
   done_testing;
 }
 


### PR DESCRIPTION
Fixes #565

## Summary

- The nvim report's POD documented a default sign priority of 10, but
  the generated `coverage.lua` uses 1. The code's low default is the
  intended behaviour, keeping coverage signs below other sign
  producers, so the documentation now matches it and a test asserts
  the two defaults agree.

## Ticket

Fixes #565