### PR TITLE
Emit editor report criteria in canonical order

### DIFF
--- a/lib/Devel/Cover/Base/Editor.pm
+++ b/lib/Devel/Cover/Base/Editor.pm
@@ -14,8 +14,9 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
+use Devel::Cover::DB  ();
 use Devel::Cover::Log qw( dcinfo );
-use Template 2.00 ();
+use Template 2.00     ();
 
 sub report ($pkg, $db, $options) {
   my $template = Template->new({
@@ -47,7 +48,8 @@ sub report ($pkg, $db, $options) {
     files   =>
       [grep !$db->cover->file($_)->{meta}{uncompiled}, $options->{file}->@*],
     cover => $db->cover,
-    types => [grep $_ ne "time" && $_ ne "total", keys $options->{show}->%*],
+    types =>
+      [grep $options->{show}{$_} && $_ ne "time", @Devel::Cover::DB::Criteria],
   };
 
   my $out = "$options->{outputdir}/$options->{outputfile}";

--- a/lib/Devel/Cover/Report/Nvim.pm
+++ b/lib/Devel/Cover/Report/Nvim.pm
@@ -447,11 +447,12 @@ that line.
 
 The signs are as follows:
 
- P - Pod coverage
  S - Statement coverage
- R - Subroutine coverage
  B - Branch coverage
  C - Condition coverage
+ M - MC/DC coverage
+ R - Subroutine coverage
+ P - Pod coverage
 
 The last of the criteria, in the order given above, is the one which is
 displayed.  Correctly covered criteria are shown in green.  Incorrectly

--- a/lib/Devel/Cover/Report/Vim.pm
+++ b/lib/Devel/Cover/Report/Vim.pm
@@ -297,11 +297,12 @@ that line.
 
 The signs are as follows:
 
- P - Pod coverage
  S - Statement coverage
- R - Subroutine coverage
  B - Branch coverage
  C - Condition coverage
+ M - MC/DC coverage
+ R - Subroutine coverage
+ P - Pod coverage
 
 The last of the criteria, in the order given above, is the one which is
 displayed.  Correctly covered criteria are shown in green.  Incorrectly

--- a/t/internal/editor_types.t
+++ b/t/internal/editor_types.t
@@ -1,0 +1,64 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( diag done_testing is is_deeply ok )];
+use Devel::Cover::DB             ();
+use Devel::Cover::Test::Showcase qw(
+  create_cover_db
+  run_cover
+  setup_lib_dir
+  slurp
+);
+
+sub types_from_vim_report ($cover_db, $libdir, $seed) {
+  local $ENV{PERL_HASH_SEED}    = $seed;
+  local $ENV{PERL_PERTURB_KEYS} = "0";
+  my ($out, $exit) = run_cover(
+    "--select_dir", $libdir, "--report", "vim", "--silent", $cover_db,
+  );
+  is $exit, 0, "cover --report vim exits 0 (seed $seed)" or diag $out;
+  my $vim = slurp("$cover_db/coverage.vim");
+  my ($list) = $vim =~ /^let s:types = \[(.*?)\]/ms;
+  ok defined $list, "types list found in coverage.vim (seed $seed)";
+  [grep !/_error$/, ($list // "") =~ /"(\w+)"/g]
+}
+
+# Criteria must come out in canonical order, identical under any hash seed
+sub test_editor_types_order () {
+  my ($tmpdir, $libdir) = setup_lib_dir;
+  my $cover_db = create_cover_db($tmpdir, $libdir);
+
+  my $t0 = types_from_vim_report($cover_db, $libdir, "0x0");
+  my $t1 = types_from_vim_report($cover_db, $libdir, "0x1");
+
+  my %seen      = map { $_ => 1 } @$t0;
+  my @canonical = grep $_ ne "time", @Devel::Cover::DB::Criteria;
+  my @expected  = grep $seen{$_}, @canonical;
+
+  ok @expected >= 4, "several criteria collected" or diag "@expected";
+  is_deeply $t0, \@expected, "types in canonical order (seed 0x0)";
+  is_deeply $t1, \@expected, "types in canonical order (seed 0x1)";
+  ok !$seen{time} && !$seen{total}, "time and total are excluded";
+}
+
+sub main () {
+  test_editor_types_order;
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
Fixes #566

## Summary

- The vim and nvim reports built their criteria list from hash keys,
  whose order is randomised per process, so identical runs produced
  differently ordered `coverage.vim` / `coverage.lua` files and the
  sign shown on a multi-criterion line changed at random.
- The shared editor base class now filters the canonical criteria list
  from `Devel::Cover::DB`, so the order is deterministic (statement,
  branch, condition, mcdc, subroutine, pod) and the display priority is
  fixed with pod highest. The documented sign order in both reports is
  updated to match, and gains the missing MC/DC sign.

## Ticket

Fixes #566