### PR TITLE
GH-573 Quote file names passed to git blame

### DIFF
--- a/lib/Devel/Cover/Annotation/Git.pm
+++ b/lib/Devel/Cover/Annotation/Git.pm
@@ -27,14 +27,24 @@ sub new ($class, @args) {
   bless $self, $class
 }
 
+sub _shell_quote ($file) {
+  if ($^O eq "MSWin32") {
+    $file =~ s/"/""/g;
+    return qq("$file");
+  }
+  $file =~ s/'/'\\''/g;
+  "'$file'"
+}
+
 sub get_annotations ($self, $file) {
   return if exists $self->{_annotations}{$file};
   my $annotations = $self->{_annotations}{$file} = [];
 
   print "cover: Getting git annotation information for $file\n";
 
+  my $quoted  = _shell_quote($file);
   my $command = $self->{command};
-  $command =~ s/\[\[file\]\]/$file/g;
+  $command =~ s/\[\[file\]\]/$quoted/g;
   # print "Running [$command]\n";
   open my $c, "-|", $command or warn("cover: Can't run $command: $!\n"), return;
   my @annotation;

--- a/t/internal/annotation_git.t
+++ b/t/internal/annotation_git.t
@@ -17,7 +17,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
 use File::Temp qw( tempdir );
-use Test::More import => [qw( done_testing is )];
+use Test::More import => [qw( done_testing is ok )];
 
 use Devel::Cover::Annotation::Git;
 
@@ -38,15 +38,16 @@ PERL
   $helper
 }
 
+sub annotator_for ($helper) {
+  Devel::Cover::Annotation::Git->new(command => qq("$^X" "$helper" [[file]]))
+}
+
 sub test_version_column () {
-  my $helper = write_helper;
-  my $git    = Devel::Cover::Annotation::Git->new(
-    command => qq("$^X" "$helper" [[file]]));
+  my $git  = annotator_for(write_helper);
   my $file = "lib/Foo.pm";
 
   my @warnings;
   local $SIG{__WARN__} = sub { push @warnings, @_ };
-
   $git->get_annotations($file);
 
   is $git->text($file, 1, 0), "deadbeef", "version column holds short SHA";
@@ -54,6 +55,39 @@ sub test_version_column () {
   is "@warnings", "", "no warnings while parsing blame output";
 }
 
+sub write_args_helper () {
+  my $helper = "$Dir/args.pl";
+  open my $fh, ">", $helper or die "Can't open $helper: $!";
+  print $fh <<'PERL';
+my $args = join "|", @ARGV;
+print "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef 1 1 1\n";
+print "author $args\n";
+print "author-time 1234567890\n";
+print "\tmy code line\n";
+PERL
+  close $fh or die "Can't close $helper: $!";
+  $helper
+}
+
+sub test_path_with_spaces () {
+  my $git  = annotator_for(write_args_helper);
+  my $file = "dir with space/file.pm";
+  $git->get_annotations($file);
+  is $git->text($file, 1, 1), $file, "path with spaces arrives as one argument";
+}
+
+sub test_path_with_metacharacters () {
+  my $git   = annotator_for(write_args_helper);
+  my $probe = "$Dir/pwned";
+  my $file  = "x.pm; touch $probe";
+  $git->get_annotations($file);
+  is $git->text($file, 1, 1), $file,
+    "metacharacters arrive literally in one argument";
+  ok !-e $probe, "no shell command injected via the file name";
+}
+
 test_version_column;
+test_path_with_spaces;
+test_path_with_metacharacters;
 
 done_testing;

--- a/t/internal/annotation_git.t
+++ b/t/internal/annotation_git.t
@@ -1,0 +1,59 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is )];
+
+use Devel::Cover::Annotation::Git;
+
+my $Dir = tempdir(CLEANUP => 1);
+
+sub write_helper () {
+  # A plain heredoc, not <<~, because indented heredocs need 5.26
+  my $helper = "$Dir/blame.pl";
+  open my $fh, ">", $helper or die "Can't open $helper: $!";
+  print $fh <<'PERL';
+my $sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+print "$sha 1 1 1\n";
+print "author A U Thor\n";
+print "author-time 1234567890\n";
+print "\tmy code line\n";
+PERL
+  close $fh or die "Can't close $helper: $!";
+  $helper
+}
+
+sub test_version_column () {
+  my $helper = write_helper;
+  my $git    = Devel::Cover::Annotation::Git->new(
+    command => qq("$^X" "$helper" [[file]]));
+  my $file = "lib/Foo.pm";
+
+  my @warnings;
+  local $SIG{__WARN__} = sub { push @warnings, @_ };
+
+  $git->get_annotations($file);
+
+  is $git->text($file, 1, 0), "deadbeef", "version column holds short SHA";
+  is $git->text($file, 1, 1), "A U Thor", "author column";
+  is "@warnings", "", "no warnings while parsing blame output";
+}
+
+test_version_column;
+
+done_testing;


### PR DESCRIPTION
## Summary

Git annotation built its `git blame` command by substituting the file path into a template and running it through a single-string pipe open, with the path unquoted. A file under a directory whose name contains a space word-split into several arguments, so blame received the wrong name and the annotation columns were silently empty. Shell metacharacters in a name were interpreted by the shell. The substituted value is now shell-quoted, leaving the rest of the user-configurable template untouched so pipes and extra flags in a custom `-command` keep working.

Also adds the regression test for the version-column parse fixed in the earlier modernisation sweep, which had landed without one. Both tests are hermetic, feeding canned porcelain output through the command template with no git binary or scratch repository.

## Ticket

Closes #573