### PR TITLE
GH-575 Remove Truth_Table error debug line

### DIFF
--- a/lib/Devel/Cover/Truth_Table.pm
+++ b/lib/Devel/Cover/Truth_Table.pm
@@ -243,7 +243,6 @@ sub new_primitive {
 #-------------------------------------------------------------------------------
 sub error {
   my $self = shift;
-  if (@_) { print "[[[", $self->[shift]->error, "]]]\n"; die }
   return $self->[shift]->error if @_;
   foreach (@$self) {
     return 1 if $_->error;


### PR DESCRIPTION
## Summary

A leftover debug `print` and `die` in `Truth_Table::error` shadowed the indexed return, so `$tt->error(0)` printed noise and died. Deleting it lets the real path run.

## Ticket

Closes #575