### PR TITLE
GH-577 Count nested elsif against its own if

### DIFF
--- a/lib/Devel/Cover/Static.pm
+++ b/lib/Devel/Cover/Static.pm
@@ -80,7 +80,9 @@ sub _count_decisions ($node) {
     if ($type =~ /^(?:if|unless)$/) {
       $decisions++;
       my $elsifs = $c->find(sub {
-        $_[1]->isa("PPI::Token::Word") && $_[1]->content eq "elsif"
+        $_[1]->isa("PPI::Token::Word")
+          && $_[1]->content eq "elsif"
+          && $_[1]->parent == $c
       }) || [];
       $decisions += @$elsifs;
     }

--- a/t/internal/static.t
+++ b/t/internal/static.t
@@ -344,6 +344,75 @@ sub test_per_sub_missing () {
   ok !defined $subs, "per_sub: missing file returns undef";
 }
 
+# Nested if with elsif: the elsif belongs to the inner if only and must not
+# also be counted by the enclosing if.
+sub test_nested_elsif () {
+  my $file = write_file("Nested.pm", <<'EOPERL');
+package Nested;
+use strict;
+use warnings;
+
+sub outer {
+  my ($x, $y, $z) = @_;
+  if ($x) {
+    if ($y) {
+      return "y";
+    } elsif ($z) {
+      return "z";
+    }
+  }
+  return "none";
+}
+
+1
+EOPERL
+
+  my $counts = Devel::Cover::Static::count_criteria($file);
+  ok defined $counts, "nested elsif: returns counts";
+
+  # outer if + inner if + one elsif = 3 decisions => 6 outcomes
+  is $counts->{branch}, 6, "nested elsif: 6 outcomes (3 decisions x 2)";
+
+  my $subs    = Devel::Cover::Static::per_sub_complexity($file);
+  my %by_name = map { $_->{name} => $_ } grep $_->{name} ne "BEGIN", @$subs;
+  is $by_name{outer}{cc}, 4, "nested elsif: outer CC = 4 (3 decisions + 1)";
+}
+
+# Triple nesting: a single elsif must be counted exactly once however deeply
+# its if is nested.
+sub test_triple_nested_elsif () {
+  my $file = write_file("Triple.pm", <<'EOPERL');
+package Triple;
+use strict;
+use warnings;
+
+sub deep {
+  my ($a, $b, $c, $d) = @_;
+  if ($a) {
+    if ($b) {
+      if ($c) {
+        return 1;
+      } elsif ($d) {
+        return 2;
+      }
+    }
+  }
+  return 0;
+}
+
+1
+EOPERL
+
+  my $counts = Devel::Cover::Static::count_criteria($file);
+
+  # three ifs + one elsif = 4 decisions => 8 outcomes
+  is $counts->{branch}, 8, "triple nested: 8 outcomes (4 decisions x 2)";
+
+  my $subs    = Devel::Cover::Static::per_sub_complexity($file);
+  my %by_name = map { $_->{name} => $_ } grep $_->{name} ne "BEGIN", @$subs;
+  is $by_name{deep}{cc}, 5, "triple nested: deep CC = 5 (4 decisions + 1)";
+}
+
 sub main () {
   test_minimal;
   test_branches;
@@ -354,6 +423,8 @@ sub main () {
   test_per_sub_complexity;
   test_per_sub_forward;
   test_per_sub_missing;
+  test_nested_elsif;
+  test_triple_nested_elsif;
   done_testing;
 }
 


### PR DESCRIPTION
## Summary

`Devel::Cover::Static` counted an `elsif` once for its own `if`/`unless` and again for every enclosing one, because the search for `elsif` tokens was recursive with no ownership check. A nested `if` with an `elsif` therefore over-reported decisions, inflating the branch count, cyclomatic complexity, CRAP and SCAR in the static estimates for files with no coverage. The `elsif` search now only counts tokens whose parent is the compound being measured. This affects only the estimated figures for untested files on the `--select_dir` path, and only when PPI is installed.

## Ticket

Closes #577