### PR TITLE
GH-579 Reconcile cpancover POD with real options

### DIFF
--- a/bin/cpancover
+++ b/bin/cpancover
@@ -182,17 +182,15 @@ cpancover - report coverage statistics on CPAN modules
 =head1 SYNOPSIS
 
   cpancover --help --info --version
-            --collect --redo_cpancover_html --redo_html --force --dryrun
-            --modules module_name
-            --results_dir /path/to/dir
-            --outputdir /path/to/dir
-            --outputfile filename.html
+            --build --generate_html --rebuild --rebuild_batch n
+            --latest --local --local_build
+            --modules module_name --module_file file
+            --results_dir /path/to/dir --output_file filename.html
             --report report_name
-            --generate_html
             --compress_old_versions number_to_keep
-            --local
-            --local_build
-            --rebuild --rebuild_batch n
+            --force --dryrun --verbose
+            --workers n --timeout seconds
+            --bin_dir /path --docker command --env name
 
 =head1 DESCRIPTION
 
@@ -204,22 +202,27 @@ The following command line options are supported:
   -i --info               - show documentation
   -v --version            - show version
 
-  --collect               - collect coverage from modules       (on)
-  --compress_old_versions - compress data older than n versions (3)
-  --directory             - location of the modules             ($cwd)
+  --bin_dir               - location of the cover binaries     ($0 dir)
+  --build                 - collect coverage from modules       (on)
+  --compress_old_versions - compress data older than n versions (0)
+  --docker                - docker command to use               (docker)
   --dryrun                - don't execute (for some commands)   (off)
-  --force                 - retry failed builds                 (off)
+  --env                   - collection environment              (prod)
+  --force                 - recollect coverage                  (off)
   --generate_html         - generate html                       (off)
+  --latest                - process latest CPAN releases        (off)
   --local                 - use local (uninstalled) code        (off)
-  --local_build           - build coveraage for all the modules (off)
-  --modules               - modules to use                      (all in $dir)
-  --outputdir             - where to store output               ($directory)
-  --outputfile            - top level index                     (coverage.html)
-  --rebuild               - rebuild already-covered modules     (off)
-  --rebuild_batch         - how many distdirs per rebuild pass  (100)
-  --redo_cpancover_html   - don't set default modules           (off)
-  --redo_html             - force html generation for modules   (off)
-  --report                - report to use                       (html)
+  --local_build           - build coverage for all the modules  (off)
+  --module_file           - read module list from a file        (none)
+  --modules               - modules to use                (all in results_dir)
+  --output_file           - top level index                     (index.html)
+  --rebuild               - rebuild already-covered modules      (off)
+  --rebuild_batch         - how many distdirs per rebuild pass   (100)
+  --report                - report to use                        (html)
+  --results_dir           - where to store output               ($cwd)
+  --timeout               - per-distribution timeout in seconds  (1800)
+  --verbose               - verbose output                       (off)
+  --workers               - number of parallel workers           (0)
 
 =head1 DETAILS
 

--- a/t/internal/cpancover_options.t
+++ b/t/internal/cpancover_options.t
@@ -1,0 +1,57 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin    ();
+use File::Spec ();
+
+use Test::More import => [qw( done_testing is_deeply )];
+
+sub read_script () {
+  my $script
+    = File::Spec->catfile($FindBin::Bin, "..", "..", "bin", "cpancover");
+  open my $fh, "<", $script or die "Can't open $script: $!";
+  my $src = do { local $/; <$fh> };
+  close $fh or die "Can't close $script: $!";
+  $src
+}
+
+# Long option names accepted by the GetOptions spec (drop =s/=i/! and split
+# aliases, then ignore single-character short forms like h, i, v).
+sub spec_options ($src) {
+  my ($spec) = $src =~ /GetOptions\(\s*\$Options,\s*qw\(\s*(.*?)\)\s*\)/s;
+  my %real;
+  for my $tok (split " ", $spec) {
+    $tok =~ s/[=:].*//;
+    $tok =~ s/!$//;
+    $real{$_} = 1 for grep length > 1, split /\|/, $tok;
+  }
+  \%real
+}
+
+# Long option names documented in the POD OPTIONS section.
+sub documented_options ($src) {
+  my ($opts_pod) = $src =~ /=head1 OPTIONS\b(.*?)=head1/s;
+  +{ map { $_ => 1 } $opts_pod =~ /--(\w+)/g }
+}
+
+sub test_options () {
+  my $src = read_script;
+  is_deeply [sort keys documented_options($src)->%*],
+    [sort keys spec_options($src)->%*],
+    "documented options match the GetOptions spec";
+}
+
+test_options;
+
+done_testing;


### PR DESCRIPTION
## Summary

`bin/cpancover` parses options with no pass-through, so any unknown option is fatal. Its POD had drifted from the real `GetOptions` spec - it documented options that do not exist (`--collect`, `--directory`, `--outputdir`, `--outputfile`, `--redo_cpancover_html`, `--redo_html`), gave wrong defaults for a couple more, and left around ten real options undocumented. Following the documentation therefore aborted with "Bad option". The SYNOPSIS and OPTIONS sections now match the accepted options and their real defaults, and a new test parses both the spec and the POD and asserts they list the same long options, so the drift cannot recur silently.

## Ticket

Closes #579