### PR TITLE
GH-581 Report gcov2perl branch coverage by default

### DIFF
--- a/bin/gcov2perl
+++ b/bin/gcov2perl
@@ -74,7 +74,7 @@ sub add_cover ($file) {
   $f =~ s/.gcov$//;
 
   my %run;
-  $run{collected} = ["statement"];
+  $run{collected} = ["statement", "branch"];
   $run{start}     = $run{finish} = time;
   require Devel::Cover::DB::Structure;
   my $structure = Devel::Cover::DB::Structure->new;

--- a/t/fixtures/gcov2perl/branch.c.fixture
+++ b/t/fixtures/gcov2perl/branch.c.fixture
@@ -1,0 +1,9 @@
+/* vim: set ft=c: */
+/* Branch test file for gcov2perl */
+
+int f(int x) {
+    if (x) {
+        return 0;
+    }
+    return 1;
+}

--- a/t/fixtures/gcov2perl/branch.c.gcov.fixture
+++ b/t/fixtures/gcov2perl/branch.c.gcov.fixture
@@ -1,0 +1,16 @@
+        -:    0:Source:branch.c
+        -:    0:Graph:branch-branch.gcno
+        -:    0:Data:branch-branch.gcda
+        -:    0:Runs:1
+        -:    0:Programs:1
+        -:    1:/* vim: set ft=c: */
+        -:    2:/* Branch test file for gcov2perl */
+        -:    3:
+        1:    4:int f(int x) {
+        1:    5:    if (x) {
+branch  0 taken 1
+branch  1 taken 0
+        1:    6:        return 0;
+        -:    7:    }
+    #####:    8:    return 1;
+        1:    9:}

--- a/t/internal/gcov2perl.t
+++ b/t/internal/gcov2perl.t
@@ -13,22 +13,24 @@ use File::Copy     qw( copy );
 use File::Spec     ();
 use File::Temp     qw( tempdir );
 
+use Devel::Cover::DB::IO ();
+
 my $Test_dir = dirname(__FILE__);
 my $Root     = File::Spec->catdir($Test_dir, "..", "..");
 my $Bin      = File::Spec->catfile($Root, "bin", "gcov2perl");
 my $Fixtures = File::Spec->catdir($Root, "t", "fixtures", "gcov2perl");
 
-sub setup () {
+sub setup ($stem) {
   my $tmpdir = tempdir(CLEANUP => 1);
 
   copy(
-    File::Spec->catfile($Fixtures, "simple.c.fixture"),
-    File::Spec->catfile($tmpdir,   "simple.c"),
-  ) or die "Failed to copy simple.c.fixture: $!";
+    File::Spec->catfile($Fixtures, "$stem.c.fixture"),
+    File::Spec->catfile($tmpdir,   "$stem.c"),
+  ) or die "Failed to copy $stem.c.fixture: $!";
   copy(
-    File::Spec->catfile($Fixtures, "simple.c.gcov.fixture"),
-    File::Spec->catfile($tmpdir,   "simple.c.gcov"),
-  ) or die "Failed to copy simple.c.gcov.fixture: $!";
+    File::Spec->catfile($Fixtures, "$stem.c.gcov.fixture"),
+    File::Spec->catfile($tmpdir,   "$stem.c.gcov"),
+  ) or die "Failed to copy $stem.c.gcov.fixture: $!";
 
   $tmpdir
 }
@@ -104,10 +106,44 @@ sub test_skip_core ($tmpdir) {
     "runs directory created for CORE source with -no-skip-core";
 }
 
+# Read the collected criteria list from the single run that gcov2perl wrote.
+# gcov2perl writes a run but does not merge it into the top-level database, so
+# read the run file directly rather than through Devel::Cover::DB.
+sub run_collected ($db_dir) {
+  my $runs_dir = File::Spec->catdir($db_dir, "runs");
+  opendir my $dh, $runs_dir or die "Cannot open $runs_dir: $!";
+  my ($run) = grep !/^\./, readdir $dh;
+  closedir $dh;
+
+  my $run_dir = File::Spec->catdir($runs_dir, $run);
+  opendir my $rh, $run_dir or die "Cannot open $run_dir: $!";
+  my ($file) = grep !/^\./ && !/\.lock$/, readdir $rh;
+  closedir $rh;
+
+  my $data
+    = Devel::Cover::DB::IO->new->read(File::Spec->catfile($run_dir, $file));
+  [map $data->{runs}{$_}{collected}->@*, keys $data->{runs}->%*]
+}
+
+sub test_branch_collected ($tmpdir) {
+  my $gcov_file = File::Spec->catfile($tmpdir, "branch.c.gcov");
+  my $db_dir    = File::Spec->catdir($tmpdir, "cover_db");
+  my ($exit_code, $output) = run_gcov2perl($db_dir, $gcov_file);
+
+  is $exit_code, 0, "gcov2perl exits successfully on branch fixture";
+  like $output, qr/Writing coverage database/,
+    "gcov2perl writes database for branch fixture";
+
+  my $collected = run_collected($db_dir);
+  ok scalar(grep $_ eq "branch", @$collected),
+    "branch is advertised in collected criteria";
+}
+
 sub main () {
-  my $tmpdir = setup;
+  my $tmpdir = setup("simple");
   test_gcov2perl($tmpdir);
   test_skip_core($tmpdir);
+  test_branch_collected(setup("branch"));
   done_testing;
 }
 


### PR DESCRIPTION
## Summary

`gcov2perl` reads and stores both statement and branch coverage from gcov output, but the run it wrote advertised only `statement` in its `collected` list. Because `cover` defaults its report selection to the run's collected set, the branch data was silently omitted from reports unless the user asked for `-coverage branch`. Adding `branch` to `collected` lines it up with the `add_criteria` calls and the counts already written, so a default `cover` run now shows the branch coverage that was there all along. A new branch fixture and test assert the written run lists `branch`.

## Ticket

Closes #581