### PR TITLE
GH-583 Don't re-apply ignore_re at report stage

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -315,7 +315,7 @@ sub do_test ($dbname) {
     for $Options->{select_re}->@*, map quotemeta, map glob,
     $Options->{select}->@*;
 
-  $Options->{$_} = [] for qw( ignore ignoring select select_re );
+  $Options->{$_} = [] for qw( ignore ignore_re select select_re );
   $Options->{report} = ["html"] unless $Options->{report}->@*;
 
   my $opts = join " ", grep $_, $ENV{DEVEL_COVER_TEST_OPTS},


### PR DESCRIPTION
## Summary

`cover -test` folds `-ignore_re` patterns into the options passed to the child test run, then clears the option lists so they are not applied a second time when reporting. The reset list cleared a misspelt `ignoring` key instead of `ignore_re`, so the patterns were re-applied at report stage and could wrongly drop files whose database name differs from their collection-time name.

## Ticket

Closes #583