### PR TITLE
GH-585 Allow -annotation with report options

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -123,7 +123,6 @@ sub get_options () {
       )
       #>>>
     );
-  Getopt::Long::Configure("nopass_through");
   $Options->{report} = ["html"]
     if !$Options->{report}->@* && !exists $Options->{write};
 
@@ -215,16 +214,19 @@ sub check_options () {
   pod2usage(-exitval => 0, -verbose => 1) if $Options->{help};
   pod2usage(-exitval => 0, -verbose => 2) if $Options->{info};
 
-  # This is a bit of a hack but it basically works.  It's possible to specify
-  # multiple reports and they arew run at the end.  This is why we need to store
-  # @argv, and restore it for each report to be able to provess the options.
-  # But we need to remove report options from @ARGV so we can see what's left
-  # and use that to get the cover_db name.  So just take the first report and
-  # process its options here.
-  my $options = dclone($Options);
-  my $report  = $Options->{report}[0] or return;
-  my $format  = "Devel::Cover::Report::\u$report";
-  $format->get_options($options) if $format->can("get_options");
+  # Strip every report's options from @ARGV, as the annotation loop above
+  # did, so only the database names remain.  Everything runs under
+  # pass_through, so each consumer ignores options it does not own.
+  for my $report ($Options->{report}->@*) {
+    my $format = "Devel::Cover::Report::\u$report";
+    $format->get_options(dclone($Options)) if $format->can("get_options");
+  }
+
+  # Anything left starting with "-" is unknown to every consumer.
+  if (my @unknown = grep /^-/, @ARGV) {
+    dcerror "Unknown option: $_" for @unknown;
+    exit 1;
+  }
 
   \@argv
 }

--- a/t/internal/cover_annotation_options.t
+++ b/t/internal/cover_annotation_options.t
@@ -12,6 +12,7 @@ use warnings;
 use feature qw( postderef signatures );
 no warnings qw( experimental::postderef experimental::signatures );
 
+use Config     qw( %Config );
 use Cwd        qw( getcwd );
 use File::Spec ();
 use File::Temp qw( tempdir );
@@ -53,9 +54,9 @@ sub run_cover (@args) {
 
 sub test_report_annotation_combination () {
   my ($rc, $out) = run_cover(
-    "-silent", "-report", "json", "-outputfile",
-    File::Spec->catfile($Tmpdir, "out.json"),
-    "-annotation", "random", "-count", 3,
+    "-silent",  "-report",     "json",   "-outputfile",
+    "out.json", "-annotation", "random", "-count",
+    3,
   );
   is $rc, 0, "report and annotation option sets don't collide";
   unlike $out, qr/Unknown option|Bad option|Invalid command line options/,
@@ -70,7 +71,7 @@ sub test_unknown_option_rejected () {
 }
 
 sub main () {
-  local $ENV{PERL5LIB} = join ":", $Blib_lib, $Blib_arch,
+  local $ENV{PERL5LIB} = join $Config{path_sep}, $Blib_lib, $Blib_arch,
     ($ENV{PERL5LIB} // ());
 
   build_db;

--- a/t/internal/cover_annotation_options.t
+++ b/t/internal/cover_annotation_options.t
@@ -1,0 +1,82 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Cwd        qw( getcwd );
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use Test::More import => [qw( done_testing is isnt like note plan unlike )];
+
+my $Project   = getcwd;
+my $Cover     = File::Spec->catfile($Project, "bin", "cover");
+my $Blib_lib  = File::Spec->catdir($Project, "blib", "lib");
+my $Blib_arch = File::Spec->catdir($Project, "blib", "arch");
+
+unless (-f $Cover && -d $Blib_lib && -d $Blib_arch) {
+  plan skip_all => "build artefacts missing - run after `make`";
+  exit;
+}
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+my $Db     = File::Spec->catdir($Tmpdir, "cover_db");
+
+sub build_db () {
+  my $script = File::Spec->catfile($Tmpdir, "covered.pl");
+  open my $fh, ">", $script or die "open $script: $!";
+  print {$fh} "my \$x = 0;\n\$x++ for 1 .. 3;\n";
+  close $fh or die "close $script: $!";
+
+  my @cmd = (
+    $^X, "-I$Blib_lib", "-I$Blib_arch", "-MDevel::Cover=-db,$Db,-silent",
+    $script,
+  );
+  system(@cmd) == 0 or die "failed to build test db";
+}
+
+sub run_cover (@args) {
+  my $cmd = join " ", $^X, $Cover, @args, $Db, "2>&1";
+  my $out = `$cmd`;
+  note $out;
+  ($? >> 8, $out)
+}
+
+sub test_report_annotation_combination () {
+  my ($rc, $out) = run_cover(
+    "-silent", "-report", "json", "-outputfile",
+    File::Spec->catfile($Tmpdir, "out.json"),
+    "-annotation", "random", "-count", 3,
+  );
+  is $rc, 0, "report and annotation option sets don't collide";
+  unlike $out, qr/Unknown option|Bad option|Invalid command line options/,
+    "no option-parsing error emitted";
+}
+
+sub test_unknown_option_rejected () {
+  my ($rc, $out)
+    = run_cover("-silent", "-report", "text", "-definitely_not_an_option");
+  isnt $rc, 0, "unknown option still fails";
+  like $out, qr/Unknown option/, "unknown option reported clearly";
+}
+
+sub main () {
+  local $ENV{PERL5LIB} = join ":", $Blib_lib, $Blib_arch,
+    ($ENV{PERL5LIB} // ());
+
+  build_db;
+  test_report_annotation_combination;
+  test_unknown_option_rejected;
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

Combining `-annotation` with a report that defines its own options made `cover` die in both directions - the report rejected the annotation's options and the annotation rejected the report's, because every consumer parsed the shared leftover `@ARGV` under `nopass_through`. Getopt::Long now stays in `pass_through` for the whole run, every report's options are stripped before the database names are read from `@ARGV`, and anything still unclaimed after all consumers have parsed is rejected with a clear `Unknown option` message rather than being mistaken for a database name. No report or annotation module changes.

New test `t/internal/cover_annotation_options.t` builds a small database and checks that the previously fatal report and annotation combination succeeds and that an unknown option still fails clearly.

## Ticket

Closes #585