### PR TITLE
GH-593 Fix XS memory leaks and latent defects

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -3034,6 +3034,7 @@ BOOT:
     MUTEX_INIT(&DC_mutex);
 #endif
     initialise(aTHX);
+    /* Deliberately replaces any prior runops loop - loops cannot chain */
     if (MY_CXT.replace_ops) {
       replace_ops(aTHX);
       PL_runops = runops_orig;

--- a/Cover.xs
+++ b/Cover.xs
@@ -2437,7 +2437,7 @@ static int runops_cover(pTHX) {
 
     /* Check to see whether we are interested in this file */
 
-    if (PL_op->op_type == OP_NEXTSTATE)
+    if (PL_op->op_type == OP_NEXTSTATE || PL_op->op_type == OP_DBSTATE)
       check_if_collecting(aTHX_ cCOP);
     else if (PL_op->op_type == OP_ENTERSUB)
       store_return(aTHX);

--- a/Cover.xs
+++ b/Cover.xs
@@ -783,7 +783,7 @@ static void store_module(pTHX) {
   dMY_CXT;
   dSP;
 
-  SvSetSV_nosteal(MY_CXT.module, (SV*)newSVpv(SvPV_nolen(TOPs), 0));
+  sv_setpv(MY_CXT.module, SvPV_nolen(TOPs));
   NDEB(D(L, "require %s\n", SvPV_nolen(MY_CXT.module)));
 }
 

--- a/Cover.xs
+++ b/Cover.xs
@@ -947,6 +947,7 @@ static AV *get_conds(pTHX_ AV *conds) {
 
   t = SvPV_nolen(tid);
   cref = hv_fetch(threads, t, strlen(t), 1);
+  SvREFCNT_dec(tid);
 
   if (SvROK(*cref))
     thrconds = (AV *)SvRV(*cref);

--- a/Cover.xs
+++ b/Cover.xs
@@ -472,7 +472,7 @@ static int check_if_collecting(pTHX_ COP *cop) {
 
   NDEB(D(L, "%s - %d\n", SvPV_nolen(MY_CXT.lastfile), MY_CXT.collecting_here));
 
-  if (SvTRUE(MY_CXT.module)) {
+  if (file && SvTRUE(MY_CXT.module)) {
     STRLEN mlen,
            flen = strlen(file);
     char  *m    = SvPV(MY_CXT.module, mlen);

--- a/Cover.xs
+++ b/Cover.xs
@@ -392,14 +392,14 @@ static void set_firsts_if_needed(pTHX) {
     SV **cv = av_fetch(PL_initav, 0, 0);
     if (*cv != init) {
       av_unshift(PL_initav, 1);
-      av_store(PL_initav, 0, init);
+      av_store(PL_initav, 0, SvREFCNT_inc(init));
     }
   }
   if (PL_endav && av_len(PL_endav) >= 0) {
     SV **cv = av_fetch(PL_endav, 0, 0);
     if (*cv != end) {
       av_unshift(PL_endav, 1);
-      av_store(PL_endav, 0, end);
+      av_store(PL_endav, 0, SvREFCNT_inc(end));
     }
   }
 }
@@ -2965,7 +2965,7 @@ set_last_end()
   PPCODE:
     int i;
     SV *end = (SV *)get_cv("last_end", 0);
-    av_push(PL_endav, end);
+    av_push(PL_endav, SvREFCNT_inc(end));
     NDEB(svdump(end));
     if (!MY_CXT.ends) MY_CXT.ends = newAV();
     if (PL_endav)

--- a/Cover.xs
+++ b/Cover.xs
@@ -1065,7 +1065,7 @@ static void add_condition(pTHX_ SV *cond_ref, int value) {
 #else
   i = 1;
 #endif
-  while (av_len(conds) > i) av_pop(conds);
+  while (av_len(conds) > i) SvREFCNT_dec(av_pop(conds));
 
   NDEB(svdump(conds));
   NDEB(D(L, "addr is %p, next is %p, PL_op is %p, length is %zd final is %d\n",

--- a/t/internal/dbstate_collecting.t
+++ b/t/internal/dbstate_collecting.t
@@ -1,0 +1,102 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( realpath );
+use File::Path qw( make_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is like )];
+use Devel::Cover::Test::Showcase qw( run_cover );
+
+my $Stub = <<'PERL';
+package Devel::DCStub;
+package DB;
+sub DB  { }
+sub sub { no strict "refs"; &$DB::sub }
+1;
+PERL
+
+my $Helper = <<'PERL';
+package Helper;
+my $loaded = 1;
+1;
+PERL
+
+# Clearing $^P before the require makes Helper compile with OP_NEXTSTATE ops
+# although the pre-compiled main script runs OP_DBSTATE ops. With
+# -replace_ops 0 the collecting decision comes from the %Files cache, which
+# add_cvs sweeps populate during real runs - seed it here. Helper's
+# OP_NEXTSTATE ops then turn collection off, and only the OP_DBSTATE refresh
+# can turn it back on for the statements after the require.
+my $Target = <<'PERL';
+use File::Basename ();
+my $dir = File::Basename::dirname(__FILE__);
+$Devel::Cover::Files{ +__FILE__ } = 1;
+$Devel::Cover::Files{"$dir/Helper.pm"} = 0;
+my $x = 1;
+$^P = 0;
+require Helper;
+my $y = $x + 1;
+my $z = $y + 1;
+print "ok\n";
+PERL
+
+# Under an external debugger statement ops compile as OP_DBSTATE, and with
+# -replace_ops 0 the runops_cover loop must refresh the collecting state for
+# them just as it does for OP_NEXTSTATE, or statements are lost.
+sub main () {
+  my $tmpdir  = realpath(tempdir(CLEANUP => 1));
+  my $stubdir = File::Spec->catdir($tmpdir, "Devel");
+  make_path($stubdir);
+
+  my %write = (
+    File::Spec->catfile($stubdir, "DCStub.pm") => $Stub,
+    File::Spec->catfile($tmpdir,  "Helper.pm") => $Helper,
+    File::Spec->catfile($tmpdir,  "target.pl") => $Target,
+  );
+  for my $path (sort keys %write) {
+    open my $fh, ">", $path or die "Cannot write $path: $!";
+    print $fh $write{$path};
+    close $fh or die "Cannot close $path: $!";
+  }
+
+  my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+  my $target   = File::Spec->catfile($tmpdir, "target.pl");
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my $cmd
+    = "$^X -Iblib/lib -Iblib/arch -I$tmpdir -d:DCStub"
+    . " -MDevel::Cover=-replace_ops,0"
+    . ",-db,$cover_db,-silent,1,-merge,0"
+    . " $target 2>&1";
+  my $out = `$cmd`;
+  is $?,   0,      "covered run under debugger stub exits 0" or diag $out;
+  is $out, "ok\n", "target runs normally";
+
+  my ($report, $exit) = run_cover(
+    "--report", "text", "-coverage", "statement", "--silent", $cover_db,
+  );
+  is $exit, 0, "cover --report text exits 0" or diag $report;
+
+  my ($stmt) = $report =~ /target\.pl\s+([\d.]+)/;
+  is $stmt, "100.0", "all target statements covered" or diag $report;
+
+  done_testing;
+}
+
+main;

--- a/test_output/cover/overload_bool2.5.020000
+++ b/test_output/cover/overload_bool2.5.020000
@@ -46,7 +46,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
                1                               
                1                               
 17                                             
-18             3                           3       sub meh { 1 }
+18             2                           2       sub meh { 1 }
 19                                             }
 20                                             
 21             1                               my $string = "hi";
@@ -63,6 +63,6 @@ Subroutine Count  CC  SCAR Location
 BEGIN          1   1   0.0 tests/overload_bool2:10
 BEGIN          1   1   0.0 tests/overload_bool2:11
 BEGIN          1   1   0.0 tests/overload_bool2:16
-meh            3   1   0.0 tests/overload_bool2:18
+meh            2   1   0.0 tests/overload_bool2:18
 
 

--- a/test_output/cover/overload_bool2.5.022000
+++ b/test_output/cover/overload_bool2.5.022000
@@ -46,7 +46,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
                1                               
                1                               
 17                                             
-18             3                           3       sub meh { 1 }
+18             2                           2       sub meh { 1 }
 19                                             }
 20                                             
 21             1                               my $string = "hi";
@@ -64,6 +64,6 @@ Subroutine Count  CC  SCAR Location
 BEGIN          1   1   0.0 tests/overload_bool2:10
 BEGIN          1   1   0.0 tests/overload_bool2:11
 BEGIN          1   1   0.0 tests/overload_bool2:16
-meh            3   1   0.0 tests/overload_bool2:18
+meh            2   1   0.0 tests/overload_bool2:18
 
 

--- a/utils/typemap
+++ b/utils/typemap
@@ -24,7 +24,7 @@ T_SV_OBJ
 
 OUTPUT
 T_OP_OBJ
-    sv_setiv(newSVrv($arg, cc_opclassname(aTHX_ (OP*)$var)), PTR2IV($var));
+    sv_setiv(newSVrv($arg, dc_op_classname(aTHX_ (OP*)$var)), PTR2IV($var));
 
 T_SV_OBJ
     make_sv_object(aTHX_ ($arg), (SV*)($var));


### PR DESCRIPTION
## Summary

Fixes four SV reference-count leaks in the XS layer, three of which grow without bound in long-running covered processes. The fourth left the INIT/END arrays sharing a single reference with the owning GVs, which could become a use-after-free under full interpreter destruction. Also adds a NULL guard for `CopFILE` in the module-tracking block, refreshes the collecting state for `OP_DBSTATE` ops in `runops_cover` so external debugger runs with `-replace_ops 0` no longer lose statements, corrects the undefined function name in the `T_OP_OBJ` output typemap, and documents the deliberate `PL_runops` replacement in BOOT.

The leak fixes were verified by peak RSS measurements on both threaded and non-threaded builds, and the `OP_DBSTATE` fix has a new regression test.

## Ticket

Closes #593