### PR TITLE
GH-595 Skip tests needing optional modules

### DIFF
--- a/t/internal/cover_annotation_options.t
+++ b/t/internal/cover_annotation_options.t
@@ -17,7 +17,8 @@ use Cwd        qw( getcwd );
 use File::Spec ();
 use File::Temp qw( tempdir );
 
-use Test::More import => [qw( done_testing is isnt like note plan unlike )];
+use Test::More import =>
+  [qw( done_testing is isnt like note plan skip unlike )];
 
 my $Project   = getcwd;
 my $Cover     = File::Spec->catfile($Project, "bin", "cover");
@@ -75,7 +76,11 @@ sub main () {
     ($ENV{PERL5LIB} // ());
 
   build_db;
-  test_report_annotation_combination;
+  SKIP: {
+    skip "JSON::MaybeXS not available", 2
+      unless eval { require JSON::MaybeXS; 1 };
+    test_report_annotation_combination;
+  }
   test_unknown_option_rejected;
   done_testing;
 }

--- a/t/internal/editor_types.t
+++ b/t/internal/editor_types.t
@@ -16,7 +16,7 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Test::More import => [qw( diag done_testing is is_deeply ok )];
+use Test::More import => [qw( diag done_testing is is_deeply ok plan )];
 use Devel::Cover::DB             ();
 use Devel::Cover::Test::Showcase qw(
   create_cover_db
@@ -24,6 +24,11 @@ use Devel::Cover::Test::Showcase qw(
   setup_lib_dir
   slurp
 );
+
+eval "require Template; 1" or do {
+  plan skip_all => "Template not available";
+  exit;
+};
 
 sub types_from_vim_report ($cover_db, $libdir, $seed) {
   local $ENV{PERL_HASH_SEED}    = $seed;

--- a/t/internal/nvim_report.t
+++ b/t/internal/nvim_report.t
@@ -16,13 +16,18 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Test::More import => [qw( diag done_testing is like ok unlike )];
+use Test::More import => [qw( diag done_testing is like ok plan unlike )];
 use Devel::Cover::Test::Showcase qw(
   create_cover_db
   run_cover
   setup_lib_dir
   slurp
 );
+
+eval "require Template; 1" or do {
+  plan skip_all => "Template not available";
+  exit;
+};
 
 # Stored file keys must be matched as literal text, not as Lua patterns
 sub test_nvim_report_literal_matching () {

--- a/t/internal/vim_report.t
+++ b/t/internal/vim_report.t
@@ -16,13 +16,18 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Test::More import => [qw( diag done_testing is like unlike )];
+use Test::More import => [qw( diag done_testing is like plan unlike )];
 use Devel::Cover::Test::Showcase qw(
   create_cover_db
   run_cover
   setup_lib_dir
   slurp
 );
+
+eval "require Template; 1" or do {
+  plan skip_all => "Template not available";
+  exit;
+};
 
 # Stored file keys must be matched as literal text, not as Vim regexes
 sub test_vim_report_literal_matching () {


### PR DESCRIPTION
## Summary

Template and JSON::MaybeXS are optional, but four tests failed rather than skipping on a perl without them. The editor report tests now skip without Template, and the annotation option collision check skips without JSON::MaybeXS, matching the existing behaviour of the JSON tests. Verified against two threaded perls lacking the modules and a full perl where all assertions still run.

## Ticket

Closes #595