### PR TITLE
GH-603 Walk each CV's pad once per report

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -128,6 +128,7 @@ sub _is_const_right ($op) {
 
 our $File;                # Last filename we saw.  (localised)
 our $Line;                # Last line number we saw.  (localised)
+our $Walk_seen;           # CVs walked this check_files run.  (localised)
 our $Collect;             # Whether or not we are collecting
                           # coverage data.  We make two passes
                           # over conditions.  (localised)
@@ -568,16 +569,14 @@ sub check_file ($cv) {
 # The seen hash stops loops from self-referential pad entries
 sub pad_cvs ($cv, $seen = {}) {
   $seen->{$$cv}++;
-  return
-       unless $cv->can("PADLIST")
-    && $cv->PADLIST->can("ARRAY")
-    && $cv->PADLIST->ARRAY
-    && $cv->PADLIST->ARRAY->can("ARRAY");
+  my $padlist = $cv->can("PADLIST") ? $cv->PADLIST : undef;
+  my $array   = $padlist && $padlist->can("ARRAY") ? $padlist->ARRAY : undef;
+  return unless $array && $array->can("ARRAY");
   my @cvs = grep ref eq "B::CV" && check_file($_) && !$seen->{$$_}++,
-    $cv->PADLIST->ARRAY->ARRAY;
+    $array->ARRAY;
   # A my sub keeps its prototype in the padname's PROTOCV (5.22+), not the
   # value slot, which is empty once its scope has exited
-  my $names = $cv->PADLIST->ARRAYelt(0);
+  my $names = $padlist->ARRAYelt(0);
   push @cvs, grep ref eq "B::CV" && check_file($_) && !$seen->{$$_}++,
     map ref && $_->can("PROTOCV") ? $_->PROTOCV : (), $names->ARRAY
     if $names && $names->can("ARRAY");
@@ -588,8 +587,11 @@ sub B::GV::find_cv ($gv) {
   my $cv = $gv->CV;
   return unless $$cv;
 
+  my $seen = $Walk_seen // {};
+  return if $seen->{$$cv};
+
   $Cvs{$cv} ||= $cv if check_file($cv);
-  $Cvs{$_}  ||= $_ for pad_cvs($cv);
+  $Cvs{$_}  ||= $_ for pad_cvs($cv, $seen);
 }
 
 sub sub_info ($cv) {
@@ -638,12 +640,13 @@ sub sub_info ($cv) {
   ($name, $start)
 }
 
-sub add_cvs {
-  $Cvs{$_} ||= $_ for pad_cvs(B::main_cv);
+sub add_cvs ($seen = {}) {
+  $Cvs{$_} ||= $_ for pad_cvs(B::main_cv, $seen);
 }
 
 sub check_files {
-  add_cvs();
+  local $Walk_seen = {};
+  add_cvs($Walk_seen);
 
   my %seen_pkg;
   my %seen_cv;

--- a/t/internal/pad_walk.t
+++ b/t/internal/pad_walk.t
@@ -1,0 +1,110 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( realpath );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is ok )];
+
+# check_files discovers pad anon subs by walking each CV's pad tree with
+# pad_cvs.  An Exporter-aliased sub is reachable from the glob of every
+# package that imported it, so without a report-wide record of which CVs
+# have already been walked the same CV is walked once per importing
+# package.  Repeating the walk cannot change which subs are covered - every
+# write into %Cvs is idempotent - so the redundant walks are pure waste.
+# This test asserts the invariant that within a single check_files run no
+# CV is walked more than once.
+
+# Run a program that imports one sub into several packages under coverage,
+# with pad_cvs and check_files wrapped in the child to count, within a
+# single check_files run, how many pad_cvs calls land on a CV already
+# walked in that run.  Return that redundant-walk count.
+sub redundant_walks ($packages) {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+
+  my $util = <<'PM';
+package Util;
+use Exporter 'import';
+our @EXPORT_OK = qw( shared_sub );
+sub shared_sub { $_[0] + 1 }
+1;
+PM
+
+  my $prog = "use strict;\nuse warnings;\n";
+  $prog .= <<'INSTR';
+my %seen;
+my $redundant = 0;
+my $orig = \&Devel::Cover::pad_cvs;
+no warnings qw( redefine prototype );
+*Devel::Cover::pad_cvs = sub {
+  my $cv = $_[0];
+  $redundant++ if ref $cv && $seen{$$cv}++;
+  goto &$orig;
+};
+my $check = \&Devel::Cover::check_files;
+*Devel::Cover::check_files = sub {
+  %seen      = ();
+  $redundant = 0;
+  my @r = $check->(@_);
+  print "REDUNDANT:$redundant\n";
+  @r;
+};
+INSTR
+  $prog
+    .= "package Pkg$_;\nuse Util qw( shared_sub );\n"
+    . "sub run { shared_sub($_) }\n"
+    for 1 .. $packages;
+  $prog .= "package main;\n";
+  $prog .= "Pkg${_}::run();\n" for 1 .. $packages;
+
+  my %write = (
+    File::Spec->catfile($tmpdir, "Util.pm") => $util,
+    File::Spec->catfile($tmpdir, "prog.pl") => $prog,
+  );
+  for my $path (sort keys %write) {
+    open my $fh, ">", $path or die "Cannot write $path: $!";
+    print $fh $write{$path};
+    close $fh or die "Cannot close $path: $!";
+  }
+
+  my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+  my $program  = File::Spec->catfile($tmpdir, "prog.pl");
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my $cmd
+    = "$^X -Iblib/lib -Iblib/arch -I$tmpdir"
+    . " -MDevel::Cover=-db,$cover_db,-silent,1,-merge,0,-select,Util,-ignore,."
+    . " $program 2>&1";
+  my $out = `$cmd`;
+  my ($redundant) = $out =~ /^REDUNDANT:(\d+)$/m;
+  diag $out unless defined $redundant;
+  $redundant
+}
+
+sub test_no_redundant_walks () {
+  my $redundant = redundant_walks(8);
+  is $redundant, 0,
+    "no CV is walked more than once in a single check_files run";
+}
+
+sub main () {
+  test_no_redundant_walks;
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

Devel::Cover discovers anonymous subs by walking the pad tree of every CV at report time. An Exporter-aliased sub is reachable from the glob of every package that imported it, so it was walked once per importing package, and each `pad_cvs` call re-evaluated the CV's `PADLIST` several times over. The walk is idempotent, so repeating it is pure waste.

## Changes

- Share one seen set across `add_cvs` and `find_cv` so each CV is walked once per report rather than once per importing package.
- Cache the repeated `PADLIST` and `ARRAY` lookups in `pad_cvs`.
- Leave the run-time `add_cvs` path untouched, so the transient-anon behaviour it guards stays unchanged.

## Implications

- Coverage output is unchanged - the full golden suite stays byte-identical on `dc-dev` and `dc-5.20.0`.
- `check_files` runs at the exit of every instrumented process, so a suite with many test files pays the saving per process. In benchmarks it runs from a few per cent faster on a lightly-aliased program up to around a fifth faster on a heavily-aliased one.

## Ticket

Closes #603