### PR TITLE
GH-308 Cover subs swapped out of the symbol table

### DIFF
--- a/docs/technical/wrapped-sub-coverage.md
+++ b/docs/technical/wrapped-sub-coverage.md
@@ -1,0 +1,116 @@
+# Coverage for Subs Swapped Out of the Symbol Table
+
+A named sub can be replaced in the symbol table by a wrapper while the original
+sub is kept alive somewhere the wrapper can reach. The classic case is a method
+modifier - Moose's `around`, and the same pattern in Moo,
+`Class::Method::Modifiers`, `Hook::LexWrap` and hand-rolled code such as
+
+```perl
+sub original { ... }
+my $orig = \&original;
+*original = sub { ... $orig->(@_) ... };
+```
+
+After the swap `*original{CODE}` is the wrapper. The original sub still exists
+and still runs (the wrapper calls it), but it is no longer reachable from any
+glob in the symbol table. It survives only as a reference the wrapper closes
+over.
+
+## Why the coverage was lost
+
+Devel::Cover builds its subroutine and statement structure at report time by
+walking for CVs from two roots (`check_files` in `Devel/Cover.pm`): the symbol
+table (every package's glob `CODE` slots, via `walksymtable`) and the pads of
+the CVs it finds (`pad_cvs`, which picks up anon prototypes and lexical `my`
+subs).
+
+A displaced original is in neither place. Its glob now holds the wrapper, and it
+is not an anon prototype in a pad. So although its ops were instrumented at
+compile time and its counts were recorded at run time, no structure entry is
+built for it and the counts are dropped. The file then reports full coverage
+with the original's body invisible - the same silently-inflated percentage
+described in `require-toplevel-coverage.md`.
+
+This is issue GH-308 (its title notes it "affects method modifiers and
+friends").
+
+## What is recovered
+
+`pad_cvs` follows a pad slot that holds a reference, not only a slot that holds
+a CV directly (`ref_cvs`):
+
+- a reference straight to a CV (the `my $orig = \&original` form), and
+- a reference one level deep into a plain array or hash the sub closes over.
+
+The second case is how Class::MOP, and so Moose, keeps the original. The wrapper
+closes over a plain hash whose `orig` entry is the original method. `orig` sits
+one container deep whatever the number or mix of modifiers, because Class::MOP
+coalesces `before`, `after` and `around` into a single wrapper.
+
+Two rules keep this precise and cheap. A CV reached through a reference is kept
+only if it is a genuinely named sub (`recoverable_sub`) - not an anon, and not
+an internal clone with a generated name such as Moose's `:around` modifier CV or
+a pragma's `BEGIN` block. Those share a body with a sub already found the normal
+way, so recording them again would duplicate it, and because the duplicate
+shares a start op with the original the report-time dedup would pick between
+them non-deterministically. Descent also stops after one container and does not
+enter blessed containers, so a sub closing over an object does not drag the
+object's whole graph into the walk.
+
+The cost is paid only when building the report, and only for subs that close
+over references. A program with no method modifiers pays effectively nothing. A
+program full of them pays in proportion to the number recovered, which is the
+inherent cost of covering subs that were previously absent.
+
+The tests are in `t/internal/wrapped_sub.t`: the direct reference form, the
+hash-held and array-held forms, and a real Moose `around` modifier (skipped when
+Moose is not installed).
+
+## Known limitations
+
+Recovery is a heuristic, not a guarantee. It finds the original only where the
+wrapper reaches it through a pad, within one plain container. It does not find
+an original that is
+
+- nested two or more containers deep,
+- held inside a blessed object the wrapper closes over, or
+- kept in a package variable and looked up at call time rather than closed over
+  (such an original is in no pad at all).
+
+## A route to a real guarantee
+
+The heuristic re-discovers subs by walking the symbol table and pads, so it is
+bound by where a sub can be reached from. A mechanism that instead remembers
+each sub as it runs would not have that bound.
+
+Devel::Cover already intercepts every call through `dc_entersub` (it replaces
+`PL_ppaddr[OP_ENTERSUB]`). That hook could record the entered CV, so every sub
+that actually executes is remembered regardless of what later happens to its
+glob. A displaced original still runs - the wrapper calls it - so it would be
+recorded even in the cases the heuristic misses above (each of those originals
+does execute and is simply unreachable from the walk roots at report time). A
+sub that never runs needs no run coverage and is still reported as uncovered
+from the symbol-table walk, so entry capture is enough to close the gap for
+executed subs. At report time the recorded CVs are merged into the walk's
+results before the structure is built, and the existing subroutine, statement
+and branch machinery covers them.
+
+The reference held to each recorded CV must be weak. A weak reference does not
+raise the CV's reference count, so DESTROY timing, memory use and what stays
+alive are all unchanged - the tool must not alter the behaviour of the program
+it measures. It also degrades sensibly. When a CV is freed before the report is
+built (a closure created, called and dropped mid-run), `Scalar::Util::weaken`
+nulls the reference to `undef`, so the report step skips it rather than reading
+a freed or reused slot. Those subs ran but their optree is gone, so no structure
+can be built for them, and they are counted as dropped rather than crashing the
+report. A weak reference is safe against address reuse in a way raw address
+tracking is not.
+
+The costs are why this is a larger change than the heuristic and belongs on its
+own branch. `dc_entersub` is on the call hot path, so recording a CV there - a
+lookup to skip ones already seen, and a weaken on first sight - is collection
+cost, the more sensitive kind, and would likely be gated behind an option. It
+holds one small weak-reference SV per distinct executed CV for the length of the
+run, and the interaction with threaded builds (weak references are
+per-interpreter) and with getting the entered CV cleanly for XS subs both need
+care. Measuring the hot-path cost is the first step before committing to it.

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -35,6 +35,7 @@ use B  ## no perlimports
   OPf_KIDS
   OPf_SPECIAL
   OPf_WANT
+  SVf_ROK
   ppname
   walksymtable
   );
@@ -566,14 +567,55 @@ sub check_file ($cv) {
   $use
 }
 
+# A sub recovered through a reference is only wanted if it is a genuine named
+# sub.  An anon, or an internal clone with a generated name (Moose's ":around"
+# modifier CV, a pragma's BEGIN block), shares its body with a sub already
+# found the normal way and would otherwise be recorded a second time.
+sub recoverable_sub ($cv) {
+  my $gv = $cv->GV;
+  return 0 unless ref $gv && !$gv->isa("B::SPECIAL");
+  my $name = $gv->NAME;
+  defined $name
+    && $name =~ /^\w+$/
+    && $name ne "__ANON__"
+    && $name !~ /^(?:BEGIN|END|INIT|CHECK|UNITCHECK)$/
+}
+
+# Collect the named subs reachable from a pad slot by following a reference:
+# directly to a CV, or one level deep through a plain array or hash the sub
+# closes over.  That is where a method modifier keeps the original sub it
+# replaced in the symbol table, so without this its body is dropped from
+# coverage.  Descent stops after one container so a wrapper's own deeper
+# machinery is not reached; blessed containers are not descended, so a sub
+# closing over an object does not drag its whole graph in, and $seen guards a
+# cyclic structure.
+sub ref_cvs ($sv, $seen, $depth = 1) {
+  my $r = ref $sv or return ();
+  if ($r ne "B::AV" && $r ne "B::HV") {
+    return ()
+      unless $sv->can("FLAGS") && $sv->can("RV") && ($sv->FLAGS & SVf_ROK);
+    $sv = $sv->RV;
+    $r  = ref $sv;
+    return recoverable_sub($sv) ? $sv : () if $r eq "B::CV";
+    return () unless $r eq "B::AV" || $r eq "B::HV";
+  }
+  return () unless $depth;
+  return () if $sv->can("SvSTASH") && ref($sv->SvSTASH) ne "B::SPECIAL";
+  return () if $seen->{$$sv}++;
+  my @elems = $r eq "B::AV" ? $sv->ARRAY : do { my %h = $sv->ARRAY; values %h };
+  map ref_cvs($_, $seen, $depth - 1), @elems
+}
+
 # The seen hash stops loops from self-referential pad entries
 sub pad_cvs ($cv, $seen = {}) {
   $seen->{$$cv}++;
   my $padlist = $cv->can("PADLIST") ? $cv->PADLIST : undef;
   my $array   = $padlist && $padlist->can("ARRAY") ? $padlist->ARRAY : undef;
   return unless $array && $array->can("ARRAY");
+  # A slot holding a CV directly is an anon prototype; a slot holding a
+  # reference may lead to a named sub swapped out of its glob by a wrapper
   my @cvs = grep ref eq "B::CV" && check_file($_) && !$seen->{$$_}++,
-    $array->ARRAY;
+    map ref eq "B::CV" ? $_ : ref_cvs($_, $seen), $array->ARRAY;
   # A my sub keeps its prototype in the padname's PROTOCV (5.22+), not the
   # value slot, which is empty once its scope has exited
   my $names = $padlist->ARRAYelt(0);

--- a/t/internal/wrapped_sub.t
+++ b/t/internal/wrapped_sub.t
@@ -19,9 +19,12 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 use Cwd        qw( realpath );
 use File::Spec ();
 use File::Temp qw( tempdir );
-use Test::More import => [qw( diag done_testing is ok )];
+use Test::More import => [qw( diag done_testing is ok $TODO )];
 
 use Devel::Cover::DB ();
+
+# Set within a TODO block for the cases the heuristic cannot yet recover
+our $TODO;
 
 # A named sub replaced in the symbol table by a wrapper survives only as a
 # reference held inside the wrapper's closure pad, no longer reachable from any
@@ -208,11 +211,98 @@ PROG
   is $l && $l->[0]->covered, 1, "and has a count";
 }
 
+# The cases below are the documented limits of the reference-following
+# heuristic (docs/technical/wrapped-sub-coverage.md).  Each original runs but
+# is not recovered, so the assertions are wrapped in a TODO block - they are
+# the red anchor for the entry-capture follow-up, and will flip to passing
+# (unexpectedly) once that lands, which is the signal to drop the TODO.
+
+# The original sits two containers deep, past the single level the heuristic
+# descends.
+sub test_deep_container_todo () {
+  my $f = covered_file("WrappedDeep", <<'PERL', <<'PROG', "21\n") or return;
+package WrappedDeep;
+
+sub original {
+  my $n = shift;
+  $n * 2;
+}
+
+my $reg = { inner => { orig => \&original } };
+*original = sub { $reg->{inner}{orig}->(shift) + 1 };
+
+1;
+PERL
+use WrappedDeep;
+print WrappedDeep::original(10), "\n";
+PROG
+
+  local $TODO = "original nested past one container is not yet recovered";
+  my $sub = $f->subroutine->location(4);
+  ok $sub, "deeply-held wrapped sub is collected";
+  is $sub && $sub->[0]->covered, 1, "and is reported as covered";
+}
+
+# The original is kept in a blessed object the wrapper closes over, which the
+# heuristic does not descend.
+sub test_blessed_holder_todo () {
+  my $f = covered_file("WrappedBlessed", <<'PERL', <<'PROG', "21\n") or return;
+package WrappedBlessed;
+
+sub original {
+  my $n = shift;
+  $n * 2;
+}
+
+my $holder = bless { orig => \&original }, "WrappedBlessed::Holder";
+*original = sub { $holder->{orig}->(shift) + 1 };
+
+1;
+PERL
+use WrappedBlessed;
+print WrappedBlessed::original(10), "\n";
+PROG
+
+  local $TODO = "original held in a blessed object is not yet recovered";
+  my $sub = $f->subroutine->location(4);
+  ok $sub, "blessed-held wrapped sub is collected";
+  is $sub && $sub->[0]->covered, 1, "and is reported as covered";
+}
+
+# The original is kept in a package variable and looked up at call time, so it
+# is in no pad the walk reaches.
+sub test_global_registry_todo () {
+  my $f = covered_file("WrappedReg", <<'PERL', <<'PROG', "21\n") or return;
+package WrappedReg;
+
+sub original {
+  my $n = shift;
+  $n * 2;
+}
+
+our %REG = (orig => \&original);
+*original = sub { $REG{orig}->(shift) + 1 };
+
+1;
+PERL
+use WrappedReg;
+print WrappedReg::original(10), "\n";
+PROG
+
+  local $TODO = "original kept in a package variable is not yet recovered";
+  my $sub = $f->subroutine->location(4);
+  ok $sub, "registry-held wrapped sub is collected";
+  is $sub && $sub->[0]->covered, 1, "and is reported as covered";
+}
+
 sub main () {
   test_glob_wrapped_sub;
   test_hash_wrapped_sub;
   test_array_wrapped_sub;
   test_moose_around_original;
+  test_deep_container_todo;
+  test_blessed_holder_todo;
+  test_global_registry_todo;
   done_testing;
 }
 

--- a/t/internal/wrapped_sub.t
+++ b/t/internal/wrapped_sub.t
@@ -1,0 +1,219 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( realpath );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is ok )];
+
+use Devel::Cover::DB ();
+
+# A named sub replaced in the symbol table by a wrapper survives only as a
+# reference held inside the wrapper's closure pad, no longer reachable from any
+# stash glob.  Devel::Cover discovers subs from stash glob slots and from direct
+# CV pad values, but not from a pad slot that is a reference to a CV, so the
+# original sub is never found and its statements, though instrumented and
+# executed, are dropped from the report.  The file then reports full coverage
+# while the original body is invisible.  This is the pattern behind Moose
+# "around" and every other method modifier.  See GH-308.
+
+# Write a module and a program using it, run the program under coverage and
+# return the cover object for the module's file.
+sub covered_file ($name, $module, $program, $expect) {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+
+  my %write = (
+    File::Spec->catfile($tmpdir, "$name.pm") => $module,
+    File::Spec->catfile($tmpdir, "prog.pl")  => $program,
+  );
+  for my $path (sort keys %write) {
+    open my $fh, ">", $path or die "Cannot write $path: $!";
+    print $fh $write{$path};
+    close $fh or die "Cannot close $path: $!";
+  }
+
+  my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+  my $prog     = File::Spec->catfile($tmpdir, "prog.pl");
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my $cmd
+    = "$^X -Iblib/lib -Iblib/arch -I$tmpdir"
+    . " -MDevel::Cover=-db,$cover_db,-silent,1,-merge,0"
+    . ",-select,$name,-ignore,."
+    . " $prog 2>&1";
+  my $out = `$cmd`;
+  is $?,   0,       "$name: covered run exits 0" or diag $out;
+  is $out, $expect, "$name: module code ran";
+
+  my $db     = Devel::Cover::DB->new(db => $cover_db)->merge_runs;
+  my ($file) = grep m|\Q$name\E\.pm$|, $db->cover->items;
+  ok $file, "$name.pm is in the coverage database" or return;
+  $db->cover->file($file)
+}
+
+# A named sub kept in a lexical, then replaced in its glob by a wrapper closing
+# over that lexical.  The original runs when the wrapper calls it, so its body
+# statements and the subroutine itself must be covered rather than omitted.
+# This is the reduced form of a method modifier.
+sub test_glob_wrapped_sub () {
+  my $f = covered_file("Wrapped", <<'PERL', <<'PROG', "21\n") or return;
+package Wrapped;
+
+sub original {
+  my $n = shift;
+  $n * 2;
+}
+
+my $orig = \&original;
+*original = sub { $orig->(shift) + 1 };
+
+1;
+PERL
+use Wrapped;
+print Wrapped::original(10), "\n";
+PROG
+
+  my $stmt = $f->statement;
+  for my $line (4, 5) {
+    my $l = $stmt->location($line);
+    ok $l, "wrapped sub body statement on line $line is collected";
+    is $l && $l->[0]->covered, 1, "and has a count";
+  }
+
+  my $subs = $f->subroutine;
+  my $sub  = $subs->location(4);
+  ok $sub, "the wrapped original sub is collected";
+  is $sub && $sub->[0]->name,    "original", "and keeps its name";
+  is $sub && $sub->[0]->covered, 1,          "and is reported as covered";
+}
+
+# A wrapper that reaches the original through a plain hash it closes over,
+# rather than a direct lexical.  This is how Class::MOP (and so Moose) holds
+# the original method, so the pad walk must descend through the hash to find
+# it.
+sub test_hash_wrapped_sub () {
+  my $f = covered_file("WrappedHash", <<'PERL', <<'PROG', "21\n") or return;
+package WrappedHash;
+
+sub original {
+  my $n = shift;
+  $n * 2;
+}
+
+my %tbl = (orig => \&original);
+*original = sub { $tbl{orig}->(shift) + 1 };
+
+1;
+PERL
+use WrappedHash;
+print WrappedHash::original(10), "\n";
+PROG
+
+  my $stmt = $f->statement;
+  for my $line (4, 5) {
+    my $l = $stmt->location($line);
+    ok $l, "hash-held wrapped sub body statement on line $line is collected";
+    is $l && $l->[0]->covered, 1, "and has a count";
+  }
+  my $sub = $f->subroutine->location(4);
+  ok $sub, "the hash-held wrapped sub is collected";
+  is $sub && $sub->[0]->covered, 1, "and is reported as covered";
+}
+
+# A wrapper that reaches the original through a plain array it closes over,
+# the list-of-modifiers form.  The pad walk must descend through the array.
+sub test_array_wrapped_sub () {
+  my $f = covered_file("WrappedArray", <<'PERL', <<'PROG', "21\n") or return;
+package WrappedArray;
+
+sub original {
+  my $n = shift;
+  $n * 2;
+}
+
+my @mods = (\&original);
+*original = sub { $mods[0]->(shift) + 1 };
+
+1;
+PERL
+use WrappedArray;
+print WrappedArray::original(10), "\n";
+PROG
+
+  my $stmt = $f->statement;
+  for my $line (4, 5) {
+    my $l = $stmt->location($line);
+    ok $l, "array-held wrapped sub body statement on line $line is collected";
+    is $l && $l->[0]->covered, 1, "and has a count";
+  }
+  my $sub = $f->subroutine->location(4);
+  ok $sub, "the array-held wrapped sub is collected";
+  is $sub && $sub->[0]->covered, 1, "and is reported as covered";
+}
+
+# The motivating case: a Moose "around" modifier.  Moose installs a
+# Class::MOP wrapper into the method glob and keeps the original method only
+# inside the wrapper's closure hash, so the original body vanishes from
+# coverage unless the pad walk descends into that hash.  Moose is loaded
+# through a variable so a bareword require does not make perlcritic treat
+# this test as a Moose class.
+sub test_moose_around_original () {
+  my $moose = "Moose.pm";
+  return unless eval { require $moose; 1 };
+  my $f = covered_file("MooseAnimal", <<'PERL', <<'PROG', "loud generic\n");
+package MooseAnimal;
+use Moose;
+
+sub speak {
+  my $self = shift;
+  "generic";
+}
+
+around speak => sub {
+  my ($orig, $self) = @_;
+  "loud " . $self->$orig;
+};
+
+__PACKAGE__->meta->make_immutable;
+1;
+PERL
+use MooseAnimal;
+my $a = MooseAnimal->new;
+print $a->speak, "\n";
+PROG
+  return unless $f;
+
+  my $sub = $f->subroutine->location(5);
+  ok $sub, "the original around-wrapped method is collected";
+  is $sub && $sub->[0]->name,    "speak", "and keeps its name";
+  is $sub && $sub->[0]->covered, 1,       "and is reported as covered";
+
+  my $l = $f->statement->location(6);
+  ok $l, "the original method body statement is collected";
+  is $l && $l->[0]->covered, 1, "and has a count";
+}
+
+sub main () {
+  test_glob_wrapped_sub;
+  test_hash_wrapped_sub;
+  test_array_wrapped_sub;
+  test_moose_around_original;
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

A named sub replaced in its glob by a method modifier - Moose's `around` and the same pattern in Moo, `Class::Method::Modifiers`, `Hook::LexWrap` or a hand-rolled `*foo = sub {... $orig ...}` - survives only through the wrapper's closure. The report-time CV walk never reached it, so its body was dropped from coverage while the file still read 100% covered.

The pad walk now follows references out of the wrapper - straight to a CV, or one plain container deep into an array or hash it closes over - to recover the original, which is where Class::MOP and so Moose keep it. A recovered sub is kept only when it is genuinely named, so an anon or an internal clone such as Moose's `:around` CV is not recorded a second time.

Recovery is a bounded heuristic, not a guarantee. It does not reach an original nested deeper, held in a blessed object, or kept in a package variable and looked up at call time. Those limits, and the entry-capture mechanism that would close them, are written up in `docs/technical/wrapped-sub-coverage.md`. Three `TODO` tests cover those cases, failing as expected now and passing once that follow-up is done.

## Ticket

Closes #308