### PR TITLE
GH-608 Consolidate HTML report helpers

### DIFF
--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -14,6 +14,7 @@ use 5.42.0;
 use Devel::Cover::DB           ();
 use Devel::Cover::DB::IO::JSON ();
 use Devel::Cover::Dumper       qw( Dumper );
+use Devel::Cover::Html_Common  ();
 use Devel::Cover::Web          qw( write_file );
 
 use JSON::MaybeXS      ();
@@ -290,11 +291,7 @@ class Devel::Cover::Collection {
   }
 
   method coverage_class ($pc) {
-        $pc eq "n/a" ? "na"
-      : $pc < 75     ? "c0"
-      : $pc < 90     ? "c1"
-      : $pc < 100    ? "c2"
-      : "c3"
+    Devel::Cover::Html_Common::coverage_class($pc)
   }
 
   method _process_template ($template, $name, $vars, $file) {

--- a/lib/Devel/Cover/Html_Common.pm
+++ b/lib/Devel/Cover/Html_Common.pm
@@ -9,7 +9,8 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 use Exporter qw( import );
 
-our @EXPORT_OK = qw( launch highlight $Have_highlighter );
+our @EXPORT_OK
+  = qw( launch highlight $Have_highlighter coverage_class default_thresholds );
 
 our $Have_highlighter;
 my ($Have_ppi, $Have_perltidy);
@@ -20,6 +21,14 @@ BEGIN {
   eval "use Perl::Tidy";
   $Have_perltidy    = !$@;
   $Have_highlighter = $Have_ppi || $Have_perltidy;
+}
+
+sub default_thresholds () { { c0 => 75, c1 => 90, c2 => 100 } }
+
+sub coverage_class ($pc, $t = undef) {
+  $t //= default_thresholds;
+  return "na" if !defined $pc || $pc eq "n/a";
+  $pc < $t->{c0} ? "c0" : $pc < $t->{c1} ? "c1" : $pc < $t->{c2} ? "c2" : "c3"
 }
 
 sub launch ($package, $opt) {
@@ -124,6 +133,19 @@ hash so that C<noppihtml> and C<noperltidy> flags are respected.
 =item $Have_highlighter
 
 True if PPI::HTML or Perl::Tidy is available.
+
+=item coverage_class ($percentage, $thresholds)
+
+Map a coverage percentage to a CSS band name (C<c0>, C<c1>, C<c2> or
+C<c3>). An undefined percentage or the string C<n/a> maps to C<na>. The
+optional C<$thresholds> hashref carries C<c0>, C<c1> and C<c2> cut-off
+points. It defaults to the values from C<default_thresholds> when omitted.
+
+=item default_thresholds
+
+Return a fresh hashref of the default band cut-off points (C<c0> 75,
+C<c1> 90, C<c2> 100). A new copy is returned each call so callers may
+mutate their own thresholds without affecting the defaults.
 
 =back
 

--- a/lib/Devel/Cover/Html_Common.pm
+++ b/lib/Devel/Cover/Html_Common.pm
@@ -7,10 +7,14 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
-use Exporter qw( import );
+use Exporter    qw( import );
+use Digest::MD5 ();
+use Encode      ();
 
-our @EXPORT_OK
-  = qw( launch highlight $Have_highlighter coverage_class default_thresholds );
+our @EXPORT_OK = qw(
+  launch highlight $Have_highlighter
+  coverage_class default_thresholds unique_filenames
+);
 
 our $Have_highlighter;
 my ($Have_ppi, $Have_perltidy);
@@ -29,6 +33,25 @@ sub coverage_class ($pc, $t = undef) {
   $t //= default_thresholds;
   return "na" if !defined $pc || $pc eq "n/a";
   $pc < $t->{c0} ? "c0" : $pc < $t->{c1} ? "c1" : $pc < $t->{c2} ? "c2" : "c3"
+}
+
+sub unique_filenames (@files) {
+  my (%name, %seen);
+  for my $file (sort @files) {
+    my $n = $file =~ s/\W/-/gr;
+    if ($seen{$n}) {
+      my $digest = Digest::MD5::md5_hex(Encode::encode_utf8($file));
+      my $len    = 8;
+      my $suffix = substr $digest, 0, $len;
+      while ($seen{"$n--$suffix"}) {
+        $suffix = substr $digest, 0, ++$len;
+      }
+      $n .= "--$suffix";
+    }
+    $seen{$n}++;
+    $name{$file} = $n;
+  }
+  \%name
 }
 
 sub launch ($package, $opt) {
@@ -146,6 +169,16 @@ points. It defaults to the values from C<default_thresholds> when omitted.
 Return a fresh hashref of the default band cut-off points (C<c0> 75,
 C<c1> 90, C<c2> 100). A new copy is returned each call so callers may
 mutate their own thresholds without affecting the defaults.
+
+=item unique_filenames (@files)
+
+Map each source path to a unique page name, returned as a hashref. Each
+name reduces every non-word character to a hyphen, as the reports have
+always done. That mapping is many-to-one, so distinct paths such as
+C<X/Y.pm> and C<X-Y.pm> can produce the same name. When two paths
+collide, the sorted-first path keeps the plain name and each later
+collider is given a stable suffix of C<--> plus the leading hex
+characters of the MD5 of its path. Non-colliding paths are unchanged.
 
 =back
 

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 use Devel::Cover::Html_Common  ## no perlimports
-  qw( launch highlight $Have_highlighter );
+  qw( launch highlight $Have_highlighter coverage_class default_thresholds );
 use Devel::Cover::Inc ();
 use Devel::Cover::Log qw( dcinfo );
 use Devel::Cover::Web qw( write_file );
@@ -37,16 +37,11 @@ sub oclass ($o, $criterion) {
   $o ? class($o->percentage, $o->error, $criterion) : ""
 }
 
-my $Threshold = { c0 => 75, c1 => 90, c2 => 100 };
+my $Threshold = default_thresholds;
 
 sub class ($pc, $err, $criterion) {
   return "" if $criterion eq "time";
-  no warnings "uninitialized";
-     !$err                   ? "c3"
-    : $pc < $Threshold->{c0} ? "c0"
-    : $pc < $Threshold->{c1} ? "c1"
-    : $pc < $Threshold->{c2} ? "c2"
-    :                          "c3"
+  !$err ? "c3" : coverage_class($pc // 0, $Threshold)
 }
 
 sub get_summary ($file, $criterion) {

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -19,7 +19,8 @@ BEGIN {
 }
 
 use Devel::Cover::Html_Common  ## no perlimports
-  qw( launch highlight $Have_highlighter coverage_class default_thresholds );
+  qw( launch highlight $Have_highlighter
+  coverage_class default_thresholds unique_filenames );
 use Devel::Cover::Inc ();
 use Devel::Cover::Log qw( dcinfo );
 use Devel::Cover::Web qw( write_file );
@@ -378,9 +379,7 @@ sub report ($pkg, $db, $options) {
       map { my $ann = $_; map $ann->header($_), 0 .. $ann->count - 1 }
         $options->{annotations}->@*
     ],
-    filenames => {
-      map { $_ => do { (my $f = $_) =~ s/\W/-/g; $f } } $options->{file}->@*
-    },
+    filenames  => unique_filenames($options->{file}->@*),
     exists     => { map { $_ => -e } $options->{file}->@* },
     uncompiled => {
       map { $_ => ($db->cover->file($_)->{meta}{uncompiled} ? 1 : 0) }

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -20,8 +20,10 @@ BEGIN {
 BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
 
 ## no perlimports
-use Devel::Cover::Html_Common
-  qw( $Have_highlighter highlight launch coverage_class default_thresholds );
+use Devel::Cover::Html_Common qw(
+  $Have_highlighter highlight launch
+  coverage_class default_thresholds unique_filenames
+);
 use Devel::Cover::Web             qw( $Cov $Crisp_base_css $Crisp_theme_js );
 use Devel::Cover::Condition_table ();
 use Devel::Cover::DB              ();
@@ -1243,9 +1245,7 @@ sub report ($pkg, $db, $options) {
       my @c = $db->criteria;
       +{ (map { $_ => ucfirst } @c), mcdc => "MC/DC", total => "total" }
     },
-    filenames => {
-      map { $_ => do { (my $f = $_) =~ s/\W/-/g; $f } } $options->{file}->@*
-    },
+    filenames      => unique_filenames($options->{file}->@*),
     have_ppi       => eval { require PPI; 1 } ? 1 : 0,
     favicon_colour => favicon("c3"),
     report_id      => $options->{outputdir},

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -20,7 +20,8 @@ BEGIN {
 BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
 
 ## no perlimports
-use Devel::Cover::Html_Common     qw( $Have_highlighter highlight launch );
+use Devel::Cover::Html_Common
+  qw( $Have_highlighter highlight launch coverage_class default_thresholds );
 use Devel::Cover::Web             qw( $Cov $Crisp_base_css $Crisp_theme_js );
 use Devel::Cover::Condition_table ();
 use Devel::Cover::DB              ();
@@ -36,7 +37,7 @@ use POSIX          qw( strftime );
 our %R;
 my %Assets;
 
-my $Threshold = { c0 => 75, c1 => 90, c2 => 100 };
+my $Threshold = default_thresholds;
 
 sub crit_name ($c) {
   qq(<span class="name-full">$R{full}{$c}</span>)
@@ -742,12 +743,7 @@ HTML
 sub class ($pc, $err, $criterion) {
   return "" if $criterion && $criterion eq "time";
   return "na" unless defined $pc && $pc =~ /\A[0-9.]+\z/;
-  no warnings "uninitialized";
-     !$err                   ? "c3"
-    : $pc < $Threshold->{c0} ? "c0"
-    : $pc < $Threshold->{c1} ? "c1"
-    : $pc < $Threshold->{c2} ? "c2"
-    :                          "c3"
+  !$err ? "c3" : coverage_class($pc, $Threshold)
 }
 
 sub oclass ($o, $criterion) {

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1190,9 +1190,9 @@ sub generate_index ($outdir, $options, $file_data, $total, $dist) {
 }
 
 sub generate_file_pages ($outdir, $file_data) {
-  for my $idx (0 .. $#$file_data) {
-    my $fd = $file_data->[$idx];
-    next unless $fd->{exists};
+  my @pages = grep $_->{exists}, @$file_data;
+  for my $idx (0 .. $#pages) {
+    my $fd   = $pages[$idx];
     my $file = $fd->{name};
     $R{scar_subs} = $R{db}->scar_sub_lookup($file);
     my $lines
@@ -1206,8 +1206,8 @@ sub generate_file_pages ($outdir, $file_data) {
       )
       : totals_for($file);
 
-    my $prev = $idx > 0            ? $file_data->[$idx - 1] : undef;
-    my $next = $idx < $#$file_data ? $file_data->[$idx + 1] : undef;
+    my $prev = $idx > 0       ? $pages[$idx - 1] : undef;
+    my $next = $idx < $#pages ? $pages[$idx + 1] : undef;
 
     write_file(
       "$outdir/$fd->{link}",

--- a/lib/Devel/Cover/Report/Html_minimal.pm
+++ b/lib/Devel/Cover/Report/Html_minimal.pm
@@ -8,7 +8,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 use HTML::Entities qw( encode_entities );
 use Getopt::Long   qw( GetOptions );
 use Devel::Cover::Html_Common  ## no perlimports
-  qw( launch coverage_class default_thresholds );
+  qw( launch coverage_class default_thresholds unique_filenames );
 use Devel::Cover::Log         qw( dcinfo );
 use Devel::Cover::Truth_Table ();
 
@@ -688,9 +688,7 @@ sub get_options ($self, $opt) {
 # Entry point for printing HTML reports
 sub report ($pkg, $db, $opt) {
   my @files = $opt->{file}->@*;
-  %Filenames = map {
-    $_ => do { (my $f = $_) =~ s/\W/-/g; $f }
-  } @files;
+  %Filenames = unique_filenames(@files)->%*;
 
   print_stylesheet($db, $opt);
   for my $file (@files) {

--- a/lib/Devel/Cover/Report/Html_minimal.pm
+++ b/lib/Devel/Cover/Report/Html_minimal.pm
@@ -5,9 +5,10 @@ use warnings;
 use feature qw( postderef signatures );
 no warnings qw( experimental::postderef experimental::signatures );
 
-use HTML::Entities            qw( encode_entities );
-use Getopt::Long              qw( GetOptions );
-use Devel::Cover::Html_Common qw( launch );          ## no perlimports
+use HTML::Entities qw( encode_entities );
+use Getopt::Long   qw( GetOptions );
+use Devel::Cover::Html_Common  ## no perlimports
+  qw( launch coverage_class default_thresholds );
 use Devel::Cover::Log         qw( dcinfo );
 use Devel::Cover::Truth_Table ();
 
@@ -135,7 +136,7 @@ sub merge_lineops (@ops) {
 
 my %Filenames;
 my @Class     = qw( c0 c1 c2 c3 );
-my $Threshold = { c0 => 75, c1 => 90, c2 => 100 };
+my $Threshold = default_thresholds;
 
 # Determine the CSS class based on boolean coverage
 sub bclass (@vals) {
@@ -146,10 +147,7 @@ sub bclass (@vals) {
 # Determine the CSS class based on percent covered
 sub pclass ($p, $e) {
   return $Class[3] unless $e;
-  $p < $Threshold->{c0} && return $Class[0];
-  $p < $Threshold->{c1} && return $Class[1];
-  $p < $Threshold->{c2} && return $Class[2];
-  $Class[3]
+  coverage_class($p // 0, $Threshold)
 }
 
 # Dispatch to the appropriate coverage report renderer

--- a/lib/Devel/Cover/Report/Html_subtle.pm
+++ b/lib/Devel/Cover/Report/Html_subtle.pm
@@ -7,7 +7,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 # VERSION
 
 use Devel::Cover::Html_Common  ## no perlimports
-  qw( launch coverage_class default_thresholds );
+  qw( launch coverage_class default_thresholds unique_filenames );
 use Devel::Cover::Log qw( dcinfo );
 use Devel::Cover::Truth_Table;  ## no perlimports
 
@@ -402,8 +402,7 @@ sub report ($pkg, $db, $options) {
       [Devel::Cover::Report::Html_subtle::Template::Provider->new({})],
   });
 
-  %Filenames
-    = map { $_ => do { (my $f = $_) =~ s/\W/-/g; $f } } $options->{file}->@*;
+  %Filenames   = unique_filenames($options->{file}->@*)->%*;
   %File_exists = map { $_ => -e } $options->{file}->@*;
 
   print_stylesheet($db, $options);

--- a/lib/Devel/Cover/Report/Html_subtle.pm
+++ b/lib/Devel/Cover/Report/Html_subtle.pm
@@ -6,9 +6,10 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
-use Devel::Cover::Html_Common qw( launch );  ## no perlimports
-use Devel::Cover::Log         qw( dcinfo );
-use Devel::Cover::Truth_Table;               ## no perlimports
+use Devel::Cover::Html_Common  ## no perlimports
+  qw( launch coverage_class default_thresholds );
+use Devel::Cover::Log qw( dcinfo );
+use Devel::Cover::Truth_Table;  ## no perlimports
 
 use Getopt::Long   qw( GetOptions );
 use Template 2.00  ();
@@ -17,21 +18,28 @@ use HTML::Entities qw( encode_entities );
 my $Template;
 my %Filenames;
 my %File_exists;
-my $Perlver = join ".", map { ord } split //, $^V;
+my $Perlver    = join ".", map { ord } split //, $^V;
+my $Threshold  = default_thresholds;
+my %Class_name = (
+  na => "uncovered",
+  c0 => "uncovered",
+  c1 => "covered75",
+  c2 => "covered90",
+  c3 => "covered",
+);
 
 sub get_options ($self, $opt) {
   $opt->{option}{outputfile} = "coverage.html";
+  $Threshold->{$_} = $opt->{"report_$_"}
+    for grep { defined $opt->{"report_$_"} } qw( c0 c1 c2 );
   die "Invalid command line options"
     unless GetOptions($opt->{option}, qw( outputfile=s ));
 }
 
 # Determine the CSS class for an element based on percent covered
 sub cvg_class ($pc, $err = undef) {
-  defined $err && !$err ? "covered"
-    : $pc < 75          ? "uncovered"
-    : $pc < 90          ? "covered75"
-    : $pc < 100         ? "covered90"
-    :                     "covered";
+  return "covered" if defined $err && !$err;
+  $Class_name{ coverage_class($pc // 0, $Threshold) }
 }
 
 # Determine which metrics to include in report

--- a/t/internal/cover_annotation_options.t
+++ b/t/internal/cover_annotation_options.t
@@ -36,7 +36,7 @@ my $Db     = File::Spec->catdir($Tmpdir, "cover_db");
 sub build_db () {
   my $script = File::Spec->catfile($Tmpdir, "covered.pl");
   open my $fh, ">", $script or die "open $script: $!";
-  print {$fh} "my \$x = 0;\n\$x++ for 1 .. 3;\n";
+  print $fh "my \$x = 0;\n\$x++ for 1 .. 3;\n";
   close $fh or die "close $script: $!";
 
   my @cmd = (

--- a/t/internal/coverage_class.t
+++ b/t/internal/coverage_class.t
@@ -1,0 +1,73 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is )];
+
+use Devel::Cover::Html_Common         qw( coverage_class default_thresholds );
+use Devel::Cover::Report::Html_subtle ();
+
+sub test_default_banding () {
+  is coverage_class(0),     "c0", "0% is c0";
+  is coverage_class(74.99), "c0", "just below c0 threshold";
+  is coverage_class(75),    "c1", "at c0 threshold";
+  is coverage_class(89.99), "c1", "just below c1 threshold";
+  is coverage_class(90),    "c2", "at c1 threshold";
+  is coverage_class(99.99), "c2", "just below c2 threshold";
+  is coverage_class(100),   "c3", "100% is c3";
+  is coverage_class("n/a"), "na", "n/a maps to na";
+  is coverage_class(undef), "na", "undef maps to na";
+}
+
+sub test_custom_thresholds () {
+  my $t = { c0 => 25, c1 => 50, c2 => 75 };
+  is coverage_class(20, $t), "c0", "custom c0";
+  is coverage_class(30, $t), "c1", "custom c1";
+  is coverage_class(60, $t), "c2", "custom c2";
+  is coverage_class(80, $t), "c3", "custom c3";
+}
+
+sub test_default_thresholds_copy () {
+  my $d = default_thresholds;
+  $d->{c0} = 1;
+  is default_thresholds->{c0}, 75, "defaults are not shared state";
+}
+
+# Runs last: get_options mutates module-level threshold state.
+sub test_html_subtle_honours_thresholds () {
+  is Devel::Cover::Report::Html_subtle::cvg_class(80), "covered75",
+    "default thresholds: 80% is covered75";
+
+  local @ARGV = ();
+  Devel::Cover::Report::Html_subtle->get_options(
+    { option => {}, report_c0 => 85, report_c1 => 95, report_c2 => 100 });
+  is Devel::Cover::Report::Html_subtle::cvg_class(80), "uncovered",
+    "custom c0: 80% is uncovered";
+  is Devel::Cover::Report::Html_subtle::cvg_class(90), "covered75",
+    "custom c1: 90% is covered75";
+  is Devel::Cover::Report::Html_subtle::cvg_class(97), "covered90",
+    "custom c2: 97% is covered90";
+  is Devel::Cover::Report::Html_subtle::cvg_class(100), "covered",
+    "100% is covered";
+}
+
+test_default_banding;
+test_custom_thresholds;
+test_default_thresholds_copy;
+test_html_subtle_honours_thresholds;
+
+done_testing;

--- a/t/internal/html_crisp_missing_file.t
+++ b/t/internal/html_crisp_missing_file.t
@@ -1,0 +1,65 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use Test::More import => [qw( diag done_testing is ok plan unlike )];
+use Devel::Cover::Test::Showcase qw(
+  create_cover_db
+  run_cover
+  setup_lib_dir
+  slurp
+);
+
+eval "require HTML::Entities; 1" or do {
+  plan skip_all => "HTML::Entities not available";
+  exit;
+};
+
+sub main () {
+  my ($tmpdir, $libdir) = setup_lib_dir;
+  my $cover_db = create_cover_db($tmpdir, $libdir);
+
+  # Remove one covered source file after collection, before reporting, so the
+  # database references a file that no longer exists on disk.
+  my $missing = File::Spec->catfile($libdir, "Covered", "Utils.pm");
+  unlink $missing or die "Cannot unlink $missing: $!";
+
+  my $outdir = File::Spec->catdir($tmpdir, "html");
+  my ($out, $exit) = run_cover(
+    "--select_dir", $libdir, "--report", "html_crisp",
+    "--outputdir",  $outdir, "--silent", $cover_db,
+  );
+  is $exit, 0, "report generated with a missing source file" or diag $out;
+
+  my @pages = glob "$outdir/*.html";
+  ok @pages, "pages were generated";
+  is 0 + (grep /-Covered-Utils-pm\.html$/, @pages), 0,
+    "no page is written for the missing file";
+
+  # The leading hyphen (mangled path separator) and capital C keep this from
+  # matching the Uncovered/Utils.pm twin, which exists and must keep its page.
+  for my $page (@pages) {
+    my $name = $page =~ s{.*/}{}r;
+    unlike slurp($page), qr/href="[^"]*-Covered-Utils-pm\.html/,
+      "$name has no link to the missing file's page";
+  }
+
+  done_testing;
+}
+
+main;

--- a/t/internal/html_filename_collision.t
+++ b/t/internal/html_filename_collision.t
@@ -1,0 +1,118 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( realpath );
+use File::Path qw( make_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is is_deeply isnt like ok )];
+
+use Devel::Cover::Html_Common    qw( unique_filenames );
+use Devel::Cover::Test::Showcase qw( run_cover slurp );
+
+sub test_mapping () {
+  my $m = unique_filenames("X/Y.pm", "X-Y.pm");
+  is $m->{"X-Y.pm"}, "X-Y-pm", "sorted-first path keeps the plain name";
+  like $m->{"X/Y.pm"}, qr/\AX-Y-pm--[0-9a-f]{8}\z/,
+    "collider gets a digest suffix";
+  isnt $m->{"X/Y.pm"}, $m->{"X-Y.pm"}, "colliding paths map to unique names";
+
+  my $m2 = unique_filenames("t/foo/bar.t", "t/foo-bar.t");
+  isnt $m2->{"t/foo/bar.t"}, $m2->{"t/foo-bar.t"},
+    "second collision pair maps to unique names";
+
+  is unique_filenames("lib/Foo.pm")->{"lib/Foo.pm"}, "lib-Foo-pm",
+    "non-colliding path is unchanged";
+
+  is_deeply unique_filenames("X-Y.pm", "X/Y.pm"), $m,
+    "mapping is independent of argument order";
+}
+
+# Build a cover_db over two source paths that both mangle to the same page
+# name (X/Y.pm and X-Y.pm both become <path>-X-Y-pm), then run each report
+# and require both sources to survive in the generated pages.
+sub setup_colliding_db () {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+  my $libdir = File::Spec->catdir($tmpdir, "lib");
+  make_path(File::Spec->catdir($libdir, "X"));
+
+  my $slash = File::Spec->catfile($libdir, "X", "Y.pm");
+  open my $sfh, ">", $slash or die "Cannot write $slash: $!";
+  print $sfh "package X::Y;\nsub in_x_slash_y { 1 }\n1;\n";
+  close $sfh or die "Cannot close $slash: $!";
+
+  my $dash = File::Spec->catfile($libdir, "X-Y.pm");
+  open my $dfh, ">", $dash or die "Cannot write $dash: $!";
+  print $dfh "package X_Y;\nsub in_x_dash_y { 1 }\n1;\n";
+  close $dfh or die "Cannot close $dash: $!";
+
+  my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+  my $select   = quotemeta $libdir;
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my $cmd
+    = "$^X -Iblib/lib -Iblib/arch -I$libdir"
+    . " -MDevel::Cover=-db,$cover_db,-silent,1,-merge,0,-select,$select"
+    . " -e 'use X::Y; require q($dash);"
+    . " X::Y::in_x_slash_y(); X_Y::in_x_dash_y()' 2>&1";
+  my $out = `$cmd`;
+  die "Failed to create cover_db:\n$out\n" if $?;
+
+  ($tmpdir, $cover_db)
+}
+
+sub test_reports_keep_both ($tmpdir, $cover_db, $have_template) {
+  for my $report (qw( html_basic html_subtle html_minimal html_crisp )) {
+    next if $report =~ /^html_(basic|subtle)$/ && !$have_template;
+
+    # Only html_basic and html_crisp accept the highlighter switches.
+    my @highlight
+      = $report =~ /^html_(basic|crisp)$/ ? ("-noppihtml", "-noperltidy") : ();
+
+    my $outdir = File::Spec->catdir($tmpdir, $report);
+    my ($out, $exit) = run_cover(
+      "--report", $report,    "--outputdir", $outdir,
+      "--silent", @highlight, $cover_db,
+    );
+    is $exit, 0, "$report: cover exits 0" or diag $out;
+
+    # Exclude the index (coverage.html): it names subs in its summary even
+    # when a file page is overwritten, which would mask the collision.
+    my @pages = grep !m{/coverage\.html$}, glob "$outdir/*.html";
+    ok(
+      (grep { slurp($_) =~ /in_x_slash_y/ } @pages),
+      "$report: X/Y.pm source appears in a file page",
+    );
+    ok(
+      (grep { slurp($_) =~ /in_x_dash_y/ } @pages),
+      "$report: X-Y.pm source appears in a file page",
+    );
+  }
+}
+
+sub main () {
+  test_mapping;
+
+  my $have_template = eval "require Template; 1";
+  my ($tmpdir, $cover_db) = setup_colliding_db;
+  test_reports_keep_both($tmpdir, $cover_db, $have_template);
+
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

Three of the HTML reporters carried duplicated logic that had drifted out of step, along with two related bugs. Move the shared logic into `Devel::Cover::Html_Common` and fix the bugs there.

## Changes

- Move the percentage-to-CSS-band mapping into `Html_Common` and delegate from the four HTML reports and `Collection.pm`. `html_subtle` now honours the `-report_c0/c1/c2` threshold options it previously accepted and silently ignored.
- Add a shared `unique_filenames` helper so distinct source paths that mangle to the same page name (for example `X/Y.pm` and `X-Y.pm`) each get their own page instead of one silently overwriting the other.
- Filter the crisp report's file list to files present on disk before choosing each page's prev/next neighbours, so navigation no longer links to a page that was never written.

## Implications

- Report output is unchanged for the common case. Only `html_subtle` under custom thresholds, colliding source paths, and pages neighbouring a missing file behave differently, and each of those was previously wrong.

## Ticket

Closes #608