### PR TITLE
GH-610 Guard fork result in Collection::_sys

### DIFF
--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -101,7 +101,7 @@ class Devel::Cover::Collection {
     my $pid;
     eval {
       open STDIN, "<", "/dev/null" or die "Can't read /dev/null: $!";
-      $pid = open my $fh, "-|" // die "Can't fork: $!";
+      $pid = open(my $fh, "-|") // die "Can't fork: $!";
       if ($pid) {
         my $printed = 0;
         local $SIG{ALRM} = sub { die "alarm\n" };


### PR DESCRIPTION
## Summary

`Devel::Cover::Collection::_sys` runs every external command the cpancover collection machinery uses. It forks a child with a pipe open and is meant to die cleanly if the fork fails, but a precedence bug meant the guard never ran.

## Changes

- Parenthesise `open` so the `// die` checks its return value. The `//` bound to the pipe-open mode constant, so the compiler folded the guard away, and a failed fork (`EAGAIN` under load in a multi-worker run) sent the parent into the child branch to `exec` the command instead of dying.

## Implications

- No test accompanies the fix. Forcing a fork failure isn't practical here - overriding `open` breaks compilation of the bareword-filehandle dup in the child branch, and a genuine fork failure can't be provoked portably. The existing suite still exercises the success path through `sys`/`fsys`.

## Ticket

Closes #610