### PR TITLE
GH-613 Sort compilation report lines by line number

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Sort statement, subroutine and pod lines in the compilation report by line
+  number - they previously appeared in per-run hash order (GH-613)
 - Collect coverage for top-level statements, branches and conditions in
   required modules by keeping their optrees alive until report time - such
   code was previously absent from reports entirely (GH-51)

--- a/lib/Devel/Cover/Report/Compilation.pm
+++ b/lib/Devel/Cover/Report/Compilation.pm
@@ -19,7 +19,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 sub print_statement ($db, $file, $) {
   my $statements = $db->cover->file($file)->statement or return;
 
-  for my $location ($statements->items) {
+  for my $location (sort { $a <=> $b } $statements->items) {
     for my $statement ($statements->location($location)->@*) {
       next if $statement->covered;
       print "Uncovered statement at $file line $location\n";
@@ -94,7 +94,7 @@ sub print_mcdc ($db, $file, $) {
 sub print_subroutines ($db, $file, $) {
   my $subroutines = $db->cover->file($file)->subroutine or return;
 
-  for my $location ($subroutines->items) {
+  for my $location (sort { $a <=> $b } $subroutines->items) {
     for my $sub ($subroutines->location($location)->@*) {
       next if $sub->covered;
       print "Uncovered subroutine ", $sub->name, " at $file line $location\n";
@@ -105,7 +105,7 @@ sub print_subroutines ($db, $file, $) {
 sub print_pod ($db, $file, $) {
   my $pod = $db->cover->file($file)->pod or return;
 
-  for my $location ($pod->items) {
+  for my $location (sort { $a <=> $b } $pod->items) {
     for my $p ($pod->location($location)->@*) {
       next if $p->covered;
       print "Uncovered pod at $file line $location\n";

--- a/t/internal/compilation.t
+++ b/t/internal/compilation.t
@@ -16,8 +16,9 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Test::More import => [qw( diag done_testing is like )];
-use Devel::Cover::Test::Showcase qw(
+use Test::More import => [qw( diag done_testing is is_deeply like )];
+use Devel::Cover::Report::Compilation ();
+use Devel::Cover::Test::Showcase      qw(
   create_cover_db
   run_cover
   setup_lib_dir
@@ -43,10 +44,86 @@ sub test_compilation_report () {
     "uncovered subroutine line emitted";
   like $out, qr|Uncovered MC/DC pair \([^)]*\) at .* line \d+: .+|,
     "uncovered MC/DC pair line emitted";
+
+  my %stmt_lines;
+  while ($out =~ /^Uncovered statement at (\S+) line (\d+)$/gm) {
+    push $stmt_lines{$1}->@*, $2;
+  }
+  for my $file (sort keys %stmt_lines) {
+    is_deeply $stmt_lines{$file}, [sort { $a <=> $b } $stmt_lines{$file}->@*],
+      "statement lines ascending for $file";
+  }
+}
+
+{
+
+  package Mock::Item;
+  sub new     ($class) { bless {}, $class }
+  sub covered ($self)  { 0 }
+  sub name    ($self)  { "mock_sub" }
+}
+
+{
+
+  package Mock::Criterion;
+  sub new   ($class, @locations) { bless { locations => \@locations }, $class }
+  sub items ($self)              { $self->{locations}->@* }
+  sub location ($self, $loc)     { [Mock::Item->new] }
+}
+
+{
+
+  package Mock::File;
+  sub new        ($class, $crit) { bless { crit => $crit }, $class }
+  sub statement  ($self)         { $self->{crit} }
+  sub subroutine ($self)         { $self->{crit} }
+  sub pod        ($self)         { $self->{crit} }
+}
+
+{
+
+  package Mock::Cover;
+  sub new  ($class, $file) { bless { file => $file }, $class }
+  sub file ($self, $name)  { $self->{file} }
+}
+
+{
+
+  package Mock::DB;
+  sub new   ($class, $cover) { bless { cover => $cover }, $class }
+  sub cover ($self)          { $self->{cover} }
+}
+
+sub capture_lines ($print_sub) {
+  my $crit = Mock::Criterion->new(10, 2, 19, 7, 13);
+  my $db   = Mock::DB->new(Mock::Cover->new(Mock::File->new($crit)));
+  my $output;
+  {
+    open my $fh, ">", \$output or die "Cannot open scalar ref: $!";
+    local *STDOUT = $fh;
+    $print_sub->($db, "Mock.pm", {});
+    close $fh or die "Cannot close scalar ref: $!";
+  }
+  [$output =~ /line (\d+)$/gm]
+}
+
+# Hash order can coincidentally ascend, so feed a fixed non-ascending order.
+sub test_lines_sorted () {
+  my %print = (
+    statement  => \&Devel::Cover::Report::Compilation::print_statement,
+    subroutine => \&Devel::Cover::Report::Compilation::print_subroutines,
+    pod        => \&Devel::Cover::Report::Compilation::print_pod,
+  );
+  for my $criterion (sort keys %print) {
+    my $lines = capture_lines($print{$criterion});
+    is_deeply $lines, [2, 7, 10, 13, 19],
+      "$criterion lines emitted in ascending order";
+  }
 }
 
 sub main () {
   test_compilation_report;
+  test_lines_sorted;
   done_testing;
 }
 


### PR DESCRIPTION
Closes #613

## Summary

- The compilation report's statement, subroutine and pod loops iterated their locations in hash order, so those lines shuffled on every run, defeating quickfix-style navigation. The branch, condition and MC/DC loops in the same file already sorted numerically.
- Add the identical numeric sort to the three loops, with a deterministic mock-driven test (fixed non-ascending order, so it fails every run before the fix) plus an integration ordering check over the Showcase fixture.