### PR TITLE
GH-612 Centralise criterion metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Show subroutine call counts in the text2 report's per-line column - the
+  column previously showed a flat 100 or 0 (GH-612)
 - Sort statement, subroutine and pod lines in the compilation report by line
   number - they previously appeared in per-run hash order (GH-613)
 - Collect coverage for top-level statements, branches and conditions in

--- a/bin/cover
+++ b/bin/cover
@@ -18,9 +18,10 @@ BEGIN {
   # VERSION
 }
 
-use Devel::Cover::DB  ();
-use Devel::Cover::Inc ();
-use Devel::Cover::Log qw( dcerror dcinfo );
+use Devel::Cover::Criterion ();
+use Devel::Cover::DB        ();
+use Devel::Cover::Inc       ();
+use Devel::Cover::Log       qw( dcerror dcinfo );
 
 BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
 
@@ -129,15 +130,13 @@ sub get_options () {
   # handle comma separated ops, like -coverage branch,statement
 
   # also accept them in the same format they're output
-  my %coverage_abbrev = (
-    stmt => "statement",
-    bran => "branch",
-    cond => "condition",
-    sub  => "subroutine",
-  );
+  my %coverage_abbrev = map {
+    my $short = Devel::Cover::Criterion->criterion_class($_)->shortname;
+    $short ne $_ ? ($short => $_) : ()
+  } Devel::Cover::Criterion->criterion_names;
 
-  my %coverage_allowed = map { $_ => 1 } values %coverage_abbrev, "mcdc",
-    "time", "pod";
+  my %coverage_allowed
+    = map { $_ => 1 } Devel::Cover::Criterion->criterion_names;
   my %options_coverage = map { $_ => 1 } split /,/, join ",",
     $Options->{coverage}->@*;
 

--- a/lib/Devel/Cover/Base/Editor.pm
+++ b/lib/Devel/Cover/Base/Editor.pm
@@ -14,9 +14,10 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
-use Devel::Cover::DB  ();
-use Devel::Cover::Log qw( dcinfo );
-use Template 2.00     ();
+use Devel::Cover::Criterion ();
+use Devel::Cover::DB        ();
+use Devel::Cover::Log       qw( dcinfo );
+use Template 2.00           ();
 
 sub report ($pkg, $db, $options) {
   my $template = Template->new({
@@ -49,7 +50,7 @@ sub report ($pkg, $db, $options) {
       [grep !$db->cover->file($_)->{meta}{uncompiled}, $options->{file}->@*],
     cover => $db->cover,
     types =>
-      [grep $options->{show}{$_} && $_ ne "time", @Devel::Cover::DB::Criteria],
+      [grep $options->{show}{$_}, Devel::Cover::Criterion->editor_criteria],
   };
 
   my $out = "$options->{outputdir}/$options->{outputfile}";

--- a/lib/Devel/Cover/Branch.pm
+++ b/lib/Devel/Cover/Branch.pm
@@ -34,6 +34,10 @@ sub values    ($self)     { $self->[0]->@* }
 sub text      ($self)     { $self->[1]{text} }
 sub criterion ($self)     { "branch" }
 
+sub shortname        ($class) { "bran" }
+sub detail_criterion ($class) { "branch" }
+sub sign_letter      ($class) { "B" }
+
 sub percentage ($self) {
   my $t = $self->total;
   $t ? int($self->covered / $t * 100) : 0;

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -11,6 +11,7 @@ use 5.42.0;
 
 # VERSION
 
+use Devel::Cover::Criterion    ();
 use Devel::Cover::DB           ();
 use Devel::Cover::DB::IO::JSON ();
 use Devel::Cover::Dumper       qw( Dumper );
@@ -375,17 +376,24 @@ class Devel::Cover::Collection {
     $self->file($f);
     say "\n\nWriting collection output to $f ...";
 
+    my @crit = (Devel::Cover::Criterion->coverage_criteria, "total");
     my $vars = {
       title       => "Coverage report",
       modules     => {},
       vals        => {},
-      headers     => [grep !/time/, @Devel::Cover::DB::Criteria_short, "total"],
-      criteria    => [grep !/time/, @Devel::Cover::DB::Criteria,       "total"],
-      col_headers => do {
-        my @f = (grep(!/time/, @Devel::Cover::DB::Criteria),       "total");
-        my @s = (grep(!/time/, @Devel::Cover::DB::Criteria_short), "total");
-        [map { { full => ucfirst($f[$_]), short => $s[$_] } } 0 .. $#f]
-      },
+      criteria    => \@crit,
+      col_headers => [
+        map {
+          my $class
+            = $_ eq "total"
+            ? undef
+            : Devel::Cover::Criterion->criterion_class($_);
+          {
+            full  => $class ? $class->display_name : "Total",
+            short => $class ? $class->shortname    : "total",
+          }
+        } @crit
+      ],
     };
 
     opendir my $dh, $d or die "Can't opendir $d: $!";

--- a/lib/Devel/Cover/Condition.pm
+++ b/lib/Devel/Cover/Condition.pm
@@ -25,8 +25,12 @@ sub text ($self) {
 
 sub type      ($self) { $self->[1]{type} }
 sub criterion ($self) { "condition" }
-sub count     ($self) { Carp::confess("count() must be overridden") }
-sub headers   ($self) { Carp::confess("headers() must be overridden") }
+
+sub shortname        ($class) { "cond" }
+sub detail_criterion ($class) { "condition" }
+sub sign_letter      ($class) { "C" }
+sub count            ($self)  { Carp::confess("count() must be overridden") }
+sub headers          ($self)  { Carp::confess("headers() must be overridden") }
 
 1
 

--- a/lib/Devel/Cover/Criterion.pm
+++ b/lib/Devel/Cover/Criterion.pm
@@ -125,11 +125,79 @@ Devel::Cover::Criterion - Code coverage metrics for Perl
 
 =head1 DESCRIPTION
 
-Abstract base class for all the coverage criteria.
+Abstract base class for all the coverage criteria. It also carries the
+canonical criterion list and per-criterion metadata as class methods, so
+reporters can ask about a criterion instead of hardcoding names, regexes
+and lists.
 
 =head1 SEE ALSO
 
  Devel::Cover
+
+=head1 CLASS METHODS
+
+=head2 criterion_names
+
+  my @names = Devel::Cover::Criterion->criterion_names;
+
+Return the canonical criterion names in order. The
+C<@Devel::Cover::DB::Criteria> and C<@Devel::Cover::DB::Criteria_short>
+lists derive from this metadata.
+
+=head2 criterion_class ($name)
+
+  my $class = Devel::Cover::Criterion->criterion_class("branch");
+
+Return the class implementing the named criterion.
+
+=head2 coverage_criteria
+
+Return the criterion names that measure coverage - every criterion
+except time.
+
+=head2 editor_criteria
+
+Return the criterion names shown by the editor reports, in canonical
+order. The Vim and Nvim templates place signs last-in-list-wins, so this
+order is the sign display priority.
+
+=head1 CRITERION METADATA
+
+Each criterion class answers these, overriding the base defaults.
+
+=head2 shortname
+
+The abbreviation used in summary headers and C<-coverage> options, such
+as C<stmt> or C<bran>.
+
+=head2 display_name
+
+The human-readable name, such as C<Statement> or C<MC/DC>.
+
+=head2 display_mode
+
+Either C<count> or C<percentage> - which of C<covered> and C<percentage>
+reporters display for a single value.
+
+=head2 detail_criterion
+
+The criterion name whose per-file detail page this criterion's values
+link to, or undef when there is none. Pod links to the subroutine page.
+
+=head2 has_detail_page
+
+True only when a criterion owns its own detail page - branch, condition,
+mcdc and subroutine.
+
+=head2 measures_coverage
+
+False only for time, which is timing data rather than a coverage
+criterion.
+
+=head2 sign_letter
+
+The editor sign character, such as C<S> or C<B>. Undef for time, which
+has no sign.
 
 =head1 METHODS
 

--- a/lib/Devel/Cover/Criterion.pm
+++ b/lib/Devel/Cover/Criterion.pm
@@ -33,6 +33,32 @@ for my $class (qw(
     or die "Failed to load Devel::Cover::$class: $@";
 }
 
+my @Criteria = qw( statement branch condition mcdc subroutine pod time );
+
+sub criterion_names ($class) { @Criteria }
+
+sub criterion_class ($class, $name) { "Devel::Cover::" . ucfirst $name }
+
+sub coverage_criteria ($class) {
+  grep $class->criterion_class($_)->measures_coverage, @Criteria
+}
+
+sub editor_criteria ($class) {
+  grep defined $class->criterion_class($_)->sign_letter, @Criteria
+}
+
+sub shortname        ($class) { $class->criterion }
+sub display_name     ($class) { ucfirst $class->criterion }
+sub display_mode     ($class) { "percentage" }
+sub detail_criterion ($class) { undef }
+
+sub has_detail_page ($class) {
+  ($class->detail_criterion // "") eq $class->criterion
+}
+
+sub measures_coverage ($class) { 1 }
+sub sign_letter       ($class) { undef }
+
 sub coverage    ($self) { $self->[0] }
 sub information ($self) { $self->[1] }
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -1380,7 +1380,8 @@ a valid database file it is read automatically.
   my @c = $db->criteria;
 
 Return the list of coverage criteria names (e.g. C<statement>, C<branch>,
-C<condition>, ...).
+C<condition>, ...). The list derives from
+L<Devel::Cover::Criterion>'s metadata.
 
 =head2 criteria_short
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -31,9 +31,10 @@ my $Has_term_size = eval { require Term::Size };
 
 my $DB = "cover.15";  # Version of the database
 
-@Devel::Cover::DB::Criteria
-  = (qw( statement branch condition mcdc subroutine pod time ));
-@Devel::Cover::DB::Criteria_short   = (qw( stmt bran cond mcdc sub pod time ));
+@Devel::Cover::DB::Criteria = Devel::Cover::Criterion->criterion_names;
+@Devel::Cover::DB::Criteria_short
+  = map Devel::Cover::Criterion->criterion_class($_)->shortname,
+  @Devel::Cover::DB::Criteria;
 $Devel::Cover::DB::Ignore_filenames = qr/   # Used by Devel::Cover
   # Moose
   (?:

--- a/lib/Devel/Cover/Mcdc.pm
+++ b/lib/Devel/Cover/Mcdc.pm
@@ -22,6 +22,10 @@ sub text      ($self) { $self->[1]{text} }
 sub labels    ($self) { $self->[1]{labels} // [] }
 sub criterion ($self) { "mcdc" }
 
+sub display_name     ($class) { "MC/DC" }
+sub detail_criterion ($class) { "mcdc" }
+sub sign_letter      ($class) { "M" }
+
 # True for a decision too wide to analyse; see LIMITATIONS below
 sub unanalysed ($self) { $self->[1]{unanalysed} ? 1 : 0 }
 

--- a/lib/Devel/Cover/Pod.pm
+++ b/lib/Devel/Cover/Pod.pm
@@ -25,6 +25,10 @@ sub percentage  ($self) { $self->[0] ? 100 : 0 }
 sub error       ($self) { $self->simple_error }
 sub criterion   ($self) { "pod" }
 
+sub display_mode     ($class) { "count" }
+sub detail_criterion ($class) { "subroutine" }
+sub sign_letter      ($class) { "P" }
+
 sub calculate_summary ($self, $db, $file) {
   return unless $INC{"Pod/Coverage.pm"};
 

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -21,9 +21,10 @@ BEGIN {
 use Devel::Cover::Html_Common  ## no perlimports
   qw( launch highlight $Have_highlighter
   coverage_class default_thresholds unique_filenames );
-use Devel::Cover::Inc ();
-use Devel::Cover::Log qw( dcinfo );
-use Devel::Cover::Web qw( write_file );
+use Devel::Cover::Criterion ();
+use Devel::Cover::Inc       ();
+use Devel::Cover::Log       qw( dcinfo );
+use Devel::Cover::Web       qw( write_file );
 
 BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
 
@@ -59,10 +60,11 @@ sub get_summary ($file, $criterion) {
   $vals->{total}   = $c->{total};
   $vals->{details} = "$vals->{covered} / $vals->{total}";
 
-  my $cr = $criterion eq "pod" ? "subroutine" : $criterion;
-  return $vals
-    if $cr !~ /^(?:branch|condition|mcdc|subroutine)$/
-    || !exists $R{filenames}{$file};
+  my $cr
+    = $criterion eq "total"
+    ? undef
+    : Devel::Cover::Criterion->criterion_class($criterion)->detail_criterion;
+  return $vals if !defined $cr || !exists $R{filenames}{$file};
   return $vals if $R{uncompiled}{$file};
   $vals->{link} = "$R{filenames}{$file}--$cr.html";
 
@@ -88,14 +90,14 @@ sub _build_coverage_criteria ($criteria, $n, $count) {
     my $o   = shift $criteria->{$c}->@*;
     $more ||= $criteria->{$c}->@*;
 
-    my $link      = $c          !~ /statement|time/;
-    my $pc        = $link && $c !~ /subroutine|pod/;
+    my $meta      = Devel::Cover::Criterion->criterion_class($c);
+    my $cr        = $meta->detail_criterion;
+    my $pc        = $meta->display_mode eq "percentage";
     my $text      = $o ? $pc ? $o->percentage : $o->covered : "&nbsp;";
     my $criterion = { text => $text, class => oclass($o, $c) };
-    my $cr        = $c eq "pod" ? "subroutine" : $c;
 
     $criterion->{link} = "$R{filenames}{$R{file}}--$cr.html#$n-$count"
-      if $o && $link;
+      if $o && defined $cr;
     push @entries, $criterion;
   }
   (\@entries, $more)

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -26,6 +26,7 @@ use Devel::Cover::Html_Common qw(
 );
 use Devel::Cover::Web             qw( $Cov $Crisp_base_css $Crisp_theme_js );
 use Devel::Cover::Condition_table ();
+use Devel::Cover::Criterion       ();
 use Devel::Cover::DB              ();
 use Devel::Cover::Inc             ();
 use Devel::Cover::Log             qw( dcinfo );
@@ -1230,20 +1231,30 @@ sub report ($pkg, $db, $options) {
     options  => $options,
     version  => $VERSION,
     showing  => [grep $options->{show}{$_}, $db->criteria],
-    criteria => [grep $_ ne "time", grep $options->{show}{$_}, $db->criteria],
-    headers  => [
-      map  { ($db->criteria_short)[$_] }
-      grep { $options->{show}{ ($db->criteria)[$_] } }
-        (0 .. $db->criteria - 1)
+    criteria => [
+      grep Devel::Cover::Criterion->criterion_class($_)->measures_coverage,
+      grep $options->{show}{$_},
+      $db->criteria,
     ],
-    short => do {
-      my @c = $db->criteria;
-      my @s = $db->criteria_short;
-      +{ (map { $c[$_] => $s[$_] } 0 .. $#c), total => "total" }
+    headers => [
+      map Devel::Cover::Criterion->criterion_class($_)->shortname,
+      grep $options->{show}{$_},
+      $db->criteria,
+    ],
+    short => {
+      (
+        map { $_ => Devel::Cover::Criterion->criterion_class($_)->shortname }
+          $db->criteria
+      ),
+      total => "total",
     },
-    full => do {
-      my @c = $db->criteria;
-      +{ (map { $_ => ucfirst } @c), mcdc => "MC/DC", total => "total" }
+    full => {
+      (
+        map {
+          $_ => Devel::Cover::Criterion->criterion_class($_)->display_name
+        } $db->criteria
+      ),
+      total => "total",
     },
     filenames      => unique_filenames($options->{file}->@*),
     have_ppi       => eval { require PPI; 1 } ? 1 : 0,

--- a/lib/Devel/Cover/Report/Html_minimal.pm
+++ b/lib/Devel/Cover/Report/Html_minimal.pm
@@ -5,8 +5,9 @@ use warnings;
 use feature qw( postderef signatures );
 no warnings qw( experimental::postderef experimental::signatures );
 
-use HTML::Entities qw( encode_entities );
-use Getopt::Long   qw( GetOptions );
+use HTML::Entities          qw( encode_entities );
+use Getopt::Long            qw( GetOptions );
+use Devel::Cover::Criterion ();
 use Devel::Cover::Html_Common  ## no perlimports
   qw( launch coverage_class default_thresholds unique_filenames );
 use Devel::Cover::Log         qw( dcinfo );
@@ -317,7 +318,7 @@ sub _render_coverage_cells ($out, $fin, $opt, $show, $metric) {
         print $out "<div>", $m->{string}, "</div>";
       } else {
         my $link;
-        if ($c =~ /^(?:branch|condition|mcdc|subroutine)$/) {
+        if (Devel::Cover::Criterion->criterion_class($c)->has_detail_page) {
           $link = get_link($fin, $c, $.);
         }
 
@@ -572,6 +573,30 @@ sub print_sub_report ($db, $file, $opt) {
 }
 
 # Print the database summary report
+sub _print_summary_cell ($fh, $file, $c, $summary, $uncompiled) {
+  my $pc = $summary->{$c}{percent};
+  my ($class, $popup, $link);
+
+  my $meta
+    = $c eq "total" ? undef : Devel::Cover::Criterion->criterion_class($c);
+  if ($pc eq "n/a" || ($meta && !$meta->measures_coverage)) {
+    $class = $popup = "";
+  } else {
+    $class = sprintf ' class="%s"', pclass($pc, $summary->{$c}{error});
+    $popup = sprintf ' title="%s"', $c . ": " . $summary->{$c}{ratio};
+    if (!$uncompiled && $meta && $meta->has_detail_page) {
+      $link = get_link($file, $c);
+    }
+  }
+
+  if ($link) {
+    printf $fh "<td%s%s>" . '<a href="%s">%s</a></td>', $class, $popup, $link,
+      $pc;
+  } else {
+    printf $fh "<td%s%s>%s</td>", $class, $popup, $pc;
+  }
+}
+
 sub print_summary_report ($db, $options) {
   my $outfile = "$options->{outputdir}/$options->{option}{outputfile}";
 
@@ -642,27 +667,7 @@ END_HTML
     print $fh " <em>(untested)</em>" if $uncompiled;
     print $fh "</td>";
 
-    for my $c (@$show) {
-      my $pc = $summary->{$c}{percent};
-      my ($class, $popup, $link);
-
-      if ($pc eq "n/a" || $c eq "time") {
-        $class = $popup = "";
-      } else {
-        $class = sprintf ' class="%s"', pclass($pc, $summary->{$c}{error});
-        $popup = sprintf ' title="%s"', $c . ": " . $summary->{$c}{ratio};
-        if (!$uncompiled && $c =~ /^(?:branch|condition|mcdc|subroutine)$/) {
-          $link = get_link($file, $c);
-        }
-      }
-
-      if ($link) {
-        printf $fh "<td%s%s>" . '<a href="%s">%s</a></td>', $class, $popup,
-          $link, $pc;
-      } else {
-        printf $fh "<td%s%s>%s</td>", $class, $popup, $pc;
-      }
-    }
+    _print_summary_cell($fh, $file, $_, $summary, $uncompiled) for @$show;
     print $fh "</tr>\n";
   }
   print $fh "</table>\n</body>\n</html>\n";

--- a/lib/Devel/Cover/Report/Html_subtle.pm
+++ b/lib/Devel/Cover/Report/Html_subtle.pm
@@ -6,6 +6,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
+use Devel::Cover::Criterion ();
 use Devel::Cover::Html_Common  ## no perlimports
   qw( launch coverage_class default_thresholds unique_filenames );
 use Devel::Cover::Log qw( dcinfo );
@@ -99,13 +100,14 @@ sub _build_criterion_metrics ($c, $metric, $file_data, $file, $line_num) {
         };
     }
   } else {
+    my $meta = Devel::Cover::Criterion->criterion_class($c);
     while (my $o = shift $metric->{$c}->@*) {
       push @p, {
-          text => ($c =~ /^(?:statement|pod|time)$/)
-          ? $o->covered
-          : $o->percentage,
-          class => $c eq "time" ? undef : $o->error ? "uncovered" : "covered",
-          link  => undef,
+          text => $meta->display_mode eq "count" ? $o->covered : $o->percentage,
+          class => $meta->measures_coverage
+          ? ($o->error ? "uncovered" : "covered")
+          : undef,
+          link => undef,
         };
     }
   }
@@ -353,7 +355,11 @@ sub print_summary ($db, $options) {
         : "n/a";
 
       if ($pc ne "n/a") {
-        if ($criterion ne "time") {
+        if (
+          $criterion eq "total"
+          || Devel::Cover::Criterion->criterion_class($criterion)
+          ->measures_coverage
+        ) {
           $vals->{$file}{$criterion}{class} = cvg_class($pc);
         }
         if (!$is_uncompiled && exists $Filenames{$file}) {

--- a/lib/Devel/Cover/Report/Json.pm
+++ b/lib/Devel/Cover/Report/Json.pm
@@ -14,6 +14,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
+use Devel::Cover::Criterion    ();
 use Devel::Cover::DB::IO::JSON ();
 use Devel::Cover::Inc          ();
 use Devel::Cover::Log          qw( dcinfo );
@@ -196,7 +197,10 @@ sub get_options ($self, $opt) {
 }
 
 sub report ($pkg, $db, $options) {
-  my %sum_options = map { $_ => 1 } grep !/time/, $db->all_criteria, "force";
+  my %sum_options = map { $_ => 1 } "force", grep {
+    $_ eq "total"
+      || Devel::Cover::Criterion->criterion_class($_)->measures_coverage
+  } $db->all_criteria;
   $db->calculate_summary(%sum_options);
 
   my %files;

--- a/lib/Devel/Cover/Report/Json_summary.pm
+++ b/lib/Devel/Cover/Report/Json_summary.pm
@@ -14,6 +14,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
+use Devel::Cover::Criterion    ();
 use Devel::Cover::DB::IO::JSON ();
 use Devel::Cover::Log          qw( dcinfo );
 
@@ -28,7 +29,10 @@ sub add_runs ($db) {
 }
 
 sub report ($pkg, $db, $options) {
-  my %options = map { $_ => 1 } grep !/time/, $db->all_criteria, "force";
+  my %options = map { $_ => 1 } "force", grep {
+    $_ eq "total"
+      || Devel::Cover::Criterion->criterion_class($_)->measures_coverage
+  } $db->all_criteria;
   $db->calculate_summary(%options);
 
   my $json = { runs => add_runs($db), summary => $db->{summary} };

--- a/lib/Devel/Cover/Report/Sort.pm
+++ b/lib/Devel/Cover/Report/Sort.pm
@@ -14,9 +14,13 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
+use Devel::Cover::Criterion ();
+
 sub print_sort ($db, $options) {
   my %runs;
-  my @collected = grep $_ ne "time", $options->{coverage}->@*;
+  my @collected
+    = grep Devel::Cover::Criterion->criterion_class($_)->measures_coverage,
+    $options->{coverage}->@*;
   for my $r (sort { $a->{start} <=> $b->{start} } $db->runs) {
     say "Run:          ", $r->run;
     say "Perl version: ", $r->perl;

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -14,15 +14,20 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
-use Devel::Cover::Path qw( common_prefix );
+use Devel::Cover::Criterion ();
+use Devel::Cover::Path      qw( common_prefix );
+
+sub _display_mode ($c) {
+  Devel::Cover::Criterion->criterion_class($c)->display_mode
+}
 
 sub _print_criteria_value ($o, $c) {
-  $c =~ /statement|sub|pod|time/ ? $o->covered : $o->percentage
+  _display_mode($c) eq "count" ? $o->covered : $o->percentage
 }
 
 sub _format_value ($o, $c) {
   my $value = _print_criteria_value($o, $c);
-  $value = sprintf "%3d", $value if $c !~ /statement|sub|pod|time/;
+  $value = sprintf "%3d", $value if _display_mode($c) eq "percentage";
   $value = "-$value" if $o->uncoverable;
   $value = "*$value" if $o->error;
   $value

--- a/lib/Devel/Cover/Report/Text2.pm
+++ b/lib/Devel/Cover/Report/Text2.pm
@@ -7,7 +7,8 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
-use List::Util qw( max );
+use List::Util              qw( max );
+use Devel::Cover::Criterion ();
 use Devel::Cover::Truth_Table;
 use Devel::Cover::Path qw( common_prefix );
 
@@ -96,9 +97,9 @@ EOT
         @$value   = map $_->[0]->text, $file_data->condition->truth_table($.);
         $error  ||= $file_data->condition->error($.);
       } else {
+        my $mode = Devel::Cover::Criterion->criterion_class($c)->display_mode;
         for my $o ($metric{$c}->@*) {
-          push @$value,
-            ($c =~ /statement|pod|time/) ? $o->covered : $o->percentage;
+          push @$value, $mode eq "count" ? $o->covered : $o->percentage;
           $error ||= $o->error;
         }
       }

--- a/lib/Devel/Cover/Statement.pm
+++ b/lib/Devel/Cover/Statement.pm
@@ -24,6 +24,10 @@ sub percentage  ($self) { $self->[0] ? 100 : 0 }
 sub error       ($self) { $self->simple_error }
 sub criterion   ($self) { "statement" }
 
+sub shortname    ($class) { "stmt" }
+sub display_mode ($class) { "count" }
+sub sign_letter  ($class) { "S" }
+
 1
 
 __END__

--- a/lib/Devel/Cover/Subroutine.pm
+++ b/lib/Devel/Cover/Subroutine.pm
@@ -24,6 +24,11 @@ sub error       ($self) { $self->simple_error }
 sub name        ($self) { $self->[1] }
 sub criterion   ($self) { "subroutine" }
 
+sub shortname        ($class) { "sub" }
+sub display_mode     ($class) { "count" }
+sub detail_criterion ($class) { "subroutine" }
+sub sign_letter      ($class) { "R" }
+
 1
 
 __END__

--- a/lib/Devel/Cover/Time.pm
+++ b/lib/Devel/Cover/Time.pm
@@ -21,6 +21,10 @@ sub covered     ($self) { $$self }
 sub total       ($self) { 1 }
 sub percentage  ($self) { $$self ? 100 : 0 }
 sub error       ($self) { 0 }
+sub criterion   ($self) { "time" }
+
+sub display_mode      ($class) { "count" }
+sub measures_coverage ($class) { 0 }
 
 sub calculate_summary ($self, $db, $file) {
   $db->{summary}{$file}{time}{total} += $$self;

--- a/t/internal/criterion_meta.t
+++ b/t/internal/criterion_meta.t
@@ -1,0 +1,139 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is is_deeply ok )];
+
+use Devel::Cover::Criterion ();
+use Devel::Cover::DB        ();
+
+my %Expected = (
+  statement => {
+    shortname         => "stmt",
+    display_name      => "Statement",
+    display_mode      => "count",
+    detail_criterion  => undef,
+    has_detail_page   => "",
+    measures_coverage => 1,
+    sign_letter       => "S",
+  },
+  branch => {
+    shortname         => "bran",
+    display_name      => "Branch",
+    display_mode      => "percentage",
+    detail_criterion  => "branch",
+    has_detail_page   => 1,
+    measures_coverage => 1,
+    sign_letter       => "B",
+  },
+  condition => {
+    shortname         => "cond",
+    display_name      => "Condition",
+    display_mode      => "percentage",
+    detail_criterion  => "condition",
+    has_detail_page   => 1,
+    measures_coverage => 1,
+    sign_letter       => "C",
+  },
+  mcdc => {
+    shortname         => "mcdc",
+    display_name      => "MC/DC",
+    display_mode      => "percentage",
+    detail_criterion  => "mcdc",
+    has_detail_page   => 1,
+    measures_coverage => 1,
+    sign_letter       => "M",
+  },
+  subroutine => {
+    shortname         => "sub",
+    display_name      => "Subroutine",
+    display_mode      => "count",
+    detail_criterion  => "subroutine",
+    has_detail_page   => 1,
+    measures_coverage => 1,
+    sign_letter       => "R",
+  },
+  pod => {
+    shortname         => "pod",
+    display_name      => "Pod",
+    display_mode      => "count",
+    detail_criterion  => "subroutine",
+    has_detail_page   => "",
+    measures_coverage => 1,
+    sign_letter       => "P",
+  },
+  time => {
+    shortname         => "time",
+    display_name      => "Time",
+    display_mode      => "count",
+    detail_criterion  => undef,
+    has_detail_page   => "",
+    measures_coverage => 0,
+    sign_letter       => undef,
+  },
+);
+
+sub test_canonical_lists () {
+  my @names = Devel::Cover::Criterion->criterion_names;
+  is_deeply \@names,
+    [qw( statement branch condition mcdc subroutine pod time )],
+    "canonical criterion names in order";
+
+  is_deeply \@Devel::Cover::DB::Criteria, \@names,
+    "DB Criteria list derives from the metadata";
+  is_deeply \@Devel::Cover::DB::Criteria_short,
+    [qw( stmt bran cond mcdc sub pod time )],
+    "DB short list derives from the metadata";
+}
+
+sub test_criterion_metadata () {
+  for my $name (Devel::Cover::Criterion->criterion_names) {
+    my $class = Devel::Cover::Criterion->criterion_class($name);
+    is $class->criterion, $name, "$class criterion is $name";
+    my $e = $Expected{$name};
+    for my $method (sort keys %$e) {
+      is $class->$method, $e->{$method}, "$name $method";
+    }
+  }
+}
+
+sub test_derived_lists () {
+  is_deeply [Devel::Cover::Criterion->coverage_criteria],
+    [qw( statement branch condition mcdc subroutine pod )],
+    "coverage_criteria excludes time";
+
+  is_deeply [Devel::Cover::Criterion->editor_criteria],
+    [qw( statement branch condition mcdc subroutine pod )],
+    "editor_criteria is the canonical order minus time";
+}
+
+sub test_condition_subclasses () {
+  ok +Devel::Cover::Condition_or_2->measures_coverage,
+    "Condition subclasses inherit metadata";
+  is +Devel::Cover::Condition_or_2->shortname, "cond",
+    "Condition subclasses inherit the shortname";
+}
+
+sub main () {
+  test_canonical_lists;
+  test_criterion_metadata;
+  test_derived_lists;
+  test_condition_subclasses;
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

- Every reporter re-encoded per-criterion facts (abbreviations, count versus percentage display, detail pages, sign letters, whether time measures coverage) with its own literal regexes, maps and lists - wiring in MC/DC took ten reporter-by-reporter commits.
- Add class methods on the `Devel::Cover::Criterion` subclasses carrying that metadata, with `t/internal/criterion_meta.t` asserting every value, and derive `@Devel::Cover::DB::Criteria` and `@Devel::Cover::DB::Criteria_short` from it unchanged.
- Migrate every consumer to metadata lookups: `bin/cover`'s coverage maps, the text and text2 reports, all four HTML reports, the json, json_summary and sort reports, the cpancover index in `Collection.pm`, and the editor sign types in `Base/Editor.pm`.

## Implications

- Report output is preserved, verified by the golden files and a byte-comparison harness over all twelve reporters, with two deliberate exceptions. The text2 per-line subroutine column shows the call count instead of a flat 100 or 0, and the cpancover index header reads MC/DC rather than Mcdc (never released - MC/DC is new this cycle).
- The Vim/Nvim template definition lists stay literal - regenerating them is not byte-identical and needs in-editor verification, and the sign display priority already comes from the metadata order.
- The full suite passes on dc-dev and dc-5.38.0.

## Ticket

Closes #612