### PR TITLE
GH-619 Tidy html_subtle subroutine anchor and test

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Close the anchor element on html_subtle subroutine page rows (GH-619)
 - Sort the html_subtle subroutine page by name then line - same-named subs
   such as BEGIN blocks previously appeared in per-run hash order (GH-615)
 - Show subroutine call counts in the text2 report's per-line column - the

--- a/lib/Devel/Cover/Report/Html_subtle.pm
+++ b/lib/Devel/Cover/Report/Html_subtle.pm
@@ -712,7 +712,9 @@ $Templates{subroutines} = <<'HTML';
 
   [% FOREACH sub = subroutines %]
     <tr align="center" valign="top">
-      <td class="[% sub.class %]"> <a id="[% sub.ref %]"> [% sub.name %] </td>
+      <td class="[% sub.class %]">
+        <a id="[% sub.ref %]"> [% sub.name %] </a>
+      </td>
       <td> [% sub.line %] </td>
     </tr>
   [% END %]

--- a/t/internal/html_subtle_sub_order.t
+++ b/t/internal/html_subtle_sub_order.t
@@ -17,7 +17,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
 use File::Temp qw( tempdir );
-use Test::More import => [qw( done_testing is_deeply ok plan )];
+use Test::More import => [qw( done_testing is is_deeply ok plan )];
 use Devel::Cover::Test::Showcase qw( slurp );
 
 BEGIN {
@@ -100,9 +100,13 @@ sub test_rows_sorted () {
 
   my ($page) = glob "$tmpdir/*--subroutine.html";
   ok $page, "subroutine page generated";
-  my @rows = slurp($page) =~ /<a id="line(\d+)"> (\w+) /g;
+  my $html = slurp($page);
+  my @rows = $html =~ /<a id="line(\d+)"> (\w+)/g;
   is_deeply \@rows, [3, "BEGIN", 12, "BEGIN", 7, "foo"],
     "rows sorted by name then line";
+  my $opens  = () = $html =~ /<a /g;
+  my $closes = () = $html =~ m|</a>|g;
+  is $closes, $opens, "every anchor is closed";
 }
 
 sub main () {


### PR DESCRIPTION
Fixes #619

## Summary

- Close the anchor element the subtle report's subroutine rows open - the branch, condition and MC/DC pages already close theirs.
- Loosen the sub-order test's row match so template reflows don't break it, and check every anchor gets closed.