### PR TITLE
GH-618 Sort text report subs by line number

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Sort same-named subs in the text report numerically by line (GH-618)
 - Close the anchor element on html_subtle subroutine page rows (GH-619)
 - Sort the html_subtle subroutine page by name then line - same-named subs
   such as BEGIN blocks previously appeared in per-run hash order (GH-615)

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -391,7 +391,7 @@ sub _gather_subs ($dfile, $pods, $display_name, $scar_lookup) {
   my %by_type;
   my $has_scar = %$scar_lookup;
 
-  for my $location ($subs->items) {
+  for my $location (sort { $a <=> $b } $subs->items) {
     my $l = $subs->location($location);
     my $d = $pods && $pods->location($location);
     for my $sub (@$l) {
@@ -442,8 +442,7 @@ sub print_subroutines ($db, $file, $options, $short) {
       $has_scar ? ("-" x $maxw->{cc}, "-" x $maxw->{cr}) : (), "-" x $maxw->{h};
 
     for my $s (sort keys $by_type->{$type}->%*) {
-      printf $tpl, $s, @$_
-        for sort { $a->[-1] cmp $b->[-1] } $by_type->{$type}{$s}->@*;
+      printf $tpl, $s, @$_ for $by_type->{$type}{$s}->@*;
     }
     say "";
   }

--- a/t/internal/html_filename_collision.t
+++ b/t/internal/html_filename_collision.t
@@ -63,13 +63,16 @@ sub setup_colliding_db () {
 
   my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
   my $select   = quotemeta $libdir;
+  # Pre-double backslashes - perl's -M q() processing halves them
+  $select =~ s|\\|\\\\|g if $^O eq "MSWin32";
   local $ENV{DEVEL_COVER_SELF};
   delete $ENV{DEVEL_COVER_SELF};
+  my $prog
+    = "use X::Y; require q($dash); X::Y::in_x_slash_y(); X_Y::in_x_dash_y()";
   my $cmd
     = "$^X -Iblib/lib -Iblib/arch -I$libdir"
     . " -MDevel::Cover=-db,$cover_db,-silent,1,-merge,0,-select,$select"
-    . " -e 'use X::Y; require q($dash);"
-    . " X::Y::in_x_slash_y(); X_Y::in_x_dash_y()' 2>&1";
+    . qq( -e "$prog" 2>&1);
   my $out = `$cmd`;
   die "Failed to create cover_db:\n$out\n" if $?;
 

--- a/t/internal/text_sub_order.t
+++ b/t/internal/text_sub_order.t
@@ -1,0 +1,95 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is_deeply )];
+use Devel::Cover::Report::Text ();
+
+{
+
+  package Mock::Sub;
+  sub new         ($class, $name) { bless { name => $name }, $class }
+  sub name        ($self)         { $self->{name} }
+  sub covered     ($self)         { 1 }
+  sub uncoverable ($self)         { 0 }
+}
+
+{
+
+  package Mock::Criterion;
+  sub new ($class, @locations) { bless { locations => \@locations }, $class }
+  sub items ($self) { map $_->[0], $self->{locations}->@* }
+
+  sub location ($self, $loc) { [
+    map Mock::Sub->new($_->[1]),
+    grep { $_->[0] == $loc } $self->{locations}->@*,
+  ] }
+}
+
+{
+
+  package Mock::File;
+  sub new        ($class, $crit) { bless { crit => $crit }, $class }
+  sub subroutine ($self)         { $self->{crit} }
+}
+
+{
+
+  package Mock::Cover;
+  sub new  ($class, $file) { bless { file => $file }, $class }
+  sub file ($self, $name)  { $self->{file} }
+}
+
+{
+
+  package Mock::DB;
+  sub new             ($class, $cover) { bless { cover => $cover }, $class }
+  sub cover           ($self)          { $self->{cover} }
+  sub scar_sub_lookup ($self, $)       { {} }
+}
+
+# Same-named subs sorted by their location string put line 12 before line 9,
+# so use lines either side of a digit-count boundary, fed in visit order 12
+# then 9 so hash order can't accidentally produce the expected result.
+sub test_locations_numeric () {
+  my $crit = Mock::Criterion->new([12, "BEGIN"], [9, "BEGIN"], [5, "foo"]);
+  my $db   = Mock::DB->new(Mock::Cover->new(Mock::File->new($crit)));
+
+  my $output;
+  {
+    open my $fh, ">", \$output or die "Cannot open scalar ref: $!";
+    local *STDOUT = $fh;
+    Devel::Cover::Report::Text::print_subroutines(
+      $db, "Mock.pm",
+      { show      => {} },
+      { "Mock.pm" => "Mock.pm" },
+    );
+    close $fh or die "Cannot close scalar ref: $!";
+  }
+
+  my @rows = $output =~ /^(\S+)\s+\d+\s+(\S+:\d+)/gm;
+  is_deeply \@rows,
+    ["BEGIN", "Mock.pm:9", "BEGIN", "Mock.pm:12", "foo", "Mock.pm:5"],
+    "same-named subs listed in numeric line order";
+}
+
+sub main () {
+  test_locations_numeric;
+  done_testing;
+}
+
+main;

--- a/test_output/cover/cond_branch.5.020000
+++ b/test_output/cover/cond_branch.5.020000
@@ -523,6 +523,8 @@ Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- ---------------------
 BEGIN          1   1   0.0 tests/cond_branch:10 
 BEGIN          1   1   0.0 tests/cond_branch:11 
+BEGIN          1   1   0.0 tests/cond_branch:79 
+BEGIN          1   1   0.0 tests/cond_branch:85 
 BEGIN          1   1   0.0 tests/cond_branch:112
 BEGIN          1   1   0.0 tests/cond_branch:118
 BEGIN          1   1   0.0 tests/cond_branch:149
@@ -530,8 +532,6 @@ BEGIN          1   1   0.0 tests/cond_branch:156
 BEGIN          1   1   0.0 tests/cond_branch:202
 BEGIN          1   1   0.0 tests/cond_branch:211
 BEGIN          1   1   0.0 tests/cond_branch:229
-BEGIN          1   1   0.0 tests/cond_branch:79 
-BEGIN          1   1   0.0 tests/cond_branch:85 
 __ANON__       4   2   6.9 tests/cond_branch:219
 __ANON__       4   2   6.9 tests/cond_branch:224
 __ANON__       4   2  14.6 tests/cond_branch:230

--- a/test_output/cover/cond_branch.5.044000
+++ b/test_output/cover/cond_branch.5.044000
@@ -523,6 +523,8 @@ Subroutine Count  CC  SCAR Location
 ---------- ----- --- ----- ---------------------
 BEGIN          1   1   0.0 tests/cond_branch:10 
 BEGIN          1   1   0.0 tests/cond_branch:11 
+BEGIN          1   1   0.0 tests/cond_branch:79 
+BEGIN          1   1   0.0 tests/cond_branch:85 
 BEGIN          1   1   0.0 tests/cond_branch:112
 BEGIN          1   1   0.0 tests/cond_branch:118
 BEGIN          1   1   0.0 tests/cond_branch:149
@@ -530,8 +532,6 @@ BEGIN          1   1   0.0 tests/cond_branch:156
 BEGIN          1   1   0.0 tests/cond_branch:202
 BEGIN          1   1   0.0 tests/cond_branch:211
 BEGIN          1   1   0.0 tests/cond_branch:229
-BEGIN          1   1   0.0 tests/cond_branch:79 
-BEGIN          1   1   0.0 tests/cond_branch:85 
 __ANON__       4   2   6.9 tests/cond_branch:219
 __ANON__       4   2   6.9 tests/cond_branch:224
 __ANON__       4   2  14.6 tests/cond_branch:230

--- a/test_output/cover/module_class.5.038000
+++ b/test_output/cover/module_class.5.038000
@@ -78,9 +78,9 @@ Covered Subroutines
 
 Subroutine Count  CC  SCAR Location          
 ---------- ----- --- ----- ------------------
+BEGIN          1   1   0.0 Class_animal.pm:9 
 BEGIN          1   1   0.0 Class_animal.pm:10
 BEGIN          1   1   0.0 Class_animal.pm:11
-BEGIN          1   1   0.0 Class_animal.pm:9 
 __ANON__       1   1   0.0 Class_animal.pm:17
 name           1   1   0.0 Class_animal.pm:19
 speak          1   1   0.0 Class_animal.pm:20


### PR DESCRIPTION
## Summary

The text report's subroutine section sorted the rows for a repeated sub name by their location as a string, so a `BEGIN` block at line 12 listed before one at line 9. Sort the locations numerically when gathering them instead, add a mock-based test that feeds lines either side of a digit-count boundary, and regenerate the golden files that embedded the old order.

## Ticket

Closes #618