### PR TITLE
GH-624 Package dev docker source without dzil

### DIFF
--- a/docker/BUILD
+++ b/docker/BUILD
@@ -209,12 +209,11 @@ build() {
   if [[ $env == dev ]]; then
     local dir=docker/devel-cover-local/src
     rm -rf $dir
-    dzil clean
-    dzil build
-    cp -a "Devel-Cover-$(make show_version)" $dir
+    mkdir -p $dir
+    git ls-files -z --cached --others --exclude-standard |
+      tar --null -cf - -T - | tar -xf - -C $dir
     docker build --no-cache -t "$user/devel-cover-dc" docker/devel-cover-local
     rm -rf $dir
-    dzil clean
   else
     docker build --no-cache --build-arg BRANCH="$src" \
       -t "$user/devel-cover-dc" docker/devel-cover-git


### PR DESCRIPTION
## Summary

The dev image build ran `dzil build` on the host to package the local checkout, so it failed on machines without Dist::Zilla. Copy the working tree with `git ls-files` piped through `tar` instead - local modifications and untracked files are kept, ignored files are excluded, and no perl tooling is needed on the host. The containers run `Makefile.PL` against `/dc` either way, so the resulting image matches what the prod git clone path produces. Verified with both GNU tar and bsdtar.

## Ticket

Closes #624