### PR TITLE
GH-629 Skip magical containers in the pad walk

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Skip magical containers in the wrapped-sub pad walk - a sub closing over a
+  reference to a tied array previously crashed the covered process (GH-629)
 - Sort same-named subs in the text report numerically by line (GH-618)
 - Close the anchor element on html_subtle subroutine page rows (GH-619)
 - Sort the html_subtle subroutine page by name then line - same-named subs

--- a/docs/technical/wrapped-sub-coverage.md
+++ b/docs/technical/wrapped-sub-coverage.md
@@ -55,7 +55,10 @@ way, so recording them again would duplicate it, and because the duplicate
 shares a start op with the original the report-time dedup would pick between
 them non-deterministically. Descent also stops after one container and does not
 enter blessed containers, so a sub closing over an object does not drag the
-object's whole graph into the walk.
+object's whole graph into the walk. Magical containers are not entered either. A
+tied container's contents come from its `FETCH`, and the report-time walk must
+never run user code - and `B::AV::ARRAY` on a tied array reads the empty real
+array with the size the tie magic reports, which crashes the process.
 
 The cost is paid only when building the report, and only for subs that close
 over references. A program with no method modifiers pays effectively nothing. A
@@ -63,8 +66,8 @@ program full of them pays in proportion to the number recovered, which is the
 inherent cost of covering subs that were previously absent.
 
 The tests are in `t/internal/wrapped_sub.t`: the direct reference form, the
-hash-held and array-held forms, and a real Moose `around` modifier (skipped when
-Moose is not installed).
+hash-held and array-held forms, a wrapper closing over a reference to a tied
+array, and a real Moose `around` modifier (skipped when Moose is not installed).
 
 ## Known limitations
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -586,9 +586,10 @@ sub recoverable_sub ($cv) {
 # closes over.  That is where a method modifier keeps the original sub it
 # replaced in the symbol table, so without this its body is dropped from
 # coverage.  Descent stops after one container so a wrapper's own deeper
-# machinery is not reached; blessed containers are not descended, so a sub
-# closing over an object does not drag its whole graph in, and $seen guards a
-# cyclic structure.
+# machinery is not reached.  Blessed containers are not descended, so a sub
+# closing over an object does not drag its whole graph in.  Magical containers
+# are not descended, since reading a tied one would run user code.  The $seen
+# hash guards a cyclic structure.
 sub ref_cvs ($sv, $seen, $depth = 1) {
   my $r = ref $sv or return ();
   if ($r ne "B::AV" && $r ne "B::HV") {
@@ -601,6 +602,7 @@ sub ref_cvs ($sv, $seen, $depth = 1) {
   }
   return () unless $depth;
   return () if $sv->can("SvSTASH") && ref($sv->SvSTASH) ne "B::SPECIAL";
+  return () if $sv->MAGICAL;
   return () if $seen->{$$sv}++;
   my @elems = $r eq "B::AV" ? $sv->ARRAY : do { my %h = $sv->ARRAY; values %h };
   map ref_cvs($_, $seen, $depth - 1), @elems

--- a/t/internal/wrapped_sub.t
+++ b/t/internal/wrapped_sub.t
@@ -169,6 +169,47 @@ PROG
   is $sub && $sub->[0]->covered, 1, "and is reported as covered";
 }
 
+# A wrapper closing over a reference to a tied array.  Descending into a
+# tied container would run FETCH at report time, and B::AV::ARRAY walks the
+# empty real array with the magical size, crashing the process.  The walk
+# must skip tied containers and survive to report the file.
+sub test_tied_container () {
+  my $f = covered_file("WrappedTied", <<'PERL', <<'PROG', "21\n") or return;
+package WrappedTied;
+
+sub original {
+  my $n = shift;
+  $n * 2;
+}
+
+package WrappedTied::Tie;
+sub TIEARRAY  { bless {}, shift }
+sub FETCHSIZE {2}
+sub FETCH     {undef}
+
+package WrappedTied;
+my $orig = \&original;
+tie my @tied, "WrappedTied::Tie";
+my $ref = \@tied;
+*original = sub { my $keep = $ref; $orig->(shift) + 1 };
+
+1;
+PERL
+use WrappedTied;
+print WrappedTied::original(10), "\n";
+PROG
+
+  my $stmt = $f->statement;
+  for my $line (4, 5) {
+    my $l = $stmt->location($line);
+    ok $l, "statement beside a tied array on line $line is collected";
+    is $l && $l->[0]->covered, 1, "and has a count";
+  }
+  my $sub = $f->subroutine->location(4);
+  ok $sub, "the wrapped sub beside a tied array is collected";
+  is $sub && $sub->[0]->covered, 1, "and is reported as covered";
+}
+
 # The motivating case: a Moose "around" modifier.  Moose installs a
 # Class::MOP wrapper into the method glob and keeps the original method only
 # inside the wrapper's closure hash, so the original body vanishes from
@@ -299,6 +340,7 @@ sub main () {
   test_glob_wrapped_sub;
   test_hash_wrapped_sub;
   test_array_wrapped_sub;
+  test_tied_container;
   test_moose_around_original;
   test_deep_container_todo;
   test_blessed_holder_todo;


### PR DESCRIPTION
Fixes #629

## Summary
- The wrapped-sub pad walk descended into tied arrays, where `B::AV::ARRAY` sizes the array through the tie magic but walks the empty real store, so covering any code with a sub closing over a reference to a tied array crashed with SIGSEGV. Readonly ties arrays, which is how Perl-Critic-PJCJ hit this under cpancover.
- Skip magical containers in `ref_cvs` - a tied container's contents come from user code, which the report-time walk must never run, so nothing recoverable is lost.