### PR TITLE
GH-631 Prefer existing paths when naming shared content

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Improve the choice of reported name for files with identical content
+  (GH-631)
 - Skip magical containers in the wrapped-sub pad walk - a sub closing over a
   reference to a tied array previously crashed the covered process (GH-629)
 - Sort same-named subs in the text report numerically by line (GH-618)

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -20,10 +20,12 @@ use Devel::Cover::DB::IO    ();
 use Devel::Cover::Log       qw( dcinfo dcwarn );
 
 use Carp         qw( carp croak );
+use Cwd          ();
 use Digest::MD5  ();
-use Fcntl        qw( :flock );
+use Fcntl        qw( LOCK_EX LOCK_NB );
 use File::Find   qw( find );
 use File::Path   qw( rmtree );
+use File::Spec   ();
 use List::Util   qw( any );
 use Scalar::Util qw( blessed reftype );
 
@@ -1206,23 +1208,60 @@ sub _file_digest ($r, $file) {
   undef
 }
 
+sub _lib_preferred ($self, $file) {
+  return $file unless $self->{prefer_lib};
+  my $ff = $file;
+  $ff =~ s|^blib/||;
+  -e $ff ? $ff : $file
+}
+
+# The same content can be recorded under more than one name - a copy or a
+# symlink run from a directory deleted before the report is built.  When
+# names compete for a digest, prefer a path that still exists, outside the
+# temp directory and relative to the project tree, so a vanished alias
+# cannot become the reported name and hide the real file.
+sub _choose_canonical_files ($self, $runs, $digests, $uncoverable) {
+  my %candidates;
+  for my $run (@$runs) {
+    my $r = $self->{runs}{$run};
+    next unless $r->{collected};
+    for my $file (sort keys $r->{digests}->%*) {
+      my $digest = $r->{digests}{$file} or next;
+      $candidates{$digest}{ $self->_lib_preferred($file) }++;
+    }
+  }
+
+  my $tmpdir = File::Spec->tmpdir;
+  my %tmp    = map { $_ => 1 } grep defined, $tmpdir,
+    eval { Cwd::realpath($tmpdir) };
+  my $score = sub ($file) {
+    (-e $file ? 4 : 0) + (grep(index($file, "$_/") == 0, keys %tmp) ? 0 : 2)
+      + (File::Spec->file_name_is_absolute($file) ? 0 : 1)
+  };
+  for my $digest (sort keys %candidates) {
+    my @names = sort keys $candidates{$digest}->%*;
+    next if @names < 2;
+    my ($best) = sort {
+      $score->($b) <=> $score->($a) || length $a <=> length $b || $a cmp $b
+    } @names;
+    $digests->{$digest} = $best;
+    $self->uncoverable_comments($uncoverable, $best, $digest);
+  }
+}
+
 sub _cover_file (
   $self,  $file,        $f,       $r,     $st,
   $cover, $uncoverable, $digests, $files, $warned,
 ) {
   my $digest = _file_digest($r, $file) or return;
+  my $ff     = $self->_lib_preferred($file);
 
   dcinfo "merging data for $file into $digests->{$digest}"
-    if !$files->{$file}++ && $digests->{$digest};
+    if !$files->{$file}++ && $digests->{$digest} && $digests->{$digest} ne $ff;
 
   $self->uncoverable_comments($uncoverable, $file, $digest)
     unless $digests->{$digest};
 
-  my $ff = $file;
-  if ($self->{prefer_lib}) {
-    $ff =~ s|^blib/||;
-    $ff = $file unless -e $ff;
-  }
   my $cf = $cover->{ $digests->{$digest} ||= $ff } ||= {};
   $cf->{meta}{digest} = $digest;
 
@@ -1257,7 +1296,6 @@ sub cover ($self) {
   my $cover       = $self->{cover} = {};
   my $uncoverable = {};
   my $st          = $self->{_structure} // do {
-    require Devel::Cover::DB::Structure;  ## no perlimports
     Devel::Cover::DB::Structure->new(base => $self->{base})->read_all;
   };
 
@@ -1268,6 +1306,8 @@ sub cover ($self) {
     ($self->{runs}{$b}{start} || 0) <=> ($self->{runs}{$a}{start} || 0)
       || $b cmp $a
   } keys $self->{runs}->%*;
+
+  $self->_choose_canonical_files(\@runs, \%digests, $uncoverable);
 
   my %warned;
   for my $run (@runs) {

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -1296,6 +1296,7 @@ sub cover ($self) {
   my $cover       = $self->{cover} = {};
   my $uncoverable = {};
   my $st          = $self->{_structure} // do {
+    require Devel::Cover::DB::Structure;  ## no perlimports
     Devel::Cover::DB::Structure->new(base => $self->{base})->read_all;
   };
 

--- a/t/internal/digest_name.t
+++ b/t/internal/digest_name.t
@@ -71,6 +71,8 @@ sub main () {
   my $cover = Devel::Cover::DB->new(db => $db)->merge_runs->cover;
   my %item;
   @item{ $cover->items } = ();
+  # Devel::Cover records Windows paths with forward slashes
+  tr|\\|/| for $real, $alias;
   ok exists $item{$real},   "the surviving path is the canonical name";
   ok !exists $item{$alias}, "the vanished alias is not reported";
 

--- a/t/internal/digest_name.t
+++ b/t/internal/digest_name.t
@@ -1,0 +1,85 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( realpath );
+use File::Path qw( remove_tree );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is ok )];
+
+use Devel::Cover::DB ();
+
+# The same content can be recorded under several names - a copy or symlink of
+# a script run from a temp directory that is deleted before the report is
+# built.  The canonical name for the digest must be a path that still exists,
+# not whichever name the newest run happened to use, or the report shows an
+# unlinkable stub and drops the real file.
+
+my $Tmpdir = realpath(tempdir(CLEANUP => 1));
+
+sub write_file ($path, $content) {
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $content;
+  close $fh or die "Cannot close $path: $!";
+}
+
+sub run_covered ($db, $script) {
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my $cmd = "$^X -Iblib/lib -Iblib/arch"
+    . " -MDevel::Cover=-db,$db,-silent,1 $script 2>&1";
+  my $out = `$cmd`;
+  is $?, 0, "covered run of $script exits 0" or diag $out;
+}
+
+sub main () {
+  my $keep_dir = File::Spec->catdir($Tmpdir, "keep");
+  my $gone_dir = File::Spec->catdir($Tmpdir, "gone");
+  for my $dir ($keep_dir, $gone_dir) {
+    mkdir $dir or die "Cannot mkdir $dir: $!";
+  }
+
+  my $content = qq(my \$x = shift // 1;\nprint "ran\\n";\n);
+  my $real    = File::Spec->catfile($keep_dir, "script.pl");
+  my $alias   = File::Spec->catfile($gone_dir, "script-alias.pl");
+  write_file($_, $content) for $real, $alias;
+
+  # Removing the digests cache between the runs stands in for a parent
+  # process clobbering it, so the alias run records its own name.  The alias
+  # run is the newest and is processed first when the cover data is built
+  my $db = File::Spec->catdir($Tmpdir, "cover_db");
+  run_covered($db, $real);
+  unlink File::Spec->catfile($db, "digests");
+  run_covered($db, $alias);
+  remove_tree($gone_dir);
+
+  my $cover = Devel::Cover::DB->new(db => $db)->merge_runs->cover;
+  my %item;
+  @item{ $cover->items } = ();
+  ok exists $item{$real},   "the surviving path is the canonical name";
+  ok !exists $item{$alias}, "the vanished alias is not reported";
+
+  my $file = $cover->file($real) or return done_testing;
+  my $l    = $file->statement->location(1);
+  ok $l, "the surviving path holds the statement data";
+  is $l && $l->[0]->covered, 2, "with the counts of both runs merged";
+
+  done_testing
+}
+
+main


### PR DESCRIPTION
Fixes #631

## Summary
- The report named a digest after whichever path the newest run happened to use, so content also recorded under a since-deleted temp alias - a symlinked git hook run by a test - could be reported under the vanished name while the real file dropped out of the report.
- Choose the canonical name per digest up front, scoring the candidates - an existing path beats a missing one, outside the temp directory beats inside, relative beats absolute - and read uncoverable comments from the chosen name.
- The structure store had the same weakness one layer down - each digest-keyed entry names a single file inside, last writer wins, and reading the structure back dropped any entry whose named file could not be re-read. Keep such entries for digest lookups instead, since the stored digest already identifies the content.