### PR TITLE
GH-636 Publish cpancover reports when tests fail

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Publish cpancover reports even when a module's tests fail under coverage -
+  such modules previously got no report at all (GH-636)
+- Kill commands that exceed the cpancover timeout - the pipeline previously
+  waited for the hung command to finish anyway (GH-636)
 - Improve the choice of reported name for files with identical content
   (GH-631)
 - Skip magical containers in the wrapped-sub pad walk - a sub closing over a

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -241,7 +241,8 @@ class Devel::Cover::Collection {
     }
     my @test_cmd
       = (@cmd, "--test", "--report", $report, "--outputfile", $output_file);
-    $output .= "dc -> @test_cmd\n" . $self->fbsys(@test_cmd);
+    # failing tests must not stop the report - the db is still valid
+    $output .= "dc -> @test_cmd\n" . $self->bsys(@test_cmd);
     my @json_cmd = (@cmd, "-report", "json_summary", "-nosummary");
     $output .= "dc -> @json_cmd\n" . $self->fsys(@json_cmd);
 

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -100,9 +100,11 @@ class Devel::Cover::Collection {
     # say "Setting alarm for $timeout seconds";
     my $ok = 0;
     my $pid;
+    # declared here so a timeout die doesn't close it and wait for the child
+    my $fh;
     eval {
       open STDIN, "<", "/dev/null" or die "Can't read /dev/null: $!";
-      $pid = open(my $fh, "-|") // die "Can't fork: $!";
+      $pid = open($fh, "-|") // die "Can't fork: $!";
       if ($pid) {
         my $printed = 0;
         local $SIG{ALRM} = sub { die "alarm\n" };
@@ -145,6 +147,8 @@ class Devel::Cover::Collection {
       my $pgrp = getpgrp $pid;
       my $n    = kill "-KILL", $pgrp;
       warn "killed $n processes";
+      # reap the killed child - close reports its death, which is expected
+      close $fh if $fh;                 ## no critic (RequireCheckedClose)
     }
     my $output = length $output2 ? "$output1\n...\n$output2" : $output1;
     warn $output if !$ok && length $output;

--- a/t/internal/collection_run.t
+++ b/t/internal/collection_run.t
@@ -1,0 +1,83 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();  ## no perlimports
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( getcwd );
+use File::Path qw( make_path );
+use File::Temp qw( tempdir );
+
+use Test::More import => [qw( done_testing is like ok plan )];
+
+BEGIN {
+  plan skip_all => "Devel::Cover::Collection requires Perl 5.42" if $] < 5.042;
+  plan skip_all => "Devel::Cover::Collection is not portable to Windows"
+    if $^O eq "MSWin32";
+  for my $module (qw( Template Parallel::Iterator JSON::MaybeXS )) {
+    plan skip_all => "$module required for this test"
+      unless eval "require $module; 1";
+  }
+}
+
+use Devel::Cover::Collection ();
+
+my $Tmp       = tempdir CLEANUP => 1;
+my $Bin       = "$Tmp/bin";
+my $Build_dir = "$Tmp/build/My-Module-1.02-1234";
+make_path $Bin, $Build_dir;
+
+# A fake cover: --test leaves a valid cover_db but reports failing tests,
+# any report run succeeds and records that it happened
+open my $fh, ">", "$Bin/cover" or die "Can't open $Bin/cover: $!";
+print $fh <<'EOS';
+use strict;
+use warnings;
+if (grep $_ eq "--test", @ARGV) {
+  mkdir "cover_db" or die "Can't mkdir cover_db: $!";
+  open my $fh, ">", "cover_db/marker" or die "Can't open marker: $!";
+  print $fh "coverage\n";
+  close $fh or die "Can't close marker: $!";
+  print "Result: FAIL\n";
+  exit 3;
+}
+open my $fh, ">", "cover_db/report_generated" or die "Can't open report: $!";
+close $fh or die "Can't close report: $!";
+exit 0;
+EOS
+close $fh or die "Can't close $Bin/cover: $!";
+
+my $Collection = Devel::Cover::Collection->new(
+  bin_dir     => $Bin,
+  results_dir => "$Tmp/results",
+);
+
+my @Warnings;
+local $SIG{__WARN__} = sub { push @Warnings, @_ };
+
+my $Cwd = getcwd;
+open my $Saved_stdout, ">&", \*STDOUT       or die "Can't save STDOUT: $!";
+open STDOUT,           ">",  "$Tmp/run.out" or die "Can't redirect STDOUT: $!";
+my $Err = do { local $@; eval { $Collection->run($Build_dir) }; $@ };
+open STDOUT, ">&", $Saved_stdout or die "Can't restore STDOUT: $!";
+chdir $Cwd or die "Can't chdir $Cwd: $!";
+
+my $Rdir = "$Tmp/results/My-Module-1.02";
+is $Err, "", "run survives a failing test suite";
+ok -e "$Rdir/marker",           "coverage database is published";
+ok -e "$Rdir/report_generated", "report generation still runs";
+like join("", @Warnings), qr/exit 3/, "test failure is still warned";
+
+done_testing;

--- a/t/internal/collection_sys.t
+++ b/t/internal/collection_sys.t
@@ -55,12 +55,13 @@ like $Warned, qr/exit 3/,        "warning reports the exit status";
 like $Warned, qr/STDOUT DETAIL/, "warning includes the command's stdout";
 like $Warned, qr/STDERR DETAIL/, "warning includes the command's stderr";
 
-my $Quick = Devel::Cover::Collection->new(timeout => 2);
+my $Quick = Devel::Cover::Collection->new(timeout => 1);
 ($Output, $Warned) = bsys_warnings(
   $Quick, $^X, "-e", '$| = 1; print uc("before hang"), "\n"; sleep 30'
 );
 is $Output, "", "timeout returns empty string";
 like $Warned, qr/Timed out/,   "timeout is warned";
 like $Warned, qr/BEFORE HANG/, "timeout warning includes the command's output";
+like $Warned, qr/killed [1-9]\d* process/, "timeout kills the hung command";
 
 done_testing;


### PR DESCRIPTION
## Summary

Some modules' tests fail under coverage even though they pass when run normally, for example when Devel::Cover's `$^P` flags change how string evals are named. `Collection::run` died on the non-zero exit from `cover --test`, so cpancover published nothing for such modules and marked them failed, where the old pipeline still published a report. Run the test command through `bsys` instead, so the report is still generated and the database still moves into the results directory. A genuine build failure still fails when the missing database can't be moved.

Also fix the `_sys` timeout, which never actually killed a hung command - the timeout die closed the pipe handle as the eval unwound, and that close waited for the child to exit on its own before the kill ran. Declare the handle outside the eval and kill the process group before reaping the child. This also cuts the timeout test in `t/internal/collection_sys.t` from thirty seconds to about one.

## Ticket

Closes #636