### PR TITLE
GH-638 Use the standard 5.44.0 tarball URL

### DIFF
--- a/docker/perl-5.44.0/Dockerfile
+++ b/docker/perl-5.44.0/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget --progress=dot:giga https://cpan.metacpan.org/authors/id/L/LE/LEONT/perl-5.44.0.tar.gz \
+RUN wget --progress=dot:giga https://cpan.metacpan.org/src/5.0/perl-5.44.0.tar.gz \
     -O - | tar xzf - -C /usr/local/src
 
 WORKDIR /usr/local/src/perl-5.44.0


### PR DESCRIPTION
## Summary

`src/5.0/` on CPAN lagged the 5.44.0 release when the docker files were generated, so `docker/perl-5.44.0/Dockerfile` carried the author fallback URL that `docker/BUILD` chose. The tarball has since appeared in the standard location, so switch the Dockerfile to it, matching the other perl version docker files and what `docker/BUILD` would generate today.

## Ticket

Closes #638