### PR TITLE
GH-633 Fix spurious uncovered elsif statements

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1329,8 +1329,25 @@ sub _walk_statement ($op, $type) {
   }
 }
 
+sub _walk_elsif_chain ($cv, $false) {
+  while (B::class($false) ne "NULL" && is_ifelse_cont($false)) {
+    my $newop = $false->first;
+    $Seen{cond_expr}{$$newop} = 1;
+    my $newcond = $newop->first;
+    my $newtrue = $newcond->sibling;
+    if ($newcond->name eq "lineseq") {
+      $newcond = $newcond->first->sibling;
+    }
+    $false = $newtrue->sibling;
+    if ($Coverage{branch}) {
+      my $newtext = _deparse_expr($cv, $newcond, 1, 0);
+      add_branch_cover($newop, "elsif", "elsif ($newtext) { }", $File, $Line);
+    }
+  }
+}
+
 sub _walk_cond_expr ($cv, $op) {
-  return unless $Collect && $Coverage{branch};
+  return unless $Collect;
   return if $Seen{cond_expr}{$$op};
   local ($File, $Line) = ($File, $Line);
   my $cond  = $op->first;
@@ -1358,23 +1375,15 @@ sub _walk_cond_expr ($cv, $op) {
   }
 
   if (!$is_statement) {
+    return unless $Coverage{branch};
     my $text = _deparse_expr($cv, $cond, 8, 0);
     add_branch_cover($op, "if", "$text ? :", $File, $Line);
   } else {
-    my $text = _deparse_expr($cv, $cond, 1, 0);
-    add_branch_cover($op, "if", "if ($text) { }", $File, $Line);
-    while (B::class($false) ne "NULL" && is_ifelse_cont($false)) {
-      my $newop = $false->first;
-      $Seen{cond_expr}{$$newop} = 1;
-      my $newcond = $newop->first;
-      my $newtrue = $newcond->sibling;
-      if ($newcond->name eq "lineseq") {
-        $newcond = $newcond->first->sibling;
-      }
-      $false = $newtrue->sibling;
-      my $newtext = _deparse_expr($cv, $newcond, 1, 0);
-      add_branch_cover($newop, "elsif", "elsif ($newtext) { }", $File, $Line);
+    if ($Coverage{branch}) {
+      my $text = _deparse_expr($cv, $cond, 1, 0);
+      add_branch_cover($op, "if", "if ($text) { }", $File, $Line);
     }
+    _walk_elsif_chain($cv, $false);
   }
 }
 

--- a/test_output/cover/elsif_statement_only.5.020000
+++ b/test_output/cover/elsif_statement_only.5.020000
@@ -1,0 +1,82 @@
+cover: Reading database from ...
+-------------------------- ------ ------ ------
+File                         stmt  total   scar
+-------------------------- ------ ------ ------
+tests/elsif_statement_only  100.0  100.0   19.5
+Total                       100.0  100.0   19.5
+-------------------------- ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/elsif_statement_only
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+ 7 100.0  7.0 19.5
+
+Worst Subroutines
+-----------------
+
+Subroutine CC SCAR  Location                     
+---------- -- ----  -----------------------------
+with_else   4 13.9  tests/elsif_statement_only:16
+no_else     4 13.9  tests/elsif_statement_only:29
+
+line  err   stmt   code
+1                  #!/usr/bin/env perl
+2                  
+3                  # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                  
+5                  # This software is free.  It is licensed under the same terms as Perl itself.
+6                  
+7                  # The latest version of this software should be available from my homepage:
+8                  # https://pjcj.net
+9                  
+10                 # __COVER__ criteria statement
+11                 
+12             1   use strict;
+               1   
+               1   
+13             1   use warnings;
+               1   
+               1   
+14                 
+15                 sub with_else {
+16             4     my $x = shift;
+17             4     if ($x == 1) {
+18             1       return "one";
+19                   } elsif ($x == 2) {
+20             1       return "two";
+21                   } elsif ($x == 3) {
+22             1       return "three";
+23                   } else {
+24             1       return "many";
+25                   }
+26                 }
+27                 
+28                 sub no_else {
+29             4     my $x = shift;
+30             4     if ($x == 1) {
+31             1       return "one";
+32                   } elsif ($x == 2) {
+33             1       return "two";
+34                   } elsif ($x == 3) {
+35             1       return "three";
+36                   }
+37             1     return "many";
+38                 }
+39                 
+40             1   for my $x (1 .. 4) {
+41             4     with_else($x);
+42             4     no_else($x);
+43                 }
+
+

--- a/tests/elsif_statement_only
+++ b/tests/elsif_statement_only
@@ -1,0 +1,43 @@
+#!/usr/bin/env perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# __COVER__ criteria statement
+
+use strict;
+use warnings;
+
+sub with_else {
+  my $x = shift;
+  if ($x == 1) {
+    return "one";
+  } elsif ($x == 2) {
+    return "two";
+  } elsif ($x == 3) {
+    return "three";
+  } else {
+    return "many";
+  }
+}
+
+sub no_else {
+  my $x = shift;
+  if ($x == 1) {
+    return "one";
+  } elsif ($x == 2) {
+    return "two";
+  } elsif ($x == 3) {
+    return "three";
+  }
+  return "many";
+}
+
+for my $x (1 .. 4) {
+  with_else($x);
+  no_else($x);
+}


### PR DESCRIPTION
## Summary

- Collecting statement coverage without branch coverage gave the final `elsif` of an else-less chain a statement record that can never execute, so tools reading the database reported those lines as uncovered.
- The walker only spotted that arm's dead COP as part of the `elsif` condition when the branch walk had marked the chain as seen.
- Walk `elsif` chains whenever collecting, keeping just the branch records behind the branch criterion.

## Ticket

Closes #633