### PR TITLE
GH-641 Skip Html_subtle tests without Template

### DIFF
--- a/t/internal/coverage_class.t
+++ b/t/internal/coverage_class.t
@@ -16,10 +16,9 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Test::More import => [qw( done_testing is )];
+use Test::More import => [qw( done_testing is skip )];
 
-use Devel::Cover::Html_Common         qw( coverage_class default_thresholds );
-use Devel::Cover::Report::Html_subtle ();
+use Devel::Cover::Html_Common qw( coverage_class default_thresholds );
 
 sub test_default_banding () {
   is coverage_class(0),     "c0", "0% is c0";
@@ -68,6 +67,11 @@ sub test_html_subtle_honours_thresholds () {
 test_default_banding;
 test_custom_thresholds;
 test_default_thresholds_copy;
-test_html_subtle_honours_thresholds;
+
+SKIP: {
+  skip "Template not available", 5
+    unless eval { require Devel::Cover::Report::Html_subtle; 1 };
+  test_html_subtle_honours_thresholds;
+}
 
 done_testing;


### PR DESCRIPTION
## Summary

- The compile-time load of `Html_subtle` died when Template Toolkit was missing, failing the whole of `coverage_class.t`.
- Require it at runtime and skip just the threshold tests, since the banding tests don't need it.

## Ticket

Closes #641