### PR TITLE
GH-643 Pass environment to the build container

### DIFF
--- a/bin/cpancover
+++ b/bin/cpancover
@@ -220,7 +220,7 @@ The following command line options are supported:
   --rebuild_batch         - how many distdirs per rebuild pass   (100)
   --report                - report to use                        (html)
   --results_dir           - where to store output               ($cwd)
-  --timeout               - per-distribution timeout in seconds  (1800)
+  --timeout               - per-distribution timeout in seconds  (3600)
   --verbose               - verbose output                       (off)
   --workers               - number of parallel workers           (0)
 

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -76,7 +76,7 @@ class Devel::Cover::Collection {
     $rebuild       //= 0;
     $rebuild_batch //= 100;
     $report        //= "html";
-    $timeout       //= $ENV{CPANCOVER_TIMEOUT} // 30 * 60;  # half an hour
+    $timeout       //= $ENV{CPANCOVER_TIMEOUT} // 60 * 60;             # an hour
     $verbose       //= 0;
     $workers       //= 0;
     $ENV{CPANCOVER_TIMEOUT} = $timeout;
@@ -1093,7 +1093,7 @@ Report format to generate. Default: 'html'.
 
 =head3 timeout
 
-Timeout in seconds for coverage runs. Default: 1800 (30 minutes).
+Timeout in seconds for coverage runs. Default: 3600 (60 minutes).
 
 =head3 verbose
 

--- a/utils/dc
+++ b/utils/dc
@@ -613,6 +613,15 @@ recipe_docker-name() {
   docker_name "${args[@]:-}"
 }
 
+cpancover_env_flags() {
+  local -n flags="$1"
+  local var value
+  flags=()
+  while IFS='=' read -r var value; do
+    flags+=(--env "$var=$value")
+  done < <(env | grep -E '^(CPANCOVER_|DEVEL_COVER_)' || true)
+}
+
 cpancover_controller_command() {
   local name="${1:?No name specified}"
   shift
@@ -622,9 +631,7 @@ cpancover_controller_command() {
   local tty_flag=""
   [[ -t 0 ]] && tty_flag="-t"
   local env_flags=()
-  while IFS='=' read -r var value; do
-    env_flags+=(--env "$var=$value")
-  done < <(env | grep -E '^(CPANCOVER_|DEVEL_COVER_)' || true)
+  cpancover_env_flags env_flags
   "$docker" run -i ${tty_flag:+"$tty_flag"} \
     --mount "type=bind,source=$sock,target=$sock" \
     --mount "type=bind,source=$results_dir,target=/remote_staging" \
@@ -673,7 +680,10 @@ recipe_cpancover-docker-module() {
   ((verbose)) && pi "module: $module"
   local v=
   ((verbose)) && v=--verbose
+  local env_flags=()
+  cpancover_env_flags env_flags
   container=$($docker run -d \
+    ${env_flags[@]:+"${env_flags[@]}"} \
     --label "cpancover.env=$env" \
     --rm=false --memory=1g --name="$name" \
     "$docker_image" \

--- a/utils/dc
+++ b/utils/dc
@@ -670,7 +670,7 @@ recipe_cpancover-docker-module() {
   local module="${1:?No module specified}"
   local name="${2:?No name specified}"
   local staging="${3:-$results_dir}"
-  local module_timeout="${CPANCOVER_TIMEOUT:-1800}" # half an hour
+  local module_timeout="${CPANCOVER_TIMEOUT:-3600}" # an hour
   local log_ext=out
   cpancover_compression_enabled && log_ext=out.gz
 


### PR DESCRIPTION
## Summary

Setting `CPANCOVER_TIMEOUT` on a controller run had no effect inside the module build container. The `docker run` that launches it forwarded no environment, so `Collection` fell back to its 1800 second default and killed long `cover --test` runs at 30 minutes - Moose-2.4000 on the dev tree hit this and was published without a report (#644 covers that side).

Forward the same `CPANCOVER_*` and `DEVEL_COVER_*` variables the controller launch already gets, sharing the loop through a `cpancover_env_flags` helper.

Also bump the default per-distribution timeout from half an hour to an hour, in all the places it appears.

## Implications

- The recipe runs from the `dc` baked into the controller image, so the fix only takes effect on the server after an image rebuild.

## Ticket

Closes #643