### PR TITLE
GH-650 Detect containers via /.dockerenv

### DIFF
--- a/utils/dc
+++ b/utils/dc
@@ -203,8 +203,8 @@ parse_options() {
         ;;
       esac
       shift
-      if grep -q "/docker/" /proc/self/mountinfo 2>/dev/null; then
-        # we're inside a docker container so use the remote staging directory
+      if [[ -f /.dockerenv ]]; then
+        # docker creates /.dockerenv only inside a container
         results_dir=/remote_staging
       fi
       ;;

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -314,6 +314,25 @@ sub controller_rebuild_module_recipe () {
     "runs the inner rebuild-module recipe";
 }
 
+sub controller_staging_on_host () {
+  my $bin = tempdir(CLEANUP => 1);
+  make_docker_stub($bin);
+  local $ENV{PATH} = "$bin:$ENV{PATH}";
+  my $module = "P/PJ/PJCJ/Foo-Bar-1.00.tar.gz";
+  my $work   = tempdir(CLEANUP => 1);
+  my $home   = tempdir(CLEANUP => 1);
+
+  {
+    local $ENV{STUB_CALLS} = "$work/calls";
+    local $ENV{HOME}       = $home;
+    dc("-e", "dev", "cpancover-controller-rebuild-module", $module);
+  }
+
+  like slurp("$work/calls"),
+    qr{source=\Q$home\E/cover/staging_dev,target=/remote_staging},
+    "host run mounts the staging dir, even with containers running";
+}
+
 sub make_seed_source ($src) {
   mkdir "$src/$_"
     or die "Can't mkdir $src/$_: $!"
@@ -377,6 +396,7 @@ sub main () {
     rebuild_batch_cleanup
     rebuild_module_recipe
     controller_rebuild_module_recipe
+    controller_staging_on_host
     seed_recipe
   );
   for my $test (@tests) {


### PR DESCRIPTION
## Summary

`dc` decided it was inside a container by grepping `/proc/self/mountinfo` for `/docker/`, but a running container adds matching rootfs and netns mounts to the host's mountinfo too. Restarting the controller while builds from the previous run were still finishing then swapped the staging directory for `/remote_staging`, which can't be created on the host. Check for `/.dockerenv` instead, which docker creates only inside containers, and add a regression test that runs a controller recipe without `-r` and checks the mounted staging directory.

## Ticket

Closes #650