### PR TITLE
GH-652 Link cpancover versions to MetaCPAN

### DIFF
--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -393,6 +393,20 @@ class Devel::Cover::Collection {
     defined $line && length $line ? $line : undef
   }
 
+  method add_metacpan_links ($vars) {
+    for my $mods (values $vars->{modules}->%*) {
+      for my $mod (@$mods) {
+        my $m   = $mod->{module};
+        my $log = $vars->{vals}{$m}{log};
+        if (defined $log && $log =~ /^\w-\w\w-(\w+)-\Q$m\E${Dist_ext_re}--/) {
+          $mod->{metacpan} = "https://metacpan.org/release/$1/$m";
+        } elsif (defined $mod->{name}) {
+          $mod->{metacpan} = "https://metacpan.org/dist/$mod->{name}";
+        }
+      }
+    }
+  }
+
   method generate_html {
     my ($d) = $self->made_res_dir;
     chdir $d or die "Can't chdir $d: $!\n";
@@ -469,6 +483,7 @@ class Devel::Cover::Collection {
     }
 
     $self->resolve_log_links($d, \@mods, $vars);
+    $self->add_metacpan_links($vars);
 
     # print "vars ", Dumper $vars;
     $self->write_summary($vars);
@@ -967,7 +982,13 @@ $Templates{module_by_start} = <<'EOT';
           [% module.name || module.module %]
         [% END %]
       </td>
-      <td>[% module.version %]</td>
+      <td>
+        [% IF module.metacpan %]
+          <a href="[% module.metacpan %]">[% module.version %]</a>
+        [% ELSE %]
+          [% module.version %]
+        [% END %]
+      </td>
       <td>
         [% IF vals.$m.log %]
           <a href="[% root %][% vals.$m.log %]">&para;</a>

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -150,6 +150,17 @@ unlike $Page{dist_d}, qr{href="\.\./\Q$Ref3\E"},
 like $Page{dist_d}, qr{href="\.\./\Q$Log_new\E"},
   "dependency dist links its target's log via .log_ref";
 
+like $Page{dist}, qr{href="https://metacpan\.org/release/PJCJ/\Q$Dist\E"},
+  "version links the metacpan release parsed from the log";
+like $Page{dist_b}, qr{href="https://metacpan\.org/release/PJCJ/\Q$Dist2\E"},
+  "version links the metacpan release for an uncompressed log";
+like $Page{dist_d}, qr{href="https://metacpan\.org/release/PJCJ/\Q$Dist3\E"},
+  "version links the metacpan release via the name-matched log";
+like $Page{dist_d}, qr{href="https://metacpan\.org/dist/Dep-Only"},
+  "dependency dist falls back to the metacpan dist link";
+unlike $Page{dist_d}, qr{href="https://metacpan\.org/release/\w+/\Q$Dist4\E"},
+  "dependency dist gets no release link from its target's log";
+
 my $Version = $Devel::Cover::Inc::VERSION . $Devel::Cover::Inc::Dev;
 for my $name (sort keys %Page) {
   like $Page{$name}, qr{Devel::Cover</a>\s+\Q$Version\E\s+by},


### PR DESCRIPTION
## Summary

On the cpancover distribution pages the version number was plain text. Link it to the release on metacpan.org, pointing at the exact release when the author id can be parsed from the build log and falling back to the distribution page otherwise. The release URL is built from the distdir name, so a release shipping a stale META version still links to the true release.

## Ticket

Closes #652