### PR TITLE
GH-654 Disable mod_perl 1.x via distroprefs

### DIFF
--- a/docker/devel-cover-base/Dockerfile
+++ b/docker/devel-cover-base/Dockerfile
@@ -29,6 +29,7 @@ RUN mkdir -p /root/.cpan/CPAN                                               && \
       '    q(https://cpan.metacpan.org/),'                                     \
       '    q(https://www.cpan.org/),'                                          \
       '  ],'                                                                   \
+      '  prefs_dir => q(/root/.cpan/prefs),'                                   \
       '}; 1;'                                                                  \
       > /root/.cpan/CPAN/MyConfig.pm                                        && \
     cpan -Ti                                                                   \
@@ -44,3 +45,5 @@ RUN mkdir -p /root/.cpan/CPAN                                               && \
       Template                                                              && \
     rm -rf ~/.cpan/build ~/.cpan/sources/authors ~/.cpanm                      \
       ~/.local/share/.cpan/build ~/.local/share/.cpan/sources/authors
+
+COPY prefs/ /root/.cpan/prefs/

--- a/docker/devel-cover-base/prefs/01.mod_perl1.dd
+++ b/docker/devel-cover-base/prefs/01.mod_perl1.dd
@@ -1,0 +1,5 @@
+$VAR1 = {
+  match    => { distribution => 'mod_perl-1\.' },
+  disabled => 1,
+  comment  => "mod_perl 1.x Makefile.PL prompts and loops with no tty",
+};


### PR DESCRIPTION
## Summary

A build container spent its full one-hour timeout spinning in mod_perl 1.31's interactive Makefile.PL, pulled in through SOAP::Lite's optional `Apache` prereq. Add a CPAN distroprefs document to the build image that disables mod_perl 1.x outright, so CPAN refuses it immediately and dependent builds fail the optional prereq in seconds instead of burning an hour. The document uses the `.dd` format, which CPAN reads without any YAML module, and `prefs_dir` is set explicitly in the generated CPAN config.

## Ticket

Closes #654