### PR TITLE
GH-656 Link the CPANCover header to the home page

### DIFF
--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -832,7 +832,7 @@ https://pjcj.net
 <body>
 <header class="header">
 <div class="header-inner">
-<h1>CPANCover</h1>
+<h1><a href="[% root %]index.html">CPANCover</a></h1>
 <div class="header-stats">
 <button class="theme-toggle" aria-label="Toggle dark mode">&#x263e;</button>
 </div>

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -636,6 +636,15 @@ JS
 my $Collection_extra_css = <<'CSS';
 /* Collection page styles */
 
+.header h1 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.header h1 a:hover {
+  text-decoration: underline;
+}
+
 table {
   border-collapse: collapse;
   margin: 0 0 24px;

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -128,6 +128,8 @@ for my $name (qw( index about )) {
     "$name page links script relatively";
   like $Page{$name}, qr{href="about\.html"},
     "$name page links about page relatively";
+  like $Page{$name}, qr{<h1><a href="index\.html">CPANCover</a></h1>},
+    "$name page header links home";
 }
 
 like $Page{index}, qr{href="dist/F\.html"}, "index links dist page";
@@ -135,6 +137,8 @@ like $Page{index}, qr{href="dist/F\.html"}, "index links dist page";
 like $Page{dist}, qr{href="\.\./collection\.css"}, "dist page links stylesheet";
 like $Page{dist}, qr{src="\.\./collection\.js"},   "dist page links script";
 like $Page{dist}, qr{href="\.\./about\.html"},     "dist page links about page";
+like $Page{dist}, qr{<h1><a href="\.\./index\.html">CPANCover</a></h1>},
+  "dist page header links home";
 like $Page{dist}, qr{href="\.\./\Q$Dist\E/index\.html"},
   "dist page links module report";
 like $Page{dist}, qr{href="\.\./\Q$Log_new\E"},


### PR DESCRIPTION
## Summary

Wrap the CPANCover title in the collection page header in a link to the home page, so users can return to the index from any dist listing or the about page. Style the link to keep the header's current look, with an underline on hover.

## Ticket

Closes #656