### PR TITLE
GH-644 Don't publish builds with no report

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Mark cpancover builds failed when the report file was never written, and
+  don't link distributions whose report page is missing - a report command
+  dying part-way previously published truncated results behind a broken
+  link (GH-644)
 - Publish cpancover reports even when a module's tests fail under coverage -
   such modules previously got no report at all (GH-636)
 - Kill commands that exceed the cpancover timeout - the pipeline previously

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -256,6 +256,8 @@ class Devel::Cover::Collection {
     my $err  = do {
       local $@;
       eval {
+        die "No $output_file report generated for $module\n"
+          unless -e "$db/$output_file";
         my @json_cmd = (@cmd, "-report", "json_summary", "-nosummary");
         $output .= "dc -> @json_cmd\n";
         $output .= $self->fsys(@json_cmd);
@@ -466,7 +468,7 @@ class Devel::Cover::Collection {
       my $m = $vars->{vals}{$module} = {};
       $m->{module} = $mod;
       $m->{link}   = "$module/index.html"
-        if $json->{summary}{Total}{total}{total};
+        if $json->{summary}{Total}{total}{total} && -e "$d/$module/index.html";
 
       for my $criterion ($vars->{criteria}->@*) {
         my $summary = $json->{summary}{Total}{$criterion};
@@ -1281,9 +1283,11 @@ Runs coverage analysis on a single build directory. Creates coverage reports
 in the results directory. The C<cover> invocation is passed C<--select_dir>
 pointing at C<blib> (falling back to C<lib>, then the build directory) so
 files no test exercised appear in the report as untested, and a distribution
-without any tests still produces a report rather than failing. If a step
-after the test run dies, the collected output is printed before the error
-propagates.
+without any tests still produces a report rather than failing. The report
+file is the success test. If the test run dies part-way and leaves no
+report, nothing is published and the failure propagates, even though a
+failing test suite alone does not. If a step after the test run dies, the
+collected output is printed before the error propagates.
 
 =head3 run_all
 
@@ -1309,7 +1313,8 @@ actually attempted.
   $collection->generate_html;
 
 Generates HTML coverage reports for all modules in the results directory.
-Creates an index page, per-module pages, and an about page.
+Creates an index page, per-module pages, and an about page. A module is
+only linked when its report page exists on disk.
 
 =head3 coverage_class
 

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -44,6 +44,7 @@ my $Dist3   = "Dangle-Ref-3.00";
 my $Log3    = "P-PJ-PJCJ-Dangle-Ref-3.00.tar.gz--1234567892.123456.out";
 my $Ref3    = "P-PJ-PJCJ-Dangle-Ref-3.00.tar.gz--9999999999.123456.out";
 my $Dist4   = "Dep-Only-4.00";
+my $Dist5   = "No-Page-5.00";
 
 sub write_file ($path, $content) {
   open my $fh, ">", $path or die "Can't open $path: $!";
@@ -59,7 +60,7 @@ sub slurp ($path) {
   $content
 }
 
-sub write_dist ($dir, $dist, $name, $version, $log = undef) {
+sub write_dist ($dir, $dist, $name, $version, $log = undef, $page = 1) {
   make_path("$dir/$dist");
 
   my $criterion = { percentage => 85.5, covered => 10, total => 12 };
@@ -68,7 +69,8 @@ sub write_dist ($dir, $dist, $name, $version, $log = undef) {
     summary => { Total => { total => $criterion, statement => $criterion } },
   };
   write_file("$dir/$dist/cover.json", JSON::PP->new->encode($cover));
-  write_file("$dir/$log",             "log\n") if defined $log;
+  write_file("$dir/$dist/index.html", "report\n") if $page;
+  write_file("$dir/$log",             "log\n")    if defined $log;
 }
 
 sub seed_page ($dir, $file) {
@@ -95,6 +97,9 @@ sub setup_results_dir {
   write_dist($dir, $Dist4, "Dep-Only", "4.00");
   write_file("$dir/$Dist4/.log_ref", "$Log_new\n");
 
+  # $Dist5 has coverage totals but its report page was never written
+  write_dist($dir, $Dist5, "No-Page", "5.00", undef, 0);
+
   make_path("$dir/dist");
   seed_page($dir, $_) for qw( index.html dist/F.html about.html );
 
@@ -113,6 +118,7 @@ my %Page = (
   dist   => slurp("$Dir/dist/F.html"),
   dist_b => slurp("$Dir/dist/B.html"),
   dist_d => slurp("$Dir/dist/D.html"),
+  dist_n => slurp("$Dir/dist/N.html"),
   about  => slurp("$Dir/about.html"),
 );
 
@@ -141,6 +147,9 @@ like $Page{dist}, qr{<h1><a href="\.\./index\.html">CPANCover</a></h1>},
   "dist page header links home";
 like $Page{dist}, qr{href="\.\./\Q$Dist\E/index\.html"},
   "dist page links module report";
+like $Page{dist_n}, qr{No-Page}, "dist without a report page is listed";
+unlike $Page{dist_n}, qr{href="\.\./\Q$Dist5\E/index\.html"},
+  "dist without a report page is not linked";
 like $Page{dist}, qr{href="\.\./\Q$Log_new\E"},
   "dist page links the log named in .log_ref";
 unlike $Page{dist}, qr{href="\.\./\Q$Log\E"},

--- a/t/internal/collection_run.t
+++ b/t/internal/collection_run.t
@@ -38,9 +38,10 @@ my $Tmp = tempdir CLEANUP => 1;
 my $Bin = "$Tmp/bin";
 make_path $Bin;
 
-# A fake cover: records its arguments, --test leaves a valid cover_db but
-# reports failing tests, any report run succeeds and records that it
-# happened, or fails when FAKE_COVER_FAIL_REPORT is set
+# A fake cover: records its arguments, --test leaves a valid cover_db and
+# a report file (unless FAKE_COVER_NO_REPORT is set) but reports failing
+# tests, any report run succeeds and records that it happened, or fails
+# when FAKE_COVER_FAIL_REPORT is set
 open my $Fh, ">", "$Bin/cover" or die "Can't open $Bin/cover: $!";
 print $Fh <<'EOS';
 use strict;
@@ -53,6 +54,11 @@ if (grep $_ eq "--test", @ARGV) {
   open my $mfh, ">", "cover_db/marker" or die "Can't open marker: $!";
   print $mfh "coverage\n";
   close $mfh or die "Can't close marker: $!";
+  unless ($ENV{FAKE_COVER_NO_REPORT}) {
+    open my $ofh, ">", "cover_db/index.html" or die "Can't open report: $!";
+    print $ofh "report\n";
+    close $ofh or die "Can't close report: $!";
+  }
   print "Result: FAIL\n";
   exit 3;
 }
@@ -86,6 +92,7 @@ sub run_scenario (%opt) {
   my @warnings;
   local $SIG{__WARN__}               = sub { push @warnings, @_ };
   local $ENV{FAKE_COVER_FAIL_REPORT} = $opt{fail_report} // "";
+  local $ENV{FAKE_COVER_NO_REPORT}   = $opt{no_report}   // "";
 
   my $cwd = getcwd;
 
@@ -109,6 +116,7 @@ sub test_failing_tests_still_publish () {
   my $r = run_scenario(dirs => ["blib", "lib"]);
   is $r->{err}, "", "run survives a failing test suite";
   ok -e "$r->{rdir}/marker",           "coverage database is published";
+  ok -e "$r->{rdir}/index.html",       "report file is published";
   ok -e "$r->{rdir}/report_generated", "report generation still runs";
   like $r->{warnings}, qr/exit 3/,              "test failure is still warned";
   like $r->{args},     qr/--select_dir blib\b/, "blib preferred as select_dir";
@@ -129,8 +137,16 @@ sub test_log_survives_report_failure () {
   like $r->{stdout}, qr/json_summary/,      "report command is logged";
 }
 
+sub test_missing_report_fails () {
+  my $r = run_scenario(dirs => ["lib"], no_report => 1);
+  like $r->{err}, qr/No index\.html report/, "missing report file fails run";
+  ok !-d $r->{rdir}, "nothing is published without a report";
+  like $r->{stdout}, qr/Testing My-Module/, "collected output is still printed";
+}
+
 test_failing_tests_still_publish;
 test_select_dir_fallbacks;
 test_log_survives_report_failure;
+test_missing_report_fails;
 
 done_testing;

--- a/t/internal/digest_name.t
+++ b/t/internal/digest_name.t
@@ -70,6 +70,7 @@ sub main () {
   run_covered($db, $alias);
   remove_tree($gone_dir);
 
+  local $Devel::Cover::Silent = 1;
   my $cover = Devel::Cover::DB->new(db => $db)->merge_runs->cover;
   my %item;
   @item{ $cover->items } = ();

--- a/t/internal/version_suffix.t
+++ b/t/internal/version_suffix.t
@@ -69,7 +69,7 @@ sub main () {
   my ($tmpdir, $cover_db) = setup_db;
 
   for my $report (qw( html_crisp html_basic html_subtle html_minimal vim )) {
-    next if $report =~ /^html_(basic|subtle)$/ && !$have_template;
+    next if $report =~ /^(?:html_basic|html_subtle|vim)$/ && !$have_template;
 
     my $outdir = File::Spec->catdir($tmpdir, $report);
     my ($rout, $exit) = run_cover(


### PR DESCRIPTION
## Summary

When the report command died part-way - killed by the timeout in the case that exposed this - the collection still published the cover_db, so the index linked a page that was never written and the percentages in cpancover.json came from a truncated test run.

Make the report file the success test in `run()`. If the output file is absent after the test run, nothing is published and the module keeps its failed marker with the usual retry semantics. A failing test suite with a written report still publishes, keeping the GH-636 behaviour. As a safety net, `generate_html` only links a distribution whose `index.html` exists on disk, which stays correct under compression where the sidecar machinery leaves an `index.html` beside `index.html.gz`.

## Ticket

Closes #644