### PR TITLE
GH-661 Fix branch coverage without condition

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -1897,6 +1897,29 @@ static OP *skip_nulled_ops(OP *o) {
 }
 
 /*
+ * Credit this short circuit to PL_op, to outer same-type logops taken in
+ * the same jump, and to any skipped statement logop whose own cover_logop
+ * never fires.
+ */
+static void credit_short_circuit(pTHX) {
+  OP *up = skip_nulled_ops(OpSIBLING(cLOGOP->op_first)->op_next);
+  OP *skipped;
+
+  while (up && up->op_type == PL_op->op_type) {
+    NDEB(D(L, "Considering adding %p (%s) -> (%p) from %p (%s) -> (%p)\n",
+           up, PL_op_name[up->op_type], up->op_next,
+           PL_op, PL_op_name[PL_op->op_type], PL_op->op_next));
+    add_conditional(aTHX_ up, 3);
+    up = skip_nulled_ops(OpSIBLING(cLOGOPx(up)->op_first)->op_next);
+  }
+  add_conditional(aTHX_ PL_op, 3);
+
+  skipped = PL_op;
+  while ((skipped = find_skipped_conditional(aTHX_ skipped)) != NULL)
+    add_conditional(aTHX_ skipped, 2); /* Should this ever be 1? */
+}
+
+/*
  * Snapshot+pop the active DC if PL_op's short-circuit completes the
  * decision.  SC at PL_op completes the decision when PL_op is the
  * decision root, OR when SC propagates up a same-type chain of logops
@@ -1984,8 +2007,24 @@ static void cover_logop(pTHX) {
   NDEB(D(L, "logop() at %p\n", PL_op));
   NDEB(op_dump(PL_op));
 
-  if (!collecting(Condition))
+  if (!collecting(Condition)) {
+    /*
+     * Branch counts are derived from the condition slots, so record them
+     * even without condition coverage.  For branches we only need to know
+     * whether the op short circuited.
+     */
+    if (!collecting(Branch)) return;
+    if (PL_op->op_type != OP_AND && PL_op->op_type != OP_OR) return;
+    if (cLOGOP->op_first->op_type == OP_ITER) return;
+    {
+      dSP;
+      if (PL_op->op_type == OP_AND ? SvTRUE(TOPs) : !SvTRUE(TOPs))
+        add_conditional(aTHX_ PL_op, 2);
+      else
+        credit_short_circuit(aTHX);
+    }
     return;
+  }
 
   if (cLOGOP->op_first->op_type == OP_ITER) {
     /* loop - ignore it for now */
@@ -2168,21 +2207,7 @@ static void cover_logop(pTHX) {
       }
     } else {
       /* short circuit */
-      OP *up = skip_nulled_ops(OpSIBLING(cLOGOP->op_first)->op_next);
-      OP *skipped;
-
-      while (up && up->op_type == PL_op->op_type) {
-        NDEB(D(L, "Considering adding %p (%s) -> (%p) from %p (%s) -> (%p)\n",
-               up, PL_op_name[up->op_type], up->op_next,
-               PL_op, PL_op_name[PL_op->op_type], PL_op->op_next));
-        add_conditional(aTHX_ up, 3);
-        up = skip_nulled_ops(OpSIBLING(cLOGOPx(up)->op_first)->op_next);
-      }
-      add_conditional(aTHX_ PL_op, 3);
-
-      skipped = PL_op;
-      while ((skipped = find_skipped_conditional(aTHX_ skipped)) != NULL)
-        add_conditional(aTHX_ skipped, 2); /* Should this ever be 1? */
+      credit_short_circuit(aTHX);
 
       /*
        * For MC/DC: short-circuit means columns under this op's right

--- a/docs/technical/branches_and_conditions.md
+++ b/docs/technical/branches_and_conditions.md
@@ -218,6 +218,15 @@ Index   Meaning
    conditions that were never resolved (e.g., because of an early `return`
    before the right operand's follow-on op was reached) are collected here.
 
+6. **Branch without condition**: when branch coverage is collected without
+   condition coverage, `cover_logop` still records outcomes for `OP_AND` and
+   `OP_OR` into the condition array, because `add_branch_cover` derives branch
+   counts from it. Only whether the op short-circuited matters for branch
+   coverage, so the non-short-circuit case records index 2 immediately and never
+   installs the `get_condition` hook. A short circuit goes through
+   `credit_short_circuit`, which also credits outer same-type logops taken in
+   the same jump and any enclosing statement logop the jump skipped.
+
 ### `cover_cond` - branch data from `cond_expr`
 
 The `cond_expr` op (`?:` / `if-else`) uses a simpler mechanism. `cover_cond`

--- a/test_output/cover/branch_no_condition.5.020000
+++ b/test_output/cover/branch_no_condition.5.020000
@@ -1,0 +1,130 @@
+cover: Reading database from ...
+------------------------- ------ ------ ------ ------
+File                        stmt   bran  total   scar
+------------------------- ------ ------ ------ ------
+tests/branch_no_condition  100.0  100.0  100.0   24.8
+Total                      100.0  100.0  100.0   24.8
+------------------------- ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/branch_no_condition
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+12 100.0 12.0 24.8
+
+Worst Subroutines
+-----------------
+
+Subroutine  CC SCAR  Location                    
+----------- -- ----  ----------------------------
+modifiers    4 13.9  tests/branch_no_condition:40
+chain        3 11.0  tests/branch_no_condition:18
+disjunction  3 11.0  tests/branch_no_condition:47
+
+line  err   stmt   bran   code
+1                         #!/usr/bin/env perl
+2                         
+3                         # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                         
+5                         # This software is free.  It is licensed under the same terms as Perl itself.
+6                         
+7                         # The latest version of this software should be available from my homepage:
+8                         # https://pjcj.net
+9                         
+10                        # __COVER__ criteria statement branch
+11                        
+12             1          use strict;
+               1          
+               1          
+13             1          use warnings;
+               1          
+               1          
+14                        
+15             1          my $side_effect;
+16                        
+17                        sub chain {
+18             3            my $x = shift;
+19             3            my $r;
+20             3    100     if    ($x == 1) { $r = "one" }
+               1    100   
+21             1            elsif ($x == 2) { $r = "two" }
+22                          $r
+23             3          }
+24                        
+25                        sub plain_if {
+26             2            my $x = shift;
+27             2            my $r;
+28             2    100     if ($x) { $r = "yes" }
+               1          
+29                          $r
+30             2          }
+31                        
+32                        sub plain_unless {
+33             2            my $x = shift;
+34             2            my $r;
+35             2    100     unless ($x) { $r = "no" }
+               1          
+36                          $r
+37             2          }
+38                        
+39                        sub modifiers {
+40             2            my $x = shift;
+41             2    100     $side_effect        = "if" if $x;
+42             2    100     $x and $side_effect = "and";
+43             2    100     $x or $side_effect  = "or";
+44                        }
+45                        
+46                        sub disjunction {
+47             3            my ($a, $b) = @_;
+48             3            my $r;
+49             3    100     if ($a || $b) { $r = "either" }
+               2          
+50                          $r
+51             3          }
+52                        
+53                        sub conjunction {
+54             3            my ($a, $b) = @_;
+55             3    100     $side_effect = "both" if $a && $b;
+56                        }
+57                        
+58             1          chain($_) for 1 .. 3;
+59                        
+60             1          plain_if($_)     for 0, 1;
+61             1          plain_unless($_) for 0, 1;
+62             1          modifiers($_)    for 0, 1;
+63                        
+64             1          disjunction(1, 0);
+65             1          disjunction(0, 1);
+66             1          disjunction(0, 0);
+67                        
+68             1          conjunction(0, 0);
+69             1          conjunction(1, 0);
+70             1          conjunction(1, 1);
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+20           100      1      2   if ($x == 1) { }
+             100      1      1   elsif ($x == 2) { }
+28           100      1      1   if ($x)
+35           100      1      1   unless ($x)
+41           100      1      1   if $x
+42           100      1      1   if $x
+43           100      1      1   unless $x
+49           100      2      1   if ($a or $b)
+55           100      1      2   if $a and $b
+
+

--- a/test_output/cover/branch_no_condition.5.044000
+++ b/test_output/cover/branch_no_condition.5.044000
@@ -1,0 +1,130 @@
+cover: Reading database from ...
+------------------------- ------ ------ ------ ------
+File                        stmt   bran  total   scar
+------------------------- ------ ------ ------ ------
+tests/branch_no_condition  100.0  100.0  100.0   24.8
+Total                      100.0  100.0  100.0   24.8
+------------------------- ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/branch_no_condition
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+12 100.0 12.0 24.8
+
+Worst Subroutines
+-----------------
+
+Subroutine  CC SCAR  Location                    
+----------- -- ----  ----------------------------
+modifiers    4 13.9  tests/branch_no_condition:40
+chain        3 11.0  tests/branch_no_condition:18
+disjunction  3 11.0  tests/branch_no_condition:47
+
+line  err   stmt   bran   code
+1                         #!/usr/bin/env perl
+2                         
+3                         # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                         
+5                         # This software is free.  It is licensed under the same terms as Perl itself.
+6                         
+7                         # The latest version of this software should be available from my homepage:
+8                         # https://pjcj.net
+9                         
+10                        # __COVER__ criteria statement branch
+11                        
+12             1          use strict;
+               1          
+               1          
+13             1          use warnings;
+               1          
+               1          
+14                        
+15             1          my $side_effect;
+16                        
+17                        sub chain {
+18             3            my $x = shift;
+19             3            my $r;
+20             3    100     if    ($x == 1) { $r = "one" }
+               1    100   
+21             1            elsif ($x == 2) { $r = "two" }
+22                          $r
+23             3          }
+24                        
+25                        sub plain_if {
+26             2            my $x = shift;
+27             2            my $r;
+28             2    100     if ($x) { $r = "yes" }
+               1          
+29                          $r
+30             2          }
+31                        
+32                        sub plain_unless {
+33             2            my $x = shift;
+34             2            my $r;
+35             2    100     unless ($x) { $r = "no" }
+               1          
+36                          $r
+37             2          }
+38                        
+39                        sub modifiers {
+40             2            my $x = shift;
+41             2    100     $side_effect        = "if" if $x;
+42             2    100     $x and $side_effect = "and";
+43             2    100     $x or $side_effect  = "or";
+44                        }
+45                        
+46                        sub disjunction {
+47             3            my ($a, $b) = @_;
+48             3            my $r;
+49             3    100     if ($a || $b) { $r = "either" }
+               2          
+50                          $r
+51             3          }
+52                        
+53                        sub conjunction {
+54             3            my ($a, $b) = @_;
+55             3    100     $side_effect = "both" if $a && $b;
+56                        }
+57                        
+58             1          chain($_) for 1 .. 3;
+59                        
+60             1          plain_if($_)     for 0, 1;
+61             1          plain_unless($_) for 0, 1;
+62             1          modifiers($_)    for 0, 1;
+63                        
+64             1          disjunction(1, 0);
+65             1          disjunction(0, 1);
+66             1          disjunction(0, 0);
+67                        
+68             1          conjunction(0, 0);
+69             1          conjunction(1, 0);
+70             1          conjunction(1, 1);
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+20           100      1      2   if ($x == 1) { }
+             100      1      1   elsif ($x == 2) { }
+28           100      1      1   if ($x)
+35           100      1      1   unless ($x)
+41           100      1      1   if $x
+42           100      1      1   $x and $side_effect = "and"
+43           100      1      1   $x or $side_effect = "or"
+49           100      2      1   if ($a or $b)
+55           100      1      2   if $a and $b
+
+

--- a/tests/branch_no_condition
+++ b/tests/branch_no_condition
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# __COVER__ criteria statement branch
+
+use strict;
+use warnings;
+
+my $side_effect;
+
+sub chain {
+  my $x = shift;
+  my $r;
+  if    ($x == 1) { $r = "one" }
+  elsif ($x == 2) { $r = "two" }
+  $r
+}
+
+sub plain_if {
+  my $x = shift;
+  my $r;
+  if ($x) { $r = "yes" }
+  $r
+}
+
+sub plain_unless {
+  my $x = shift;
+  my $r;
+  unless ($x) { $r = "no" }
+  $r
+}
+
+sub modifiers {
+  my $x = shift;
+  $side_effect        = "if" if $x;
+  $x and $side_effect = "and";
+  $x or $side_effect  = "or";
+}
+
+sub disjunction {
+  my ($a, $b) = @_;
+  my $r;
+  if ($a || $b) { $r = "either" }
+  $r
+}
+
+sub conjunction {
+  my ($a, $b) = @_;
+  $side_effect = "both" if $a && $b;
+}
+
+chain($_) for 1 .. 3;
+
+plain_if($_)     for 0, 1;
+plain_unless($_) for 0, 1;
+modifiers($_)    for 0, 1;
+
+disjunction(1, 0);
+disjunction(0, 1);
+disjunction(0, 0);
+
+conjunction(0, 0);
+conjunction(1, 0);
+conjunction(1, 1);


### PR DESCRIPTION
## Summary

Collecting branch coverage without condition coverage left every and/or based branch permanently at 0/0 - the final `elsif` of an else-less chain from the ticket, but also plain `if` with no `else`, `unless`, and statement modifiers. Their counts are derived from the condition slots, which `cover_logop` only filled when condition coverage was on.

Record the short-circuit outcome in `cover_logop` when collecting branch alone. Whether the op short-circuited is all branch coverage needs, so the right operand's value is never observed and none of the op-hijacking machinery is involved.

## Ticket

Closes #661