### PR TITLE
GH-663 Make caddy recipes work on cpancover.com

### DIFF
--- a/utils/dc
+++ b/utils/dc
@@ -884,7 +884,9 @@ recipe_cpancover-serve() {
 }
 
 cpancover_caddyfile() {
-  local www_dir="$results_dir/../www"
+  local www_dir
+  www_dir=$("$readl" -f "$results_dir/../www" 2>/dev/null) ||
+    www_dir="$results_dir/../www"
   cat <<EOF
 cpancover.com, www.cpancover.com {
   root * $www_dir
@@ -908,10 +910,16 @@ cpancover_validated_caddyfile() {
   local tmpfile
   tmpfile="$(mktemp)"
   cpancover_caddyfile >"$tmpfile"
-  if ! caddy validate --adapter caddyfile --config "$tmpfile"; then
-    rm -f "$tmpfile"
+  caddy fmt --overwrite "$tmpfile" >&2
+  # validate with the log discarded so no root is needed for /var/log/caddy
+  local checkfile
+  checkfile="$(mktemp)"
+  sed 's|output file .*|output discard|' "$tmpfile" >"$checkfile"
+  if ! caddy validate --adapter caddyfile --config "$checkfile" >&2; then
+    rm -f "$tmpfile" "$checkfile"
     pf "Caddyfile validation failed"
   fi
+  rm -f "$checkfile"
   echo "$tmpfile"
 }
 
@@ -919,14 +927,14 @@ cpancover_configure_caddy() {
   local caddyfile="/etc/caddy/Caddyfile"
   local tmpfile
   tmpfile="$(cpancover_validated_caddyfile)"
-  trap 'rm -f "$tmpfile"' RETURN
   if diff -q "$caddyfile" "$tmpfile" >/dev/null 2>&1; then
     pi "Caddyfile is already up to date"
-    return
+  else
+    sudo install -m 644 -o root -g root "$tmpfile" "$caddyfile"
+    sudo systemctl reload caddy
+    pi "Caddyfile updated and Caddy reloaded"
   fi
-  sudo install -m 644 -o root -g root "$tmpfile" "$caddyfile"
-  sudo systemctl reload caddy
-  pi "Caddyfile updated and Caddy reloaded"
+  rm -f "$tmpfile"
 }
 
 recipe_cpancover-configure-caddy() {
@@ -937,16 +945,19 @@ cpancover_check_caddy() {
   local caddyfile="/etc/caddy/Caddyfile"
   local tmpfile
   tmpfile="$(cpancover_validated_caddyfile)"
-  trap 'rm -f "$tmpfile"' RETURN
   pi "Generated config validates OK"
-  local differ="diff -u"
-  command -v delta >/dev/null && differ="delta"
-  if diff -q "$caddyfile" "$tmpfile" >/dev/null 2>&1; then
+  if [[ ! -f $caddyfile ]]; then
+    pi "No installed Caddyfile at $caddyfile - generated config:"
+    cat "$tmpfile"
+  elif diff -q "$caddyfile" "$tmpfile" >/dev/null 2>&1; then
     pi "Caddyfile is up to date"
   else
+    local differ="diff -u"
+    command -v delta >/dev/null && differ="delta"
     pw "Caddyfile differs from generated config:"
-    $differ "$caddyfile" "$tmpfile"
+    $differ "$caddyfile" "$tmpfile" || true
   fi
+  rm -f "$tmpfile"
 }
 
 recipe_cpancover-check-caddy() {

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -10,8 +10,9 @@
 
 use 5.42.0;
 
-use Test2::V0  qw( done_testing is isnt like ok skip_all subtest );
+use Test2::V0  qw( diag done_testing is isnt like ok skip_all subtest unlike );
 use Config     qw( %Config );
+use Cwd        qw( realpath );
 use File::Temp qw( tempdir );
 
 skip_all "dc recipes are not portable to Windows" if $^O eq "MSWin32";
@@ -355,6 +356,83 @@ sub make_seed_source ($src) {
 
 sub inode ($path) { (stat $path)[1] }
 
+sub make_caddy_stub ($bin) {
+  write_file("$bin/caddy", <<~'SH');
+    #!/bin/sh
+    echo "$*" >>"${STUB_CALLS:-/dev/null}"
+    cmd="$1"
+    shift
+    case "$cmd" in
+      validate)
+        cfg=
+        while [ $# -gt 0 ]; do
+          [ "$1" = "--config" ] && cfg="$2"
+          shift
+        done
+        cat "$cfg" >>"${STUB_CADDY_CFG:-/dev/null}"
+        if grep -q "output file" "$cfg"; then
+          echo "mkdir /var/log/caddy: permission denied" >&2
+          exit 1
+        fi
+        ;;
+    esac
+    exit 0
+    SH
+  chmod 0755, "$bin/caddy" or die "Can't chmod caddy stub: $!";
+}
+
+sub check_caddy_recipe () {
+  my $bin = tempdir(CLEANUP => 1);
+  make_caddy_stub($bin);
+  local $ENV{PATH} = "$bin:$ENV{PATH}";
+  my $work = tempdir(CLEANUP => 1);
+  my $base = tempdir(CLEANUP => 1);
+  mkdir "$base/$_"
+    or die "Can't mkdir $base/$_: $!"
+    for "data", "data/cover", "data/cover/staging", "data/cover/www";
+  symlink "$base/data/cover", "$base/cover"
+    or die "Can't symlink $base/cover: $!";
+
+  my $out;
+  {
+    local $ENV{STUB_CALLS}     = "$work/calls";
+    local $ENV{STUB_CADDY_CFG} = "$work/cfg";
+    $out = qx($Dc -r "$base/cover/staging" cpancover-check-caddy 2>&1);
+  }
+  is $?, 0, "check-caddy succeeds without root" or diag $out;
+
+  my $cfg  = slurp("$work/cfg");
+  my $root = realpath("$base/data/cover/www");
+  like $cfg, qr{^\s*root \* \Q$root\E$}m,
+    "web root is canonicalised through symlinks";
+  like $cfg,   qr{output discard},       "validation copy discards the log";
+  unlike $cfg, qr{output file},          "validation copy has no log file";
+  like slurp("$work/calls"), qr{^fmt }m, "generated config is formatted";
+
+  unless (-e "/etc/caddy/Caddyfile") {
+    like $out, qr{no installed Caddyfile}i, "missing installed file reported";
+    like $out, qr{output file /var/log/caddy/cpancover\.com\.log},
+      "returned config keeps the real log output";
+  }
+}
+
+sub check_caddy_root_fallback () {
+  my $bin = tempdir(CLEANUP => 1);
+  make_caddy_stub($bin);
+  local $ENV{PATH} = "$bin:$ENV{PATH}";
+  my $work = tempdir(CLEANUP => 1);
+  my $base = tempdir(CLEANUP => 1);
+
+  {
+    local $ENV{STUB_CADDY_CFG} = "$work/cfg";
+    my $out = qx($Dc -r "$base/missing/staging" cpancover-check-caddy 2>&1);
+    is $?, 0, "check-caddy succeeds with a nonexistent results dir"
+      or diag $out;
+  }
+  like slurp("$work/cfg"), qr{^\s*root \* \Q$base\E/missing/staging/\.\./www$}m,
+    "web root falls back to the literal path";
+}
+
 sub seed_recipe () {
   my $base = tempdir(CLEANUP => 1);
   my $src  = "$base/src";
@@ -398,6 +476,8 @@ sub main () {
     controller_rebuild_module_recipe
     controller_staging_on_host
     seed_recipe
+    check_caddy_recipe
+    check_caddy_root_fallback
   );
   for my $test (@tests) {
     no strict qw( refs );


### PR DESCRIPTION
## Summary

The `cpancover-check-caddy` and `cpancover-configure-caddy` recipes could not run on cpancover.com, so the live Caddyfile stayed hand-maintained.

- Canonicalise the generated web root, since the literal `$results_dir/../www` runs through `/home/pjcj`, which the `caddy` user cannot traverse. On the server it now resolves to `/data/cover/www`, which is world-traversable.
- Validate a copy of the config with the log writer swapped to `output discard`, so no root is needed to create `/var/log/caddy` and `check-caddy` works without sudo.
- Run `caddy fmt` on the generated config so diffs against the installed file stay quiet.
- Make `check-caddy` report a missing installed Caddyfile (and print the generated config) rather than diffing against it, and don't let diff's exit status kill it under `set -e`.
- Replace the `RETURN` traps with explicit cleanup - they fire in the caller's scope, where the local `$tmpfile` no longer exists under `set -u`.

## Ticket

Closes #663