### PR TITLE
GH-665 Fix cpancover rebuild loop stall

### DIFF
--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -685,6 +685,11 @@ class Devel::Cover::Collection {
     my @paths;
     for my $d (@candidates) {
       if (defined(my $path = $self->cpan_path_for($d))) {
+        my $resolved = $path =~ s|.*/||r =~ s/${Dist_ext_re}$//r;
+        if ($resolved ne $d) {
+          say "Marking $d rebuilt, resolves to $resolved";
+          $self->set_rebuilt($d);
+        }
         push @paths, $path;
       } else {
         say "Purging defunct $d";
@@ -695,8 +700,7 @@ class Devel::Cover::Collection {
     }
     return 0 unless @paths;
     $self->set_modules(@paths);
-    $self->cover_modules;
-    scalar @paths
+    $self->cover_modules
   }
 
   method write_status (%counts) {
@@ -1458,10 +1462,21 @@ C<next_rebuild_batch>, resolves each to a CPAN path via
 C<cpan_path_for>, sets C<modules> to the resulting list, and invokes
 C<cover_modules>. A distdir whose lookup fails is treated as no longer
 on CPAN and purged: the distdir itself, its C<__failed__/> marker, and
-its C<__rebuilt__/> marker are all removed. Returns the number of
-modules fed to C<cover_modules> (zero if the queue is empty or every
-lookup failed). Intended to be called from the rebuild loop recipe in
-C<utils/dc>.
+its C<__rebuilt__/> marker are all removed.
+
+A candidate may resolve to a path naming a different distdir - an old
+release with no usable log resolves through C<cpanm --info> to the
+current release. Such a candidate is marked rebuilt here, because
+C<cover_modules> keys its markers on the resolved name and would
+otherwise leave the candidate pending, so the same batch would recur
+on every pass and the rebuild would never finish. The resolved path is
+still passed on so a release that has never been covered gets built.
+
+Returns the number of builds C<cover_modules> ran (zero if the queue
+is empty, every lookup failed, or every resolved release was already
+covered and rebuilt). The rebuild loop recipe in C<utils/dc> uses this
+count to decide whether the HTML needs regenerating. Intended to be
+called from that recipe.
 
 =head3 write_status (%counts)
 

--- a/xt/collection.t
+++ b/xt/collection.t
@@ -942,12 +942,49 @@ sub rebuild_pass_method () {
 
   my $called = 0;
   no warnings "redefine";
-  local *Devel::Cover::Collection::cover_modules = sub { $called++ };
+  local *Devel::Cover::Collection::cover_modules = sub { $called++; 7 };
 
-  is $hc->rebuild_pass, 2, "rebuild_pass returns count of resolved modules";
+  is $hc->rebuild_pass, 7, "rebuild_pass returns the cover_modules count";
   is $called,           1, "cover_modules called once per pass";
   is $hc->modules, ["AUTHOR/Alpha-1.0.tar.gz", "AUTHOR/Bravo-1.0.tar.gz"],
     "rebuild_pass sets modules to resolved paths";
+  ok -e $hc->rebuilt_file("Bravo-2.0"),
+    "candidate resolving to a different distdir is marked rebuilt";
+  ok !-e $hc->rebuilt_file("Alpha-1.0"),
+    "candidate resolving to itself is left for cover_modules to mark";
+}
+
+sub rebuild_pass_mismatched_candidate () {
+  skip_all "uses fsys which requires alarm" if $Is_win32;
+
+  # An old release with no usable log resolves via cpanm to the current
+  # release, which is already covered and rebuilt, so cover_modules
+  # skips it silently. The old candidate must still gain a __rebuilt__
+  # marker or the same batch recurs forever and the loop never ends.
+  my $dir = tempdir(CLEANUP => 1);
+  my $bin = tempdir(CLEANUP => 1);
+  make_cpanm_stub($bin);
+  local $ENV{PATH} = "$bin:$ENV{PATH}";
+
+  my $c = Devel::Cover::Collection->new(
+    results_dir   => $dir,
+    rebuild       => 1,
+    rebuild_batch => 10,
+  );
+
+  for my $d (qw( Single-1.0 Single-2.0 )) {
+    mkdir "$dir/$d" or die;
+    open my $fh, ">", "$dir/$d/cover.json" or die;
+    print $fh "{}";
+    close $fh or die;
+  }
+  $c->set_rebuilt("Single-1.0");
+
+  is $c->rebuild_pass, 0, "rebuild_pass runs no builds for skipped candidate";
+  ok -e $c->rebuilt_file("Single-2.0"),
+    "candidate resolving to a rebuilt distdir is marked rebuilt";
+  ok $c->all_rebuilt, "all_rebuilt true once mismatched candidate is marked";
+  is [$c->next_rebuild_batch], [], "batch empty so the rebuild can finish";
 }
 
 sub template_provider_fetch () {
@@ -1004,6 +1041,7 @@ sub main () {
     cpan_path_for_method
     write_status_method
     rebuild_pass_method
+    rebuild_pass_mismatched_candidate
     template_provider_fetch
   );
   #>>>


### PR DESCRIPTION
## Summary

- Mark a rebuild candidate rebuilt when its CPAN path resolves to a different distdir. `cover_modules` keys its markers on the resolved name, so such a candidate stayed pending forever and the same batch recurred on every pass.
- Return the number of builds `cover_modules` ran from `rebuild_pass` rather than the batch size, so passes that only flush markers don't regenerate the site HTML.

## Ticket

Closes #665