### PR TITLE
GH-215 Escape and encode HTML report text

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -180,13 +180,18 @@ sub check_options () {
   $Options->{report} = [
     grep {
       my $report = $_;
-      my $format = "Devel::Cover::Report::\u$report";
-      eval "use $format";
-      if ($@) {
-        dcerror "$report is not a recognised output format\n$@";
+      if ($report !~ /^\w+$/) {
+        dcerror "$report is not a recognised output format\n";
         ()
       } else {
-        $report
+        my $format = "Devel::Cover::Report::\u$report";
+        eval "use $format";
+        if ($@) {
+          dcerror "$report is not a recognised output format\n$@";
+          ()
+        } else {
+          $report
+        }
       }
     } $Options->{report}->@*
   ];
@@ -198,6 +203,10 @@ sub check_options () {
 
   $Options->{annotations} = [];
   for my $ann ($Options->{annotation}->@*) {
+    if ($ann !~ /^\w+$/) {
+      dcerror "$ann is not a recognised annotation\n";
+      exit 1;
+    }
     my $annotation = "Devel::Cover::Annotation::\u$ann";
     eval "use $annotation";
     if ($@) {

--- a/bin/queue
+++ b/bin/queue
@@ -127,8 +127,7 @@ helper visit_latest_releases => sub ($c, $cb) {
 app->minion->add_task(
   generate_html => sub ($job) {
     my $results = $job->app->results->to_abs;
-    my $command = "dc -v -r $results cpancover-generate-html";
-    system $command;
+    system "dc", "-v", "-r", $results, "cpancover-generate-html";
   }
 );
 
@@ -168,9 +167,18 @@ app->minion->add_task(
       $release = $d->distvname;
     }
 
+    # The first two directories repeat the leading characters of the author id
+    my $author_path
+      = qr{\A([A-Z])/\1([A-Z0-9])/\1\2[A-Z0-9]*/[A-Za-z0-9][\w.+-]*\z};
+    unless ($path =~ $author_path) {
+      $job->fail({ message => "Refusing to process malformed path '$path'" });
+      return;
+    }
+
     my $results = $job->app->results->to_abs;
-    my $command = "dc -v -r $results cpancover $path";
-    my $output  = capture_merged { system $command };
+    my @command = ("dc", "-v", "-r", $results, "cpancover", $path);
+    my $command = join " ", @command;
+    my $output  = capture_merged { system @command };
     say STDERR $output if $Debug;
 
     if ($job->app->release_covered($release)) {

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -987,7 +987,7 @@ $Templates{module_by_start} = <<'EOT';
     <tr>
       <td>
         [% IF vals.$m.link %]
-          <a href="[% root %][%- vals.$m.link -%]">
+          <a href="[% root %][%- vals.$m.link | html -%]">
             [% (module.name || module.module) | html %]
           </a>
         [% ELSE %]
@@ -1003,7 +1003,7 @@ $Templates{module_by_start} = <<'EOT';
       </td>
       <td>
         [% IF vals.$m.log %]
-          <a href="[% root %][% vals.$m.log %]">&para;</a>
+          <a href="[% root %][% vals.$m.log | html %]">&para;</a>
         [% END %]
       </td>
       [% FOREACH criterion = criteria %]

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -19,11 +19,10 @@ use Devel::Cover::Html_Common  ();
 use Devel::Cover::Inc          ();
 use Devel::Cover::Web          qw( write_file );
 
-use JSON::MaybeXS      ();
-use Parallel::Iterator qw( iterate_as_array );
-use POSIX              qw( setsid );
-use Template           ();
-use Time::HiRes        qw( alarm time );
+use JSON::MaybeXS ();
+use POSIX         qw( setsid );
+use Template      ();
+use Time::HiRes   qw( alarm time );
 
 use feature "class";
 
@@ -163,6 +162,13 @@ class Devel::Cover::Collection {
   method fsys  (@a) { $self->_sys(4e4, @a) // die "Can't run @a" }
   method fbsys (@a) { $self->_sys(0,   @a) // die "Can't run @a" }
 
+  # Only the parallel paths need Parallel::Iterator, so load it on demand
+  # and leave report generation working without it
+  sub _iterate (@args) {
+    require Parallel::Iterator;
+    Parallel::Iterator::iterate_as_array(@args)
+  }
+
   method add_modules     (@o) { push @$modules, @o }
   method set_modules     (@o) { @$modules = @o }
   method set_module_file ($f) { $self->_set_module_file($f) }
@@ -277,7 +283,7 @@ class Devel::Cover::Collection {
   }
 
   method run_all {
-    my @res = iterate_as_array(
+    my @res = _iterate(
       { workers => $workers },
       sub {
         my (undef, $d) = @_;
@@ -730,7 +736,7 @@ class Devel::Cover::Collection {
     push @cmd, "--results_dir", $results_dir if defined $results_dir;
     push @cmd, "--verbose" if $verbose;
     my @command = (@cmd, "cpancover-docker-module");
-    my @res     = iterate_as_array(
+    my @res     = _iterate(
       { workers => $workers },
       sub {
         # say "mod ", Dumper \@_;
@@ -982,17 +988,17 @@ $Templates{module_by_start} = <<'EOT';
       <td>
         [% IF vals.$m.link %]
           <a href="[% root %][%- vals.$m.link -%]">
-            [% module.name || module.module %]
+            [% (module.name || module.module) | html %]
           </a>
         [% ELSE %]
-          [% module.name || module.module %]
+          [% (module.name || module.module) | html %]
         [% END %]
       </td>
       <td>
         [% IF module.metacpan %]
-          <a href="[% module.metacpan %]">[% module.version %]</a>
+          <a href="[% module.metacpan | html %]">[% module.version | html %]</a>
         [% ELSE %]
-          [% module.version %]
+          [% module.version | html %]
         [% END %]
       </td>
       <td>

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -271,7 +271,7 @@ class Devel::Cover::Collection {
         # TODO - option to merge DB with existing one
         # TODO - portability
         $output .= $self->fsys("rm", "-rf", $rdir);
-        $output .= `rm -f $db/structure/*.lock`;
+        $output .= $self->fsys("rm", "-f",  glob "$db/structure/*.lock");
         $output .= $self->fsys("mv", $db,   $rdir);
         $output .= $self->fsys("rm", "-rf", $db);
       };
@@ -532,8 +532,8 @@ class Devel::Cover::Collection {
         my $archive = "$v->{dir}.tar.xz";
         my @cmd1
           = ($self->dc_file, "-r", $parent, "cpancover-uncompress-dir", $s);
-        my @cmd2 = ("bash", "-c",  "tar cf - -C $parent $s | xz -z > $archive");
-        my @cmd3 = ("rm",   "-rf", $v->{dir});
+        my @cmd2 = ("tar", "cJf", $archive, "-C", $parent, "--", $s);
+        my @cmd3 = ("rm",  "-rf", $v->{dir});
 
         if ($dryrun) {
           say for "compressing $s", "@cmd1", "@cmd2", "@cmd3";

--- a/lib/Devel/Cover/Html_Common.pm
+++ b/lib/Devel/Cover/Html_Common.pm
@@ -7,13 +7,15 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
-use Exporter    qw( import );
-use Digest::MD5 ();
-use Encode      ();
+use Exporter       qw( import );
+use Digest::MD5    ();
+use Encode         ();
+use HTML::Entities ();
 
 our @EXPORT_OK = qw(
   launch highlight $Have_highlighter
   coverage_class default_thresholds unique_filenames
+  decode_guess escape_html source_layer
 );
 
 our $Have_highlighter;
@@ -116,7 +118,36 @@ sub highlight ($option, @all_lines) {
   return;
 }
 
-1;
+sub decode_guess ($text) {
+  return $text unless defined $text;
+  my $chars = eval {
+    Encode::decode("UTF-8", $text, Encode::FB_CROAK | Encode::LEAVE_SRC)
+  };
+  $chars //= eval { Encode::decode("iso-8859-1", $text) };
+  $chars // $text
+}
+
+sub escape_html ($text) {
+  # The characters that must be escaped in HTML text and attribute values
+  state $unsafe = q(<>&"');
+  HTML::Entities::encode_entities(decode_guess($text), $unsafe)
+}
+
+sub source_layer ($file) {
+  open my $fh, "<", $file or return "";
+  my $bytes = do { local $/; <$fh> };
+  close $fh or return "";
+  my $utf8 = defined $bytes && eval {
+    Encode::decode("UTF-8", $bytes, Encode::FB_CROAK | Encode::LEAVE_SRC);
+    1
+  };
+  $utf8 ? ":encoding(UTF-8)" : ":encoding(iso-8859-1)"
+}
+
+"
+The sirens are screaming and the fires are howling
+Way down in the valley tonight
+"
 
 __END__
 
@@ -179,6 +210,28 @@ C<X/Y.pm> and C<X-Y.pm> can produce the same name. When two paths
 collide, the sorted-first path keeps the plain name and each later
 collider is given a stable suffix of C<--> plus the leading hex
 characters of the MD5 of its path. Non-colliding paths are unchanged.
+
+=item decode_guess ($text)
+
+Return C<$text> as a character string. Covered source files carry no
+encoding declaration the reports could trust, so this guesses. The bytes
+are decoded as strict UTF-8 when they form a valid sequence and as
+Latin-1 when they do not, a guess that cannot fail. A string that
+already contains wide characters is returned unchanged, since both
+decodes refuse it. Undefined input is returned unchanged.
+
+=item escape_html ($text)
+
+Return C<$text> decoded via C<decode_guess> with the HTML-unsafe
+characters C<< < > & " ' >> escaped as entities. Other characters,
+including non-ASCII ones, are left alone so that UTF-8 output renders
+them directly.
+
+=item source_layer ($file)
+
+Return the I/O layer with which to read the source file C<$file>, using
+the same guess as C<decode_guess>. An unreadable file yields an empty
+string so the caller's own open reports the error.
 
 =back
 

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -20,7 +20,8 @@ BEGIN {
 
 use Devel::Cover::Html_Common  ## no perlimports
   qw( launch highlight $Have_highlighter
-  coverage_class default_thresholds unique_filenames );
+  coverage_class default_thresholds unique_filenames
+  decode_guess escape_html source_layer );
 use Devel::Cover::Criterion ();
 use Devel::Cover::Inc       ();
 use Devel::Cover::Log       qw( dcinfo );
@@ -28,9 +29,8 @@ use Devel::Cover::Web       qw( write_file );
 
 BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
 
-use HTML::Entities qw( encode_entities );
-use Getopt::Long   qw( GetOptions );
-use Template 2.00  ();
+use Getopt::Long  qw( GetOptions );
+use Template 2.00 ();
 
 my $Template;
 my %R;
@@ -116,18 +116,19 @@ sub _add_uncovered_links ($lines) {
 
 sub _highlight_text ($text) {
   my @html = $Have_highlighter ? highlight($R{options}{option}, $text) : ();
-  @html ? $html[0] : encode_entities($text)
+  @html ? $html[0] : escape_html($text)
 }
 
 sub print_file () {
   my @lines;
   my $f = $R{db}->cover->file($R{file});
 
-  open my $fh, "<", $R{file} or warn("Unable to open $R{file}: $!\n"), return;
+  open my $fh, "<" . source_layer($R{file}), $R{file}
+    or warn("Unable to open $R{file}: $!\n"), return;
   my @all_lines = <$fh>;
 
   my @hl = $Have_highlighter ? highlight($R{options}{option}, @all_lines) : ();
-  @all_lines = @hl ? @hl : map encode_entities($_), @all_lines;
+  @all_lines = @hl ? @hl : map escape_html($_), @all_lines;
 
   my $linen = 1;
   line: while (defined(my $l = shift @all_lines)) {
@@ -175,7 +176,9 @@ sub print_file () {
 
   my $vars = { R => \%R, lines => \@lines };
 
-  $Template->process("file", $vars, $R{file_html}) or die $Template->error;
+  $Template->process(
+    "file", $vars, $R{file_html}, { binmode => ":encoding(UTF-8)" }
+  ) or die $Template->error;
 }
 
 sub print_branches () {
@@ -206,7 +209,9 @@ sub print_branches () {
   my $vars = { R => \%R, branches => \@branches };
 
   my $html = "$R{options}{outputdir}/$R{filenames}{$R{file}}--branch.html";
-  $Template->process("branches", $vars, $html) or die $Template->error;
+  $Template->process(
+    "branches", $vars, $html, { binmode => ":encoding(UTF-8)" }
+  ) or die $Template->error;
 }
 
 sub print_conditions () {
@@ -239,7 +244,7 @@ sub print_conditions () {
   my @types = map {
     name    => s/_/ /gr,
     headers =>
-      [map encode_entities($_), ($r->{$_}[0]{condition}->headers || [])->@*],
+      [map escape_html($_), ($r->{$_}[0]{condition}->headers || [])->@*],
     conditions => $r->{$_},
   }, sort keys %$r;
   #>>>
@@ -247,7 +252,9 @@ sub print_conditions () {
   my $vars = { R => \%R, types => \@types };
 
   my $html = "$R{options}{outputdir}/$R{filenames}{$R{file}}--condition.html";
-  $Template->process("conditions", $vars, $html) or die $Template->error;
+  $Template->process(
+    "conditions", $vars, $html, { binmode => ":encoding(UTF-8)" }
+  ) or die $Template->error;
 }
 
 sub print_mcdc () {
@@ -273,8 +280,7 @@ sub print_mcdc () {
           map {
             my $unc = $m->uncoverable($_);
             +{
-              label =>
-                encode_entities(($unc ? "-" : "") . ($labels[$_] // "")),
+              label => escape_html(($unc ? "-" : "") . ($labels[$_] // "")),
               class => $vals[$_] || $unc ? "c3" : "c0",
             }
           } 0 .. $#vals,
@@ -287,7 +293,8 @@ sub print_mcdc () {
   my $vars = { R => \%R, decisions => \@decisions };
 
   my $html = "$R{options}{outputdir}/$R{filenames}{$R{file}}--mcdc.html";
-  $Template->process("mcdc", $vars, $html) or die $Template->error;
+  $Template->process("mcdc", $vars, $html, { binmode => ":encoding(UTF-8)" })
+    or die $Template->error;
 }
 
 sub print_subroutines () {
@@ -309,7 +316,7 @@ sub print_subroutines () {
       my $p = shift @p;
       push @$subs, {
           line   => $line,
-          name   => $o->name,
+          name   => decode_guess($o->name),
           count  => $s ? $o->covered              : "",
           class  => $s ? oclass($o, "subroutine") : "",
           pod    => $p ? $p->covered ? "Yes" : "No" : "n/a",
@@ -321,7 +328,9 @@ sub print_subroutines () {
   my $vars = { R => \%R, subs => $subs };
 
   my $html = "$R{options}{outputdir}/$R{filenames}{$R{file}}--subroutine.html";
-  $Template->process("subroutines", $vars, $html) or die $Template->error;
+  $Template->process(
+    "subroutines", $vars, $html, { binmode => ":encoding(UTF-8)" }
+  ) or die $Template->error;
 }
 
 sub print_summary () {
@@ -331,7 +340,8 @@ sub print_summary () {
   };
 
   my $html = "$R{options}{outputdir}/$R{options}{option}{outputfile}";
-  $Template->process("summary", $vars, $html) or die $Template->error;
+  $Template->process("summary", $vars, $html, { binmode => ":encoding(UTF-8)" })
+    or die $Template->error;
 
   $html
 }

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -452,7 +452,7 @@ https://pjcj.net
   <script type="text/javascript" src="common.js"></script>
   <script type="text/javascript" src="css.js"></script>
   <script type="text/javascript" src="standardista-table-sorting.js"></script>
-  <title> [% title || "Coverage Summary" %] </title>
+  <title> [% (title || "Coverage Summary") | html %] </title>
 </head>
 <body>
   [% content %]
@@ -463,7 +463,7 @@ HTML
 $Templates{header} = <<'HTML';
 <table>
   <tr>
-    <th colspan="4">[% R.file %]</th>
+    <th colspan="4">[% R.file | html %]</th>
   </tr>
   <tr class="hblank"><td class="dblank"></td></tr>
   <tr>
@@ -499,7 +499,7 @@ $Templates{summary} = <<'HTML';
 <table>
   <tr>
     <td class="sh" align="right">Module</td>
-    <td class="sv" align="left" colspan="4">[% R.module.name %]</td>
+    <td class="sv" align="left" colspan="4">[% R.module.name | html %]</td>
   </tr>
   <tr>
     <td class="sh" align="right">Version</td>
@@ -577,12 +577,12 @@ function filter_files(filter_by) {
 
   <tfoot>
   [% FOREACH file = files %]
-    <tr align="center" valign="top" class="[% file %]">
+    <tr align="center" valign="top" class="[% file | html %]">
       <td align="left">
         [% IF R.exists.$file %]
-          <a href="[% R.filenames.$file %].html"> [% file %] </a>
+          <a href="[% R.filenames.$file %].html"> [% file | html %] </a>
         [% ELSE %]
-          [% file %]
+          [% file | html %]
         [% END %]
         [% IF R.uncompiled.$file %] <em>(untested)</em>[% END %]
       </td>
@@ -809,7 +809,7 @@ $Templates{subroutines} = <<'HTML';
       [% IF R.options.show.pod %]
         <td class="[% sub.pclass %]"> [% sub.pod %] </td>
       [% END %]
-      <td> [% sub.name %] </td>
+      <td> [% sub.name | html %] </td>
     </tr>
   [% END %]
 </table>

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -503,7 +503,7 @@ $Templates{summary} = <<'HTML';
   </tr>
   <tr>
     <td class="sh" align="right">Version</td>
-    <td class="sv" align="left" colspan="4">[% R.module.version %]</td>
+    <td class="sv" align="left" colspan="4">[% R.module.version | html %]</td>
   </tr>
   <tr>
     <td class="sh" align="right">Database:</td>

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -49,7 +49,7 @@ sub crit_name ($c) {
 
 sub render_layout (%args) {
   my $asset_prefix = $args{asset_prefix} // "";
-  my $title        = $args{title} || "Coverage Report";
+  my $title        = encode_entities($args{title} || "Coverage Report");
   my $content      = $args{content} // "";
   <<HTML
 <!DOCTYPE html>
@@ -107,8 +107,9 @@ HTML
   if ($f->{worst_subs}->@*) {
     $o .= qq(<dl class="scar-tip-subs">\n);
     for ($f->{worst_subs}->@*) {
-      my $cls = scar_class($_->{scar});
-      $o .= qq(<dt>$_->{name}</dt><dd class="$cls">$_->{crap}</dd>\n);
+      my $cls  = scar_class($_->{scar});
+      my $name = encode_entities($_->{name});
+      $o .= qq(<dt>$name</dt><dd class="$cls">$_->{crap}</dd>\n);
     }
     $o .= "</dl>\n";
   }
@@ -146,17 +147,17 @@ sub cov_cell ($s, $uncompiled, $data_value = undef, $link = undef) {
 }
 
 sub file_row ($f, $dir) {
-  my $cls = "dir-file" . ($f->{uncompiled} ? " untested" : "");
-  my $name
-    = $f->{exists}
-    ? qq(<a href="$f->{link}">$f->{basename}</a>)
-    : $f->{basename};
-  my $badge    = $f->{uncompiled} ? untested_badge() . "\n" : "";
+  my $cls      = "dir-file" . ($f->{uncompiled} ? " untested" : "");
+  my $base     = encode_entities($f->{basename});
+  my $name     = $f->{exists}     ? qq(<a href="$f->{link}">$base</a>) : $base;
+  my $badge    = $f->{uncompiled} ? untested_badge() . "\n"            : "";
   my $linkable = $f->{exists} && !$f->{uncompiled};
 
-  my $o = <<HTML;
-<tr class="$cls" data-dir="$dir">
-<td data-value="$f->{short}">$name $badge</td>
+  my $edir   = encode_entities($dir);
+  my $eshort = encode_entities($f->{short});
+  my $o      = <<HTML;
+<tr class="$cls" data-dir="$edir">
+<td data-value="$eshort">$name $badge</td>
 HTML
 
   for my $c ($R{criteria}->@*) {
@@ -191,10 +192,10 @@ sub render_worst_files ($worst) {
   my $o = qq(<div class="worst-files">\n<h2>Top SCAR</h2>\n);
   for my $f (@$worst) {
     next if _numeric_scar($f) == 0;
-    my $cls = "scar-" . scar_class($f->{file_scar});
-    my $name
-      = $f->{exists} ? qq(<a href="$f->{link}">$f->{short}</a>) : $f->{short};
-    my $badge = $f->{uncompiled} ? untested_badge() . "\n" : "";
+    my $cls   = "scar-" . scar_class($f->{file_scar});
+    my $short = encode_entities($f->{short});
+    my $name  = $f->{exists}     ? qq(<a href="$f->{link}">$short</a>) : $short;
+    my $badge = $f->{uncompiled} ? untested_badge() . "\n"             : "";
     my $tip   = scar_tip($f);
     my $scar  = $f->{file_scar};
 
@@ -386,8 +387,8 @@ HTML
 HTML
 
   for my $g (@groups) {
-    $o .= qq(<tr class="dir-header" data-dir="$g->{dir}">\n)
-      . "<td>$g->{dir}</td>\n";
+    my $edir = encode_entities($g->{dir});
+    $o .= qq(<tr class="dir-header" data-dir="$edir">\n) . "<td>$edir</td>\n";
     $o .= cov_cell($g->{criteria}{$_}, 0) for $R{criteria}->@*;
     $o .= cov_cell($g->{total},        0);
     $o .= scar_cell($g);
@@ -622,12 +623,13 @@ sub render_source_line ($line) {
 }
 
 sub render_file_page ($fd, $lines, $total, $prev_file, $next_file) {
-  my $o = $fd->{uncompiled} ? qq(<div class="untested-page">\n) : "";
+  my $o     = $fd->{uncompiled} ? qq(<div class="untested-page">\n) : "";
+  my $short = encode_entities($fd->{short});
 
   $o .= <<HTML;
 <div class="header">
 <div class="header-inner">
-<h1>$fd->{short}
+<h1>$short
 @{[ $fd->{uncompiled} ? untested_badge() : "" ]}</h1>
 <div class="header-stats">
 <span class="filter-label">filter:</span>
@@ -713,7 +715,7 @@ HTML
   $o .= file_nav($prev_file, $next_file);
   $o .= <<HTML;
 <div class="minimap"></div>
-<table class="source-table" role="table" aria-label="Coverage for $fd->{short}">
+<table class="source-table" role="table" aria-label="Coverage for $short">
 HTML
 
   $o .= render_source_line($_) for @$lines;
@@ -729,12 +731,12 @@ sub file_nav ($prev_file, $next_file) {
   my $prev
     = $prev_file
     ? qq(<a href="$prev_file->{link}" class="nav-prev">)
-    . "&laquo; $prev_file->{short}</a>"
+    . "&laquo; @{[ encode_entities($prev_file->{short}) ]}</a>"
     : "";
   my $next
     = $next_file
     ? qq(<a href="$next_file->{link}" class="nav-next">)
-    . "$next_file->{short} &raquo;</a>"
+    . "@{[ encode_entities($next_file->{short}) ]} &raquo;</a>"
     : "";
   <<HTML
 <div class="file-nav">

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -23,6 +23,7 @@ BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
 use Devel::Cover::Html_Common qw(
   $Have_highlighter highlight launch
   coverage_class default_thresholds unique_filenames
+  decode_guess escape_html source_layer
 );
 use Devel::Cover::Web             qw( $Cov $Crisp_base_css $Crisp_theme_js );
 use Devel::Cover::Condition_table ();
@@ -32,11 +33,10 @@ use Devel::Cover::Inc             ();
 use Devel::Cover::Log             qw( dcinfo );
 use Devel::Cover::Path            qw( common_prefix );
 
-use File::Path     qw( mkpath );
-use Getopt::Long   qw( GetOptions );
-use HTML::Entities qw( encode_entities );
-use List::Util     qw( any );
-use POSIX          qw( strftime );
+use File::Path   qw( mkpath );
+use Getopt::Long qw( GetOptions );
+use List::Util   qw( any );
+use POSIX        qw( strftime );
 our %R;
 my %Assets;
 
@@ -49,7 +49,7 @@ sub crit_name ($c) {
 
 sub render_layout (%args) {
   my $asset_prefix = $args{asset_prefix} // "";
-  my $title        = encode_entities($args{title} || "Coverage Report");
+  my $title        = escape_html($args{title} || "Coverage Report");
   my $content      = $args{content} // "";
   <<HTML
 <!DOCTYPE html>
@@ -108,7 +108,7 @@ HTML
     $o .= qq(<dl class="scar-tip-subs">\n);
     for ($f->{worst_subs}->@*) {
       my $cls  = scar_class($_->{scar});
-      my $name = encode_entities($_->{name});
+      my $name = escape_html($_->{name});
       $o .= qq(<dt>$name</dt><dd class="$cls">$_->{crap}</dd>\n);
     }
     $o .= "</dl>\n";
@@ -148,13 +148,13 @@ sub cov_cell ($s, $uncompiled, $data_value = undef, $link = undef) {
 
 sub file_row ($f, $dir) {
   my $cls      = "dir-file" . ($f->{uncompiled} ? " untested" : "");
-  my $base     = encode_entities($f->{basename});
+  my $base     = escape_html($f->{basename});
   my $name     = $f->{exists}     ? qq(<a href="$f->{link}">$base</a>) : $base;
   my $badge    = $f->{uncompiled} ? untested_badge() . "\n"            : "";
   my $linkable = $f->{exists} && !$f->{uncompiled};
 
-  my $edir   = encode_entities($dir);
-  my $eshort = encode_entities($f->{short});
+  my $edir   = escape_html($dir);
+  my $eshort = escape_html($f->{short});
   my $o      = <<HTML;
 <tr class="$cls" data-dir="$edir">
 <td data-value="$eshort">$name $badge</td>
@@ -193,7 +193,7 @@ sub render_worst_files ($worst) {
   for my $f (@$worst) {
     next if _numeric_scar($f) == 0;
     my $cls   = "scar-" . scar_class($f->{file_scar});
-    my $short = encode_entities($f->{short});
+    my $short = escape_html($f->{short});
     my $name  = $f->{exists}     ? qq(<a href="$f->{link}">$short</a>) : $short;
     my $badge = $f->{uncompiled} ? untested_badge() . "\n"             : "";
     my $tip   = scar_tip($f);
@@ -387,7 +387,7 @@ HTML
 HTML
 
   for my $g (@groups) {
-    my $edir = encode_entities($g->{dir});
+    my $edir = escape_html($g->{dir});
     $o .= qq(<tr class="dir-header" data-dir="$edir">\n) . "<td>$edir</td>\n";
     $o .= cov_cell($g->{criteria}{$_}, 0) for $R{criteria}->@*;
     $o .= cov_cell($g->{total},        0);
@@ -624,7 +624,7 @@ sub render_source_line ($line) {
 
 sub render_file_page ($fd, $lines, $total, $prev_file, $next_file) {
   my $o     = $fd->{uncompiled} ? qq(<div class="untested-page">\n) : "";
-  my $short = encode_entities($fd->{short});
+  my $short = escape_html($fd->{short});
 
   $o .= <<HTML;
 <div class="header">
@@ -731,12 +731,12 @@ sub file_nav ($prev_file, $next_file) {
   my $prev
     = $prev_file
     ? qq(<a href="$prev_file->{link}" class="nav-prev">)
-    . "&laquo; @{[ encode_entities($prev_file->{short}) ]}</a>"
+    . "&laquo; @{[ escape_html($prev_file->{short}) ]}</a>"
     : "";
   my $next
     = $next_file
     ? qq(<a href="$next_file->{link}" class="nav-next">)
-    . "@{[ encode_entities($next_file->{short}) ]} &raquo;</a>"
+    . "@{[ escape_html($next_file->{short}) ]} &raquo;</a>"
     : "";
   <<HTML
 <div class="file-nav">
@@ -889,7 +889,7 @@ sub line_subroutines ($f, $n) {
   return unless $loc && @$loc;
   my $cl = $R{scar_subs} || {};
   map { {
-    name    => encode_entities($_->name),
+    name    => escape_html($_->name),
     covered => $_->covered,
     class   => oclass($_, "subroutine"),
     cc      => ($cl->{ "$n\0" . $_->name } // {})->{cc},
@@ -918,7 +918,7 @@ sub line_branches ($f, $n) {
       total_count => $t + $f,
       true_class  => class($t, $_->error(0), "branch"),
       false_class => class($f, $_->error(1), "branch"),
-      text        => encode_entities($_->text // ""),
+      text        => escape_html($_->text // ""),
     }
   } @$loc
 }
@@ -931,7 +931,7 @@ sub _cond_fragment ($s) {
       return $h;
     }
   }
-  encode_entities($s)
+  escape_html($s)
 }
 
 # Mark the decision's own operator, distinguishing it from those in operands
@@ -939,7 +939,7 @@ sub _cond_expr ($c) {
   my ($left, $op, $right) = $c->[1]->@{qw( left op right )};
   _cond_fragment($left)
     . ' <span class="cond-op">'
-    . encode_entities($op)
+    . escape_html($op)
     . "</span> "
     . _cond_fragment($right)
 }
@@ -953,7 +953,7 @@ sub line_condition_cells ($f, $n) {
     {
       type    => $c->type,
       text    => _cond_expr($c),
-      headers => [map encode_entities($_), ($c->headers // [])->@*],
+      headers => [map escape_html($_), ($c->headers // [])->@*],
       parts   => [
         map { {
           count => $c->value($_),
@@ -983,13 +983,12 @@ sub line_truth_tables ($f, $n) {
     my @labels  = $_->labels;
     my @headers = map { chr ord("A") + $_ } 0 .. $#labels;
     {
-      expr       => encode_entities($_->expr),
-      short_expr => encode_entities($_->short_expr),
+      expr       => escape_html($_->expr),
+      short_expr => escape_html($_->short_expr),
       rows       => \@rows,
       headers    => \@headers,
       legend     => [
-        map { {
-          letter => $headers[$_], label => encode_entities($labels[$_]) } }
+        map { { letter => $headers[$_], label => escape_html($labels[$_]) } }
           0 .. $#labels
       ],
     }
@@ -1005,7 +1004,7 @@ sub line_mcdc ($f, $n) {
     my @vals   = $m->values;
     my @labels = $m->labels->@*;
     {
-      text       => encode_entities($m->text),
+      text       => escape_html($m->text),
       percentage => $m->percentage,
       covered    => $m->covered,
       total      => $m->total,
@@ -1016,7 +1015,7 @@ sub line_mcdc ($f, $n) {
         map {
           my $unc = $m->uncoverable($_);
           {
-            label   => encode_entities(($unc ? "-" : "") . ($labels[$_] // "")),
+            label   => escape_html(($unc ? "-" : "") . ($labels[$_] // "")),
             covered => $vals[$_]         ? 1    : 0,
             class   => $vals[$_] || $unc ? "c3" : "c0",
           }
@@ -1052,12 +1051,13 @@ sub line_partial ($line, $bd, $cd, $tts, $sd, $md) {
 }
 
 sub read_source ($file) {
-  open my $fh, "<", $file or warn("Unable to open $file: $!\n"), return;
+  open my $fh, "<" . source_layer($file), $file
+    or warn("Unable to open $file: $!\n"), return;
   my @all_lines = <$fh>;
   close $fh or die "Can't close $file: $!\n";
 
   my @hl = $Have_highlighter ? highlight($R{options}{option}, @all_lines) : ();
-  @hl ? @hl : map encode_entities($_), @all_lines
+  @hl ? @hl : map escape_html($_), @all_lines
 }
 
 sub build_source_lines ($file) {
@@ -1134,7 +1134,7 @@ sub build_untested_source_lines ($file) {
 }
 
 sub write_file ($path, $content) {
-  open my $fh, ">", $path or die "Can't open $path: $!\n";
+  open my $fh, ">:encoding(UTF-8)", $path or die "Can't open $path: $!\n";
   print $fh $content;
   close $fh or die "Can't close $path: $!\n";
 }

--- a/lib/Devel/Cover/Report/Html_minimal.pm
+++ b/lib/Devel/Cover/Report/Html_minimal.pm
@@ -5,11 +5,11 @@ use warnings;
 use feature qw( postderef signatures );
 no warnings qw( experimental::postderef experimental::signatures );
 
-use HTML::Entities          qw( encode_entities );
 use Getopt::Long            qw( GetOptions );
 use Devel::Cover::Criterion ();
 use Devel::Cover::Html_Common  ## no perlimports
-  qw( launch coverage_class default_thresholds unique_filenames );
+  qw( launch coverage_class default_thresholds unique_filenames
+  escape_html source_layer );
 use Devel::Cover::Log         qw( dcinfo );
 use Devel::Cover::Truth_Table ();
 
@@ -224,7 +224,7 @@ sub print_stylesheet ($db, $options) {
 # Print the HTML document header
 sub print_html_header ($fh, $title) {
   my $version = $VERSION . $Devel::Cover::Inc::Dev;
-  $title = encode_entities($title);
+  $title = escape_html($title);
   print $fh <<"END_HTML";
 <!DOCTYPE html
      PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
@@ -252,7 +252,7 @@ END_HTML
 sub print_summary ($fh, $title, $file, $raw_pct, $err, $db) {
   my $percent = sprintf "%.1f", $raw_pct || 0;
   my $class   = pclass($percent, $err);
-  $file = encode_entities($file);
+  $file = escape_html($file);
 
   print $fh <<"END_HTML";
 <body>
@@ -293,7 +293,7 @@ sub get_link ($file, $type = undef, $line = undef) {
 sub escape_HTML ($text) {  ## no critic (NamingConventions::Capitalization)
   chomp $text;
 
-  $text = encode_entities($text);
+  $text = escape_html($text);
 
   # Do not allow FF in text
   $text =~ tr/\x0c//d;
@@ -343,8 +343,10 @@ sub _render_coverage_cells ($out, $fin, $opt, $show, $metric) {
 # Print coverage overview report for a file
 sub print_file_report ($db, $fin, $opt) {
   my $fout = "$opt->{outputdir}/$Filenames{$fin}.html";
-  open my $in,  "<", $fin  or warn("Can't read file '$fin' [$!]\n"),  return;
-  open my $out, ">", $fout or warn("Can't open file '$fout' [$!]\n"), return;
+  open my $in, "<" . source_layer($fin), $fin
+    or warn("Can't read file '$fin' [$!]\n"), return;
+  open my $out, ">:encoding(UTF-8)", $fout
+    or warn("Can't open file '$fout' [$!]\n"), return;
 
   my ($show, $th) = get_showing_headers($db, $opt);
   my $file_data = $db->cover->file($fin);
@@ -427,7 +429,8 @@ sub print_branch_report ($db, $file, $opt) {
   return unless $data;
 
   my $fout = "$opt->{outputdir}/$Filenames{$file}--branch.html";
-  open my $out, ">", $fout or warn("Can't open file '$fout' [$!]\n"), return;
+  open my $out, ">:encoding(UTF-8)", $fout
+    or warn("Can't open file '$fout' [$!]\n"), return;
 
   print_html_header($out, "Branch Coverage: $file");
   print_summary(
@@ -464,7 +467,8 @@ sub print_condition_report ($db, $file, $opt) {
   return unless $data;
 
   my $fout = "$opt->{outputdir}/$Filenames{$file}--condition.html";
-  open my $out, ">", $fout or warn("Can't open file '$fout' [$!]\n"), return;
+  open my $out, ">:encoding(UTF-8)", $fout
+    or warn("Can't open file '$fout' [$!]\n"), return;
 
   print_html_header($out, "Condition Coverage: $file");
   print_summary(
@@ -500,7 +504,8 @@ sub print_mcdc_report ($db, $file, $opt) {
   return unless $data;
 
   my $fout = "$opt->{outputdir}/$Filenames{$file}--mcdc.html";
-  open my $out, ">", $fout or warn("Can't open file '$fout' [$!]\n"), return;
+  open my $out, ">:encoding(UTF-8)", $fout
+    or warn("Can't open file '$fout' [$!]\n"), return;
 
   print_html_header($out, "MC/DC Coverage: $file");
   print_summary(
@@ -546,7 +551,8 @@ sub print_sub_report ($db, $file, $opt) {
   return unless $data;
 
   my $fout = "$opt->{outputdir}/$Filenames{$file}--subroutine.html";
-  open my $out, ">", $fout or warn("Can't open file '$fout' [$!]\n"), return;
+  open my $out, ">:encoding(UTF-8)", $fout
+    or warn("Can't open file '$fout' [$!]\n"), return;
 
   print_html_header($out, "Subroutine Coverage: $file");
   print_summary(
@@ -603,7 +609,7 @@ sub _print_summary_cell ($fh, $file, $c, $summary, $uncompiled) {
 sub print_summary_report ($db, $options) {
   my $outfile = "$options->{outputdir}/$options->{option}{outputfile}";
 
-  open my $fh, ">", $outfile
+  open my $fh, ">:encoding(UTF-8)", $outfile
     or warn("Unable to open file '$outfile' [$!]\n"), return;
 
   my ($show, $th) = get_showing_headers($db, $options);
@@ -662,7 +668,7 @@ END_HTML
     my $summary = get_summary_for_file($db, $file, $show);
 
     my $url  = get_link($file);
-    my $name = encode_entities($file);
+    my $name = escape_html($file);
     if ($url) {
       print $fh '<tr><td align="left">' . qq(<a href="$url">$name</a>);
     } else {

--- a/lib/Devel/Cover/Report/Html_minimal.pm
+++ b/lib/Devel/Cover/Report/Html_minimal.pm
@@ -224,6 +224,7 @@ sub print_stylesheet ($db, $options) {
 # Print the HTML document header
 sub print_html_header ($fh, $title) {
   my $version = $VERSION . $Devel::Cover::Inc::Dev;
+  $title = encode_entities($title);
   print $fh <<"END_HTML";
 <!DOCTYPE html
      PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
@@ -251,6 +252,7 @@ END_HTML
 sub print_summary ($fh, $title, $file, $raw_pct, $err, $db) {
   my $percent = sprintf "%.1f", $raw_pct || 0;
   my $class   = pclass($percent, $err);
+  $file = encode_entities($file);
 
   print $fh <<"END_HTML";
 <body>
@@ -659,11 +661,12 @@ END_HTML
       = $file ne "Total" && $db->cover->file($file)->{meta}{uncompiled};
     my $summary = get_summary_for_file($db, $file, $show);
 
-    my $url = get_link($file);
+    my $url  = get_link($file);
+    my $name = encode_entities($file);
     if ($url) {
-      print $fh '<tr><td align="left">' . qq(<a href="$url">$file</a>);
+      print $fh '<tr><td align="left">' . qq(<a href="$url">$name</a>);
     } else {
-      print $fh qq(<tr><td align="left">$file);
+      print $fh qq(<tr><td align="left">$name);
     }
     print $fh " <em>(untested)</em>" if $uncompiled;
     print $fh "</td>";

--- a/lib/Devel/Cover/Report/Html_subtle.pm
+++ b/lib/Devel/Cover/Report/Html_subtle.pm
@@ -16,13 +16,13 @@ BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
 
 use Devel::Cover::Criterion ();
 use Devel::Cover::Html_Common  ## no perlimports
-  qw( launch coverage_class default_thresholds unique_filenames );
+  qw( launch coverage_class default_thresholds unique_filenames
+  escape_html source_layer );
 use Devel::Cover::Log qw( dcinfo );
 use Devel::Cover::Truth_Table;  ## no perlimports
 
-use Getopt::Long   qw( GetOptions );
-use Template 2.00  ();
-use HTML::Entities qw( encode_entities );
+use Getopt::Long  qw( GetOptions );
+use Template 2.00 ();
 
 my $Template;
 my %Filenames;
@@ -135,7 +135,8 @@ sub print_stylesheet ($db, $options) {
 
 # Print coverage overview report for a file
 sub print_file ($db, $file, $options) {
-  open my $fh, "<", $file or warn("Unable to open '$file' [$!]\n"), return;
+  open my $fh, "<" . source_layer($file), $file
+    or warn("Unable to open '$file' [$!]\n"), return;
 
   my @lines;
   my @showing = grep $options->{show}{$_}, $db->criteria;
@@ -148,7 +149,7 @@ sub print_file ($db, $file, $options) {
     chomp $l;
 
     my %metric = get_metrics($db, $options, $file_data, $.);
-    my $line   = { number => $., text => encode_entities($l), metrics => [] };
+    my $line   = { number => $., text => escape_html($l), metrics => [] };
     $line->{text} =~ s/\t/        /g;
     $line->{text} =~ s/\s/&nbsp;/g;   # IE doesn't honour "white-space: pre" CSS
 
@@ -178,7 +179,8 @@ sub print_file ($db, $file, $options) {
   };
 
   my $html = "$options->{outputdir}/$Filenames{$file}.html";
-  $Template->process("file", $vars, $html) or die $Template->error;
+  $Template->process("file", $vars, $html, { binmode => ":encoding(UTF-8)" })
+    or die $Template->error;
 }
 
 # Print branch coverage report for a file
@@ -201,7 +203,7 @@ sub print_branches ($db, $file, $options) {
             { text => "T", class => $tf[0] ? "covered" : "uncovered" },
             { text => "F", class => $tf[1] ? "covered" : "uncovered" },
           ],
-          text => encode_entities($b->text),
+          text => escape_html($b->text),
         };
     }
   }
@@ -217,7 +219,9 @@ sub print_branches ($db, $file, $options) {
   };
 
   my $html = "$options->{outputdir}/$Filenames{$file}--branch.html";
-  $Template->process("branches", $vars, $html) or die $Template->error;
+  $Template->process(
+    "branches", $vars, $html, { binmode => ":encoding(UTF-8)" }
+  ) or die $Template->error;
 }
 
 # Print condition coverage report for a file
@@ -235,7 +239,7 @@ sub print_conditions ($db, $file, $options) {
           ref        => "line$location",
           percentage => sprintf("%.0f", $c->[0]->percentage),
           class      => cvg_class($c->[0]->percentage),
-          condition  => encode_entities($c->[1]),
+          condition  => escape_html($c->[1]),
           coverage   => $c->[0]->html,
         };
     }
@@ -254,7 +258,9 @@ sub print_conditions ($db, $file, $options) {
   };
 
   my $html = "$options->{outputdir}/$Filenames{$file}--condition.html";
-  $Template->process("conditions", $vars, $html) or die $Template->error;
+  $Template->process(
+    "conditions", $vars, $html, { binmode => ":encoding(UTF-8)" }
+  ) or die $Template->error;
 }
 
 # Print MC/DC coverage report for a file
@@ -272,7 +278,7 @@ sub print_mcdc ($db, $file, $options) {
         map {
           my $unc = $m->uncoverable($_);
           qq(<span class="@{[ $vals[$_] || $unc ? "covered" : "uncovered" ]}">)
-          . encode_entities(($unc ? "-" : "") . ($labels[$_] // ""))
+          . escape_html(($unc ? "-" : "") . ($labels[$_] // ""))
           . "</span>"
         } 0 .. $#vals;
 
@@ -281,7 +287,7 @@ sub print_mcdc ($db, $file, $options) {
           ref        => "line$location",
           percentage => sprintf("%.0f", $m->percentage),
           class      => cvg_class($m->percentage),
-          decision   => encode_entities($m->text),
+          decision   => escape_html($m->text),
           atomics    => $atomics,
         };
     }
@@ -299,7 +305,8 @@ sub print_mcdc ($db, $file, $options) {
   };
 
   my $html = "$options->{outputdir}/$Filenames{$file}--mcdc.html";
-  $Template->process("mcdc", $vars, $html) or die $Template->error;
+  $Template->process("mcdc", $vars, $html, { binmode => ":encoding(UTF-8)" })
+    or die $Template->error;
 }
 
 # Print subroutine coverage report for a file
@@ -332,7 +339,9 @@ sub print_subroutines ($db, $file, $options) {
   };
 
   my $html = "$options->{outputdir}/$Filenames{$file}--subroutine.html";
-  $Template->process("subroutines", $vars, $html) or die $Template->error;
+  $Template->process(
+    "subroutines", $vars, $html, { binmode => ":encoding(UTF-8)" }
+  ) or die $Template->error;
 }
 
 # Print the database summary report
@@ -404,7 +413,8 @@ sub print_summary ($db, $options) {
   };
 
   my $html = "$options->{outputdir}/$options->{option}{outputfile}";
-  $Template->process("summary", $vars, $html) or die $Template->error;
+  $Template->process("summary", $vars, $html, { binmode => ":encoding(UTF-8)" })
+    or die $Template->error;
 
   dcinfo "HTML output written to $html";
 }
@@ -466,7 +476,7 @@ https://pjcj.net
   "https://www.w3.org/TR/xhtml-basic/xhtml-basic10.dtd">
 <html xmlns="https://www.w3.org/1999/xhtml">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"></meta>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"></meta>
   <meta http-equiv="Content-Language" content="en-us"></meta>
   <link rel="stylesheet" type="text/css" href="cover.css"></link>
   <title> [% title | html %] </title>

--- a/lib/Devel/Cover/Report/Html_subtle.pm
+++ b/lib/Devel/Cover/Report/Html_subtle.pm
@@ -469,7 +469,7 @@ https://pjcj.net
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"></meta>
   <meta http-equiv="Content-Language" content="en-us"></meta>
   <link rel="stylesheet" type="text/css" href="cover.css"></link>
-  <title> [% title %] </title>
+  <title> [% title | html %] </title>
 </head>
 <body>
   [% content %]
@@ -506,9 +506,9 @@ $Templates{summary} = <<'HTML';
     <tr align="center" valign="top">
     <td align="left">
     [% IF file_exists.$file %]
-      <a href="[%- filenames.$file -%].html"> [% file %] </a>
+      <a href="[%- filenames.$file -%].html"> [% file | html %] </a>
     [% ELSE %]
-      [% file %]
+      [% file | html %]
     [% END %]
     [% IF uncompiled.$file %] <em>(untested)</em>[% END %]
     </td>
@@ -544,7 +544,7 @@ $Templates{branches} = <<'HTML';
 <table>
   <tr>
     <td class="header" align="right">File:</td>
-    <td>[% file %]</td>
+    <td>[% file | html %]</td>
   </tr>
   <tr>
     <td class="header" align="right">Coverage:</td>
@@ -599,7 +599,7 @@ $Templates{conditions} = <<'HTML';
 <table>
   <tr>
     <td class="header" align="right">File:</td>
-    <td>[% file %]</td>
+    <td>[% file | html %]</td>
   </tr>
   <tr>
     <td class="header" align="right">Coverage:</td>
@@ -651,7 +651,7 @@ $Templates{mcdc} = <<'HTML';
 <table>
   <tr>
     <td class="header" align="right">File:</td>
-    <td>[% file %]</td>
+    <td>[% file | html %]</td>
   </tr>
   <tr>
     <td class="header" align="right">Coverage:</td>
@@ -701,7 +701,7 @@ $Templates{subroutines} = <<'HTML';
 <table>
   <tr>
     <td class="header" align="right">File:</td>
-    <td>[% file %]</td>
+    <td>[% file | html %]</td>
   </tr>
   <tr>
     <td class="header" align="right">Coverage:</td>
@@ -726,7 +726,7 @@ $Templates{subroutines} = <<'HTML';
   [% FOREACH sub = subroutines %]
     <tr align="center" valign="top">
       <td class="[% sub.class %]">
-        <a id="[% sub.ref %]"> [% sub.name %] </a>
+        <a id="[% sub.ref %]"> [% sub.name | html %] </a>
       </td>
       <td> [% sub.line %] </td>
     </tr>
@@ -744,7 +744,7 @@ $Templates{file} = <<'HTML';
 <table>
   <tr>
     <td class="header" align="right">File:</td>
-    <td>[% file %]</td>
+    <td>[% file | html %]</td>
   </tr>
   <tr>
     <td class="header" align="right">Coverage:</td>

--- a/t/internal/collection_escape.t
+++ b/t/internal/collection_escape.t
@@ -1,0 +1,71 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is like plan unlike )];
+
+eval "require HTML::Entities; 1" or do {
+  plan skip_all => "HTML::Entities not available";
+  exit;
+};
+eval "require Template; 1" or do {
+  plan skip_all => "Template not available";
+  exit;
+};
+# Collection uses the feature "class" and needs a recent Perl.
+eval "require Devel::Cover::Collection; 1" or do {
+  plan skip_all => "Devel::Cover::Collection not available: $@";
+  exit;
+};
+
+# The cpancover collection index lists every distribution's name and version.
+# Both come from the module's own cover.json (or its directory name), so they
+# may contain markup characters and must be escaped before being written.
+my $Meta = "x<MARK>&";
+
+sub render_index () {
+  my $template = Template->new({
+    LOAD_TEMPLATES => [Devel::Cover::Collection::Template::Provider->new({})],
+  });
+
+  my $vars = {
+    title        => "Coverage report",
+    root         => "",
+    module_start => "E",
+    criteria     => [],
+    col_headers  => [{ full => "Total", short => "total" }],
+    modules      => {
+      E =>
+        [{ module => "Test-1.0", name => $Meta, version => "1.0$Meta" }],
+    },
+    vals => { "Test-1.0" => {} },
+  };
+
+  my $out = "";
+  $template->process("module_by_start", $vars, \$out) or die $template->error;
+  $out
+}
+
+sub main () {
+  my $html = render_index;
+  unlike $html, qr|<MARK>|, "collection index does not emit raw module metadata";
+  like $html,   qr|&lt;MARK&gt;|, "collection index escapes module metadata";
+
+  done_testing;
+}
+
+main;

--- a/t/internal/collection_escape.t
+++ b/t/internal/collection_escape.t
@@ -37,6 +37,12 @@ eval "require Devel::Cover::Collection; 1" or do {
 # may contain markup characters and must be escaped before being written.
 my $Meta = "x<MARK>&";
 
+# The index and log links are built from the distribution directory and log
+# file names.  They land in a double-quoted href attribute, so an embedded
+# quote would end the attribute early.  They must be escaped too.
+my $Link_meta = '/x"><MARK>/index.html';
+my $Log_meta  = 'a-bc-x"><MARK>-1--1234567890.123456.out.gz';
+
 sub render_index () {
   my $template = Template->new({
     LOAD_TEMPLATES => [Devel::Cover::Collection::Template::Provider->new({})],
@@ -49,10 +55,14 @@ sub render_index () {
     criteria     => [],
     col_headers  => [{ full => "Total", short => "total" }],
     modules      => {
-      E =>
-        [{ module => "Test-1.0", name => $Meta, version => "1.0$Meta" }],
+      E => [{
+        module  => "Test-1.0",
+        name    => $Meta,
+        version => "1.0$Meta",
+      }],
     },
-    vals => { "Test-1.0" => {} },
+    vals =>
+      { "Test-1.0" => { link => $Link_meta, log => $Log_meta } },
   };
 
   my $out = "";
@@ -62,8 +72,11 @@ sub render_index () {
 
 sub main () {
   my $html = render_index;
-  unlike $html, qr|<MARK>|, "collection index does not emit raw module metadata";
-  like $html,   qr|&lt;MARK&gt;|, "collection index escapes module metadata";
+  unlike $html, qr|<MARK>|,
+    "collection index does not emit raw module metadata";
+  like $html, qr|&lt;MARK&gt;|, "collection index escapes module metadata";
+  unlike $html, qr|"><MARK>|, "collection index link stays in the attribute";
+  like $html,   qr|&quot;|, "collection index escapes the quote in href links";
 
   done_testing;
 }

--- a/t/internal/cover_plugin_name.t
+++ b/t/internal/cover_plugin_name.t
@@ -1,0 +1,68 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin    ();
+use File::Temp qw( tempdir );
+
+use Test::More import => [qw( done_testing like ok plan unlike )];
+
+# cover builds a report or annotation class name from the -report and
+# -annotation arguments and loads it through a string eval.  A name that is
+# not a plain word must be rejected before it reaches the eval, so a mistyped
+# argument gives a clear message rather than a confusing compile error.
+
+my $Root  = "$FindBin::Bin/../..";
+my $Cover = "$Root/bin/cover";
+my $Lib   = "$Root/lib";
+
+sub run_cover (@args) {
+  my $tmp = tempdir(CLEANUP => 1);
+  my $log = "$tmp/output";
+  my $pid = fork // die "Can't fork: $!";
+  if (!$pid) {
+    chdir $tmp or die "chdir $tmp: $!";
+    open STDOUT, ">",  $log   or die "Can't write $log: $!";
+    open STDERR, ">&", STDOUT or die "Can't dup stdout: $!";
+    exec $^X, "-I$Lib", $Cover, @args;
+    die "Can't exec cover: $!";
+  }
+  waitpid $pid, 0;
+  open my $fh, "<", $log or die "Can't read $log: $!";
+  my $out = do { local $/; <$fh> };
+  close $fh or die "Can't close $log: $!";
+  { out => $out, dir => $tmp }
+}
+
+sub main () {
+  my $report = run_cover("-report", 'html; open my $f, ">", "CREATED"; 1');
+  ok !-e "$report->{dir}/CREATED",
+    "-report does not evaluate its argument";
+  like $report->{out}, qr/not a recognised output format/,
+    "-report rejects an invalid format name";
+
+  my $valid = run_cover("-report", "Text");
+  unlike $valid->{out}, qr/not a recognised output format/,
+    "-report still accepts a valid format name";
+
+  my $ann = run_cover(
+    "-report",     "Text",
+    "-annotation", 'git; open my $f, ">", "CREATED"; 1',
+  );
+  ok !-e "$ann->{dir}/CREATED",
+    "-annotation does not evaluate its argument";
+
+  done_testing;
+}
+
+main;

--- a/t/internal/html_escape.t
+++ b/t/internal/html_escape.t
@@ -155,6 +155,63 @@ sub test_filename_escaped ($report, $tmpdir, $cover_db) {
   like $html, qr|&lt;MARK&gt;|, "$report: file name metacharacters are escaped";
 }
 
+# The module name and version reach the coverage summary page from the covered
+# distribution's MYMETA.json (or its directory name), so they may contain
+# markup characters and must be escaped on the summary page too.
+my $Have_cpan_meta = eval "require CPAN::Meta; 1";
+
+sub _setup_meta () {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+  my $libdir = File::Spec->catdir($tmpdir, "lib");
+  make_path($libdir);
+
+  my $path = File::Spec->catfile($libdir, "Fixture.pm");
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $Fixture;
+  close $fh or die "Cannot close $path: $!";
+
+  my $meta = File::Spec->catfile($tmpdir, "MYMETA.json");
+  open my $mh, ">", $meta or die "Cannot write $meta: $!";
+  print $mh <<'JSON';
+{
+   "name" : "x<MARK>&",
+   "version" : "1.0 x<MARK>&",
+   "abstract" : "test",
+   "dynamic_config" : 0,
+   "generated_by" : "test",
+   "license" : ["perl_5"],
+   "meta-spec" : { "version" : 2 },
+   "release_status" : "stable"
+}
+JSON
+  close $mh or die "Cannot close $meta: $!";
+
+  my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my @cmd = (
+    $^X,
+    "-Iblib/lib",
+    "-Iblib/arch",
+    "-I$libdir",
+    "-MDevel::Cover=-db,$cover_db,-dir,$tmpdir,-silent,1,-merge,0",
+    "-e",
+    "use Fixture; Fixture::decide(1, 1)",
+  );
+  system(@cmd) == 0 or die "Failed to create cover_db (status $?)";
+
+  ($tmpdir, $cover_db)
+}
+
+sub test_meta_escaped ($tmpdir, $cover_db) {
+  my $outdir = _report($tmpdir, $cover_db, "html_basic");
+  my $html   = slurp(File::Spec->catfile($outdir, "coverage.html"));
+  unlike $html, qr|<MARK>|,
+    "html_basic: summary page does not emit raw module metadata";
+  like $html, qr|&lt;MARK&gt;|,
+    "html_basic: summary page escapes module metadata";
+}
+
 # The SCAR tooltip in the crisp report emits sub names, so escape them too.
 sub test_crisp_scar_tip () {
   require Devel::Cover::Report::Html_crisp;
@@ -173,6 +230,11 @@ sub main () {
   my ($tmpdir, $cover_db) = _setup;
   test_html_basic($tmpdir, $cover_db) if $Have_template;
   test_html_crisp($tmpdir, $cover_db);
+
+  if ($Have_template && $Have_cpan_meta) {
+    my ($t, $db) = _setup_meta;
+    test_meta_escaped($t, $db);
+  }
 
   test_crisp_scar_tip;
 

--- a/t/internal/html_escape.t
+++ b/t/internal/html_escape.t
@@ -212,6 +212,94 @@ sub test_meta_escaped ($tmpdir, $cover_db) {
     "html_basic: summary page escapes module metadata";
 }
 
+# Source files are read as bytes and each high-bit byte escaped into its own
+# entity, so UTF-8 text such as an e-acute (0xC3 0xA9) garbles into
+# &Atilde;&copy;.  The reports must guess the source encoding (strict UTF-8,
+# falling back to Latin-1), escape only HTML-unsafe characters and write
+# UTF-8 output.  The regex string below guards the original ampersand
+# escaping problem: it must render with &amp;, never a bare ampersand.
+my $E_utf8   = "\xC3\xA9";
+my $E_latin1 = "\xE9";
+
+my $Encoded_fixture = <<'PERL';
+package Encoded;
+use strict;
+use warnings;
+
+sub greet {
+  my ($name) = @_;
+  my $re = '(?&param)?+';
+  return $name eq "bEbE" ? "yes" : $re;
+}
+
+1;
+PERL
+
+sub _setup_encoded ($e) {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+  my $libdir = File::Spec->catdir($tmpdir, "lib");
+  make_path($libdir);
+
+  my $path = File::Spec->catfile($libdir, "Encoded.pm");
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $Encoded_fixture =~ s/bEbE/b${e}b$e/gr;
+  close $fh or die "Cannot close $path: $!";
+
+  my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my @cmd = (
+    $^X, "-Iblib/lib", "-Iblib/arch", "-I$libdir",
+    "-MDevel::Cover=-db,$cover_db,-silent,1,-merge,0",
+    "-e", "use Encoded; Encoded::greet(q(x))",
+  );
+  system(@cmd) == 0 or die "Failed to create cover_db (status $?)";
+
+  ($tmpdir, $cover_db)
+}
+
+sub _all_pages ($outdir) {
+  join "\n", map slurp($_), glob "$outdir/*.html"
+}
+
+sub test_unicode_source ($report, $tmpdir, $cover_db, @extra) {
+  my $outdir = _report($tmpdir, $cover_db, $report, @extra);
+  my $html   = _all_pages($outdir);
+  like $html, qr/b\xC3\xA9b/, "$report: non-ASCII source renders as UTF-8";
+  unlike $html, qr/&Atilde;|&eacute;|&#233;|&#xe9;/i,
+    "$report: no byte-wise entities for non-ASCII source";
+  like $html, qr/\(\?&amp;param\)\?\+/,
+    "$report: ampersand in source is escaped";
+  $html
+}
+
+sub test_unicode_highlighted ($report, $tmpdir, $cover_db) {
+  my $outdir = _report($tmpdir, $cover_db, $report);
+  my $html   = _all_pages($outdir);
+  like $html, qr/b(\xC3\xA9|&eacute;|&#233;|&#xe9;)b/i,
+    "$report: highlighted non-ASCII source renders correctly";
+  unlike $html, qr/&Atilde;/,
+    "$report: highlighted source is not escaped byte-wise";
+  like $html, qr/\(\?&amp;param\)/,
+    "$report: highlighted ampersand in source is escaped";
+}
+
+sub test_decode_guess () {
+  require Devel::Cover::Html_Common;
+  my $d = \&Devel::Cover::Html_Common::decode_guess;
+  is $d->("b\xC3\xA9b\xC3\xA9"), "b\x{e9}b\x{e9}", "UTF-8 bytes are decoded";
+  is $d->("b\xE9b\xE9"),         "b\x{e9}b\x{e9}", "Latin-1 bytes are decoded";
+  my $wide = "snow \x{2603}";
+  is $d->($wide), $wide, "wide-character strings pass through";
+}
+
+sub test_latin1_source ($report, $tmpdir, $cover_db, @extra) {
+  my $outdir = _report($tmpdir, $cover_db, $report, @extra);
+  my $html   = _all_pages($outdir);
+  like $html, qr/b\xC3\xA9b/, "$report: Latin-1 source is transcoded to UTF-8";
+  unlike $html, qr/b\xE9b/,   "$report: no raw Latin-1 bytes in output";
+}
+
 # The SCAR tooltip in the crisp report emits sub names, so escape them too.
 sub test_crisp_scar_tip () {
   require Devel::Cover::Report::Html_crisp;
@@ -237,6 +325,31 @@ sub main () {
   }
 
   test_crisp_scar_tip;
+  test_decode_guess;
+
+  {
+    my ($t, $db) = _setup_encoded($E_utf8);
+    test_unicode_source("html_crisp", $t, $db, @No_highlight);
+    test_unicode_source("html_minimal", $t, $db);
+    if ($Have_template) {
+      test_unicode_source("html_basic", $t, $db, @No_highlight);
+      my $html = test_unicode_source("html_subtle", $t, $db);
+      like $html, qr/charset=utf-8/i, "html_subtle: declares a utf-8 charset";
+    }
+  }
+
+  if (eval "require PPI::HTML; 1") {
+    my ($t, $db) = _setup_encoded($E_utf8);
+    test_unicode_highlighted("html_crisp", $t, $db);
+    test_unicode_highlighted("html_basic", $t, $db) if $Have_template;
+  }
+
+  {
+    my ($t, $db) = _setup_encoded($E_latin1);
+    test_latin1_source("html_crisp",   $t, $db, @No_highlight);
+    test_latin1_source("html_minimal", $t, $db);
+    test_latin1_source("html_basic", $t, $db, @No_highlight) if $Have_template;
+  }
 
   unless ($^O eq "MSWin32") {
     my ($t, $db) = _setup_named_file;

--- a/t/internal/html_escape.t
+++ b/t/internal/html_escape.t
@@ -44,9 +44,9 @@ sub decide {
 1;
 PERL
 
-# When no syntax highlighter runs (none installed, or both disabled), the
-# raw source and coverage text fall back to the page unhighlighted; they
-# must be entity-escaped, not emitted raw.
+# When no syntax highlighter runs (none installed, or both disabled) the
+# source and coverage text reach the page unhighlighted, so they must still
+# be escaped.
 sub _setup () {
   my $tmpdir = realpath(tempdir(CLEANUP => 1));
   my $libdir = File::Spec->catdir($tmpdir, "lib");
@@ -71,18 +71,22 @@ sub _setup () {
   ($tmpdir, $cover_db)
 }
 
-sub _report ($tmpdir, $cover_db, $report) {
+sub _report ($tmpdir, $cover_db, $report, @extra) {
   my $outdir = File::Spec->catdir($tmpdir, $report);
   my ($out, $exit) = run_cover(
-    "--report", $report,      "--outputdir", $outdir,
-    "--silent", "-noppihtml", "-noperltidy", $cover_db,
+    "--report", $report, "--outputdir", $outdir,
+    "--silent", @extra,  $cover_db,
   );
   is $exit, 0, "cover --report $report exits 0" or diag $out;
   $outdir
 }
 
+# Disable syntax highlighting so raw source falls back unhighlighted.  Only the
+# html_basic and html_crisp backends accept these options.
+my @No_highlight = qw( -noppihtml -noperltidy );
+
 sub test_html_basic ($tmpdir, $cover_db) {
-  my $outdir = _report($tmpdir, $cover_db, "html_basic");
+  my $outdir = _report($tmpdir, $cover_db, "html_basic", @No_highlight);
 
   my ($file_page) = grep !m|/coverage\.html$| && !/--\w+\.html$/,
     glob "$outdir/*.html";
@@ -101,7 +105,7 @@ sub test_html_basic ($tmpdir, $cover_db) {
 }
 
 sub test_html_crisp ($tmpdir, $cover_db) {
-  my $outdir      = _report($tmpdir, $cover_db, "html_crisp");
+  my $outdir      = _report($tmpdir, $cover_db, "html_crisp", @No_highlight);
   my ($file_page) = grep !m|/coverage\.html$|, glob "$outdir/*.html";
   my $html        = slurp($file_page);
   unlike $html, qr|<script>xss|, "html_crisp: file page escapes raw source";
@@ -109,10 +113,77 @@ sub test_html_crisp ($tmpdir, $cover_db) {
     "html_crisp: file page contains escaped source";
 }
 
+# The covered file name reaches the report title, headings and links, and may
+# contain markup characters, so it must be escaped there too and not only in
+# the source body.  Windows file names cannot contain < > " so this is
+# exercised on Unix only.
+my $Meta = 'x<MARK>"&';
+
+sub _setup_named_file () {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+  my $script = File::Spec->catfile($tmpdir, "$Meta.pl");
+  open my $fh, ">", $script or die "Cannot write $script: $!";
+  print $fh <<'PERL';
+sub run {
+  my $n = shift;
+  if ($n > 0) {
+    return "positive";
+  }
+  return "non-positive";
+}
+run(1);
+run(-1);
+PERL
+  close $fh or die "Cannot close $script: $!";
+
+  my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my @cmd = (
+    $^X, "-Iblib/lib", "-Iblib/arch",
+    "-MDevel::Cover=-db,$cover_db,-silent,1,-merge,0", $script,
+  );
+  system(@cmd) == 0 or die "Failed to create cover_db (status $?)";
+
+  ($tmpdir, $cover_db)
+}
+
+sub test_filename_escaped ($report, $tmpdir, $cover_db) {
+  my $outdir = _report($tmpdir, $cover_db, $report);
+  my $html   = join "\n", map slurp($_), glob "$outdir/*.html";
+  unlike $html, qr|<MARK>|, "$report: raw file name metacharacters not emitted";
+  like $html, qr|&lt;MARK&gt;|, "$report: file name metacharacters are escaped";
+}
+
+# The SCAR tooltip in the crisp report emits sub names, so escape them too.
+sub test_crisp_scar_tip () {
+  require Devel::Cover::Report::Html_crisp;
+  my $tip = Devel::Cover::Report::Html_crisp::scar_tip({
+    file_scar  => "5.0",
+    file_cov   => 50,
+    file_cc    => 3,
+    file_crap  => 7.0,
+    worst_subs => [{ name => "x<MARK>", crap => "9.0", scar => 20 }],
+  });
+  unlike $tip, qr|<MARK>|, "html_crisp: scar tip does not emit raw sub name";
+  like $tip,   qr|&lt;MARK&gt;|, "html_crisp: scar tip escapes sub name";
+}
+
 sub main () {
   my ($tmpdir, $cover_db) = _setup;
   test_html_basic($tmpdir, $cover_db) if $Have_template;
   test_html_crisp($tmpdir, $cover_db);
+
+  test_crisp_scar_tip;
+
+  unless ($^O eq "MSWin32") {
+    my ($t, $db) = _setup_named_file;
+    test_filename_escaped("html_crisp",   $t, $db);
+    test_filename_escaped("html_minimal", $t, $db);
+    test_filename_escaped("html_basic",   $t, $db) if $Have_template;
+    test_filename_escaped("html_subtle",  $t, $db) if $Have_template;
+  }
+
   done_testing;
 }
 

--- a/t/internal/queue_author_path.t
+++ b/t/internal/queue_author_path.t
@@ -1,0 +1,90 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+
+use Test::More import => [qw( done_testing is ok )];
+
+# queue builds the path it hands to dc from the CPAN uploads feed, so it may
+# contain spaces or other characters a shell would split.  The path must reach
+# dc as a single argument, and anything that is not a real author path must be
+# refused.  A real author path has four components and its first two
+# directories repeat the leading characters of the author id.
+
+my $Queue = "$FindBin::Bin/../../bin/queue";
+
+sub source () {
+  open my $fh, "<", $Queue or die "Can't read $Queue: $!";
+  my $src = do { local $/; <$fh> };
+  close $fh or die "Can't close $Queue: $!";
+  $src
+}
+
+# The guard in bin/queue, extracted so the pattern is exercised directly.
+# Kept in step with the script by the source check below.
+sub accepts ($path) {
+  $path =~ m{\A([A-Z])/\1([A-Z0-9])/\1\2[A-Z0-9]*/[A-Za-z0-9][\w.+-]*\z} ? 1 : 0
+}
+
+sub main () {
+  my $src = source;
+
+  like_command($src);
+
+  for my $path (
+    "P/PJ/PJCJ/Shell-Source-0.01.tar.gz",
+    "A/AB/ABC/Foo-Bar-1.23.tar.bz2",
+    "M/MS/MSCHWERN/Test-Simple-1.302199.tar.gz",
+    "J/JV/JV/PostScript-Font-1.09.tar.gz",
+    "P/PE/PERLANCAR/App-cpanm-0.01.tar.gz",
+    "L/LD/LDS/GD-2.53.tar.gz",
+    "S/SA/SAMPLE/Foo-C++-1.0.tar.gz",
+  ) {
+    is accepts($path), 1, "genuine author path is accepted: $path";
+  }
+
+  for my $path (
+    "P/PJ/PJCJ/x.tar.gz; touch MARKER",
+    "P/PJ/PJCJ/`id`.tar.gz",
+    'P/PJ/PJCJ/$(id).tar.gz',
+    "P/PJ/PJCJ/x|nc host 1234",
+    "P/PJ/PJCJ/x.tar.gz && id",
+    "-rf /",
+    "P/PJ/../../../etc/passwd",
+    "P/PJ/PJCJ/x .tar.gz",
+  ) {
+    is accepts($path), 0, "path with metacharacters is refused: $path";
+  }
+
+  for my $path (
+    "P/PX/PJCJ/Foo-1.0.tar.gz", "X/PJ/PJCJ/Foo-1.0.tar.gz",
+    "p/pj/pjcj/Foo-1.0.tar.gz", "PJCJ/Foo-1.0.tar.gz",
+    "M/MS/MSCHWERN/sub/Test-Simple-1.0.tar.gz",
+  ) {
+    is accepts($path), 0, "malformed author path is refused: $path";
+  }
+
+  done_testing;
+}
+
+sub like_command ($src) {
+  ok $src =~ /\bsystem \@command\b/,
+    "queue runs dc through list-form system, so no shell parses the path";
+  ok $src !~ /\bsystem \$command\b/,
+    "queue does not run dc through a single-string system";
+  ok $src =~ m{\Q\A([A-Z])/\1([A-Z0-9])/\1\2[A-Z0-9]*/[A-Za-z0-9][\w.+-]*\z\E},
+    "queue guards the path with the pattern this test exercises";
+}
+
+main;


### PR DESCRIPTION
## Summary

Reported in #215, the HTML backends read covered source files as bytes and escaped every high-bit byte into its own entity, so UTF-8 text such as an e-acute rendered as mojibake. They now guess the source encoding, escape only the characters HTML requires, and write UTF-8 throughout. The same text handling covers metadata that reaches the page from the covered distribution, which may itself contain markup characters.

Alongside that, a few places built shell command strings by interpolation and so mangled any path containing a space or a shell metacharacter. Those now run as list-form commands.

## Changes

- Add an encoding guess to `Html_Common`, trying strict UTF-8 and falling back to Latin-1, and read and write report files through the matching layers.
- Escape file paths, titles, package and sub names, module name and version, and the collection index links in all four HTML backends.
- Declare a utf-8 charset in `Html_subtle`, which still claimed iso-8859-1.
- Run the old-version archiver, the lock cleanup and the queue daemon's `dc` invocations as list-form commands.
- Require a word-character name in the `cover` `-report` and `-annotation` loaders, so a mistyped value gives a clear message rather than a compile error.
- Load `Parallel::Iterator` only in the parallel paths that use it, so the collection index can be generated, and tested, without it.

## Implications

- The encoding guess is a heuristic. Anything that is not valid UTF-8 is read as Latin-1, which never fails but will render other encodings incorrectly, as it did before.
- The queue daemon accepts only a well-formed author path and fails the job otherwise. Subdirectories under an author directory are rejected, which CPAN permits but neither caller produces.

## Ticket

Closes #215
Closes #105