### PR TITLE
GH-668 Limit cpancover build container resources

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Limit each cpancover build container to the resources a build needs - CPU,
+  process count, open files, file size, Linux capabilities and privilege
+  elevation (GH-668)
 - Mark cpancover builds failed when the report file was never written, and
   don't link distributions whose report page is missing - a report command
   dying part-way previously published truncated results behind a broken

--- a/utils/dc
+++ b/utils/dc
@@ -685,7 +685,11 @@ recipe_cpancover-docker-module() {
   container=$($docker run -d \
     ${env_flags[@]:+"${env_flags[@]}"} \
     --label "cpancover.env=$env" \
-    --rm=false --memory=1g --name="$name" \
+    --rm=false --memory=1g --cpus=2 --pids-limit=512 \
+    --ulimit nofile=4096 --ulimit fsize=2147483648 \
+    --cap-drop=ALL --security-opt=no-new-privileges \
+    --env TAR_OPTIONS=--no-same-owner \
+    --name="$name" \
     "$docker_image" \
     dc $v cpancover-build-module "$module")
   ((verbose)) && pi "container is $container"

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -183,6 +183,33 @@ sub docker_module_timeout_log_ref () {
   is @tmp, 0, "no tmp files remain";
 }
 
+sub docker_module_run_limits () {
+  skip_all "timeout required" if system "command -v timeout >/dev/null 2>&1";
+  my $bin = tempdir(CLEANUP => 1);
+  make_docker_stub($bin);
+  local $ENV{PATH}         = "$bin:$ENV{PATH}";
+  local $ENV{STUB_DISTDIR} = "Foo-Bar-1.00";
+
+  my $log     = "P-PJ-PJCJ-Foo-Bar-1.00.tar.gz--123.456";
+  my $staging = tempdir(CLEANUP => 1);
+  my $work    = tempdir(CLEANUP => 1);
+
+  {
+    local $ENV{STUB_CALLS} = "$work/calls";
+    dc("-r", $staging, "cpancover-docker-module", "Foo::Bar", $log, $staging);
+  }
+
+  my ($run) = grep /^run /, split /\n/, slurp("$work/calls");
+  for my $flag (
+    "--memory=1g",                      "--cpus=2",
+    "--pids-limit=512",                 "--ulimit nofile=4096",
+    "--ulimit fsize=2147483648",        "--cap-drop=ALL",
+    "--security-opt=no-new-privileges", "--env TAR_OPTIONS=--no-same-owner",
+  ) {
+    like $run, qr/ \Q$flag\E /, "module container runs with $flag";
+  }
+}
+
 sub force_retries_failed_only () {
   skip_all "timeout required" if system "command -v timeout >/dev/null 2>&1";
   my $bin = tempdir(CLEANUP => 1);
@@ -469,6 +496,7 @@ sub main () {
     uncompress_recipe
     docker_module_log_ref
     docker_module_timeout_log_ref
+    docker_module_run_limits
     force_retries_failed_only
     cpancover_leaves_build_alone
     rebuild_batch_cleanup


### PR DESCRIPTION
## Summary

Bound each per-module cpancover container to the resources a build actually uses. Only the memory cap and the wall-clock timeout limited a build before, so a misbehaving one could hold host cores or processes for the whole hour, as the mod_perl 1.x Makefile.PL spin showed. Cap CPU, process count, open files and file size, and run the build without Linux capabilities or privilege elevation. Set `TAR_OPTIONS=--no-same-owner` since without `CAP_CHOWN` tar cannot restore archive ownership and warns on every extraction. Verified with full recipe runs of a pure-Perl and an XS distribution against the dev image.

## Ticket

Closes #668