### PR TITLE
GH-670 Run cpancover builds as an ordinary user

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Run each cpancover build container as an ordinary user (GH-670)
 - Limit each cpancover build container to the resources a build needs - CPU,
   process count, open files, file size, Linux capabilities and privilege
   elevation (GH-668)

--- a/docker/devel-cover-base/Dockerfile
+++ b/docker/devel-cover-base/Dockerfile
@@ -46,4 +46,21 @@ RUN mkdir -p /root/.cpan/CPAN                                               && \
     rm -rf ~/.cpan/build ~/.cpan/sources/authors ~/.cpanm                      \
       ~/.local/share/.cpan/build ~/.local/share/.cpan/sources/authors
 
+# hadolint ignore=SC2016
+RUN useradd --create-home cpancover                                         && \
+    mkdir -p /home/cpancover/.cpan/CPAN                                     && \
+    sed "s|/root/|/home/cpancover/|" /root/.cpan/CPAN/MyConfig.pm              \
+      > /home/cpancover/.cpan/CPAN/MyConfig.pm                              && \
+    chown -R cpancover:cpancover /home/cpancover/.cpan                      && \
+    perl -MConfig -MFile::Path=make_path -e                                    \
+      'my @d = grep $_, @Config{qw( installsitelib installsitearch             \
+        installsitebin )};                                                     \
+      make_path @d;                                                            \
+      system("chown", "-R", "cpancover:cpancover", @d) and die;                \
+      my $p = "$Config{installarchlib}/perllocal.pod";                         \
+      open my $fh, ">>", $p or die;                                            \
+      close $fh;                                                               \
+      system("chown", "cpancover:cpancover", $p) and die'
+
 COPY prefs/ /root/.cpan/prefs/
+COPY --chown=cpancover:cpancover prefs/ /home/cpancover/.cpan/prefs/

--- a/utils/dc
+++ b/utils/dc
@@ -689,6 +689,7 @@ recipe_cpancover-docker-module() {
     --ulimit nofile=4096 --ulimit fsize=2147483648 \
     --cap-drop=ALL --security-opt=no-new-privileges \
     --env TAR_OPTIONS=--no-same-owner \
+    --user cpancover \
     --name="$name" \
     "$docker_image" \
     dc $v cpancover-build-module "$module")
@@ -706,7 +707,8 @@ recipe_cpancover-docker-module() {
     fi
 
     mkdir -p "$local_staging"
-    if ! $docker cp "$name:/root/cover/staging" "$local_staging" 2>>"$log_file"; then
+    if ! $docker cp "$name:/home/cpancover/cover/staging" "$local_staging" \
+      2>>"$log_file"; then
       pe "docker cp failed for $name; see $log_file"
       rm -rf "$local_staging"
       $docker rm "$name" >/dev/null 2>&1 || true

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -205,9 +205,14 @@ sub docker_module_run_limits () {
     "--pids-limit=512",                 "--ulimit nofile=4096",
     "--ulimit fsize=2147483648",        "--cap-drop=ALL",
     "--security-opt=no-new-privileges", "--env TAR_OPTIONS=--no-same-owner",
+    "--user cpancover",
   ) {
     like $run, qr/ \Q$flag\E /, "module container runs with $flag";
   }
+
+  my ($cp) = grep /^cp /, split /\n/, slurp("$work/calls");
+  like $cp, qr|^cp \S+:/home/cpancover/cover/staging |,
+    "results are copied from the build user's home";
 }
 
 sub force_retries_failed_only () {


### PR DESCRIPTION
## Summary

Run each per-module cpancover build container as a dedicated `cpancover` user rather than root, continuing GH-668. Create the user in the base image, rewrite the baked CPAN config and distroprefs into its home, and give it the perl site directories, `/usr/local/bin` and `perllocal.pod` so dependency installs during a build keep working as before. Add `--user` to the per-module `docker run` and collect results from the user's home. The controller container and the interactive shells are unchanged. Verified with full recipe runs of a pure-Perl and an XS distribution, a runtime XS dependency install into the site directories, and the mod_perl distroprefs refusal from the user's own config.

## Implications

- Deploy by rebuilding the images before the updated `dc` serves the loops - `--user` against an image lacking the user fails immediately, while the old `dc` against the new image is unaffected.

## Ticket

Closes #670