### PR TITLE
GH-481 Overhaul uncoverable comment grammar

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,26 @@
 Devel::Cover history
 
 {{$NEXT}}
+- BREAKING: Require a type word, all or when on branch, condition and mcdc
+  uncoverable comments - a bare comment previously marked the first element
+  silently (GH-481)
+- Add an all type to uncoverable comments, marking every element of a branch,
+  condition or MC/DC decision at once (GH-481)
+- Add a when attribute to uncoverable condition comments, naming truth-table
+  rows by their operand values as the report shows them, e.g. when:0X, with
+  comma lists for several rows (GH-481)
+- Deprecate the uncoverable condition type words left, right and false -
+  using one warns and names the when replacement for the op (GH-481)
+- Attach uncoverable comments to the next line of code past blank lines and
+  other comments - they were previously discarded silently (GH-481)
+- Warn about uncoverable comments that match nothing - a wrong criterion, a
+  count past the constructs on the line, a type with no row or an unknown
+  attribute - instead of ignoring them silently (GH-481)
+- Require uncoverable to start the comment - quoted syntax in prose
+  previously created stray comments (GH-481)
+- Document uncoverable comments in full: placement for if/elsif chains, count
+  addressing of stacked ops, condition truth-table rows, and the branches of
+  unless, until and loop conditions (GH-481, GH-242)
 - Run each cpancover build container as an ordinary user (GH-670)
 - Limit each cpancover build container to the resources a build needs - CPU,
   process count, open files, file size, Linux capabilities and privilege

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1993,6 +1993,16 @@ anchored to the line of the opening if, so the comments for the whole chain
 go above that line.  Here $thing is always one, leaving five uncoverable
 branch outcomes:
 
+The "all" type marks both elements of a branch with one comment.  It is the
+natural form for a branch that can never run at all, such as an elsif in a
+chain that is never reached, so the example below can also be written:
+
+  # uncoverable branch false count:1
+  # uncoverable branch all count:2
+  # uncoverable branch all count:3
+
+Marking each element separately:
+
   # uncoverable branch false count:1
   # uncoverable branch true count:2
   # uncoverable branch false count:2
@@ -2032,6 +2042,9 @@ conditions may be modelled thus:
 C<Or> conditionals are handled in a similar fashion (TODO - provide some
 examples) but C<xor> conditionals are not properly handled yet.
 
+The "all" type marks every outcome of the condition with one comment, which
+suits a condition that can never be evaluated at all.
+
 As for branches, the "count" value may be used for either conditions in elsif
 conditionals, or for complex conditions.  Unlike branches, a condition in an
 elsif is addressed at the elsif's own line.  When one line holds several
@@ -2048,9 +2061,9 @@ An MC/DC decision can be uncoverable when an atomic condition's independence
 pair can never be formed, for example the right operand of C<//> in C<< $x //=
 $default >> when C<$default> is always defined.
 
-A bare comment marks every atomic condition of the decision uncoverable:
+The "all" type marks every atomic condition of the decision uncoverable:
 
-  # uncoverable mcdc
+  # uncoverable mcdc all
   $x //= $default;
 
 The "pair" attribute marks a single atomic condition by its position (1-based,

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -2025,6 +2025,38 @@ Marking each element separately:
     die "thing is $thing";       # uncoverable statement
   }
 
+=head4 unless, until and loop conditions
+
+A block C<unless> with no C<else>, the C<if> and C<unless> statement
+modifiers, and the conditions of C<while>, C<until> and C-style C<for> loops
+all compile to plain logops and are reported as two-element branches.  The
+report renormalises the text: C<while> conditions display as C<if (...)> and
+C<until> conditions as C<unless (...)>.  In every case the "true" element
+means the guarded code ran - the C<unless> body, or an iteration of the loop
+body - and the "false" element means it did not.  For C<unless> and C<until>
+this inverts the condition as written: the body of C<unless ($x)> runs on
+its "true" branch, when C<$x> is false.
+
+  # uncoverable branch true
+  unless ($x) { something_impossible() }
+
+An C<unless>/C<else> is different, and how it is reported depends on the
+perl version.  Up to 5.22 perl negates the condition, so the report
+displays C<if (not $x)> and the "true" element is the C<unless> body
+running.  From 5.24 perl swaps the blocks instead, so the report displays
+C<if ($x)> and the "true" element is the condition being true - the
+C<else> block of the C<unless> running.  The comment addresses the C<if>
+the report shows, so the same comment marks opposite outcomes either side
+of that boundary.  This confusion is one more reason to avoid
+C<unless>/C<else> altogether.
+
+A constant condition, as in C<unless (0)>, is folded away at compile time
+and leaves no branch to mark, so a comment there warns as unmatched.
+
+A condition inside any of these, such as C<unless ($a && $b)> or C<while
+($a && $b)>, is instrumented on its own terms, with the same truth-table
+rows as anywhere else.
+
 =head3 Conditions
 
 Because Perl short-circuits boolean operations, a condition has several

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1928,6 +1928,13 @@ followed by the name of the coverage criterion which is uncoverable.  There
 may then be further information depending on the nature of the uncoverable
 construct.
 
+Statements, subroutines and pod have a single outcome, so their comments need
+no further detail.  Branches, conditions and MC/DC decisions have several, so
+their comments must say which outcome is uncoverable: a type word such as
+"true" or "false", the "all" type which marks every outcome, a "when"
+pattern for conditions, or a "pair" position for MC/DC.  A comment which
+omits this, or which contains anything unrecognised, warns and is ignored.
+
 In all cases a L<class> attribute may be included in L<details>.  At present a
 single class attribute is recognised: L<ignore_covered_err>.  Normally, an
 error is flagged if code marked as L<uncoverable> is covered.  When the
@@ -1990,12 +1997,12 @@ If there is an elsif in the branch then it can be addressed as the second
 branch on the line by using the "count" attribute.  Further elsifs are the
 third and fourth "count" value, and so on.  Every branch in the chain is
 anchored to the line of the opening if, so the comments for the whole chain
-go above that line.  Here $thing is always one, leaving five uncoverable
-branch outcomes:
+go above that line.
 
 The "all" type marks both elements of a branch with one comment.  It is the
 natural form for a branch that can never run at all, such as an elsif in a
-chain that is never reached, so the example below can also be written:
+chain that is never reached.  Here $thing is always one, leaving five
+uncoverable branch outcomes:
 
   # uncoverable branch false count:1
   # uncoverable branch all count:2
@@ -2020,30 +2027,45 @@ Marking each element separately:
 
 =head3 Conditions
 
-Because of the way in which Perl short-circuits boolean operations, there are
-three ways in which such conditionals can be uncoverable.  In the case of C<
-$x && $y> for example, the left operator may never be true, the right operator
-may never be true, and the whole operation may never be false.  These
-conditions may be modelled thus:
+Because Perl short-circuits boolean operations, a condition has several
+distinct outcomes - one for each row of its truth table in the report.  A row
+is identified by the values of its operands: 0, 1 or X for an operand never
+evaluated.  The "when" attribute marks the row whose operand values match:
 
   # uncoverable branch true
-  # uncoverable condition left
-  # uncoverable condition false
+  # uncoverable condition when:0X
+  # uncoverable condition when:11
   if ($x && !$y) {
     $x++;  # uncoverable statement
   }
 
-  # uncoverable branch true
-  # uncoverable condition right
-  # uncoverable condition false
-  if (!$x && $y) {
-  }
+Here $x is always true, so the row where the left operand is false and the
+right never evaluated (0X) cannot occur, and !$y is always false, so the row
+where both operands are true (11) cannot occur either.  Several rows can be
+marked in one comment with a comma separated list:
 
-C<Or> conditionals are handled in a similar fashion (TODO - provide some
-examples) but C<xor> conditionals are not properly handled yet.
+  # uncoverable condition when:0X,11
+
+The rows for each kind of op, in report order, are:
+
+  $a && $b   0X 10 11
+  $a || $b   1X 01 00
+  $a xor $b  11 10 01 00
+
+An op whose right operand is a constant collapses to two rows holding the
+value of the left operand alone, 0 and 1 for C<&&>, or 1 and 0 for C<||> and
+C<//>.  A pattern which matches no row of the op warns when the report is
+generated.
 
 The "all" type marks every outcome of the condition with one comment, which
 suits a condition that can never be evaluated at all.
+
+The type words "left", "right" and "false" are deprecated.  They were named
+for the C<||> layout, where "left" is the row satisfied by the left operand,
+"right" the row satisfied by the right, and "false" the false outcome.  But
+they select rows by position - the first, second and third - which misleads
+elsewhere: on C<&&> "false" selects the 11 row, where the expression is
+true.  Using one warns, naming the "when" replacement for the op.
 
 As for branches, the "count" value may be used for either conditions in elsif
 conditionals, or for complex conditions.  Unlike branches, a condition in an
@@ -2072,14 +2094,14 @@ in the order the report lists them), leaving the rest counted as normal:
   # uncoverable mcdc pair:2
   $x = $a || $b || $c;
 
-An invalid position warns and the marker is ignored: C<pair:0> when the
+An invalid position warns and the comment is ignored: C<pair:0> when the
 comment is parsed, and a position greater than the number of atomic conditions
 in the decision when the report is generated.
 
-Condition markers also feed MC/DC: an atomic condition is excused
+Condition comments also feed MC/DC: an atomic condition is excused
 automatically when every route to demonstrating its independence needs a truth
 table row built from an outcome marked C<uncoverable condition>.  Use those
-markers when a particular outcome cannot occur, for example an error state
+comments when a particular outcome cannot occur, for example an error state
 that cannot be simulated.  If a pair could still be formed from rows not
 marked uncoverable, the atomic condition is reported missing - a test gap, not
 an excuse.  For a decision that can never execute at all, such as code inside

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1944,6 +1944,12 @@ Example:
 
   # uncoverable branch true count:1..3 class:ignore_covered_err note:error chk
 
+An uncoverable comment on a line of its own applies to the next line of code,
+skipping any blank lines and other comments in between.  A comment which never
+finds a line of code, or which matches nothing on the line it applies to - for
+example the wrong criterion, or a count past the constructs on the line -
+triggers a warning when the report is generated.
+
 =head3 Statements
 
 The "uncoverable" comment should appear on either the same line as the
@@ -1982,15 +1988,24 @@ Both branches may be uncoverable:
 
 If there is an elsif in the branch then it can be addressed as the second
 branch on the line by using the "count" attribute.  Further elsifs are the
-third and fourth "count" value, and so on:
+third and fourth "count" value, and so on.  Every branch in the chain is
+anchored to the line of the opening if, so the comments for the whole chain
+go above that line.  Here $thing is always one, leaving five uncoverable
+branch outcomes:
 
+  # uncoverable branch false count:1
+  # uncoverable branch true count:2
   # uncoverable branch false count:2
+  # uncoverable branch true count:3
+  # uncoverable branch false count:3
   if ($thing == 1) {
     handle_thing_being_one();
   } elsif ($thing == 2) {
-    handle_thing_being_tow();
+    handle_thing_being_two();    # uncoverable statement
+  } elsif ($thing == 3) {
+    handle_thing_being_three();  # uncoverable statement
   } else {
-    die "thing can only be one or two, not $thing"; # uncoverable statement
+    die "thing is $thing";       # uncoverable statement
   }
 
 =head3 Conditions
@@ -2018,7 +2033,14 @@ C<Or> conditionals are handled in a similar fashion (TODO - provide some
 examples) but C<xor> conditionals are not properly handled yet.
 
 As for branches, the "count" value may be used for either conditions in elsif
-conditionals, or for complex conditions.
+conditionals, or for complex conditions.  Unlike branches, a condition in an
+elsif is addressed at the elsif's own line.  When one line holds several
+condition ops, count:n selects them outermost first, so for C<$a && $b && $c>
+count:1 is the outer op and count:2 the inner C<$a && $b>.  To see the
+grouping perl uses, run the expression through B::Deparse:
+
+  perl -MO=Deparse,-p -e '$a && $b && $c'
+  (($a and $b) and $c);
 
 =head3 MC/DC
 

--- a/lib/Devel/Cover/Condition_table.pm
+++ b/lib/Devel/Cover/Condition_table.pm
@@ -67,6 +67,16 @@ my $Max_width = 16;
 
 sub max_width ($class) { $Max_width }
 
+sub input_patterns ($class, $type) {
+  state $patterns = {
+    map {
+      my $t = $_;
+      ($t => [map join("", $_->[0]->@*), $Primitive{$t}->@*])
+    } keys %Primitive
+  };
+  $patterns->{$type}
+}
+
 sub _hits ($condition) {
   map { defined && $_ > 0 ? 1 : 0 } $condition->[0]->@*
 }
@@ -403,6 +413,12 @@ the expression and labels but no rows.
 
 Class method.  The per-decision analysis limit of 16 atomic conditions, matching
 C<DC_MAX_DECISION_WIDTH> in the XS recorder.
+
+=head2 input_patterns ($type)
+
+Class method.  Returns an arrayref of the input patterns for a primitive
+condition type, one string per truth-table row in stored hit order, e.g.
+C<["0X", "10", "11"]> for C<and_3>.  Returns undef for an unknown type.
 
 =head2 apply_observed_vectors ($rows, $obs, $expr)
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -771,6 +771,14 @@ sub add_time ($self, $cc, $sc, $fc, $) {
   }
 }
 
+# An "all" comment parses to an undefined element index
+sub _flag_uncoverable ($entry, $uncoverable, $counts) {
+  for my $u (($uncoverable // [])->@*) {
+    my @indexes = defined $u->[0] ? $u->[0] : (0 .. $counts->$#*);
+    $entry->[2][$_] ||= $u->[1] for @indexes;
+  }
+}
+
 sub add_branch ($self, $cc, $sc, $fc, $uc) {
   my %line;
   for my $i (0 .. $#$fc) {
@@ -788,7 +796,7 @@ sub add_branch ($self, $cc, $sc, $fc, $uc) {
     } else {
       $cc->{$l}[$n] = [$fc->[$i], $sc->[$i][1]];
     }
-    $cc->{$l}[$n][2][$_->[0]] ||= $_->[1] for $uc->{$l}[$n]->@*;
+    _flag_uncoverable($cc->{$l}[$n], $uc->{$l}[$n], $fc->[$i]);
   }
 }
 
@@ -851,7 +859,7 @@ sub add_condition ($self, $cc, $sc, $fc, $uc, $di = undef) {
     } else {
       $cc->{$l}[$n] = [$fc->[$i], $sc->[$i][1]];
     }
-    $cc->{$l}[$n][2][$_->[0]] ||= $_->[1] for $uc->{$l}[$n]->@*;
+    _flag_uncoverable($cc->{$l}[$n], $uc->{$l}[$n], $fc->[$i]);
 
     if (my $obs = $di && $di->[$i]) {
       my $merged = $cc->{$l}[$n][3] //= {};
@@ -953,18 +961,19 @@ sub clean_uncoverable ($self) {
 
 sub _uncoverable_details ($criterion, $info, $file, $line) {
   my %types = (
-    branch    => { true => 0, false => 1 },
-    condition => { left => 0, right => 1, false => 2 },
+    branch    => { true => 0, false => 1, all   => undef },
+    condition => { left => 0, right => 1, false => 2, all => undef },
+    mcdc      => { all  => undef },
   );
-  my ($count, $class, $note, $type) = (1, "default", "");
+  my ($count, $class, $note, $type, $has_type) = (1, "default", "");
 
-  if ($criterion eq "branch" || $criterion eq "condition") {
+  if (my $types = $types{$criterion}) {
     if ($info =~ /^\s*(\w+)(?:\s|$)/) {
-      my $t = $1;
-      $type = $types{$criterion}{$t};
-      unless (defined $type) {
-        warn "Unknown type $t found parsing "
-          . "uncoverable $criterion at $file:$line\n";
+      $has_type = 1;
+      if (exists $types->{$1}) { $type = $types->{$1} }
+      else {
+        dcwarn "Unknown type $1 found parsing "
+          . "uncoverable $criterion at $file:$line";
         $type = 999;  # partly magic number
       }
     }
@@ -978,12 +987,18 @@ sub _uncoverable_details ($criterion, $info, $file, $line) {
   if ($info =~ /note:(.+)/)   { $note  = $1 }
   # mcdc atomic condition N (1-based)
   if ($info =~ /pair:(\d+)/) {
+    $has_type = 1;
     if ($1) { $type = $1 - 1 }
     else {
       dcwarn "Invalid pair:$1 (pairs are numbered from 1) parsing "
         . "uncoverable $criterion at $file:$line";
       return;
     }
+  }
+
+  if ($types{$criterion} && !$has_type) {
+    dcwarn "Missing type parsing uncoverable $criterion at $file:$line";
+    return;
   }
 
   (\@counts, $type, $class, $note)
@@ -1029,8 +1044,8 @@ sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
   }
   close $fh or warn "Devel::Cover: Can't close $file: $!\n";
 
-  warn scalar @waiting,
-    " unmatched uncoverable comments not found at end of $file\n"
+  dcwarn scalar @waiting
+    . " unmatched uncoverable comments not found at end of $file"
     if @waiting;
 
   # TODO - read in and merge $self->uncoverable;

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -771,6 +771,20 @@ sub add_time ($self, $cc, $sc, $fc, $) {
   }
 }
 
+# Condition words are deprecated and stay verbatim until the op is known;
+# branch words become element indexes at parse time
+my %Uncoverable_types = (
+  statement  => undef,
+  subroutine => undef,
+  pod        => undef,
+  branch     => { true => 0, false => 1, all => undef },
+  condition  =>
+    { left => "left", right => "right", false => "false", all => undef },
+  mcdc => { all => undef },
+);
+
+my %Condition_word_row = (left => 0, right => 1, false => 2);
+
 # An "all" comment parses to an undefined element index
 sub _flag_uncoverable ($entry, $uncoverable, $counts) {
   for my $u (($uncoverable // [])->@*) {
@@ -838,11 +852,11 @@ sub add_subroutine ($self, $cc, $sc, $fc, $uc) {
 #       observed_vectors() below.
 sub observed_vectors ($entry) { $entry->[3] }
 
-# A "when:<inputs>" mark resolves to the row whose operand values match;
-# marks matching no row are dropped here and warned about at report time
+# A "when:<inputs>" mark resolves to the row whose operand values match, a
+# deprecated word to its fixed row; marks naming no row are dropped here
+# and warned about at report time
 sub _resolve_condition_uncoverable ($marks, $type) {
-  return $marks
-    unless $marks && any { defined $_->[0] && $_->[0] =~ /^when:/ } @$marks;
+  return $marks unless $marks && any { defined $_->[0] } @$marks;
   require Devel::Cover::Condition_table;
   my $patterns = Devel::Cover::Condition_table->input_patterns($type) // [];
   my %row;
@@ -850,9 +864,13 @@ sub _resolve_condition_uncoverable ($marks, $type) {
   [
     map {
       my ($t, @rest) = @$_;
-      defined $t && $t =~ /^when:(.+)$/s
-        ? (defined $row{$1} ? [$row{$1}, @rest] : ())
-        : $_
+      if    (!defined $t) { $_ }
+      elsif ($t =~ /^when:(.+)$/s) {
+        defined $row{$1} ? [$row{$1}, @rest] : ()
+      } else {
+        my $i = $Condition_word_row{$t};
+        defined $i && $i < @$patterns ? [$i, @rest] : ()
+      }
     } @$marks
   ]
 }
@@ -981,15 +999,6 @@ sub delete_uncoverable ($self, $deletes) {
 
 sub clean_uncoverable ($self) {
 }
-
-my %Uncoverable_types = (
-  statement  => undef,
-  subroutine => undef,
-  pod        => undef,
-  branch     => { true => 0, false => 1, all   => undef },
-  condition  => { left => 0, right => 1, false => 2, all => undef },
-  mcdc       => { all  => undef },
-);
 
 # mcdc atomic condition N (1-based)
 sub _uncoverable_pair ($criterion, $pair, $has_type, $context) {
@@ -1381,36 +1390,42 @@ sub _cover_file (
 }
 
 # A mark that names no row, e.g. "condition false" on // or an unmatched when:
-sub _uncoverable_range_warnings ($criterion, $slot, $entry, $file, $line, $n) {
+sub _uncoverable_mark_warnings ($criterion, $slot, $entry, $file, $line, $n) {
   return unless $criterion eq "branch" || $criterion eq "condition";
   my $types = $Uncoverable_types{$criterion};
   my %words
     = map { defined $types->{$_} ? ($types->{$_} => $_) : () } keys %$types;
   my $columns = $entry->[0]->@*;
-  my $suffix  = $n ? " count:" . ($n + 1) : "";
+  my $at      = "at $file:$line" . ($n ? " count:" . ($n + 1) : "");
   my $patterns;
+  my $rows = sub {
+    $patterns //= do {
+      require Devel::Cover::Condition_table;
+      Devel::Cover::Condition_table->input_patterns($entry->[1]{type}) // []
+    }
+  };
   my @warnings;
 
   for my $mark (@$slot) {
     my $type = $mark->[0];
     next unless defined $type;
-    my $desc;
+    my $text;
     if ($type =~ /^when:(.+)$/s) {
       my $pattern = $1;
-      $patterns //= do {
-        require Devel::Cover::Condition_table;
-        Devel::Cover::Condition_table->input_patterns($entry->[1]{type}) // []
-      };
-      next if any { $_ eq $pattern } @$patterns;
-      $desc = $type;
+      next if any { $_ eq $pattern } $rows->()->@*;
+      $text = "Uncoverable $criterion $type does not apply $at";
+    } elsif (defined(my $row = $Condition_word_row{$type})) {
+      my $replacement = $rows->()->[$row];
+      $text
+        = defined $replacement
+        ? "Uncoverable condition $type is deprecated"
+        . " - use when:$replacement $at"
+        : "Uncoverable condition $type does not apply $at";
     } else {
       next if $type < $columns;
-      $desc = $words{$type};
+      $text = "Uncoverable $criterion $words{$type} does not apply $at";
     }
-    push @warnings, [
-        $line, $criterion,
-        "Uncoverable $criterion $desc does not apply at $file:$line$suffix",
-      ];
+    push @warnings, [$line, $criterion, $text];
   }
   @warnings
 }
@@ -1435,7 +1450,7 @@ sub _warn_unmatched_uncoverable ($self, $cover, $uncoverable, $digests) {
           next unless $slot && @$slot;
           if ($got && defined $got->[$n]) {
             push @warnings,
-              _uncoverable_range_warnings(
+              _uncoverable_mark_warnings(
                 $criterion, $slot, $got->[$n], $file, $line, $n,
               );
             next;

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -959,22 +959,23 @@ sub delete_uncoverable ($self, $deletes) {
 sub clean_uncoverable ($self) {
 }
 
+my %Uncoverable_types = (
+  statement  => undef,
+  subroutine => undef,
+  pod        => undef,
+  branch     => { true => 0, false => 1, all   => undef },
+  condition  => { left => 0, right => 1, false => 2, all => undef },
+  mcdc       => { all  => undef },
+);
+
 sub _uncoverable_details ($criterion, $info, $file, $line) {
-  my %types = (
-    statement  => undef,
-    subroutine => undef,
-    pod        => undef,
-    branch     => { true => 0, false => 1, all   => undef },
-    condition  => { left => 0, right => 1, false => 2, all => undef },
-    mcdc       => { all  => undef },
-  );
   my $context = "parsing uncoverable $criterion at $file:$line";
 
-  unless (exists $types{$criterion}) {
+  unless (exists $Uncoverable_types{$criterion}) {
     dcwarn "Unsupported criterion $context";
     return;
   }
-  my $types = $types{$criterion};
+  my $types = $Uncoverable_types{$criterion};
 
   my ($count, $class, $note, $type, $has_type) = (1, "default", "");
 
@@ -1331,6 +1332,22 @@ sub _cover_file (
   }
 }
 
+# A type index past the entry's columns, e.g. "condition false" on //
+sub _uncoverable_range_warnings ($criterion, $slot, $entry, $file, $line, $n) {
+  return unless $criterion eq "branch" || $criterion eq "condition";
+  my $types = $Uncoverable_types{$criterion};
+  my %words
+    = map { defined $types->{$_} ? ($types->{$_} => $_) : () } keys %$types;
+  my $columns = $entry->[0]->@*;
+  my $suffix  = $n ? " count:" . ($n + 1) : "";
+  map [$line,
+    $criterion,
+    "Uncoverable $criterion $words{$_->[0]} does not apply"
+      . " at $file:$line$suffix",
+    ],
+    grep { defined $_->[0] && $_->[0] >= $columns } @$slot
+}
+
 sub _warn_unmatched_uncoverable ($self, $cover, $uncoverable, $digests) {
   for my $digest (
     sort { $digests->{$a} cmp $digests->{$b} } keys %$uncoverable
@@ -1338,7 +1355,7 @@ sub _warn_unmatched_uncoverable ($self, $cover, $uncoverable, $digests) {
     my $file = $digests->{$digest} or next;
     my $cf   = $cover->{$file}     or next;
     my $u    = $uncoverable->{$digest};
-    my @unmatched;
+    my @warnings;
     for my $criterion (sort keys %$u) {
       next unless exists $self->{collected}{$criterion};
       my $cc = $cf->{$criterion} // {};
@@ -1347,16 +1364,30 @@ sub _warn_unmatched_uncoverable ($self, $cover, $uncoverable, $digests) {
         my $slots = $cl->{$line};
         my $got   = $cc->{$line};
         for my $n (0 .. $#$slots) {
-          next unless $slots->[$n] && $slots->[$n]->@*;
-          next if $got && defined $got->[$n];
-          push @unmatched, [$line, $criterion, $n];
+          my $slot = $slots->[$n];
+          next unless $slot && @$slot;
+          if ($got && defined $got->[$n]) {
+            push @warnings,
+              _uncoverable_range_warnings(
+                $criterion, $slot, $got->[$n], $file, $line, $n,
+              );
+            next;
+          }
+          push @warnings, [
+              $line,
+              $criterion,
+              "Unmatched uncoverable $criterion comment at $file:$line"
+              . ($n ? " count:" . ($n + 1) : ""),
+            ];
         }
       }
     }
-    for my $w (sort { $a->[0] <=> $b->[0] || $a->[1] cmp $b->[1] } @unmatched) {
-      my ($line, $criterion, $n) = @$w;
-      dcwarn "Unmatched uncoverable $criterion comment at $file:$line"
-        . ($n ? " count:" . ($n + 1) : "");
+    for my $w (
+      sort {
+        $a->[0] <=> $b->[0] || $a->[1] cmp $b->[1] || $a->[2] cmp $b->[2]
+      } @warnings
+    ) {
+      dcwarn $w->[2];
     }
   }
 }
@@ -1369,7 +1400,6 @@ sub cover ($self) {
   my $cover       = $self->{cover} = {};
   my $uncoverable = {};
   my $st          = $self->{_structure} // do {
-    require Devel::Cover::DB::Structure;  ## no perlimports
     Devel::Cover::DB::Structure->new(base => $self->{base})->read_all;
   };
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -838,6 +838,25 @@ sub add_subroutine ($self, $cc, $sc, $fc, $uc) {
 #       observed_vectors() below.
 sub observed_vectors ($entry) { $entry->[3] }
 
+# A "when:<inputs>" mark resolves to the row whose operand values match;
+# marks matching no row are dropped here and warned about at report time
+sub _resolve_condition_uncoverable ($marks, $type) {
+  return $marks
+    unless $marks && any { defined $_->[0] && $_->[0] =~ /^when:/ } @$marks;
+  require Devel::Cover::Condition_table;
+  my $patterns = Devel::Cover::Condition_table->input_patterns($type) // [];
+  my %row;
+  @row{@$patterns} = 0 .. $#$patterns;
+  [
+    map {
+      my ($t, @rest) = @$_;
+      defined $t && $t =~ /^when:(.+)$/s
+        ? (defined $row{$1} ? [$row{$1}, @rest] : ())
+        : $_
+    } @$marks
+  ]
+}
+
 # Same merge as add_branch, plus an optional per-file decision-inputs arrayref
 # (parallel to $fc, indexed by flat per-file ordinal).  When a condition's flat
 # ordinal carries observed-vector data, it is merged into the condition entry's
@@ -859,7 +878,11 @@ sub add_condition ($self, $cc, $sc, $fc, $uc, $di = undef) {
     } else {
       $cc->{$l}[$n] = [$fc->[$i], $sc->[$i][1]];
     }
-    _flag_uncoverable($cc->{$l}[$n], $uc->{$l}[$n], $fc->[$i]);
+    _flag_uncoverable(
+      $cc->{$l}[$n],
+      _resolve_condition_uncoverable($uc->{$l}[$n], $cc->{$l}[$n][1]{type}),
+      $fc->[$i],
+    );
 
     if (my $obs = $di && $di->[$i]) {
       my $merged = $cc->{$l}[$n][3] //= {};
@@ -968,6 +991,36 @@ my %Uncoverable_types = (
   mcdc       => { all  => undef },
 );
 
+# mcdc atomic condition N (1-based)
+sub _uncoverable_pair ($criterion, $pair, $has_type, $context) {
+  if ($criterion ne "mcdc") {
+    dcwarn "Attribute pair applies only to mcdc $context";
+    return;
+  }
+  if ($has_type) {
+    dcwarn "Attribute pair conflicts with all $context";
+    return;
+  }
+  unless ($pair) {
+    dcwarn "Invalid pair:$pair (pairs are numbered from 1) $context";
+    return;
+  }
+  [$pair - 1]
+}
+
+# truth-table rows by operand values, as shown in the report
+sub _uncoverable_when ($criterion, $patterns, $has_type, $context) {
+  if ($criterion ne "condition") {
+    dcwarn "Attribute when applies only to condition $context";
+    return;
+  }
+  if ($has_type) {
+    dcwarn "Attribute when conflicts with a type word $context";
+    return;
+  }
+  [map "when:" . uc, split /,/, $patterns]
+}
+
 sub _uncoverable_details ($criterion, $info, $file, $line) {
   my $context = "parsing uncoverable $criterion at $file:$line";
 
@@ -977,7 +1030,8 @@ sub _uncoverable_details ($criterion, $info, $file, $line) {
   }
   my $types = $Uncoverable_types{$criterion};
 
-  my ($count, $class, $note, $type, $has_type) = (1, "default", "");
+  my ($count, $class, $note) = (1, "default", "");
+  my (@types, $has_type);
 
   if ($info =~ s/(?:^|\s)note:(.+)$//s) { $note = $1 }
   my @words = split " ", $info;
@@ -986,7 +1040,7 @@ sub _uncoverable_details ($criterion, $info, $file, $line) {
     my $word = shift @words;
     if (exists $types->{$word}) {
       $has_type = 1;
-      $type     = $types->{$word};
+      @types    = $types->{$word};
     } else {
       dcwarn "Unknown type $word $context";
       return;
@@ -999,22 +1053,17 @@ sub _uncoverable_details ($criterion, $info, $file, $line) {
     if ($word =~ /^count:($c(?:,$c)*)$/) { $count = $1; next }
     if ($word =~ /^class:(\w+)$/)        { $class = $1; next }
     if ($word =~ /^pair:(\d+)$/) {
-      # mcdc atomic condition N (1-based)
-      my $pair = $1;
-      if ($criterion ne "mcdc") {
-        dcwarn "Attribute pair applies only to mcdc $context";
-        return;
-      }
-      if ($has_type) {
-        dcwarn "Attribute pair conflicts with all $context";
-        return;
-      }
-      unless ($pair) {
-        dcwarn "Invalid pair:$pair (pairs are numbered from 1) $context";
-        return;
-      }
+      my $pair = _uncoverable_pair($criterion, $1, $has_type, $context)
+        or return;
       $has_type = 1;
-      $type     = $pair - 1;
+      @types    = @$pair;
+      next;
+    }
+    if ($word =~ /^when:([01xX]+(?:,[01xX]+)*)$/) {
+      my $when = _uncoverable_when($criterion, $1, $has_type, $context)
+        or return;
+      $has_type = 1;
+      @types    = @$when;
       next;
     }
     dcwarn "Invalid attribute $word $context";
@@ -1025,9 +1074,10 @@ sub _uncoverable_details ($criterion, $info, $file, $line) {
     dcwarn "Missing type $context";
     return;
   }
+  @types = undef unless @types;
 
   my @counts = map { m/^(\d+)\.\.(\d+)$/ ? ($1 .. $2) : $_ } split m/,/, $count;
-  (\@counts, $type, $class, $note)
+  (\@counts, \@types, $class, $note)
 }
 
 sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
@@ -1047,13 +1097,11 @@ sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
     next unless $l =~ /$uc/ || @waiting;
     if ($2) {
       my ($code, $criterion, $info) = ($1, $2, $3);
-      my ($counts, $type, $class, $note)
+      my ($counts, $types, $class, $note)
         = _uncoverable_details($criterion, $info, $file, $.);
 
       for my $c (($counts // [])->@*) {
-        # no warnings "uninitialized";
-        # warn "pushing $criterion, $c - 1, $type, $class, $note";
-        push @waiting, [$criterion, $c - 1, $type, $class, $note];
+        push @waiting, [$criterion, $c - 1, $_, $class, $note] for @$types;
       }
 
       next unless $code =~ /\S/;
@@ -1332,7 +1380,7 @@ sub _cover_file (
   }
 }
 
-# A type index past the entry's columns, e.g. "condition false" on //
+# A mark that names no row, e.g. "condition false" on // or an unmatched when:
 sub _uncoverable_range_warnings ($criterion, $slot, $entry, $file, $line, $n) {
   return unless $criterion eq "branch" || $criterion eq "condition";
   my $types = $Uncoverable_types{$criterion};
@@ -1340,12 +1388,31 @@ sub _uncoverable_range_warnings ($criterion, $slot, $entry, $file, $line, $n) {
     = map { defined $types->{$_} ? ($types->{$_} => $_) : () } keys %$types;
   my $columns = $entry->[0]->@*;
   my $suffix  = $n ? " count:" . ($n + 1) : "";
-  map [$line,
-    $criterion,
-    "Uncoverable $criterion $words{$_->[0]} does not apply"
-      . " at $file:$line$suffix",
-    ],
-    grep { defined $_->[0] && $_->[0] >= $columns } @$slot
+  my $patterns;
+  my @warnings;
+
+  for my $mark (@$slot) {
+    my $type = $mark->[0];
+    next unless defined $type;
+    my $desc;
+    if ($type =~ /^when:(.+)$/s) {
+      my $pattern = $1;
+      $patterns //= do {
+        require Devel::Cover::Condition_table;
+        Devel::Cover::Condition_table->input_patterns($entry->[1]{type}) // []
+      };
+      next if any { $_ eq $pattern } @$patterns;
+      $desc = $type;
+    } else {
+      next if $type < $columns;
+      $desc = $words{$type};
+    }
+    push @warnings, [
+        $line, $criterion,
+        "Uncoverable $criterion $desc does not apply at $file:$line$suffix",
+      ];
+  }
+  @warnings
 }
 
 sub _warn_unmatched_uncoverable ($self, $cover, $uncoverable, $digests) {
@@ -1400,6 +1467,7 @@ sub cover ($self) {
   my $cover       = $self->{cover} = {};
   my $uncoverable = {};
   my $st          = $self->{_structure} // do {
+    require Devel::Cover::DB::Structure;  ## no perlimports
     Devel::Cover::DB::Structure->new(base => $self->{base})->read_all;
   };
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -961,46 +961,71 @@ sub clean_uncoverable ($self) {
 
 sub _uncoverable_details ($criterion, $info, $file, $line) {
   my %types = (
-    branch    => { true => 0, false => 1, all   => undef },
-    condition => { left => 0, right => 1, false => 2, all => undef },
-    mcdc      => { all  => undef },
+    statement  => undef,
+    subroutine => undef,
+    pod        => undef,
+    branch     => { true => 0, false => 1, all   => undef },
+    condition  => { left => 0, right => 1, false => 2, all => undef },
+    mcdc       => { all  => undef },
   );
+  my $context = "parsing uncoverable $criterion at $file:$line";
+
+  unless (exists $types{$criterion}) {
+    dcwarn "Unsupported criterion $context";
+    return;
+  }
+  my $types = $types{$criterion};
+
   my ($count, $class, $note, $type, $has_type) = (1, "default", "");
 
-  if (my $types = $types{$criterion}) {
-    if ($info =~ /^\s*(\w+)(?:\s|$)/) {
+  if ($info =~ s/(?:^|\s)note:(.+)$//s) { $note = $1 }
+  my @words = split " ", $info;
+
+  if ($types && @words && $words[0] =~ /^\w+$/) {
+    my $word = shift @words;
+    if (exists $types->{$word}) {
       $has_type = 1;
-      if (exists $types->{$1}) { $type = $types->{$1} }
-      else {
-        dcwarn "Unknown type $1 found parsing "
-          . "uncoverable $criterion at $file:$line";
-        $type = 999;  # partly magic number
-      }
+      $type     = $types->{$word};
+    } else {
+      dcwarn "Unknown type $word $context";
+      return;
     }
   }
 
   # e.g.: count:1 | count:2,5 | count:1,4..7
   my $c = qr/\d+(?:\.\.\d+)?/;
-  if ($info =~ /count:($c(?:,$c)*)/) { $count = $1 }
-  my @counts = map { m/^(\d+)\.\.(\d+)$/ ? ($1 .. $2) : $_ } split m/,/, $count;
-  if ($info =~ /class:(\w+)/) { $class = $1 }
-  if ($info =~ /note:(.+)/)   { $note  = $1 }
-  # mcdc atomic condition N (1-based)
-  if ($info =~ /pair:(\d+)/) {
-    $has_type = 1;
-    if ($1) { $type = $1 - 1 }
-    else {
-      dcwarn "Invalid pair:$1 (pairs are numbered from 1) parsing "
-        . "uncoverable $criterion at $file:$line";
-      return;
+  for my $word (@words) {
+    if ($word =~ /^count:($c(?:,$c)*)$/) { $count = $1; next }
+    if ($word =~ /^class:(\w+)$/)        { $class = $1; next }
+    if ($word =~ /^pair:(\d+)$/) {
+      # mcdc atomic condition N (1-based)
+      my $pair = $1;
+      if ($criterion ne "mcdc") {
+        dcwarn "Attribute pair applies only to mcdc $context";
+        return;
+      }
+      if ($has_type) {
+        dcwarn "Attribute pair conflicts with all $context";
+        return;
+      }
+      unless ($pair) {
+        dcwarn "Invalid pair:$pair (pairs are numbered from 1) $context";
+        return;
+      }
+      $has_type = 1;
+      $type     = $pair - 1;
+      next;
     }
-  }
-
-  if ($types{$criterion} && !$has_type) {
-    dcwarn "Missing type parsing uncoverable $criterion at $file:$line";
+    dcwarn "Invalid attribute $word $context";
     return;
   }
 
+  if ($types && !$has_type) {
+    dcwarn "Missing type $context";
+    return;
+  }
+
+  my @counts = map { m/^(\d+)\.\.(\d+)$/ ? ($1 .. $2) : $_ } split m/,/, $count;
   (\@counts, $type, $class, $note)
 }
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -991,7 +991,8 @@ sub _uncoverable_details ($criterion, $info, $file, $line) {
 
 sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
   my $cr = join "|", $self->{all_criteria}->@*;
-  my $uc = qr/(.*)# uncoverable ($cr)(.*)/;  # regex for uncoverable comments
+  # "uncoverable" must be the first text in the comment
+  my $uc = qr/^([^#]*)# uncoverable ($cr)(.*)/;
 
   # Look for uncoverable comments
   open my $fh, "<", $file or do {

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -1290,6 +1290,36 @@ sub _cover_file (
   }
 }
 
+sub _warn_unmatched_uncoverable ($self, $cover, $uncoverable, $digests) {
+  for my $digest (
+    sort { $digests->{$a} cmp $digests->{$b} } keys %$uncoverable
+  ) {
+    my $file = $digests->{$digest} or next;
+    my $cf   = $cover->{$file}     or next;
+    my $u    = $uncoverable->{$digest};
+    my @unmatched;
+    for my $criterion (sort keys %$u) {
+      next unless exists $self->{collected}{$criterion};
+      my $cc = $cf->{$criterion} // {};
+      my $cl = $u->{$criterion};
+      for my $line (keys %$cl) {
+        my $slots = $cl->{$line};
+        my $got   = $cc->{$line};
+        for my $n (0 .. $#$slots) {
+          next unless $slots->[$n] && $slots->[$n]->@*;
+          next if $got && defined $got->[$n];
+          push @unmatched, [$line, $criterion, $n];
+        }
+      }
+    }
+    for my $w (sort { $a->[0] <=> $b->[0] || $a->[1] cmp $b->[1] } @unmatched) {
+      my ($line, $criterion, $n) = @$w;
+      dcwarn "Unmatched uncoverable $criterion comment at $file:$line"
+        . ($n ? " count:" . ($n + 1) : "");
+    }
+  }
+}
+
 sub cover ($self) {
   return $self->{cover} if $self->{cover_valid};
 
@@ -1331,6 +1361,7 @@ sub cover ($self) {
   }
 
   $self->_derive_mcdc($cover, $uncoverable) if exists $self->{collected}{mcdc};
+  $self->_warn_unmatched_uncoverable($cover, $uncoverable, \%digests);
 
   $self->objectify_cover;
   if ($self->{files}->@*) {

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -1017,7 +1017,9 @@ sub uncoverable_comments ($self, $uncoverable, $file, $digest) {
       next unless $code =~ /\S/;
     }
 
-    # found what we are waiting for
+    # uncoverable comments wait for the next line of code
+    next if $l =~ /^\s*(?:#|$)/;
+
     while (my $w = shift @waiting) {
       my ($criterion, $count, $type, $class, $note) = @$w;
       push $uncoverable->{$digest}{$criterion}{$.}[$count]->@*,

--- a/t/internal/condition_table.t
+++ b/t/internal/condition_table.t
@@ -1289,6 +1289,16 @@ sub test_proven_compound_observed () {
   ok $t->proven, "compound decision is proven once observed vectors apply";
 }
 
+sub test_input_patterns () {
+  my $ip = sub ($type) { Devel::Cover::Condition_table->input_patterns($type) };
+  is_deeply $ip->("and_2"), [qw( 0 1 )],         "and_2 input patterns";
+  is_deeply $ip->("or_2"),  [qw( 1 0 )],         "or_2 input patterns";
+  is_deeply $ip->("and_3"), [qw( 0X 10 11 )],    "and_3 input patterns";
+  is_deeply $ip->("or_3"),  [qw( 1X 01 00 )],    "or_3 input patterns";
+  is_deeply $ip->("xor_4"), [qw( 11 10 01 00 )], "xor_4 input patterns";
+  is $ip->("unknown"), undef, "unknown type gives undef";
+}
+
 sub main () {
   test_proven_single_logop;
   test_proven_compound_synthesised;
@@ -1333,6 +1343,7 @@ sub main () {
   test_observed_vectors_mixed_chain;
   test_observed_vectors_indexed_at_root;
   test_negated_subexpr;
+  test_input_patterns;
   done_testing;
 }
 

--- a/t/internal/mcdc_too_wide.t
+++ b/t/internal/mcdc_too_wide.t
@@ -105,7 +105,7 @@ sub test_warning_respects_silent () {
 }
 
 sub test_uncoverable_marker_ignored_with_warning () {
-  my $source = "$Narrow$Decl\n# uncoverable mcdc\n$Wide\n";
+  my $source = "$Narrow$Decl\n# uncoverable mcdc all\n$Wide\n";
   my ($db, $path) = run_wide("too_wide_unc", $source);
   my ($err) = capture_stderr { $db->cover };
 

--- a/t/internal/uncoverable_all.t
+++ b/t/internal/uncoverable_all.t
@@ -1,0 +1,142 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# "# uncoverable branch all" marks every element of the branch, and the same
+# for condition and mcdc.  This is the natural comment for an elsif that can
+# never run, where naming each outcome describes something that never
+# happens (GH-481).
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is is_deeply like ok )];
+
+use Devel::Cover::Test::Internal
+  qw( parse_comments run_under_cover warnings_from write_script );
+
+sub covered_all ($label, $source, %opts) {
+  my $script = write_script("$label.pl", $source);
+  my ($db, $path) = run_under_cover($script, $label, %opts);
+  my $warnings = warnings_from { $db->cover };
+  ($db->cover, $warnings, $path)
+}
+
+sub test_parse_all_types () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable branch all
+# uncoverable condition all count:2
+# uncoverable mcdc all
+$n++;
+PERL
+  is @$warnings, 0, "parse: no warnings";
+  is_deeply $unc->{digest}{branch}{5}, [[[undef, "default", ""]]],
+    "parse: branch all gives an undefined type";
+  is_deeply $unc->{digest}{condition}{5}, [undef, [[undef, "default", ""]]],
+    "parse: condition all count:2 fills the second slot";
+  is_deeply $unc->{digest}{mcdc}{5}, [[[undef, "default", ""]]],
+    "parse: mcdc all matches the bare form";
+}
+
+sub test_bare_multi_element_comments_warn () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable branch
+# uncoverable condition
+# uncoverable mcdc
+$n++;
+PERL
+  is @$warnings, 3, "bare: one warning per comment";
+  like $warnings->[$_],
+    qr/Missing type parsing uncoverable \w+ at \Q$path\E:@{[ $_ + 2 ]}/,
+    "bare: warning gives criterion and file:line"
+    for 0 .. 2;
+  ok !exists $unc->{digest}, "bare: nothing is recorded";
+}
+
+sub test_mcdc_pair_needs_no_type () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable mcdc pair:1
+$n++;
+PERL
+  is @$warnings, 0, "pair: no warnings";
+  is_deeply $unc->{digest}{mcdc}{3}, [[[0, "default", ""]]],
+    "pair: still parses without a type word";
+}
+
+sub test_unknown_type_still_warns () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable branch frobnicate
+$n++;
+PERL
+  is @$warnings, 1, "unknown type: one warning";
+  like $warnings->[0], qr/Unknown type frobnicate/,
+    "unknown type: warning names the type";
+}
+
+sub test_branch_all_excuses_an_elsif () {
+  my ($cover, $warnings, $path)
+    = covered_all("branch_all", <<'PERL', criteria => ["statement", "branch"]);
+my $n = 0;
+my $r;
+# uncoverable branch false count:1
+# uncoverable branch all count:2
+if ($n == 0) {
+  $r = "a";
+} elsif ($n == 1) {
+  $r = "b";  # uncoverable statement
+}
+PERL
+  is @$warnings, 0, "branch all: no warnings";
+  my $branches = $cover->file($path)->criterion("branch")->location(5);
+  my $elsif    = $branches->[1];
+  ok $elsif->uncoverable(0), "branch all: true element marked";
+  ok $elsif->uncoverable(1), "branch all: false element marked";
+  is $elsif->error, 0, "branch all: no errors on the elsif";
+}
+
+sub test_condition_all_excuses_an_op () {
+  my ($cover, $warnings, $path) = covered_all(
+    "condition_all", <<'PERL', criteria => ["statement", "condition"]);
+my ($a, $b) = (1, 0);
+my $r;
+if ($a) {
+  $r = 1;
+  # uncoverable condition all
+} elsif ($a && $b) {
+  $r = 2;  # uncoverable statement
+}
+PERL
+  is @$warnings, 0, "condition all: no warnings";
+  my $conditions = $cover->file($path)->criterion("condition")->location(6);
+  my $op         = $conditions->[0];
+  ok $op->uncoverable($_), "condition all: element $_ marked"
+    for 0 .. $op->total - 1;
+  is $op->error, 0, "condition all: no errors on the op";
+}
+
+sub main () {
+  test_parse_all_types;
+  test_bare_multi_element_comments_warn;
+  test_mcdc_pair_needs_no_type;
+  test_unknown_type_still_warns;
+  test_branch_all_excuses_an_elsif;
+  test_condition_all_excuses_an_op;
+}
+
+main;
+done_testing;

--- a/t/internal/uncoverable_attach.t
+++ b/t/internal/uncoverable_attach.t
@@ -96,6 +96,26 @@ PERL
     "comment: comment attaches to the code line";
 }
 
+sub test_comment_after_code_is_recognised () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+$n++;  # uncoverable statement
+PERL
+  is @$warnings, 0, "after code: no warnings";
+  is_deeply $unc->{digest}{statement}{2}, [[[undef, "default", ""]]],
+    "after code: comment applies to its own line";
+}
+
+sub test_quoted_syntax_in_prose_is_ignored () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# see the docs for "# uncoverable branch true" comments
+if ($n == 0) { }
+PERL
+  is @$warnings, 0, "prose: no warnings";
+  ok !exists $unc->{digest}{branch}, "prose: quoted syntax creates nothing";
+}
+
 sub test_trailing_annotation_warns () {
   my ($unc, $warnings, $path) = parse_comments(<<'PERL');
 my $n = 1;
@@ -112,6 +132,8 @@ sub main () {
   test_attaches_to_next_line;
   test_skips_blank_line;
   test_skips_ordinary_comment;
+  test_comment_after_code_is_recognised;
+  test_quoted_syntax_in_prose_is_ignored;
   test_trailing_annotation_warns;
 }
 

--- a/t/internal/uncoverable_attach.t
+++ b/t/internal/uncoverable_attach.t
@@ -1,0 +1,119 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Uncoverable comments on their own line must attach to the next line of
+# code, skipping blank lines and ordinary comments (GH-481).  One with
+# nothing but blanks or comments after it must warn, not vanish.
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is is_deeply like ok )];
+
+use Devel::Cover::DB ();
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+
+{
+  no feature "signatures";
+
+  sub warnings_from (&) {
+    my ($code) = @_;
+    my $err = "";
+    open my $save_err, ">&", \*STDERR or die "Cannot dup STDERR: $!";
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">", \$err or die "Cannot redirect STDERR: $!";
+    $code->();
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">&", $save_err or die "Cannot restore STDERR: $!";
+    [split /(?<=\n)/, $err]
+  }
+}
+
+sub parse_comments ($source) {
+  my $path = File::Spec->catfile($Tmpdir, "source.pl");
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $source;
+  close $fh or die "Cannot close $path: $!";
+
+  my $unc      = {};
+  my $warnings = warnings_from {
+    Devel::Cover::DB->new->uncoverable_comments($unc, $path, "digest");
+  };
+  ($unc, $warnings, $path)
+}
+
+sub test_attaches_to_next_line () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable branch true
+if ($n == 0) { }
+PERL
+  is @$warnings, 0, "adjacent: no warnings";
+  is_deeply $unc->{digest}{branch}{3}, [[[0, "default", ""]]],
+    "adjacent: comment attaches to the code line";
+}
+
+sub test_skips_blank_line () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable branch true
+
+if ($n == 0) { }
+PERL
+  is @$warnings, 0, "blank: no warnings";
+  ok !exists $unc->{digest}{branch}{3},
+    "blank: nothing attaches to the blank line";
+  is_deeply $unc->{digest}{branch}{4}, [[[0, "default", ""]]],
+    "blank: comment attaches to the code line";
+}
+
+sub test_skips_ordinary_comment () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable branch true
+# just an ordinary comment
+if ($n == 0) { }
+PERL
+  is @$warnings, 0, "comment: no warnings";
+  ok !exists $unc->{digest}{branch}{3},
+    "comment: nothing attaches to the comment line";
+  is_deeply $unc->{digest}{branch}{4}, [[[0, "default", ""]]],
+    "comment: comment attaches to the code line";
+}
+
+sub test_trailing_annotation_warns () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable branch true
+
+PERL
+  is @$warnings, 1, "trailing: one warning";
+  like $warnings->[0], qr/unmatched uncoverable comments/,
+    "trailing: warning names the problem";
+  ok !exists $unc->{digest}{branch}, "trailing: nothing attaches";
+}
+
+sub main () {
+  test_attaches_to_next_line;
+  test_skips_blank_line;
+  test_skips_ordinary_comment;
+  test_trailing_annotation_warns;
+}
+
+main;
+done_testing;

--- a/t/internal/uncoverable_attach.t
+++ b/t/internal/uncoverable_attach.t
@@ -20,42 +20,9 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use File::Spec ();
-use File::Temp qw( tempdir );
 use Test::More import => [qw( done_testing is is_deeply like ok )];
 
-use Devel::Cover::DB ();
-
-my $Tmpdir = tempdir(CLEANUP => 1);
-
-{
-  no feature "signatures";
-
-  sub warnings_from (&) {
-    my ($code) = @_;
-    my $err = "";
-    open my $save_err, ">&", \*STDERR or die "Cannot dup STDERR: $!";
-    close STDERR or die "Cannot close STDERR: $!";
-    open STDERR, ">", \$err or die "Cannot redirect STDERR: $!";
-    $code->();
-    close STDERR or die "Cannot close STDERR: $!";
-    open STDERR, ">&", $save_err or die "Cannot restore STDERR: $!";
-    [split /(?<=\n)/, $err]
-  }
-}
-
-sub parse_comments ($source) {
-  my $path = File::Spec->catfile($Tmpdir, "source.pl");
-  open my $fh, ">", $path or die "Cannot write $path: $!";
-  print $fh $source;
-  close $fh or die "Cannot close $path: $!";
-
-  my $unc      = {};
-  my $warnings = warnings_from {
-    Devel::Cover::DB->new->uncoverable_comments($unc, $path, "digest");
-  };
-  ($unc, $warnings, $path)
-}
+use Devel::Cover::Test::Internal qw( parse_comments );
 
 sub test_attaches_to_next_line () {
   my ($unc, $warnings) = parse_comments(<<'PERL');

--- a/t/internal/uncoverable_grammar.t
+++ b/t/internal/uncoverable_grammar.t
@@ -1,0 +1,164 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Strict validation of uncoverable comment details: unsupported criteria,
+# unknown types, misspelt or misplaced attributes and malformed counts all
+# warn and drop the comment instead of being silently misread (GH-481).
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is is_deeply like ok )];
+
+use Devel::Cover::Test::Internal qw( parse_comments );
+
+sub test_unsupported_criteria_warn () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable time
+# uncoverable total
+$n++;
+PERL
+  is @$warnings, 2, "unsupported: one warning per comment";
+  like $warnings->[0],
+    qr/Unsupported criterion parsing uncoverable time at \Q$path\E:2/,
+    "unsupported: time warns";
+  like $warnings->[1],
+    qr/Unsupported criterion parsing uncoverable total at \Q$path\E:3/,
+    "unsupported: total warns";
+  ok !exists $unc->{digest}, "unsupported: nothing is recorded";
+}
+
+sub test_unknown_type_drops () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable branch frobnicate
+$n++;
+PERL
+  is @$warnings, 1, "unknown type: one warning";
+  like $warnings->[0],
+    qr/Unknown type frobnicate parsing uncoverable branch at \Q$path\E:2/,
+    "unknown type: warning names the type";
+  ok !exists $unc->{digest}, "unknown type: nothing is recorded";
+}
+
+sub test_invalid_attributes_warn () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable statement cont:2
+# uncoverable branch true clazz:x
+# uncoverable statement stray
+# uncoverable branch true extra
+# uncoverable statement count:1..
+$n++;
+PERL
+  is @$warnings, 5, "invalid attribute: one warning per comment";
+  like $warnings->[0],
+    qr/Invalid attribute cont:2 parsing uncoverable statement at \Q$path\E:2/,
+    "invalid attribute: count typo warns";
+  like $warnings->[1],
+    qr/Invalid attribute clazz:x parsing uncoverable branch at \Q$path\E:3/,
+    "invalid attribute: class typo warns";
+  like $warnings->[2],
+    qr/Invalid attribute stray parsing uncoverable statement at \Q$path\E:4/,
+    "invalid attribute: stray word warns";
+  like $warnings->[3],
+    qr/Invalid attribute extra parsing uncoverable branch at \Q$path\E:5/,
+    "invalid attribute: word after type warns";
+  my $at = qr/parsing uncoverable statement at \Q$path\E:6/;
+  like $warnings->[4], qr/Invalid attribute count:1\.\. $at/,
+    "invalid attribute: malformed count warns";
+  ok !exists $unc->{digest}, "invalid attribute: nothing is recorded";
+}
+
+sub test_pair_restrictions () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable condition left pair:1
+# uncoverable mcdc all pair:2
+# uncoverable mcdc pair:0
+$n++;
+PERL
+  is @$warnings, 3, "pair: one warning per comment";
+  my $cond = qr/parsing uncoverable condition at \Q$path\E/;
+  my $mcdc = qr/parsing uncoverable mcdc at \Q$path\E/;
+  like $warnings->[0], qr/Attribute pair applies only to mcdc $cond:2/,
+    "pair: non-mcdc criterion warns";
+  like $warnings->[1], qr/Attribute pair conflicts with all $mcdc:3/,
+    "pair: conflict with all warns";
+  like $warnings->[2], qr/Invalid pair:0 \(pairs are numbered from 1\) $mcdc:4/,
+    "pair: zero warns";
+  ok !exists $unc->{digest}, "pair: nothing is recorded";
+}
+
+sub test_double_spaced_attributes_parse () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable statement  class:ignore_covered_err
+$n++;
+PERL
+  is @$warnings, 0, "double space: no warnings";
+  is_deeply $unc->{digest}{statement}{3},
+    [[[undef, "ignore_covered_err", ""]]], "double space: class still parses";
+}
+
+sub test_count_lists_expand () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable statement count:2,4..6
+$n++;
+PERL
+  is @$warnings, 0, "count list: no warnings";
+  my $slot = [[undef, "default", ""]];
+  is_deeply $unc->{digest}{statement}{3},
+    [undef, $slot, undef, $slot, $slot, $slot],
+    "count list: ranges expand to slots";
+}
+
+sub test_note_consumes_the_rest () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable branch false class:x note:looks like cont:2 typo
+$n++;
+PERL
+  is @$warnings, 0, "note: no warnings";
+  is_deeply $unc->{digest}{branch}{3}, [[[1, "x", "looks like cont:2 typo"]]],
+    "note: takes everything after note:";
+}
+
+sub test_attribute_order_is_free () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable statement class:c count:2
+$n++;
+PERL
+  is @$warnings, 0, "order: no warnings";
+  is_deeply $unc->{digest}{statement}{3}, [undef, [[undef, "c", ""]]],
+    "order: class before count parses";
+}
+
+sub main () {
+  test_unsupported_criteria_warn;
+  test_unknown_type_drops;
+  test_invalid_attributes_warn;
+  test_pair_restrictions;
+  test_double_spaced_attributes_parse;
+  test_count_lists_expand;
+  test_note_consumes_the_rest;
+  test_attribute_order_is_free;
+}
+
+main;
+done_testing;

--- a/t/internal/uncoverable_mcdc_pair.t
+++ b/t/internal/uncoverable_mcdc_pair.t
@@ -20,43 +20,9 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use File::Spec ();
-use File::Temp qw( tempdir );
 use Test::More import => [qw( done_testing is is_deeply like ok )];
 
-use Devel::Cover::DB ();
-
-my $Tmpdir = tempdir(CLEANUP => 1);
-
-{
-  no feature "signatures";
-
-  # Warnings go to STDERR via dcwarn, not through perl's warn.
-  sub warnings_from (&) {
-    my ($code) = @_;
-    my $err = "";
-    open my $save_err, ">&", \*STDERR or die "Cannot dup STDERR: $!";
-    close STDERR or die "Cannot close STDERR: $!";
-    open STDERR, ">", \$err or die "Cannot redirect STDERR: $!";
-    $code->();
-    close STDERR or die "Cannot close STDERR: $!";
-    open STDERR, ">&", $save_err or die "Cannot restore STDERR: $!";
-    [split /(?<=\n)/, $err]
-  }
-}
-
-sub parse_comments ($source) {
-  my $path = File::Spec->catfile($Tmpdir, "source.pl");
-  open my $fh, ">", $path or die "Cannot write $path: $!";
-  print $fh $source;
-  close $fh or die "Cannot close $path: $!";
-
-  my $unc      = {};
-  my $warnings = warnings_from {
-    Devel::Cover::DB->new->uncoverable_comments($unc, $path, "digest");
-  };
-  ($unc, $warnings, $path)
-}
+use Devel::Cover::Test::Internal qw( parse_comments warnings_from );
 
 sub test_pair_zero_is_rejected () {
   my ($unc, $warnings, $path) = parse_comments(<<'PERL');

--- a/t/internal/uncoverable_unmatched.t
+++ b/t/internal/uncoverable_unmatched.t
@@ -128,6 +128,30 @@ PERL
     "sorted: condition warning second";
 }
 
+sub test_type_out_of_range_warns () {
+  my ($warnings, $path) = cover_warnings(
+    "type_range", <<'PERL', criteria => ["statement", "condition"]);
+my $n = 0;
+# uncoverable condition false
+my $r = $n // 1;
+PERL
+  is @$warnings, 1, "type range: one warning";
+  like $warnings->[0],
+    qr/Uncoverable condition false does not apply at \Q$path\E:3/,
+    "type range: warning names the type that has no column";
+}
+
+sub test_type_in_range_is_quiet () {
+  my ($warnings) = cover_warnings(
+    "type_in_range", <<'PERL', criteria => ["statement", "condition"]);
+my $n = 0;
+my $m = 1;
+# uncoverable condition false
+my $r = $n || $m;
+PERL
+  is @$warnings, 0, "type in range: no warnings";
+}
+
 sub test_silent_suppresses () {
   my $script = write_script("silent.pl", <<'PERL');
 my $n = 1;
@@ -151,6 +175,8 @@ sub main () {
   test_matched_comment_is_quiet;
   test_uncollected_criterion_is_quiet;
   test_warnings_are_sorted;
+  test_type_out_of_range_warns;
+  test_type_in_range_is_quiet;
   test_silent_suppresses;
 }
 

--- a/t/internal/uncoverable_unmatched.t
+++ b/t/internal/uncoverable_unmatched.t
@@ -146,7 +146,7 @@ sub test_type_in_range_is_quiet () {
     "type_in_range", <<'PERL', criteria => ["statement", "condition"]);
 my $n = 0;
 my $m = 1;
-# uncoverable condition false
+# uncoverable condition when:00
 my $r = $n || $m;
 PERL
   is @$warnings, 0, "type in range: no warnings";

--- a/t/internal/uncoverable_unmatched.t
+++ b/t/internal/uncoverable_unmatched.t
@@ -1,0 +1,158 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# An uncoverable comment can attach to a line and still match nothing there -
+# a branch comment above an elsif whose branches anchor at the opening if, a
+# count past the constructs on the line, or the wrong criterion entirely.
+# Such comments must warn at report time instead of vanishing (GH-481).
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is like )];
+
+use Devel::Cover::Test::Internal qw( run_under_cover write_script );
+
+{
+  no feature "signatures";
+
+  sub warnings_from (&) {
+    my ($code) = @_;
+    my $err = "";
+    open my $save_err, ">&", \*STDERR or die "Cannot dup STDERR: $!";
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">", \$err or die "Cannot redirect STDERR: $!";
+    $code->();
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">&", $save_err or die "Cannot restore STDERR: $!";
+    [split /(?<=\n)/, $err]
+  }
+}
+
+sub cover_warnings ($label, $source, %opts) {
+  my $script = write_script("$label.pl", $source);
+  my ($db, $path) = run_under_cover($script, $label, %opts);
+  my $warnings = warnings_from { $db->cover };
+  ($warnings, $path)
+}
+
+sub test_comment_above_elsif_warns () {
+  my ($warnings, $path)
+    = cover_warnings("elsif", <<'PERL', criteria => ["statement", "branch"]);
+my $n = 0;
+my $r;
+if ($n == 0) {
+  $r = "a";
+# uncoverable branch true
+} elsif ($n == 1) {
+  $r = "b";
+}
+PERL
+  is @$warnings, 1, "elsif: one warning";
+  like $warnings->[0], qr/Unmatched uncoverable branch comment at \Q$path\E:6/,
+    "elsif: warning gives criterion and file:line";
+}
+
+sub test_count_overshoot_warns () {
+  my ($warnings, $path)
+    = cover_warnings("overshoot",
+      <<'PERL', criteria => ["statement", "branch"]);
+my $n = 0;
+# uncoverable branch true count:2
+if ($n == 0) { $n++ }
+PERL
+  is @$warnings, 1, "overshoot: one warning";
+  like $warnings->[0],
+    qr/Unmatched uncoverable branch comment at \Q$path\E:3 count:2/,
+    "overshoot: warning gives the count";
+}
+
+sub test_wrong_criterion_warns () {
+  my ($warnings, $path) = cover_warnings(
+    "criterion", <<'PERL', criteria => ["statement", "branch", "condition"]);
+my $n = 1;
+# uncoverable condition left
+my $r = $n + 1;
+PERL
+  is @$warnings, 1, "criterion: one warning";
+  like $warnings->[0],
+    qr/Unmatched uncoverable condition comment at \Q$path\E:3/,
+    "criterion: warning names the criterion";
+}
+
+sub test_matched_comment_is_quiet () {
+  my ($warnings)
+    = cover_warnings("matched", <<'PERL', criteria => ["statement", "branch"]);
+my $n = 1;
+# uncoverable branch false
+if ($n) { $n++ }
+PERL
+  is @$warnings, 0, "matched: no warnings";
+}
+
+sub test_uncollected_criterion_is_quiet () {
+  my ($warnings)
+    = cover_warnings("uncollected",
+      <<'PERL', criteria => ["statement", "branch"]);
+my $n = 1;
+# uncoverable condition left
+my $r = $n + 1;
+PERL
+  is @$warnings, 0, "uncollected: no warning for uncollected criterion";
+}
+
+sub test_warnings_are_sorted () {
+  my ($warnings) = cover_warnings(
+    "sorted", <<'PERL', criteria => ["statement", "branch", "condition"]);
+my $n = 0;
+# uncoverable condition left
+# uncoverable branch true
+my $r = $n + 1;
+PERL
+  is @$warnings, 2, "sorted: two warnings";
+  like $warnings->[0], qr/uncoverable branch comment/,
+    "sorted: branch warning first";
+  like $warnings->[1], qr/uncoverable condition comment/,
+    "sorted: condition warning second";
+}
+
+sub test_silent_suppresses () {
+  my $script = write_script("silent.pl", <<'PERL');
+my $n = 1;
+# uncoverable condition left
+my $r = $n + 1;
+PERL
+  my ($db) = run_under_cover(
+    $script, "silent", criteria => ["statement", "branch", "condition"],
+  );
+  my $warnings = warnings_from {
+    local $Devel::Cover::Silent = 1;
+    $db->cover;
+  };
+  is @$warnings, 0, "silent: no warnings";
+}
+
+sub main () {
+  test_comment_above_elsif_warns;
+  test_count_overshoot_warns;
+  test_wrong_criterion_warns;
+  test_matched_comment_is_quiet;
+  test_uncollected_criterion_is_quiet;
+  test_warnings_are_sorted;
+  test_silent_suppresses;
+}
+
+main;
+done_testing;

--- a/t/internal/uncoverable_when.t
+++ b/t/internal/uncoverable_when.t
@@ -109,12 +109,40 @@ PERL
   ok !$op->uncoverable($_), "no row: row @{[ $_ + 1 ]} untouched" for 0 .. 2;
 }
 
+sub test_deprecated_words_suggest_when () {
+  my ($cover, $warnings, $path) = covered_when("deprecated", <<'PERL');
+my ($t, $f) = (1, 0);
+# uncoverable condition false
+my $r = $t && $f;
+PERL
+  is @$warnings, 1, "deprecated: one warning";
+  my $dep = qr/Uncoverable condition false is deprecated/;
+  like $warnings->[0], qr/$dep - use when:11 at \Q$path\E:3/,
+    "deprecated: warning names the when: replacement for the op";
+  my $op = $cover->file($path)->criterion("condition")->location(3)->[0];
+  ok $op->uncoverable(2), "deprecated: the word still marks its row";
+}
+
+sub test_deprecated_word_without_row_warns () {
+  my ($cover, $warnings, $path) = covered_when("deprecated_no_row", <<'PERL');
+my $n = 0;
+# uncoverable condition false
+my $r = $n // 1;
+PERL
+  is @$warnings, 1, "deprecated no row: one warning";
+  like $warnings->[0],
+    qr/Uncoverable condition false does not apply at \Q$path\E:3/,
+    "deprecated no row: only the does-not-apply warning";
+}
+
 sub main () {
   test_when_patterns_parse;
   test_when_restrictions;
   test_when_reaches_the_fourth_xor_row;
   test_when_matches_the_op_rows;
   test_when_without_matching_row_warns;
+  test_deprecated_words_suggest_when;
+  test_deprecated_word_without_row_warns;
 }
 
 main;

--- a/t/internal/uncoverable_when.t
+++ b/t/internal/uncoverable_when.t
@@ -1,0 +1,121 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# "# uncoverable condition when:<inputs>" marks the truth-table row whose
+# operand values match the pattern, as shown in the report - 0, 1 or X for
+# an operand never evaluated.  It reaches every row of every op, including
+# xor's fourth row, which no type word addresses (GH-481).
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is is_deeply like ok )];
+
+use Devel::Cover::Test::Internal
+  qw( parse_comments run_under_cover warnings_from write_script );
+
+sub covered_when ($label, $source) {
+  my $script = write_script("$label.pl", $source);
+  my ($db, $path)
+    = run_under_cover($script, $label, criteria => ["statement", "condition"]);
+  my $warnings = warnings_from { $db->cover };
+  ($db->cover, $warnings, $path)
+}
+
+sub test_when_patterns_parse () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable condition when:00
+# uncoverable condition when:1x,00 count:2
+$n++;
+PERL
+  is @$warnings, 0, "parse: no warnings";
+  is_deeply $unc->{digest}{condition}{4}, [
+      [["when:00", "default", ""]],
+      [["when:1X", "default", ""], ["when:00", "default", ""]],
+    ],
+    "parse: patterns are kept, lists expand and x is upcased";
+}
+
+sub test_when_restrictions () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable branch when:00
+# uncoverable condition left when:00
+# uncoverable condition when:2
+$n++;
+PERL
+  is @$warnings, 3, "restrictions: one warning per comment";
+  my $branch = qr/parsing uncoverable branch at \Q$path\E/;
+  my $cond   = qr/parsing uncoverable condition at \Q$path\E/;
+  like $warnings->[0], qr/Attribute when applies only to condition $branch:2/,
+    "restrictions: non-condition criterion warns";
+  like $warnings->[1], qr/Attribute when conflicts with a type word $cond:3/,
+    "restrictions: conflict with a type word warns";
+  like $warnings->[2],
+    qr/Invalid attribute when:2 parsing uncoverable condition at \Q$path\E:4/,
+    "restrictions: malformed pattern warns";
+  ok !exists $unc->{digest}, "restrictions: nothing is recorded";
+}
+
+sub test_when_reaches_the_fourth_xor_row () {
+  my ($cover, $warnings, $path) = covered_when("xor_row", <<'PERL');
+my ($t, $f) = (1, 0);
+# uncoverable condition when:00
+my $r = ($t xor $f);
+PERL
+  is @$warnings, 0, "xor: no warnings";
+  my $op = $cover->file($path)->criterion("condition")->location(3)->[0];
+  ok $op->uncoverable(3),   "xor: fourth row marked";
+  ok !$op->uncoverable($_), "xor: row @{[ $_ + 1 ]} untouched" for 0 .. 2;
+}
+
+sub test_when_matches_the_op_rows () {
+  my ($cover, $warnings, $path) = covered_when("and_rows", <<'PERL');
+my ($t, $f) = (1, 0);
+# uncoverable condition when:0X,11
+my $r = $t && $f;
+PERL
+  is @$warnings, 0, "and: no warnings";
+  my $op = $cover->file($path)->criterion("condition")->location(3)->[0];
+  ok $op->uncoverable(0),  "and: 0X marks the short-circuit row";
+  ok $op->uncoverable(2),  "and: 11 marks the both-true row";
+  ok !$op->uncoverable(1), "and: 10 row untouched";
+}
+
+sub test_when_without_matching_row_warns () {
+  my ($cover, $warnings, $path) = covered_when("no_row", <<'PERL');
+my ($t, $f) = (1, 0);
+# uncoverable condition when:01
+my $r = $t && $f;
+PERL
+  is @$warnings, 1, "no row: one warning";
+  like $warnings->[0],
+    qr/Uncoverable condition when:01 does not apply at \Q$path\E:3/,
+    "no row: warning names the pattern";
+  my $op = $cover->file($path)->criterion("condition")->location(3)->[0];
+  ok !$op->uncoverable($_), "no row: row @{[ $_ + 1 ]} untouched" for 0 .. 2;
+}
+
+sub main () {
+  test_when_patterns_parse;
+  test_when_restrictions;
+  test_when_reaches_the_fourth_xor_row;
+  test_when_matches_the_op_rows;
+  test_when_without_matching_row_warns;
+}
+
+main;
+done_testing;

--- a/t/lib/Devel/Cover/Test/Internal.pm
+++ b/t/lib/Devel/Cover/Test/Internal.pm
@@ -13,7 +13,8 @@ use feature qw( postderef signatures );
 no warnings qw( experimental::postderef experimental::signatures );
 
 use Exporter qw( import );
-our @EXPORT_OK = qw( write_script run_under_cover );
+our @EXPORT_OK
+  = qw( parse_comments run_under_cover warnings_from write_script );
 
 use Cwd        qw( abs_path );
 use File::Spec ();
@@ -30,6 +31,31 @@ sub write_script ($name, $content) {
   print $fh $content;
   close $fh or die "Cannot close $path: $!";
   $path
+}
+
+{
+  no feature "signatures";
+
+  sub warnings_from (&) {
+    my ($code) = @_;
+    my $err = "";
+    open my $save_err, ">&", \*STDERR or die "Cannot dup STDERR: $!";
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">", \$err or die "Cannot redirect STDERR: $!";
+    $code->();
+    close STDERR or die "Cannot close STDERR: $!";
+    open STDERR, ">&", $save_err or die "Cannot restore STDERR: $!";
+    [split /(?<=\n)/, $err]
+  }
+}
+
+sub parse_comments ($source) {
+  my $path     = write_script("source.pl", $source);
+  my $unc      = {};
+  my $warnings = warnings_from {
+    Devel::Cover::DB->new->uncoverable_comments($unc, $path, "digest");
+  };
+  ($unc, $warnings, $path)
 }
 
 sub run_under_cover ($script, $label, %opts) {
@@ -93,6 +119,22 @@ All functions are exported on request via L<Exporter>.
 
 Write C<$content> to a file called C<$name> in the shared temporary
 directory and return its path.
+
+=head2 warnings_from ($code)
+
+ my $warnings = warnings_from { $db->cover };
+
+Run C<$code> with STDERR captured and return an arrayref of the lines it
+wrote, keeping their trailing newlines.
+
+=head2 parse_comments ($source)
+
+ my ($unc, $warnings, $path) = parse_comments($source);
+
+Write C<$source> to a file, parse its uncoverable comments with
+L<Devel::Cover::DB/uncoverable_comments> under C<warnings_from>, and return
+the uncoverable data (keyed by the digest C<"digest">), the captured
+warnings and the file's path.
 
 =head2 run_under_cover ($script, $label, %opts)
 

--- a/test_output/cover/if.5.024000
+++ b/test_output/cover/if.5.024000
@@ -87,11 +87,11 @@ line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
 17    ***     50      0      1   if ($x)
 21    ***     50      1      0   unless ($x)
-25    ***     50      1      0   if (not $x) { }
+25    ***     50      0      1   if ($x) { }
 33    ***     50      1      0   if ($x)
 37    ***     50      1      0   if ($x) { }
 43    ***     50      0      1   unless ($x)
-47    ***     50      0      1   if (not $x) { }
+47    ***     50      1      0   if ($x) { }
 
 
 Covered Subroutines

--- a/test_output/cover/uncoverable.5.020000
+++ b/test_output/cover/uncoverable.5.020000
@@ -41,33 +41,39 @@ line  err   stmt   bran   cond   mcdc    sub   code
 15                                             # uncoverable branch true
 16                                             # uncoverable condition left
 17                                             # uncoverable condition false
-18             1   - 50   - 33   -  0          if ($x && !$y) {
-19            -0                                   $x++;  # uncoverable statement
-20                                                 # uncoverable statement
-21            -0                                   z();
-22                                             }
-23                                             
-24                                             # uncoverable branch true
-25                                             # uncoverable condition right
-26                                             # uncoverable condition false
-27             1   - 50   - 33   -  0          if (!$x && $y) {
-28                                                 # uncoverable statement count:1
-29                                                 # uncoverable statement count:2
-30            -0                                   b(); b();
-              -0                               
-31                                             
-32                                                 # uncoverable statement count:1,2
-33            -0                                   b(); b();
-              -0                               
-34                                             
-35                                                 # uncoverable statement count:1..4
-36            -0                                   b(); b(); b(); b();
-              -0                               
-              -0                               
+18                                             
+19             1   - 50   - 33   -  0          if ($x && !$y) {
+20            -0                                   $x++;  # uncoverable statement
+21                                                 # uncoverable statement
+22            -0                                   z();
+23                                             }
+24                                             
+25                                             # uncoverable branch true
+26                                             # uncoverable condition right
+27                                             # uncoverable condition false
+28                                             
+29                                             
+30                                             # an ordinary comment between the markers
+31                                               # and the code
+32                                             
+33             1   - 50   - 33   -  0          if (!$x && $y) {
+34                                                 # uncoverable statement count:1
+35                                                 # uncoverable statement count:2
+36            -0                                   b(); b();
               -0                               
 37                                             
-38                                                 # uncoverable statement count:1,2,3..4,5..7,8,9,10..11,12
-39            -0                                   b(); b(); b(); b(); b(); b(); b(); b(); b(); b(); b(); b();
+38                                                 # uncoverable statement count:1,2
+39            -0                                   b(); b();
+              -0                               
+40                                             
+41                                                 # uncoverable statement count:1..4
+42            -0                                   b(); b(); b(); b();
+              -0                               
+              -0                               
+              -0                               
+43                                             
+44                                                 # uncoverable statement count:1,2,3..4,5..7,8,9,10..11,12
+45            -0                                   b(); b(); b(); b(); b(); b(); b(); b(); b(); b(); b(); b();
               -0                               
               -0                               
               -0                               
@@ -79,32 +85,32 @@ line  err   stmt   bran   cond   mcdc    sub   code
               -0                               
               -0                               
               -0                               
-40                                             }
-41                                             
-42                                             sub z {
-43                                                 # uncoverable subroutine
-44            -0                          -0       $y++; # uncoverable statement
-45                                             }
-46                                             
-47                                             # uncoverable branch false count:1
-48                                             # uncoverable branch true  count:2
-49                                             # uncoverable branch false count:2
-50                                             # uncoverable condition left
-51                                             # uncoverable condition right
-52             1   - 50   - 33   -  0          if ($x > 0 && $y > 0) {
+46                                             }
+47                                             
+48                                             sub z {
+49                                                 # uncoverable subroutine
+50            -0                          -0       $y++; # uncoverable statement
+51                                             }
+52                                             
+53                                             # uncoverable branch false count:1
+54                                             # uncoverable branch true  count:2
+55                                             # uncoverable branch false count:2
+56                                             # uncoverable condition left
+57                                             # uncoverable condition right
+58             1   - 50   - 33   -  0          if ($x > 0 && $y > 0) {
                    -  0                        
-53             1                                   $y++;
-54                                             # uncoverable condition left
-55                                             # uncoverable condition right
-56                                             # uncoverable condition false
-57                        -  0   -  0          } elsif ($x < 2 && $y < 0) {
-58            -0                                   $y++; # uncoverable statement
-59                                             } else {
-60            -0                                   $y++; # uncoverable statement
-61                                             }
-62                                             
-63                                             # uncoverable statement
-64                                             # uncoverable subroutine
+59             1                                   $y++;
+60                                             # uncoverable condition left
+61                                             # uncoverable condition right
+62                                             # uncoverable condition false
+63                        -  0   -  0          } elsif ($x < 2 && $y < 0) {
+64            -0                                   $y++; # uncoverable statement
+65                                             } else {
+66            -0                                   $y++; # uncoverable statement
+67                                             }
+68                                             
+69                                             # uncoverable statement
+70                                             # uncoverable subroutine
 
 
 Branches
@@ -112,9 +118,9 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-18          - 50     -0      1   if ($x and not $y)
-27          - 50     -0      1   if (not $x and $y)
-52          - 50      1     -0   if ($x > 0 and $y > 0) { }
+19          - 50     -0      1   if ($x and not $y)
+33          - 50     -0      1   if (not $x and $y)
+58          - 50      1     -0   if ($x > 0 and $y > 0) { }
             -  0     -0     -0   elsif ($x < 2 and $y < 0) { }
 
 
@@ -125,10 +131,10 @@ and 3 conditions
 
 line  err      %     !l  l&&!r   l&&r   expr
 ----- --- ------ ------ ------ ------   ----
-18          - 33     -0      1     -0   $x and not $y
-27          - 33      1     -0     -0   not $x and $y
-52          - 33     -0     -0      1   $x > 0 and $y > 0
-57          -  0     -0     -0     -0   $x < 2 and $y < 0
+19          - 33     -0      1     -0   $x and not $y
+33          - 33      1     -0     -0   not $x and $y
+58          - 33     -0     -0      1   $x > 0 and $y > 0
+63          -  0     -0     -0     -0   $x < 2 and $y < 0
 
 
 MC/DC
@@ -136,10 +142,10 @@ MC/DC
 
 line  err      %  cov  tot   missing                expr
 ----- --- ------ ---- ----   --------------------   ----
-18          -  0    0    2                          $x and not $y
-27          -  0    0    2                          not $x and $y
-52          -  0    0    2                          $x > 0 and $y > 0
-57          -  0    0    2                          $x < 2 and $y < 0
+19          -  0    0    2                          $x and not $y
+33          -  0    0    2                          not $x and $y
+58          -  0    0    2                          $x > 0 and $y > 0
+63          -  0    0    2                          $x < 2 and $y < 0
 
 
 Uncovered Subroutines
@@ -147,6 +153,6 @@ Uncovered Subroutines
 
 Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------
-z             -0   1   0.0 tests/uncoverable:44
+z             -0   1   0.0 tests/uncoverable:50
 
 

--- a/test_output/cover/uncoverable.5.020000
+++ b/test_output/cover/uncoverable.5.020000
@@ -39,8 +39,8 @@ line  err   stmt   bran   cond   mcdc    sub   code
 13             1                               my $y = 1;
 14                                             
 15                                             # uncoverable branch true
-16                                             # uncoverable condition left
-17                                             # uncoverable condition false
+16                                             # uncoverable condition when:0X
+17                                             # uncoverable condition when:11
 18                                             
 19             1   - 50   - 33   -  0          if ($x && !$y) {
 20            -0                                   $x++;  # uncoverable statement
@@ -49,8 +49,8 @@ line  err   stmt   bran   cond   mcdc    sub   code
 23                                             }
 24                                             
 25                                             # uncoverable branch true
-26                                             # uncoverable condition right
-27                                             # uncoverable condition false
+26                                             # uncoverable condition when:10
+27                                             # uncoverable condition when:11
 28                                             
 29                                             
 30                                             # an ordinary comment between the markers
@@ -95,14 +95,14 @@ line  err   stmt   bran   cond   mcdc    sub   code
 53                                             # uncoverable branch false count:1
 54                                             # uncoverable branch true  count:2
 55                                             # uncoverable branch false count:2
-56                                             # uncoverable condition left
-57                                             # uncoverable condition right
+56                                             # uncoverable condition when:0X
+57                                             # uncoverable condition when:10
 58             1   - 50   - 33   -  0          if ($x > 0 && $y > 0) {
                    -  0                        
 59             1                                   $y++;
-60                                             # uncoverable condition left
-61                                             # uncoverable condition right
-62                                             # uncoverable condition false
+60                                               # uncoverable condition when:0X
+61                                               # uncoverable condition when:10
+62                                               # uncoverable condition when:11
 63                        -  0   -  0          } elsif ($x < 2 && $y < 0) {
 64            -0                                   $y++; # uncoverable statement
 65                                             } else {

--- a/test_output/cover/uncoverable.5.020000
+++ b/test_output/cover/uncoverable.5.020000
@@ -1,5 +1,5 @@
 cover: Reading database from ...
-2 unmatched uncoverable comments not found at end of tests/uncoverable
+cover: 2 unmatched uncoverable comments not found at end of tests/uncoverable
 ----------------- ------ ------ ------ ------ ------ ------ ------
 File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/uncoverable_count.5.020000
+++ b/test_output/cover/uncoverable_count.5.020000
@@ -73,21 +73,21 @@ line  err   stmt   bran   cond   code
 42                               # uncoverable branch true count:1
 43                               # uncoverable branch true count:2
 44                               # uncoverable branch false count:3
-45                               # uncoverable condition left
-46                               # uncoverable condition false
+45                               # uncoverable condition when:0X
+46                               # uncoverable condition when:11
 47             1   - 50   - 33   if ($From < $Start && $Until < $End) {
                    - 50          
                    - 50          
 48            -0                   $R = "a";  # uncoverable statement
-49                                            # uncoverable condition right count:1
-50                                            # uncoverable condition false count:1
-51                                            # uncoverable condition right count:2
-52                                            # uncoverable condition false count:2
+49                                            # uncoverable condition when:10 count:1
+50                                            # uncoverable condition when:11 count:1
+51                                            # uncoverable condition when:10 count:2
+52                                            # uncoverable condition when:11 count:2
 53                        - 33   } elsif ($From >= $Start && $From < $End && $Until >= $End) {
                           - 33   
 54            -0                   $R = "b";  # uncoverable statement
-55                                            # uncoverable condition left
-56                                            # uncoverable condition right
+55                                            # uncoverable condition when:0X
+56                                            # uncoverable condition when:10
 57                        - 33   } elsif ($From < $Start && $Until >= $End) {
 58             1                   $R = "c";
 59                               }

--- a/test_output/cover/uncoverable_count.5.020000
+++ b/test_output/cover/uncoverable_count.5.020000
@@ -1,0 +1,146 @@
+cover: Reading database from ...
+----------------------- ------ ------ ------ ------ ------
+File                      stmt   bran   cond  total   scar
+----------------------- ------ ------ ------ ------ ------
+tests/uncoverable_count  100.0  100.0  100.0  100.0    0.0
+Total                    100.0  100.0  100.0  100.0    0.0
+----------------------- ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/uncoverable_count
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+ 1 100.0  1.0  0.0
+
+line  err   stmt   bran   cond   code
+1                                #!/usr/bin/perl
+2                                
+3                                # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                
+5                                # This software is free.  It is licensed under the same terms as Perl itself.
+6                                
+7                                # The latest version of this software should be available from my homepage:
+8                                # https://pjcj.net
+9                                
+10                               # __COVER__ criteria statement branch condition
+11                               
+12             1                 use strict;
+               1                 
+               1                 
+13             1                 use warnings;
+               1                 
+               1                 
+14                               
+15             1                 my $R;
+16                               
+17                               # GH-481 - branch count:N addresses the Nth branch on the chain line, so
+18                               # count:3 reaches the second elsif.
+19                               
+20             1                 my $N = 0;
+21                               
+22                               # uncoverable branch false count:1
+23                               # uncoverable branch true count:2
+24                               # uncoverable branch false count:2
+25                               # uncoverable branch true count:3
+26                               # uncoverable branch false count:3
+27             1   - 50          if ($N == 0) {
+                   -  0          
+                   -  0          
+28             1                   $R = "zero";
+29                               } elsif ($N == 1) {
+30            -0                   $R = "one";  # uncoverable statement
+31                               } elsif ($N == 2) {
+32            -0                   $R = "two";  # uncoverable statement
+33                               } else {
+34            -0                   $R = "three";  # uncoverable statement
+35                               }
+36                               
+37                               # GH-242 - condition annotations anchor on the elsif's own line, and count:N
+38                               # addresses stacked condition ops on one line, outer op first.
+39                               
+40             1                 my ($From, $Until, $Start, $End) = (5, 20, 10, 15);
+41                               
+42                               # uncoverable branch true count:1
+43                               # uncoverable branch true count:2
+44                               # uncoverable branch false count:3
+45                               # uncoverable condition left
+46                               # uncoverable condition false
+47             1   - 50   - 33   if ($From < $Start && $Until < $End) {
+                   - 50          
+                   - 50          
+48            -0                   $R = "a";  # uncoverable statement
+49                                            # uncoverable condition right count:1
+50                                            # uncoverable condition false count:1
+51                                            # uncoverable condition right count:2
+52                                            # uncoverable condition false count:2
+53                        - 33   } elsif ($From >= $Start && $From < $End && $Until >= $End) {
+                          - 33   
+54            -0                   $R = "b";  # uncoverable statement
+55                                            # uncoverable condition left
+56                                            # uncoverable condition right
+57                        - 33   } elsif ($From < $Start && $Until >= $End) {
+58             1                   $R = "c";
+59                               }
+60                               
+61                               # Each of several if statements on one line adds its own branch, with count:N
+62                               # walking them in textual order.
+63                               
+64             1                 my ($A, $B) = (1, 0);
+65             1                 my ($X, $Y) = (0, 0);
+66                               
+67                               #<<<
+68                               # uncoverable branch false count:1
+69                               # uncoverable branch true count:2
+70                               # uncoverable statement count:4
+71             1   - 50          if ($A) { $X = 1 } if ($B) { $Y = 1 }
+               1   - 50          
+               1                 
+              -0                 
+72                               
+73                               # uncoverable branch false count:1
+74                               # uncoverable branch true count:2
+75             1   - 50          $X++ if $A; $Y++ if $B;
+               1   - 50          
+76                               #>>>
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+27          - 50      1     -0   if ($N == 0) { }
+            -  0     -0     -0   elsif ($N == 1) { }
+            -  0     -0     -0   elsif ($N == 2) { }
+47          - 50     -0      1   if ($From < $Start and $Until < $End) { }
+            - 50     -0      1   elsif ($From >= $Start and $From < $End and $Until >= $End) { }
+            - 50      1     -0   elsif ($From < $Start and $Until >= $End) { }
+71          - 50      1     -0   if ($A)
+            - 50     -0      1   if ($B)
+75          - 50      1     -0   if $A
+            - 50     -0      1   if $B
+
+
+Conditions
+----------
+
+and 3 conditions
+
+line  err      %     !l  l&&!r   l&&r   expr
+----- --- ------ ------ ------ ------   ----
+47          - 33     -0      1     -0   $From < $Start and $Until < $End
+53          - 33      1     -0     -0   $From >= $Start and $From < $End and $Until >= $End
+            - 33      1     -0     -0   $From >= $Start and $From < $End
+57          - 33     -0     -0      1   $From < $Start and $Until >= $End
+
+

--- a/test_output/cover/uncoverable_error.5.020000
+++ b/test_output/cover/uncoverable_error.5.020000
@@ -60,9 +60,9 @@ line  err   stmt   bran   cond   mcdc    sub   code
 28                                             
 29             1                                   my $y = 0;
 30                                                 # uncoverable branch true
-31                                                 # uncoverable condition left
-32                                                 # uncoverable condition right class:ignore_covered_err
-33                                                 # uncoverable condition false
+31                                                 # uncoverable condition when:0X
+32                                                 # uncoverable condition when:10 class:ignore_covered_err
+33                                                 # uncoverable condition when:11
 34             1   - 50   - 33   -  0              if ($x > 0 && $y > 0) {
 35                                                     # uncoverable statement
 36            -0                                       $y = 1;
@@ -70,8 +70,8 @@ line  err   stmt   bran   cond   mcdc    sub   code
 38                                             
 39             1    100                            while ($y < 4) {
 40                                                     # uncoverable branch false
-41                                                     # uncoverable condition left
-42                                                     # uncoverable condition right
+41                                                     # uncoverable condition when:0X
+42                                                     # uncoverable condition when:10
 43    ***      2  *-100  *- 66   - 50                  if ($x > 0 && $y > 0) {
 44             1                                           $y = 4;
 45                                                     } else {

--- a/test_output/cover/uncoverable_error_ignore.5.020000
+++ b/test_output/cover/uncoverable_error_ignore.5.020000
@@ -62,7 +62,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 30                                             
 31             1                                   my $y = 0;
 32                                                 # uncoverable branch true
-33                                                 # uncoverable condition right
+33                                                 # uncoverable condition when:10
 34    ***      1   - 50  *- 33   *  0              if ($x > 0 && $y > 0) {
 35                                                     # uncoverable statement
 36            -0                                       $y = 1;
@@ -70,8 +70,8 @@ line  err   stmt   bran   cond   mcdc    sub   code
 38                                             
 39             1    100                            while ($y < 4) {
 40                                                     # uncoverable branch false
-41                                                     # uncoverable condition left
-42                                                     # uncoverable condition right
+41                                                     # uncoverable condition when:0X
+42                                                     # uncoverable condition when:10
 43             2   -100   - 66   - 50                  if ($x > 0 && $y > 0) {
 44             1                                           $y = 4;
 45                                                     } else {

--- a/test_output/cover/uncoverable_flow.5.020000
+++ b/test_output/cover/uncoverable_flow.5.020000
@@ -1,0 +1,113 @@
+cover: Reading database from ...
+---------------------- ------ ------ ------ ------ ------
+File                     stmt   bran   cond  total   scar
+---------------------- ------ ------ ------ ------ ------
+tests/uncoverable_flow  100.0  100.0  100.0  100.0    0.0
+Total                   100.0  100.0  100.0  100.0    0.0
+---------------------- ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/uncoverable_flow
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+ 1 100.0  1.0  0.0
+
+line  err   stmt   bran   cond   code
+1                                #!/usr/bin/perl
+2                                
+3                                # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                
+5                                # This software is free.  It is licensed under the same terms as Perl itself.
+6                                
+7                                # The latest version of this software should be available from my homepage:
+8                                # https://pjcj.net
+9                                
+10                               # __COVER__ criteria statement branch condition
+11                               
+12                               # Uncoverable comments on flow control: unless, while, until, C-style for
+13                               # and statement modifiers all report their conditions as two-element
+14                               # branches whose true element means the guarded code ran.
+15                               
+16             1                 use strict;
+               1                 
+               1                 
+17             1                 use warnings;
+               1                 
+               1                 
+18                               
+19             1                 my ($t, $f) = (1, 0);
+20             1                 my $r;
+21                               
+22                               # uncoverable branch true
+23             1   - 50          unless ($t) {
+24            -0                   $r = "u1";  # uncoverable statement
+25                               }
+26                               
+27                               # uncoverable branch false
+28             1   - 50          unless ($f) {
+29             1                   $r = "u2";
+30                               }
+31                               
+32                               # uncoverable branch true
+33                               # uncoverable condition when:01,00
+34             1   - 50   - 33   unless ($t || $f) {
+35            -0                   $r = "u3";  # uncoverable statement
+36                               }
+37                               
+38                               # uncoverable branch true
+39             1   - 50          while ($f) {
+40            -0                   $r = "w1";  # uncoverable statement
+41                               }
+42                               
+43                               # uncoverable branch true
+44             1   - 50          until ($t) {
+45            -0                   $r = "t1";  # uncoverable statement
+46                               }
+47                               
+48                               # uncoverable branch true
+49             1   - 50          for (my $i = 5; $i < 3; $i++) {
+50            -0                   $r = "f1";  # uncoverable statement
+51                               }
+52                               
+53                               # uncoverable branch true
+54             1   - 50          $r = "m1" unless $t;
+55                               
+56                               # uncoverable branch false
+57             1   - 50          $r = "m2" if $t;
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+23          - 50     -0      1   unless ($t)
+28          - 50      1     -0   unless ($f)
+34          - 50     -0      1   unless ($t or $f)
+39          - 50     -0      1   if ($f)
+44          - 50     -0      1   unless ($t)
+49          - 50     -0      1   if ($i < 3)
+54          - 50     -0      1   unless $t
+57          - 50      1     -0   if $t
+
+
+Conditions
+----------
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+34          - 33      1     -0     -0   $t or $f
+
+

--- a/test_output/cover/uncoverable_mcdc.5.020000
+++ b/test_output/cover/uncoverable_mcdc.5.020000
@@ -70,7 +70,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 32                                             # true, so the inner $a && !$b outcome - the row $b's MC/DC independence pair
 33                                             # needs - can never occur.  The plain condition marker on that inner outcome
 34                                             # (count:2 selects the inner $a && $b) now also excuses $b for MC/DC, derived
-35                                             # from the compound truth table with no separate uncoverable mcdc comment.
+35                                             # from the compound truth table with no separate "# uncoverable mcdc" needed.
 36                                             sub compound_inner {
 37             3                           3     my ($a, $c) = @_;
 38             3                                 my $b = 1;

--- a/test_output/cover/uncoverable_mcdc.5.020000
+++ b/test_output/cover/uncoverable_mcdc.5.020000
@@ -74,7 +74,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 36                                             sub compound_inner {
 37             3                           3     my ($a, $c) = @_;
 38             3                                 my $b = 1;
-39                                               # uncoverable condition right count:2
+39                                               # uncoverable condition when:10 count:2
 40             3           100   - 66            return $a && $b && $c;
                           - 66                 
 41                                             }

--- a/test_output/cover/uncoverable_mcdc.5.020000
+++ b/test_output/cover/uncoverable_mcdc.5.020000
@@ -70,7 +70,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 32                                             # true, so the inner $a && !$b outcome - the row $b's MC/DC independence pair
 33                                             # needs - can never occur.  The plain condition marker on that inner outcome
 34                                             # (count:2 selects the inner $a && $b) now also excuses $b for MC/DC, derived
-35                                             # from the compound truth table with no separate "# uncoverable mcdc" needed.
+35                                             # from the compound truth table with no separate uncoverable mcdc comment.
 36                                             sub compound_inner {
 37             3                           3     my ($a, $c) = @_;
 38             3                                 my $b = 1;

--- a/test_output/cover/uncoverable_mcdc.5.020000
+++ b/test_output/cover/uncoverable_mcdc.5.020000
@@ -50,10 +50,10 @@ line  err   stmt   bran   cond   mcdc    sub   code
 12                                             
 13                                             # A // whose right operand is an always-defined variable: neither atomic
 14                                             # condition's independence pair can be formed, so the whole decision is
-15                                             # uncoverable for MC/DC.  A bare marker covers every column.
+15                                             # uncoverable for MC/DC.  The all type covers every column.
 16                                             sub dor_default {
 17             2                           2     my ($h, $k, $val) = @_;
-18                                               # uncoverable mcdc
+18                                               # uncoverable mcdc all
 19    ***      2          * 66   -  0            return $h->{$k} //= $val;
 20                                             }
 21                                             

--- a/test_output/cover/uncoverable_mcdc.5.022000
+++ b/test_output/cover/uncoverable_mcdc.5.022000
@@ -70,7 +70,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 32                                             # true, so the inner $a && !$b outcome - the row $b's MC/DC independence pair
 33                                             # needs - can never occur.  The plain condition marker on that inner outcome
 34                                             # (count:2 selects the inner $a && $b) now also excuses $b for MC/DC, derived
-35                                             # from the compound truth table with no separate uncoverable mcdc comment.
+35                                             # from the compound truth table with no separate "# uncoverable mcdc" needed.
 36                                             sub compound_inner {
 37             3                           3     my ($a, $c) = @_;
 38             3                                 my $b = 1;

--- a/test_output/cover/uncoverable_mcdc.5.022000
+++ b/test_output/cover/uncoverable_mcdc.5.022000
@@ -74,7 +74,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 36                                             sub compound_inner {
 37             3                           3     my ($a, $c) = @_;
 38             3                                 my $b = 1;
-39                                               # uncoverable condition right count:2
+39                                               # uncoverable condition when:10 count:2
 40             3           100   - 66            return $a && $b && $c;
                           - 66                 
 41                                             }

--- a/test_output/cover/uncoverable_mcdc.5.022000
+++ b/test_output/cover/uncoverable_mcdc.5.022000
@@ -70,7 +70,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 32                                             # true, so the inner $a && !$b outcome - the row $b's MC/DC independence pair
 33                                             # needs - can never occur.  The plain condition marker on that inner outcome
 34                                             # (count:2 selects the inner $a && $b) now also excuses $b for MC/DC, derived
-35                                             # from the compound truth table with no separate "# uncoverable mcdc" needed.
+35                                             # from the compound truth table with no separate uncoverable mcdc comment.
 36                                             sub compound_inner {
 37             3                           3     my ($a, $c) = @_;
 38             3                                 my $b = 1;

--- a/test_output/cover/uncoverable_mcdc.5.022000
+++ b/test_output/cover/uncoverable_mcdc.5.022000
@@ -50,10 +50,10 @@ line  err   stmt   bran   cond   mcdc    sub   code
 12                                             
 13                                             # A // whose right operand is an always-defined variable: neither atomic
 14                                             # condition's independence pair can be formed, so the whole decision is
-15                                             # uncoverable for MC/DC.  A bare marker covers every column.
+15                                             # uncoverable for MC/DC.  The all type covers every column.
 16                                             sub dor_default {
 17             2                           2     my ($h, $k, $val) = @_;
-18                                               # uncoverable mcdc
+18                                               # uncoverable mcdc all
 19    ***      2          * 66   -  0            return $h->{$k} //= $val;
 20                                             }
 21                                             

--- a/tests/if
+++ b/tests/if
@@ -22,6 +22,12 @@ unless ($x) {
     $q++
 }
 
+unless ($x) {
+  $q++
+} else {
+  $p++
+}
+
 $x = 1;
 
 if ($x) {
@@ -36,4 +42,10 @@ if ($x) {
 
 unless ($x) {
     $s++
+}
+
+unless ($x) {
+  $s++
+} else {
+  $r++
 }

--- a/tests/uncoverable
+++ b/tests/uncoverable
@@ -13,8 +13,8 @@ my $x = 1;
 my $y = 1;
 
 # uncoverable branch true
-# uncoverable condition left
-# uncoverable condition false
+# uncoverable condition when:0X
+# uncoverable condition when:11
 
 if ($x && !$y) {
     $x++;  # uncoverable statement
@@ -23,8 +23,8 @@ if ($x && !$y) {
 }
 
 # uncoverable branch true
-# uncoverable condition right
-# uncoverable condition false
+# uncoverable condition when:10
+# uncoverable condition when:11
 
 
 # an ordinary comment between the markers
@@ -53,13 +53,13 @@ sub z {
 # uncoverable branch false count:1
 # uncoverable branch true  count:2
 # uncoverable branch false count:2
-# uncoverable condition left
-# uncoverable condition right
+# uncoverable condition when:0X
+# uncoverable condition when:10
 if ($x > 0 && $y > 0) {
     $y++;
-# uncoverable condition left
-# uncoverable condition right
-# uncoverable condition false
+  # uncoverable condition when:0X
+  # uncoverable condition when:10
+  # uncoverable condition when:11
 } elsif ($x < 2 && $y < 0) {
     $y++; # uncoverable statement
 } else {

--- a/tests/uncoverable
+++ b/tests/uncoverable
@@ -15,6 +15,7 @@ my $y = 1;
 # uncoverable branch true
 # uncoverable condition left
 # uncoverable condition false
+
 if ($x && !$y) {
     $x++;  # uncoverable statement
     # uncoverable statement
@@ -24,6 +25,11 @@ if ($x && !$y) {
 # uncoverable branch true
 # uncoverable condition right
 # uncoverable condition false
+
+
+# an ordinary comment between the markers
+  # and the code
+
 if (!$x && $y) {
     # uncoverable statement count:1
     # uncoverable statement count:2

--- a/tests/uncoverable_count
+++ b/tests/uncoverable_count
@@ -1,0 +1,76 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# __COVER__ criteria statement branch condition
+
+use strict;
+use warnings;
+
+my $R;
+
+# GH-481 - branch count:N addresses the Nth branch on the chain line, so
+# count:3 reaches the second elsif.
+
+my $N = 0;
+
+# uncoverable branch false count:1
+# uncoverable branch true count:2
+# uncoverable branch false count:2
+# uncoverable branch true count:3
+# uncoverable branch false count:3
+if ($N == 0) {
+  $R = "zero";
+} elsif ($N == 1) {
+  $R = "one";  # uncoverable statement
+} elsif ($N == 2) {
+  $R = "two";  # uncoverable statement
+} else {
+  $R = "three";  # uncoverable statement
+}
+
+# GH-242 - condition annotations anchor on the elsif's own line, and count:N
+# addresses stacked condition ops on one line, outer op first.
+
+my ($From, $Until, $Start, $End) = (5, 20, 10, 15);
+
+# uncoverable branch true count:1
+# uncoverable branch true count:2
+# uncoverable branch false count:3
+# uncoverable condition left
+# uncoverable condition false
+if ($From < $Start && $Until < $End) {
+  $R = "a";  # uncoverable statement
+             # uncoverable condition right count:1
+             # uncoverable condition false count:1
+             # uncoverable condition right count:2
+             # uncoverable condition false count:2
+} elsif ($From >= $Start && $From < $End && $Until >= $End) {
+  $R = "b";  # uncoverable statement
+             # uncoverable condition left
+             # uncoverable condition right
+} elsif ($From < $Start && $Until >= $End) {
+  $R = "c";
+}
+
+# Each of several if statements on one line adds its own branch, with count:N
+# walking them in textual order.
+
+my ($A, $B) = (1, 0);
+my ($X, $Y) = (0, 0);
+
+#<<<
+# uncoverable branch false count:1
+# uncoverable branch true count:2
+# uncoverable statement count:4
+if ($A) { $X = 1 } if ($B) { $Y = 1 }
+
+# uncoverable branch false count:1
+# uncoverable branch true count:2
+$X++ if $A; $Y++ if $B;
+#>>>

--- a/tests/uncoverable_count
+++ b/tests/uncoverable_count
@@ -42,18 +42,18 @@ my ($From, $Until, $Start, $End) = (5, 20, 10, 15);
 # uncoverable branch true count:1
 # uncoverable branch true count:2
 # uncoverable branch false count:3
-# uncoverable condition left
-# uncoverable condition false
+# uncoverable condition when:0X
+# uncoverable condition when:11
 if ($From < $Start && $Until < $End) {
   $R = "a";  # uncoverable statement
-             # uncoverable condition right count:1
-             # uncoverable condition false count:1
-             # uncoverable condition right count:2
-             # uncoverable condition false count:2
+             # uncoverable condition when:10 count:1
+             # uncoverable condition when:11 count:1
+             # uncoverable condition when:10 count:2
+             # uncoverable condition when:11 count:2
 } elsif ($From >= $Start && $From < $End && $Until >= $End) {
   $R = "b";  # uncoverable statement
-             # uncoverable condition left
-             # uncoverable condition right
+             # uncoverable condition when:0X
+             # uncoverable condition when:10
 } elsif ($From < $Start && $Until >= $End) {
   $R = "c";
 }

--- a/tests/uncoverable_error
+++ b/tests/uncoverable_error
@@ -28,9 +28,9 @@ sub main {
 
     my $y = 0;
     # uncoverable branch true
-    # uncoverable condition left
-    # uncoverable condition right class:ignore_covered_err
-    # uncoverable condition false
+    # uncoverable condition when:0X
+    # uncoverable condition when:10 class:ignore_covered_err
+    # uncoverable condition when:11
     if ($x > 0 && $y > 0) {
         # uncoverable statement
         $y = 1;
@@ -38,8 +38,8 @@ sub main {
 
     while ($y < 4) {
         # uncoverable branch false
-        # uncoverable condition left
-        # uncoverable condition right
+        # uncoverable condition when:0X
+        # uncoverable condition when:10
         if ($x > 0 && $y > 0) {
             $y = 4;
         } else {

--- a/tests/uncoverable_error_ignore
+++ b/tests/uncoverable_error_ignore
@@ -30,7 +30,7 @@ sub main {
 
     my $y = 0;
     # uncoverable branch true
-    # uncoverable condition right
+    # uncoverable condition when:10
     if ($x > 0 && $y > 0) {
         # uncoverable statement
         $y = 1;
@@ -38,8 +38,8 @@ sub main {
 
     while ($y < 4) {
         # uncoverable branch false
-        # uncoverable condition left
-        # uncoverable condition right
+        # uncoverable condition when:0X
+        # uncoverable condition when:10
         if ($x > 0 && $y > 0) {
             $y = 4;
         } else {

--- a/tests/uncoverable_flow
+++ b/tests/uncoverable_flow
@@ -1,0 +1,57 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# __COVER__ criteria statement branch condition
+
+# Uncoverable comments on flow control: unless, while, until, C-style for
+# and statement modifiers all report their conditions as two-element
+# branches whose true element means the guarded code ran.
+
+use strict;
+use warnings;
+
+my ($t, $f) = (1, 0);
+my $r;
+
+# uncoverable branch true
+unless ($t) {
+  $r = "u1";  # uncoverable statement
+}
+
+# uncoverable branch false
+unless ($f) {
+  $r = "u2";
+}
+
+# uncoverable branch true
+# uncoverable condition when:01,00
+unless ($t || $f) {
+  $r = "u3";  # uncoverable statement
+}
+
+# uncoverable branch true
+while ($f) {
+  $r = "w1";  # uncoverable statement
+}
+
+# uncoverable branch true
+until ($t) {
+  $r = "t1";  # uncoverable statement
+}
+
+# uncoverable branch true
+for (my $i = 5; $i < 3; $i++) {
+  $r = "f1";  # uncoverable statement
+}
+
+# uncoverable branch true
+$r = "m1" unless $t;
+
+# uncoverable branch false
+$r = "m2" if $t;

--- a/tests/uncoverable_mcdc
+++ b/tests/uncoverable_mcdc
@@ -32,7 +32,7 @@ sub left_always_true {
 # true, so the inner $a && !$b outcome - the row $b's MC/DC independence pair
 # needs - can never occur.  The plain condition marker on that inner outcome
 # (count:2 selects the inner $a && $b) now also excuses $b for MC/DC, derived
-# from the compound truth table with no separate uncoverable mcdc comment.
+# from the compound truth table with no separate "# uncoverable mcdc" needed.
 sub compound_inner {
   my ($a, $c) = @_;
   my $b = 1;

--- a/tests/uncoverable_mcdc
+++ b/tests/uncoverable_mcdc
@@ -12,10 +12,10 @@ use warnings;
 
 # A // whose right operand is an always-defined variable: neither atomic
 # condition's independence pair can be formed, so the whole decision is
-# uncoverable for MC/DC.  A bare marker covers every column.
+# uncoverable for MC/DC.  The all type covers every column.
 sub dor_default {
   my ($h, $k, $val) = @_;
-  # uncoverable mcdc
+  # uncoverable mcdc all
   return $h->{$k} //= $val;
 }
 

--- a/tests/uncoverable_mcdc
+++ b/tests/uncoverable_mcdc
@@ -32,7 +32,7 @@ sub left_always_true {
 # true, so the inner $a && !$b outcome - the row $b's MC/DC independence pair
 # needs - can never occur.  The plain condition marker on that inner outcome
 # (count:2 selects the inner $a && $b) now also excuses $b for MC/DC, derived
-# from the compound truth table with no separate "# uncoverable mcdc" needed.
+# from the compound truth table with no separate uncoverable mcdc comment.
 sub compound_inner {
   my ($a, $c) = @_;
   my $b = 1;

--- a/tests/uncoverable_mcdc
+++ b/tests/uncoverable_mcdc
@@ -36,7 +36,7 @@ sub left_always_true {
 sub compound_inner {
   my ($a, $c) = @_;
   my $b = 1;
-  # uncoverable condition right count:2
+  # uncoverable condition when:10 count:2
   return $a && $b && $c;
 }
 


### PR DESCRIPTION
## Summary

Both tickets report the uncoverable comment system failing on if/elsif chains, and in both cases the comments were in fact working - `count:N` selects the Nth branch anchored on the line, so an elsif's branches are addressed from above the opening `if`, and an elsif's conditions from its own line. What the investigation did find was that the system failed silently at every turn: comments separated from their code were discarded, comments matching nothing were ignored, malformed details were misread, and the condition type words name rows that only make sense for `||`. This PR keeps working comments working, makes every failure visible, and gives condition rows a syntax that says what it means.

## Changes

- Attach uncoverable comments to the next line of code, past blank lines and other comments - they were previously discarded silently.
- Warn at report time about comments that match nothing - a wrong criterion, a count past the constructs on the line, or a type naming no row.
- Validate comment details strictly: misspelt attributes, stray words and malformed counts warn and drop the comment, `pair:` is restricted to mcdc, and unsupported criteria warn.
- Require "uncoverable" to start the comment, so prose quoting the syntax does not create stray comments.
- Add an `all` type marking every element of a branch, condition or MC/DC decision at once.
- Add a `when:` attribute naming condition truth-table rows by operand values as the report shows them (`when:0X`, `when:01,00`), reaching every row of every op including xor's fourth, which no type word addresses.
- Deprecate the condition type words `left`, `right` and `false` - they were named for the `||` layout and mislead elsewhere (on `&&`, `false` marks the row where the expression is true). Using one warns, naming the exact `when:` replacement for the op.
- Add tests locking in count addressing (`tests/uncoverable_count`), the flow-control constructs (`tests/uncoverable_flow` - unless, while, until, C-style for, statement modifiers), and the version-dependent reporting of unless/else (`tests/if`, which perl negates up to 5.22 and block-swaps from 5.24).
- Document all of it: comment placement for chains, count addressing, the truth-table rows of each op type, the deprecation, and the branch semantics of unless, until and loop conditions.

## Implications

- BREAKING: a bare branch, condition or mcdc comment previously marked the first element silently - it now warns and marks nothing, so reports relying on that behaviour will change.
- Deprecated type words keep marking the same rows as before, but each use now warns.

## Ticket

Closes #481
Closes #242