### PR TITLE
GH-677 Install test deps in dc-dev builds

### DIFF
--- a/utils/dc
+++ b/utils/dc
@@ -330,7 +330,7 @@ install_development_dependencies() {
 install_test_dependencies() {
   get_cpm
   $cpm install --workers="$(nice_cpus)" --global \
-    DBM::Deep
+    DBM::Deep Syntax::Operator::In
 }
 
 recipe_install-dependencies() {
@@ -370,6 +370,7 @@ recipe_install-dc-dev-perl() {
   local version="${1:?No version specified}"
   install_perl dc-dev "$version"
   install_development_dependencies
+  install_test_dependencies
 }
 
 recipe_all-gold() {


### PR DESCRIPTION
## Summary

Call the existing `install_test_dependencies` from the dc-dev build recipe, so fresh dc-dev builds no longer lack `DBM::Deep`, and add `Syntax::Operator::In` to the test dependency list. Until now both had to be installed by hand after each dc-dev rebuild.

## Ticket

Closes #677