### PR TITLE
GH-606 Record named subs as they are entered

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@ Devel::Cover history
 - Record each named sub as it is entered so subs displaced from the symbol
   table are covered wherever the wrapper keeps the original - nested
   containers, blessed holders and package variables included (GH-606)
+- Report on subs redefined at runtime, provided the original ran at least
+  once before being replaced - previously the original vanished from the
+  report (GH-606)
 - BREAKING: Require a type word, all or when on branch, condition and mcdc
   uncoverable comments - a bare comment previously marked the first element
   silently (GH-481)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Record each named sub as it is entered so subs displaced from the symbol
+  table are covered wherever the wrapper keeps the original - nested
+  containers, blessed holders and package variables included (GH-606)
 - BREAKING: Require a type word, all or when on branch, condition and mcdc
   uncoverable comments - a bare comment previously marked the first element
   silently (GH-481)

--- a/Cover.xs
+++ b/Cover.xs
@@ -170,6 +170,9 @@ typedef struct {
   AV           *require_trees;       /* [CV ref, root op addr] pairs for
                                       * require optrees kept alive past
                                       * their SAVEFREEOP */
+  HV           *entered_subs;        /* CV pointer bytes -> RV keeping each
+                                      * entered named sub alive for the
+                                      * report-time walk */
   char          profiling_key[KEY_SZ];
   bool          profiling_key_valid;
   SV           *module,
@@ -2272,10 +2275,61 @@ static OP *dc_dbstate(pTHX) {
   return MY_CXT.ppaddr[OP_DBSTATE](aTHX);
 }
 
+/*
+ * Remember each named sub as it is entered, so the report can build
+ * structure for subs later displaced from the symbol table or freed by
+ * redefinition.  The reference is strong - a recorded CV, its optree and
+ * so its op keys stay valid until report time.  Anon and cloned CVs are
+ * skipped (their coverage comes from the pad walk, and a clone shares its
+ * start op with its prototype), as are the compile-phase blocks, whose
+ * early release must not be delayed.  See
+ * docs/technical/wrapped-sub-coverage.md.
+ */
+static void record_entered_sub(pTHX) {
+  dMY_CXT;
+  SV         *sv = *PL_stack_sp;
+  CV         *cv;
+  GV         *gv;
+  const char *name;
+  STRLEN      len;
+
+  if (!sv) return;
+  if (SvTYPE(sv) == SVt_PVCV)
+    cv = (CV *)sv;
+  else if (SvROK(sv) && SvTYPE(SvRV(sv)) == SVt_PVCV)
+    cv = (CV *)SvRV(sv);
+  else if (isGV_with_GP(sv) && GvCV((GV *)sv))
+    cv = GvCV((GV *)sv);
+  else
+    return;
+
+  if (CvISXSUB(cv) || CvANON(cv) || CvCLONED(cv) || !CvROOT(cv)) return;
+  if (hv_exists(MY_CXT.entered_subs, (char *)&cv, sizeof(CV *))) return;
+
+  gv = CvGV(cv);
+  if (!gv || !isGV_with_GP((SV *)gv)) return;
+  name = GvNAME(gv);
+  len  = GvNAMELEN(gv);
+  if (!name || !len) return;
+  if ((len == 3 && strnEQ(name, "END",       3))
+   || (len == 4 && strnEQ(name, "INIT",      4))
+   || (len == 5 && strnEQ(name, "BEGIN",     5))
+   || (len == 5 && strnEQ(name, "CHECK",     5))
+   || (len == 8 && strnEQ(name, "__ANON__",  8))
+   || (len == 9 && strnEQ(name, "UNITCHECK", 9)))
+    return;
+
+  (void)hv_store(MY_CXT.entered_subs, (char *)&cv, sizeof(CV *),
+                 newRV_inc((SV *)cv), 0);
+}
+
 static OP *dc_entersub(pTHX) {
   dMY_CXT;
   NDEB(D(L, "dc_entersub() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  if (MY_CXT.covering) store_return(aTHX);
+  if (MY_CXT.covering) {
+    store_return(aTHX);
+    record_entered_sub(aTHX);
+  }
   return MY_CXT.ppaddr[OP_ENTERSUB](aTHX);
 }
 
@@ -2582,6 +2636,8 @@ static void initialise(pTHX) {
     HvSHAREKEYS_off(MY_CXT.decision_meta);
     HvSHAREKEYS_off(MY_CXT.decision_walked_cvs);
     MY_CXT.require_trees       = newAV();
+    MY_CXT.entered_subs        = newHV();
+    HvSHAREKEYS_off(MY_CXT.entered_subs);
     MY_CXT.module              = newSVpv("", 0);
     MY_CXT.lastfile            = newSVpvn("", 1);
     MY_CXT.lastfile_ptr        = NULL;
@@ -2627,8 +2683,10 @@ static int runops_cover(pTHX) {
 
     if (PL_op->op_type == OP_NEXTSTATE || PL_op->op_type == OP_DBSTATE)
       check_if_collecting(aTHX_ cCOP);
-    else if (PL_op->op_type == OP_ENTERSUB)
+    else if (PL_op->op_type == OP_ENTERSUB) {
       store_return(aTHX);
+      record_entered_sub(aTHX);
+    }
 
     if (!collecting_here(aTHX))
       goto call_fptr;
@@ -3232,6 +3290,21 @@ release_require_trees()
       }
       LEAVE;
       av_clear(MY_CXT.require_trees);
+    }
+
+void
+get_entered_subs()
+  PREINIT:
+    dMY_CXT;
+  PPCODE:
+    HE *he;
+    if (MY_CXT.entered_subs) {
+      hv_iterinit(MY_CXT.entered_subs);
+      while ((he = hv_iternext(MY_CXT.entered_subs))) {
+        SV *rv = HeVAL(he);
+        if (rv && SvROK(rv))
+          XPUSHs(sv_2mortal(dc_make_cv_sv(aTHX_ (CV *)SvRV(rv))));
+      }
     }
 
 void

--- a/docs/technical/wrapped-sub-coverage.md
+++ b/docs/technical/wrapped-sub-coverage.md
@@ -69,51 +69,64 @@ The tests are in `t/internal/wrapped_sub.t`: the direct reference form, the
 hash-held and array-held forms, a wrapper closing over a reference to a tied
 array, and a real Moose `around` modifier (skipped when Moose is not installed).
 
-## Known limitations
+## Limits of the heuristic
 
-Recovery is a heuristic, not a guarantee. It finds the original only where the
-wrapper reaches it through a pad, within one plain container. It does not find
-an original that is
+The pad walk finds the original only where the wrapper reaches it through a pad,
+within one plain container. It does not find an original that is
 
 - nested two or more containers deep,
 - held inside a blessed object the wrapper closes over, or
 - kept in a package variable and looked up at call time rather than closed over
   (such an original is in no pad at all).
 
-## A route to a real guarantee
+Entry recording, below, covers all three (GH-606).
+
+## Entry recording
 
 The heuristic re-discovers subs by walking the symbol table and pads, so it is
-bound by where a sub can be reached from. A mechanism that instead remembers
-each sub as it runs would not have that bound.
+bound by where a sub can be reached from. Entry recording removes that bound by
+remembering each sub as it runs.
 
-Devel::Cover already intercepts every call through `dc_entersub` (it replaces
-`PL_ppaddr[OP_ENTERSUB]`). That hook could record the entered CV, so every sub
-that actually executes is remembered regardless of what later happens to its
-glob. A displaced original still runs - the wrapper calls it - so it would be
-recorded even in the cases the heuristic misses above (each of those originals
-does execute and is simply unreachable from the walk roots at report time). A
-sub that never runs needs no run coverage and is still reported as uncovered
-from the symbol-table walk, so entry capture is enough to close the gap for
-executed subs. At report time the recorded CVs are merged into the walk's
-results before the structure is built, and the existing subroutine, statement
-and branch machinery covers them.
+Devel::Cover intercepts every call through `dc_entersub` (it replaces
+`PL_ppaddr[OP_ENTERSUB]`; the `runops_cover` loop mirrors it under
+`-replace_ops 0`). `record_entered_sub` there records the CV about to be
+entered, so every sub that actually executes is remembered regardless of what
+later happens to its glob. A displaced original still runs - the wrapper calls
+it - so it is recorded even where the pad walk cannot reach it. A sub that never
+runs needs no run coverage and is still reported as uncovered from the
+symbol-table walk, so entry capture closes the gap for executed subs. At report
+time `get_entered_subs` hands the recorded CVs to `_seed_entered_subs`, which
+merges them into `%Cvs` - filtered through `recoverable_sub` and `check_file`
+like the pad-walk recoveries - before `check_files` snapshots `@Cvs`, and the
+existing subroutine, statement and branch machinery covers them.
 
-The reference held to each recorded CV must be weak. A weak reference does not
-raise the CV's reference count, so DESTROY timing, memory use and what stays
-alive are all unchanged - the tool must not alter the behaviour of the program
-it measures. It also degrades sensibly. When a CV is freed before the report is
-built (a closure created, called and dropped mid-run), `Scalar::Util::weaken`
-nulls the reference to `undef`, so the report step skips it rather than reading
-a freed or reused slot. Those subs ran but their optree is gone, so no structure
-can be built for them, and they are counted as dropped rather than crashing the
-report. A weak reference is safe against address reuse in a way raw address
-tracking is not.
+Only named subs are recorded: XS subs, anonymous subs, closure clones and the
+compile-phase blocks (`BEGIN` and friends) are skipped. Anonymous subs and
+clones are covered through the pad walk when they survive, a clone shares its
+start op with its prototype so recording it would add a duplicate, and the phase
+blocks' early release must not be delayed.
 
-The costs are why this is a larger change than the heuristic and belongs on its
-own branch. `dc_entersub` is on the call hot path, so recording a CV there - a
-lookup to skip ones already seen, and a weaken on first sight - is collection
-cost, the more sensitive kind, and would likely be gated behind an option. It
-holds one small weak-reference SV per distinct executed CV for the length of the
-run, and the interaction with threaded builds (weak references are
-per-interpreter) and with getting the entered CV cleanly for XS subs both need
-care. Measuring the hot-path cost is the first step before committing to it.
+The reference held to each recorded CV is strong, not weak. A weak reference
+would be nulled the moment a sub is freed, which is exactly the case that needs
+covering: a sub redefined at runtime (`*foo = sub { ... }`) frees the original
+CV on the spot, since the glob held the only reference. With a strong reference
+the original's optree survives to report time, so its structure can be built and
+its counts - keyed by op address - can never be confused with a later op reusing
+the same address. This closes the "Redefined subroutines" limitation documented
+in the user docs since GH-88, for any original that ran at least once. An
+original redefined before it ever runs is still lost: it was never entered, and
+its optree is freed before any coverage could attach.
+
+Recording named subs only keeps the observable cost contained. A named CV lives
+to the end of the run anyway except when redefined or its package is deleted, so
+holding it does not change what stays alive, and closure DESTROY timing - the
+sensitive case, see GH-118 - is untouched because closures are never recorded. A
+redefined sub's pad now survives to report time instead of being freed at
+redefinition, which is the price of reporting on it.
+
+The hot-path cost is a few flag tests per call plus one hash lookup, keyed on
+the CV pointer, for named subs already recorded. Measured on a worst-case
+microbenchmark (ten million calls of a one-line named sub under statement
+coverage, nothing else) the difference from the previous code was about two
+percent, within run-to-run noise, so recording is always on rather than behind
+an option.

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -728,6 +728,11 @@ sub _seed_pad_cvs (@require_trees) {
   $Cvs{$_} ||= $_ for map pad_cvs($_), special_block_cvs();
 }
 
+sub _seed_entered_subs () {
+  $Cvs{$_} ||= $_
+    for grep recoverable_sub($_) && check_file($_), get_entered_subs();
+}
+
 sub report {
   local $@;
   eval { _report() };
@@ -781,6 +786,7 @@ sub _report {
   @require_trees          = grep $latest_tree{ $_->[2] } == $_, @require_trees;
 
   _seed_pad_cvs(@require_trees);
+  _seed_entered_subs();
 
   check_files();
 
@@ -1828,6 +1834,14 @@ the pad walk.
 Feed pad-only anonymous subs from required files' top-level code and from
 special blocks into C<%Cvs> before L</check_files> snapshots C<@Cvs>.
 
+=head2 _seed_entered_subs
+
+Feed the named subs recorded by the XS C<entersub> hook into C<%Cvs>
+before L</check_files> snapshots C<@Cvs>.  These are the subs that ran but
+may no longer be reachable from the symbol table or any pad - originals
+displaced by a wrapper or freed by redefinition.  Filtered through
+L</recoverable_sub> and L</check_file> like the pad-walk recoveries.
+
 =head1 REPORTING
 
 =head2 report
@@ -2154,6 +2168,13 @@ C<INIT> and C<END> block CVs for coverage.
 The top-level op trees of required files, kept alive by the XS
 C<leaveeval> hook so their statements can be covered, and released once
 reporting is done.
+
+=item C<get_entered_subs>
+
+The named subs recorded as they were entered, as C<B::CV> objects.  The
+XS C<entersub> hook keeps a strong reference to each, so a sub displaced
+from the symbol table or freed by redefinition can still be covered.  See
+F<docs/technical/wrapped-sub-coverage.md>.
 
 =item C<adjust_blocks ($stash)>
 

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -633,12 +633,13 @@ Modules used by Devel::Cover while gathering coverage:
 
 =head2 Redefined subroutines
 
-If you redefine a subroutine you may find that the original subroutine is not
-reported on.  This is because I haven't yet found a way to locate the original
-CV.  Hints, tips or patches to resolve this will be gladly accepted.
-
-The module Test::TestCoverage uses this technique and so should not be used in
-conjunction with Devel::Cover.
+If you redefine a subroutine, the original is still reported on provided it
+was called at least once before being redefined.  Devel::Cover remembers
+each named subroutine as it is entered, so redefining or wrapping it later
+does not lose its coverage.  An original that is redefined before it ever
+runs cannot be reported on - its code is freed before any coverage could
+attach to it - so its statements are absent from the report rather than
+shown as uncovered.
 
 =head1 BUGS
 

--- a/t/internal/redefined_sub.t
+++ b/t/internal/redefined_sub.t
@@ -1,0 +1,133 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( realpath );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is ok )];
+
+use Devel::Cover::DB ();
+
+# A sub redefined at runtime frees the original CV the moment its glob is
+# overwritten, since nothing else references it.  The original ran and its
+# counts were recorded, but by report time neither the symbol table nor any
+# pad reaches it, so its statements and the subroutine itself vanish from
+# the report.  This is the "Redefined subroutines" limitation documented in
+# Cover.pod since GH-88.  See GH-606.
+
+# Write a module and a program using it, run the program under coverage and
+# return the cover object for the module's file.
+sub covered_file ($name, $module, $program, $expect) {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+
+  my %write = (
+    File::Spec->catfile($tmpdir, "$name.pm") => $module,
+    File::Spec->catfile($tmpdir, "prog.pl")  => $program,
+  );
+  for my $path (sort keys %write) {
+    open my $fh, ">", $path or die "Cannot write $path: $!";
+    print $fh $write{$path};
+    close $fh or die "Cannot close $path: $!";
+  }
+
+  my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+  my $prog     = File::Spec->catfile($tmpdir, "prog.pl");
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my $cmd
+    = "$^X -Iblib/lib -Iblib/arch -I$tmpdir"
+    . " -MDevel::Cover=-db,$cover_db,-silent,1,-merge,0"
+    . ",-select,$name,-ignore,."
+    . " $prog 2>&1";
+  my $out = `$cmd`;
+  is $?,   0,       "$name: covered run exits 0" or diag $out;
+  is $out, $expect, "$name: module code ran";
+
+  my $db     = Devel::Cover::DB->new(db => $cover_db)->merge_runs;
+  my ($file) = grep m|\Q$name\E\.pm$|, $db->cover->items;
+  ok $file, "$name.pm is in the coverage database" or return;
+  $db->cover->file($file)
+}
+
+# A named sub that runs and is then replaced in its glob with nothing keeping
+# a reference to it.  The original body must still be reported as covered.
+sub test_redefined_sub () {
+  my $f = covered_file("Redefined", <<'PERL', <<'PROG', "11 20\n") or return;
+package Redefined;
+
+sub original {
+  my $n = shift;
+  $n * 2;
+}
+
+my $first = original(10);
+
+*original = sub { shift() + 1 };
+
+sub value { $first }
+
+1;
+PERL
+use Redefined;
+print Redefined::original(10), " ", Redefined::value(), "\n";
+PROG
+
+  my $stmt = $f->statement;
+  for my $line (4, 5) {
+    my $l = $stmt->location($line);
+    ok $l, "redefined sub body statement on line $line is collected";
+    is $l && $l->[0]->covered, 1, "and has a count";
+  }
+
+  my $sub = $f->subroutine->location(4);
+  ok $sub, "the redefined original sub is collected";
+  is $sub && $sub->[0]->name,    "original", "and keeps its name";
+  is $sub && $sub->[0]->covered, 1,          "and is reported as covered";
+}
+
+# A named sub redefined before it ever runs.  The original never executed, so
+# entry capture cannot see it and its optree is gone - it stays absent from
+# the report.  The file must still report cleanly.
+sub test_redefined_before_run () {
+  my $f = covered_file("Unrun", <<'PERL', <<'PROG', "11\n") or return;
+package Unrun;
+
+sub original {
+  my $n = shift;
+  $n * 2;
+}
+
+*original = sub { shift() + 1 };
+
+1;
+PERL
+use Unrun;
+print Unrun::original(10), "\n";
+PROG
+
+  my $sub = $f->subroutine->location(4);
+  is $sub, undef, "a never-run redefined sub stays absent from the report";
+}
+
+sub main () {
+  test_redefined_sub;
+  test_redefined_before_run;
+  done_testing;
+}
+
+main;

--- a/t/internal/wrapped_sub.t
+++ b/t/internal/wrapped_sub.t
@@ -19,12 +19,9 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 use Cwd        qw( realpath );
 use File::Spec ();
 use File::Temp qw( tempdir );
-use Test::More import => [qw( diag done_testing is ok $TODO )];
+use Test::More import => [qw( diag done_testing is ok )];
 
 use Devel::Cover::DB ();
-
-# Set within a TODO block for the cases the heuristic cannot yet recover
-our $TODO;
 
 # A named sub replaced in the symbol table by a wrapper survives only as a
 # reference held inside the wrapper's closure pad, no longer reachable from any
@@ -252,15 +249,14 @@ PROG
   is $l && $l->[0]->covered, 1, "and has a count";
 }
 
-# The cases below are the documented limits of the reference-following
-# heuristic (docs/technical/wrapped-sub-coverage.md).  Each original runs but
-# is not recovered, so the assertions are wrapped in a TODO block - they are
-# the red anchor for the entry-capture follow-up, and will flip to passing
-# (unexpectedly) once that lands, which is the signal to drop the TODO.
+# The cases below are past the limits of the reference-following heuristic
+# (docs/technical/wrapped-sub-coverage.md).  Each original is recovered by
+# entry recording instead - every named sub is remembered as it is entered,
+# so it is covered no matter where the wrapper keeps it.  See GH-606.
 
 # The original sits two containers deep, past the single level the heuristic
 # descends.
-sub test_deep_container_todo () {
+sub test_deep_container () {
   my $f = covered_file("WrappedDeep", <<'PERL', <<'PROG', "21\n") or return;
 package WrappedDeep;
 
@@ -278,7 +274,6 @@ use WrappedDeep;
 print WrappedDeep::original(10), "\n";
 PROG
 
-  local $TODO = "original nested past one container is not yet recovered";
   my $sub = $f->subroutine->location(4);
   ok $sub, "deeply-held wrapped sub is collected";
   is $sub && $sub->[0]->covered, 1, "and is reported as covered";
@@ -286,7 +281,7 @@ PROG
 
 # The original is kept in a blessed object the wrapper closes over, which the
 # heuristic does not descend.
-sub test_blessed_holder_todo () {
+sub test_blessed_holder () {
   my $f = covered_file("WrappedBlessed", <<'PERL', <<'PROG', "21\n") or return;
 package WrappedBlessed;
 
@@ -304,7 +299,6 @@ use WrappedBlessed;
 print WrappedBlessed::original(10), "\n";
 PROG
 
-  local $TODO = "original held in a blessed object is not yet recovered";
   my $sub = $f->subroutine->location(4);
   ok $sub, "blessed-held wrapped sub is collected";
   is $sub && $sub->[0]->covered, 1, "and is reported as covered";
@@ -312,7 +306,7 @@ PROG
 
 # The original is kept in a package variable and looked up at call time, so it
 # is in no pad the walk reaches.
-sub test_global_registry_todo () {
+sub test_global_registry () {
   my $f = covered_file("WrappedReg", <<'PERL', <<'PROG', "21\n") or return;
 package WrappedReg;
 
@@ -330,7 +324,6 @@ use WrappedReg;
 print WrappedReg::original(10), "\n";
 PROG
 
-  local $TODO = "original kept in a package variable is not yet recovered";
   my $sub = $f->subroutine->location(4);
   ok $sub, "registry-held wrapped sub is collected";
   is $sub && $sub->[0]->covered, 1, "and is reported as covered";
@@ -342,9 +335,9 @@ sub main () {
   test_array_wrapped_sub;
   test_tied_container;
   test_moose_around_original;
-  test_deep_container_todo;
-  test_blessed_holder_todo;
-  test_global_registry_todo;
+  test_deep_container;
+  test_blessed_holder;
+  test_global_registry;
   done_testing;
 }
 


### PR DESCRIPTION
## Summary

- Record every named sub as it is entered, holding a strong reference so the report can build structure for subs no longer reachable from the symbol table or any pad. This covers the three cases the pad-walk heuristic from #308 misses - originals nested past one container, held in blessed objects the wrapper closes over, or kept in package variables looked up at call time. The three TODO tests in `wrapped_sub.t` now pass.
- The same mechanism reports on subs redefined at runtime, provided the original ran at least once before being replaced, closing the "Redefined subroutines" limitation documented in the user docs since 2006. The new `redefined_sub.t` tests both sides: an original called before redefinition is reported, one replaced before it ever ran stays absent.
- Skip anon, cloned and XS subs and the compile-phase blocks, so closure destruction timing is unchanged and clones cannot duplicate their prototype's start op.
- A worst-case microbenchmark of ten million calls to a one-line named sub showed a cost of about two percent, so recording is always on rather than behind an option.

## Ticket

Closes #606