### PR TITLE
GH-213 Fix hang covering multiconcat expressions

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Fix coverage collection hanging when a multiconcat expression is followed
+  by a loop - the padrange statement walk could run forever (GH-213)
 - Record each named sub as it is entered so subs displaced from the symbol
   table are covered wherever the wrapper keeps the original - nested
   containers, blessed holders and package variables included (GH-606)

--- a/Cover.xs
+++ b/Cover.xs
@@ -2227,13 +2227,16 @@ static void cover_logop(pTHX) {
  * A sequence of variable declarations may have been optimised to a single
  * OP_PADRANGE. The original sequence may span multiple lines, but only the
  * first line has been marked as covered for now. Mark other OP_NEXTSTATE inside
- * the original sequence of statements.
+ * the original sequence of statements. Only a void-context padrange replaces
+ * whole statements. For any other padrange the sibling's op_next chain may
+ * never reach op_next (multiconcat rewires it), so the walk could loop forever.
  */
 static void cover_padrange(pTHX) {
   dMY_CXT;
   OP *next,
      *orig;
   if (!collecting(Statement)) return;
+  if ((PL_op->op_flags & OPf_WANT) != OPf_WANT_VOID) return;
   next = PL_op->op_next;
   orig = OpSIBLING(PL_op);
 

--- a/test_output/cover/multiconcat.5.020000
+++ b/test_output/cover/multiconcat.5.020000
@@ -1,0 +1,77 @@
+cover: Reading database from ...
+----------------- ------ ------ ------ ------ ------ ------ ------
+File                stmt   bran   cond   mcdc    sub  total   scar
+----------------- ------ ------ ------ ------ ------ ------ ------
+tests/multiconcat  100.0   50.0    n/a    n/a  100.0   94.1    6.9
+Total              100.0   50.0    n/a    n/a  100.0   94.1    6.9
+----------------- ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/multiconcat
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 2 92.9  2.0  6.9
+
+Worst Subroutines
+-----------------
+
+Subroutine       CC SCAR  Location            
+---------------- -- ----  --------------------
+test_multiconcat  2  7.0  tests/multiconcat:14
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/env perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10             1                           1   use strict;
+               1                               
+               1                               
+11             1                           1   use warnings;
+               1                               
+               1                               
+12                                             
+13                                             sub test_multiconcat {
+14             1                           1     my ($x, $y) = ("x", 10);
+15    ***      1   * 50                          print "prefix" . $x . (defined $y ? $y : "test") . ": ";
+16             1                                 while () { return 10 }
+               1                               
+17                                             }
+18                                             
+19             1                               test_multiconcat();
+20             1                               print "\n";
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+15    ***     50      1      0   defined $y ? :
+
+
+Covered Subroutines
+-------------------
+
+Subroutine       Count  CC  SCAR Location            
+---------------- ----- --- ----- --------------------
+BEGIN                1   1   0.0 tests/multiconcat:10
+BEGIN                1   1   0.0 tests/multiconcat:11
+test_multiconcat     1   2   7.0 tests/multiconcat:14
+
+

--- a/tests/multiconcat
+++ b/tests/multiconcat
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use strict;
+use warnings;
+
+sub test_multiconcat {
+  my ($x, $y) = ("x", 10);
+  print "prefix" . $x . (defined $y ? $y : "test") . ": ";
+  while () { return 10 }
+}
+
+test_multiconcat();
+print "\n";


### PR DESCRIPTION
## Summary

- Coverage collection hung when a padrange fed a multiconcat expression and a loop followed in the same sub, reported in the ticket against 5.28 and still present on every perl with multiconcat.
- The statement walk in `cover_padrange` assumed the sibling's `op_next` chain leads to the padrange's own `op_next`. The multiconcat rewrite breaks that for argument-loading padranges, so the walk escaped into the loop's cyclic `op_next` chain and never returned.
- Skip the walk for non-void padranges. Perl folds `nextstate` ops into a padrange only in void context, so there is nothing to mark elsewhere.
- Add the `tests/multiconcat` fixture, whose golden output is identical on every supported perl.

## Ticket

Closes #213