### PR TITLE
GH-687 Rework the Html_crisp coverage colours

### DIFF
--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1946,9 +1946,31 @@ td.chevron {
 .detail .c0 { background: var(--cov-none-bg); }
 .detail .c3 { background: var(--cov-full-bg); }
 
-.detail.cond-cells { border-left: 3px solid var(--cov-full-bg); }
-.detail.mcdc-detail { border-left: 3px solid var(--header-bg); }
-.detail.decision-vectors { border-left: 3px solid var(--border); }
+.detail.cond-cells { border-left: 3px solid var(--panel-cond); }
+.detail.mcdc-detail { border-left: 3px solid var(--panel-mcdc); }
+.detail.decision-vectors { border-left: 3px solid var(--panel-tt); }
+
+.cond-cells .head > span:first-child,
+.mcdc-detail .head > span:first-child,
+.decision-vectors .head > span:first-child {
+  padding: 0 8px;
+  border-radius: 3px;
+}
+
+.cond-cells .head > span:first-child {
+  background: var(--panel-cond);
+  color: var(--panel-cond-fg);
+}
+
+.mcdc-detail .head > span:first-child {
+  background: var(--panel-mcdc);
+  color: var(--panel-mcdc-fg);
+}
+
+.decision-vectors .head > span:first-child {
+  background: var(--panel-tt);
+  color: var(--panel-tt-fg);
+}
 
 .detail .head {
   display: flex;

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -77,7 +77,7 @@ $content
 Coverage information from
 <a href="https://metacpan.org/pod/Devel::Cover">Devel::Cover</a>
 $R{version} by <a href="https://pjcj.net">Paul Johnson</a>
-on $R{date} | Perl $R{perl_v} | $R{os}
+| $R{date} | Perl $R{perl_v} | $R{os}
 </div>
 <script src="${asset_prefix}assets/app.js"></script>
 </body>

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -232,32 +232,31 @@ sub render_dist_bar ($dist) {
   return "" unless $dt > 0;
   my $o = qq(<div class="dist-bar">\n);
   for my $seg (
-    [c0       => "--cov-none-border", $dist->{tip_c0}],
-    [c1       => "--cov-low-border",  $dist->{tip_c1}],
-    [c2       => "--cov-good-border", $dist->{tip_c2}],
-    [c3       => "--cov-full-border", $dist->{tip_c3}],
-    [untested => "--untested-bar",    $dist->{tip_untested}],
+    [c0       => $dist->{tip_c0}],
+    [c1       => $dist->{tip_c1}],
+    [c2       => $dist->{tip_c2}],
+    [c3       => $dist->{tip_c3}],
+    [untested => $dist->{tip_untested}],
   ) {
-    my ($key, $var, $tip) = @$seg;
+    my ($key, $tip) = @$seg;
     next unless $dist->{$key};
     my $w = $dist->{$key} / $dt * 100;
+    my $n = $w >= 5 ? $dist->{$key} : "";
     $o .= <<HTML;
-<div class="dist-bar-seg tip-hover" style="width:${w}%; background:var($var)">
+<div class="dist-bar-seg seg-$key tip-hover" style="width:${w}%">$n
 @{[ glass_tip($tip) ]}</div>
 HTML
   }
   $o .= "</div>\n";
   my $c3 = $Threshold->{c2} < 100 ? dist_range("c3") : "at 100%";
   my $untested
-    = $dist->{untested}
-    ? qq(<span class="leg-untested">$dist->{untested} untested</span>\n)
-    : "";
+    = $dist->{untested} ? qq(<span class="leg-untested">untested</span>\n) : "";
   $o .= <<HTML;
 <div class="dist-legend">
-<span class="leg-c0">$dist->{c0} @{[ dist_range("c0") ]}</span>
-<span class="leg-c1">$dist->{c1} @{[ dist_range("c1") ]}</span>
-<span class="leg-c2">$dist->{c2} @{[ dist_range("c2") ]}</span>
-<span class="leg-c3">$dist->{c3} $c3</span>
+<span class="leg-c0">@{[ dist_range("c0") ]}</span>
+<span class="leg-c1">@{[ dist_range("c1") ]}</span>
+<span class="leg-c2">@{[ dist_range("c2") ]}</span>
+<span class="leg-c3">$c3</span>
 $untested</div>
 HTML
   $o
@@ -2070,8 +2069,8 @@ td.chevron {
 
 .dist-bar {
   display: flex;
-  height: 12px;
-  border-radius: 3px;
+  height: 20px;
+  border-radius: 10px;
   margin-bottom: 16px;
   border: 1px solid var(--border);
 }
@@ -2079,37 +2078,51 @@ td.chevron {
 .dist-bar-seg {
   height: 100%;
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
-.dist-bar-seg:first-child { border-radius: 3px 0 0 3px; }
-.dist-bar-seg:last-child { border-radius: 0 3px 3px 0; }
-.dist-bar-seg:only-child { border-radius: 3px; }
+.dist-bar-seg:first-child { border-radius: 10px 0 0 10px; }
+.dist-bar-seg:last-child { border-radius: 0 10px 10px 0; }
+.dist-bar-seg:only-child { border-radius: 10px; }
 
 .dist-bar-seg:hover { opacity: 0.8; }
+
+.seg-c0 { background: var(--cov-none-bg); color: var(--cov-none-fg); }
+.seg-c1 { background: var(--cov-low-bg); color: var(--cov-low-fg); }
+.seg-c2 { background: var(--cov-good-bg); color: var(--cov-good-fg); }
+.seg-c3 { background: var(--cov-full-bg); color: var(--cov-full-fg); }
+.seg-untested { background: var(--untested-bar); color: var(--fg); }
 
 .dist-legend {
   display: flex;
   gap: 12px;
+  align-items: center;
   margin-bottom: 16px;
-  font-size: var(--font-size-small);
-  color: var(--fg-muted);
+  font-size: 11px;
 }
 
-.dist-legend span::before {
-  content: "";
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 2px;
-  margin-right: 4px;
-  vertical-align: middle;
+.dist-legend span {
+  padding: 1px 10px;
+  border-radius: 4px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
-.dist-legend .leg-c0::before { background: var(--cov-none-border); }
-.dist-legend .leg-c1::before { background: var(--cov-low-border); }
-.dist-legend .leg-c2::before { background: var(--cov-good-border); }
-.dist-legend .leg-c3::before { background: var(--cov-full-border); }
-.dist-legend .leg-untested::before { background: var(--untested-bar); }
+.dist-legend .leg-c0 { background: var(--cov-none-bg);
+  color: var(--cov-none-fg); }
+.dist-legend .leg-c1 { background: var(--cov-low-bg);
+  color: var(--cov-low-fg); }
+.dist-legend .leg-c2 { background: var(--cov-good-bg);
+  color: var(--cov-good-fg); }
+.dist-legend .leg-c3 { background: var(--cov-full-bg);
+  color: var(--cov-full-fg); }
+.dist-legend .leg-untested { background: var(--untested-badge-bg);
+  color: var(--untested-badge-fg); }
 
 /* Nav links */
 

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1866,9 +1866,9 @@ tr.dir-file td:first-child a {
   font-size: var(--font-size-small);
 }
 
-.exec-0 { background: var(--exec-none); }
-.exec-partial { background: var(--exec-partial); }
-.exec-covered { background: var(--exec-covered); }
+.exec-0 { background: var(--cov-none-bg); }
+.exec-partial { background: var(--cov-low-bg); }
+.exec-covered { background: var(--cov-full-bg); }
 
 .src {
   white-space: pre;
@@ -1943,10 +1943,10 @@ td.chevron {
 }
 
 .detail th { background: var(--header-bg); }
-.detail .c0 { background: var(--exec-none); }
-.detail .c3 { background: var(--exec-covered); }
+.detail .c0 { background: var(--cov-none-bg); }
+.detail .c3 { background: var(--cov-full-bg); }
 
-.detail.cond-cells { border-left: 3px solid var(--exec-covered); }
+.detail.cond-cells { border-left: 3px solid var(--cov-full-bg); }
 .detail.mcdc-detail { border-left: 3px solid var(--header-bg); }
 .detail.decision-vectors { border-left: 3px solid var(--border); }
 

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -1585,7 +1585,7 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
 }
 
 .worst-item {
-  padding: 6px 12px;
+  padding: 2px 8px;
   border-radius: 4px;
   border: 1px solid;
   font-size: var(--font-size-small);

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -222,6 +222,12 @@ our $Crisp_base_css = <<'CSS';
   --prefix-bg: #e4edf6;
   --prefix-border: #a0bcd8;
   --prefix-label: #4a6f96;
+  --panel-cond: #a0bcd8;
+  --panel-cond-fg: #1a1a1a;
+  --panel-mcdc: #7b6daa;
+  --panel-mcdc-fg: #ffffff;
+  --panel-tt: #5a9991;
+  --panel-tt-fg: #1a1a1a;
 
   /*COV:light:  */
 
@@ -277,6 +283,12 @@ our $Crisp_base_css = <<'CSS';
     --prefix-bg: #1a2a3d;
     --prefix-border: #3a6090;
     --prefix-label: #80b0e0;
+    --panel-cond: #3a6090;
+    --panel-cond-fg: #e0e0e0;
+    --panel-mcdc: #8a84b0;
+    --panel-mcdc-fg: #1a1a1a;
+    --panel-tt: #8abab4;
+    --panel-tt-fg: #1a1a1a;
 
     /*COV:dark:    */
 
@@ -324,6 +336,12 @@ html[data-theme="dark"] {
   --prefix-bg: #1a2a3d;
   --prefix-border: #3a6090;
   --prefix-label: #80b0e0;
+  --panel-cond: #3a6090;
+  --panel-cond-fg: #e0e0e0;
+  --panel-mcdc: #8a84b0;
+  --panel-mcdc-fg: #1a1a1a;
+  --panel-tt: #8abab4;
+  --panel-tt-fg: #1a1a1a;
 
   /*COV:dark:  */
 
@@ -370,6 +388,12 @@ html[data-theme="light"] {
   --prefix-bg: #e4edf6;
   --prefix-border: #a0bcd8;
   --prefix-label: #4a6f96;
+  --panel-cond: #a0bcd8;
+  --panel-cond-fg: #1a1a1a;
+  --panel-mcdc: #7b6daa;
+  --panel-mcdc-fg: #ffffff;
+  --panel-tt: #5a9991;
+  --panel-tt-fg: #1a1a1a;
 
   /*COV:light:  */
 

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -35,33 +35,12 @@ our $Cov = {
   },
 };
 
-sub _hex_rgb ($hex) {
-  map { hex } $hex =~ /[0-9a-f]{2}/gi
-}
-
-sub _rgb_hex (@rgb) {
-  sprintf "#%02x%02x%02x", @rgb
-}
-
-sub _mix ($c1, $c2, $ratio) {
-  my @a = _hex_rgb($c1);
-  my @b = _hex_rgb($c2);
-  _rgb_hex(map { int($a[$_] * $ratio + $b[$_] * (1 - $ratio) + 0.5) } 0 .. 2)
-}
-
 sub _cov_vars ($theme, $indent) {
-  my $c  = $Cov->{$theme};
-  my $bg = $theme eq "light" ? "#ffffff" : "#000000";
-  my $r  = $theme eq "light" ? 0.45      : 0.35;
-  join "", (
-    map {
-      my $n = $_;
-      map "$indent--cov-$n-$_: $c->{$n}{$_};\n", qw( bg border fg )
-    } qw( none low good full )
-    ),
-    "\n", "${indent}--exec-none: " . _mix($c->{none}{border}, $bg, $r) . ";\n",
-    "${indent}--exec-partial: " . _mix($c->{low}{border},  $bg, $r) . ";\n",
-    "${indent}--exec-covered: " . _mix($c->{full}{border}, $bg, $r) . ";\n",
+  my $c = $Cov->{$theme};
+  join "", map {
+    my $n = $_;
+    map "$indent--cov-$n-$_: $c->{$n}{$_};\n", qw( bg border fg )
+  } qw( none low good full )
 }
 
 my %Files;

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -22,16 +22,16 @@ our @EXPORT_OK = qw( write_file $Cov $Crisp_base_css $Crisp_theme_js );
 
 our $Cov = {
   light => {
-    none => { bg => "#ffcccc", border => "#dd0000", fg => "#990000" },
-    low  => { bg => "#fce8c8", border => "#c08820", fg => "#7a5810" },
-    good => { bg => "#c8e4f0", border => "#2080a8", fg => "#104860" },
-    full => { bg => "#b0f0b0", border => "#008800", fg => "#005500" },
+    none => { bg => "#fdd5d1", border => "#dd0000", fg => "#990000" },
+    low  => { bg => "#f9dfa0", border => "#c08820", fg => "#7a5810" },
+    good => { bg => "#b3ddff", border => "#2f7db1", fg => "#164666" },
+    full => { bg => "#c0f1be", border => "#008800", fg => "#005500" },
   },
   dark => {
-    none => { bg => "#5c2020", border => "#ff4444", fg => "#ffcccc" },
-    low  => { bg => "#523c14", border => "#e0a830", fg => "#f0d888" },
-    good => { bg => "#1a4858", border => "#48c0e0", fg => "#98d8f0" },
-    full => { bg => "#1a5a1a", border => "#44dd44", fg => "#bbffbb" },
+    none => { bg => "#7e0b12", border => "#ff4444", fg => "#ffcccc" },
+    low  => { bg => "#5f4a08", border => "#e0a830", fg => "#f0d888" },
+    good => { bg => "#0d527c", border => "#64b7ef", fg => "#a0d6fa" },
+    full => { bg => "#0c5e0e", border => "#44dd44", fg => "#bbffbb" },
   },
 };
 
@@ -259,7 +259,7 @@ our $Crisp_base_css = <<'CSS';
   --tip-glass-sep: rgba(0, 0, 0, 0.2);
   --tip-c0: #dd0000;
   --tip-c1: #c08820;
-  --tip-c2: #2080a8;
+  --tip-c2: #2f7db1;
   --tip-c3: #008800;
 
   --bg: #ffffff;
@@ -314,7 +314,7 @@ our $Crisp_base_css = <<'CSS';
     --tip-glass-sep: rgba(255, 255, 255, 0.2);
     --tip-c0: #ff4444;
     --tip-c1: #e0a830;
-    --tip-c2: #48c0e0;
+    --tip-c2: #64b7ef;
     --tip-c3: #44dd44;
 
     --bg: #1a1a1a;
@@ -361,7 +361,7 @@ html[data-theme="dark"] {
   --tip-glass-sep: rgba(255, 255, 255, 0.2);
   --tip-c0: #ff4444;
   --tip-c1: #e0a830;
-  --tip-c2: #48c0e0;
+  --tip-c2: #64b7ef;
   --tip-c3: #44dd44;
 
   --bg: #1a1a1a;
@@ -407,7 +407,7 @@ html[data-theme="light"] {
   --tip-glass-sep: rgba(0, 0, 0, 0.2);
   --tip-c0: #dd0000;
   --tip-c1: #c08820;
-  --tip-c2: #2080a8;
+  --tip-c2: #2f7db1;
   --tip-c3: #008800;
 
   --bg: #ffffff;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -18,8 +18,9 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 
 use File::Spec ();
 use Test::More import => [qw( diag done_testing is like ok plan unlike )];
-use Devel::Cover::Mcdc               ();  ## no perlimports
+use Devel::Cover::Mcdc               ();                    ## no perlimports
 use Devel::Cover::Report::Html_crisp ();
+use Devel::Cover::Web                qw( $Crisp_base_css );
 use Devel::Cover::Test::Showcase     qw(
   create_cover_db
   run_cover
@@ -152,6 +153,24 @@ sub test_dist_legend_custom_thresholds () {
   unlike $html, qr/at 100%/,        "no 'at 100%' label when c2 is below 100";
   like $html,   qr/files? 50-75%/,  "bar tooltip c2 range c1 to c2";
   like $html,   qr/files? 75-100%/, "bar tooltip c3 range c2 to 100";
+}
+
+sub test_palette_css () {
+  like $Crisp_base_css,   qr/--cov-none-bg: #fdd5d1/,     "light red fill";
+  like $Crisp_base_css,   qr/--cov-low-bg: #f9dfa0/,      "light gold fill";
+  like $Crisp_base_css,   qr/--cov-good-bg: #b3ddff/,     "light blue fill";
+  like $Crisp_base_css,   qr/--cov-good-border: #2f7db1/, "light blue border";
+  like $Crisp_base_css,   qr/--cov-good-fg: #164666/,     "light blue fg";
+  like $Crisp_base_css,   qr/--cov-full-bg: #c0f1be/,     "light green fill";
+  like $Crisp_base_css,   qr/--cov-none-bg: #7e0b12/,     "dark red fill";
+  like $Crisp_base_css,   qr/--cov-low-bg: #5f4a08/,      "dark gold fill";
+  like $Crisp_base_css,   qr/--cov-good-bg: #0d527c/,     "dark blue fill";
+  like $Crisp_base_css,   qr/--cov-good-border: #64b7ef/, "dark blue border";
+  like $Crisp_base_css,   qr/--cov-good-fg: #a0d6fa/,     "dark blue fg";
+  like $Crisp_base_css,   qr/--cov-full-bg: #0c5e0e/,     "dark green fill";
+  like $Crisp_base_css,   qr/--tip-c2: #2f7db1/, "light tip-c2 matches border";
+  like $Crisp_base_css,   qr/--tip-c2: #64b7ef/, "dark tip-c2 matches border";
+  unlike $Crisp_base_css, qr/#2080a8|#48c0e0/,   "no stale blue accents";
 }
 
 sub test_render_file_page () {
@@ -1027,6 +1046,7 @@ sub main () {
   test_render_layout;
   test_render_index;
   test_dist_legend_custom_thresholds;
+  test_palette_css;
   test_render_file_page;
   test_tooltip_structure;
   test_glass_tooltips;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -225,6 +225,31 @@ sub test_exec_cells_use_fills () {
   unlike $css, qr/var\(--exec-/, "no exec variable references remain";
 }
 
+sub test_panel_identity () {
+  my $css = slurp("$Outdir/assets/style.css");
+  my %panel
+    = (cond => "cond-cells", mcdc => "mcdc-detail", tt => "decision-vectors");
+  for my $p (sort keys %panel) {
+    my $cls  = $panel{$p};
+    my $edge = ".detail.$cls { border-left: 3px solid var(--panel-$p); }";
+    like $css, qr/\Q$edge\E/, "$cls edge uses its identity colour";
+    my $chip = ".$cls .head > span:first-child {\n"
+      . "  background: var(--panel-$p);\n  color: var(--panel-$p-fg);\n}";
+    like $css, qr/\Q$chip\E/, "$cls heading chip uses its identity colour";
+  }
+
+  like $Crisp_base_css, qr/--panel-cond: #a0bcd8/, "light condition identity";
+  like $Crisp_base_css, qr/--panel-cond-fg: #1a1a1a/, "light condition chip fg";
+  like $Crisp_base_css, qr/--panel-mcdc: #7b6daa/,    "light mcdc identity";
+  like $Crisp_base_css, qr/--panel-mcdc-fg: #ffffff/, "light mcdc chip fg";
+  like $Crisp_base_css, qr/--panel-tt: #5a9991/,   "light truth table identity";
+  like $Crisp_base_css, qr/--panel-cond: #3a6090/, "dark condition identity";
+  like $Crisp_base_css, qr/--panel-cond-fg: #e0e0e0/, "dark condition chip fg";
+  like $Crisp_base_css, qr/--panel-mcdc: #8a84b0/,    "dark mcdc identity";
+  like $Crisp_base_css, qr/--panel-mcdc-fg: #1a1a1a/, "dark mcdc chip fg";
+  like $Crisp_base_css, qr/--panel-tt: #8abab4/, "dark truth table identity";
+}
+
 sub test_render_file_page () {
   # Find a covered file page
   my ($covered) = grep /Covered-Calc/, keys %Golden;
@@ -1101,6 +1126,7 @@ sub main () {
   test_dist_bar_fill_segments;
   test_palette_css;
   test_exec_cells_use_fills;
+  test_panel_identity;
   test_render_file_page;
   test_tooltip_structure;
   test_glass_tooltips;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -146,13 +146,49 @@ sub test_dist_legend_custom_thresholds () {
   is $exit, 0, "custom threshold report generated" or diag $out;
 
   my $html = slurp("$outdir/coverage.html");
-  like $html,   qr/leg-c0">\d+ &lt; 25%/, "legend c0 below c0 threshold";
-  like $html,   qr/leg-c1">\d+ 25-50%/,   "legend c1 range c0 to c1";
-  like $html,   qr/leg-c2">\d+ 50-75%/,   "legend c2 range c1 to c2";
-  like $html,   qr/leg-c3">\d+ 75-100%/,  "legend c3 range c2 to 100";
-  unlike $html, qr/at 100%/,        "no 'at 100%' label when c2 is below 100";
-  like $html,   qr/files? 50-75%/,  "bar tooltip c2 range c1 to c2";
-  like $html,   qr/files? 75-100%/, "bar tooltip c3 range c2 to 100";
+  like $html,   qr/leg-c0">&lt; 25%/, "legend c0 below c0 threshold";
+  like $html,   qr/leg-c1">25-50%/,   "legend c1 range c0 to c1";
+  like $html,   qr/leg-c2">50-75%/,   "legend c2 range c1 to c2";
+  like $html,   qr/leg-c3">75-100%/,  "legend c3 range c2 to 100";
+  unlike $html, qr/at 100%/,          "no 'at 100%' label when c2 is below 100";
+  like $html,   qr/files? 50-75%/,    "bar tooltip c2 range c1 to c2";
+  like $html,   qr/files? 75-100%/,   "bar tooltip c3 range c2 to 100";
+}
+
+sub test_dist_bar_fill_segments () {
+  my $dist = {
+    dist_total   => 50,
+    c0           => 1,
+    c1           => 9,
+    c2           => 20,
+    c3           => 15,
+    untested     => 5,
+    tip_c0       => "1 file &lt; 75%",
+    tip_c1       => "9 files 75-90%",
+    tip_c2       => "20 files 90-100%",
+    tip_c3       => "15 files at 100%",
+    tip_untested => "5 untested files",
+  };
+  my $got = Devel::Cover::Report::Html_crisp::render_dist_bar($dist);
+
+  like $got, qr/class="dist-bar-seg seg-c1 tip-hover" style="width:18%">9\n/,
+    "segment uses fill class and carries its file count";
+  like $got, qr/class="dist-bar-seg seg-c2 tip-hover" style="width:40%">20\n/,
+    "largest segment carries its file count";
+  like $got, qr/class="dist-bar-seg seg-untested tip-hover"[^>]*>5\n/,
+    "untested segment has its own class and count";
+  like $got, qr/class="dist-bar-seg seg-c0 tip-hover" style="width:2%">\n/,
+    "count hidden when segment is below the width threshold";
+  unlike $got, qr/background:var/, "no inline accent backgrounds";
+
+  like $got, qr/leg-c0">&lt; 75%</,       "legend pill holds range only";
+  like $got, qr/leg-c3">at 100%</,        "legend c3 pill at default threshold";
+  like $got, qr/leg-untested">untested</, "untested pill without count";
+
+  $dist->{c2} = 0;
+  $got = Devel::Cover::Report::Html_crisp::render_dist_bar($dist);
+  unlike $got, qr/seg-c2/,           "zero-count tier has no segment";
+  like $got,   qr/leg-c2">90-100%</, "zero-count tier keeps its legend pill";
 }
 
 sub test_palette_css () {
@@ -1046,6 +1082,7 @@ sub main () {
   test_render_layout;
   test_render_index;
   test_dist_legend_custom_thresholds;
+  test_dist_bar_fill_segments;
   test_palette_css;
   test_render_file_page;
   test_tooltip_structure;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -207,6 +207,22 @@ sub test_palette_css () {
   like $Crisp_base_css,   qr/--tip-c2: #2f7db1/, "light tip-c2 matches border";
   like $Crisp_base_css,   qr/--tip-c2: #64b7ef/, "dark tip-c2 matches border";
   unlike $Crisp_base_css, qr/#2080a8|#48c0e0/,   "no stale blue accents";
+  unlike $Crisp_base_css, qr/--exec-/,           "no derived exec tints";
+}
+
+sub test_exec_cells_use_fills () {
+  my $css = slurp("$Outdir/assets/style.css");
+  like $css, qr/\.exec-0 \{ background: var\(--cov-none-bg\); \}/,
+    "unexecuted count cells use the none fill";
+  like $css, qr/\.exec-partial \{ background: var\(--cov-low-bg\); \}/,
+    "partial count cells use the low fill";
+  like $css, qr/\.exec-covered \{ background: var\(--cov-full-bg\); \}/,
+    "executed count cells use the full fill";
+  like $css, qr/\.detail \.c0 \{ background: var\(--cov-none-bg\); \}/,
+    "detail panel c0 cells use the none fill";
+  like $css, qr/\.detail \.c3 \{ background: var\(--cov-full-bg\); \}/,
+    "detail panel c3 cells use the full fill";
+  unlike $css, qr/var\(--exec-/, "no exec variable references remain";
 }
 
 sub test_render_file_page () {
@@ -1084,6 +1100,7 @@ sub main () {
   test_dist_legend_custom_thresholds;
   test_dist_bar_fill_segments;
   test_palette_css;
+  test_exec_cells_use_fills;
   test_render_file_page;
   test_tooltip_structure;
   test_glass_tooltips;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -101,7 +101,7 @@ sub test_render_layout () {
   like $got, qr/data-file-count="5"/,             "layout: file count";
   like $got, qr/<p>Hello world<\/p>/,             "layout: content";
   like $got, qr/class="footer"/,                  "layout: footer";
-  like $got, qr/1\.44 by .*\son 2026-04-08/s,     "layout: version + date";
+  like $got, qr/1\.44 by .*\s\| 2026-04-08/s,     "layout: version + date";
 }
 
 sub test_render_index () {


### PR DESCRIPTION
## Summary

Rework the tier colours in the crisp report for both themes. In dark the yellow read as brown and the blue as grey, and the light theme had the same muddy character.

- Derive both palettes in OKLCH so the four tiers sit at matched lightness and chroma, working round each theme's gamut limits (yellow in dark, red and blue in light).
- Fill the distribution bar segments with the tier colours, with counts inside, and turn the legend entries into matching pills.
- Use the tier fills for the execution count tints as well, replacing the sRGB blending that dulled them, so a red background means the same thing everywhere.
- Give the condition, MC/DC and truth table panels their own non-coverage identity colours (a left edge plus heading chip), replacing coloured edges that carried no meaning.
- Match the Top SCAR chip height to the header badges.

## Ticket

Closes #687