### PR TITLE
GH-689 Add CC and SCAR to collection tables

### DIFF
--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -22,6 +22,7 @@ use JSON::MaybeXS ();
 use POSIX         qw( setsid );
 use Template      ();
 use Time::HiRes   qw( alarm time );
+use version       ();
 
 use feature "class";
 
@@ -422,6 +423,39 @@ class Devel::Cover::Collection {
     }
   }
 
+  method _newer ($va, $vb) {
+    my ($pa, $pb) = map { eval { version->parse($_) } } $va, $vb;
+    return $pa > $pb if $pa && $pb;
+    ($va // "") gt($vb // "")
+  }
+
+  method add_overview ($vars) {
+    my %latest;
+    for my $m (values $vars->{vals}->%*) {
+      my $name = $m->{module}{name} // next;
+      my $cur  = $latest{$name};
+      $latest{$name} = $m
+        if !$cur
+        || $self->_newer($m->{module}{version}, $cur->{module}{version});
+    }
+
+    my %bands;
+    $bands{ $self->coverage_class($_->{total}{pc}) }++ for values %latest;
+
+    my $count    = keys %latest;
+    my $segments = [];
+    for my $class (qw( c3 c2 c1 c0 na )) {
+      my $n   = $bands{$class} or next;
+      my $pct = 100 * $n / $count;
+      push @$segments, {
+          class => $class,
+          pct   => sprintf("%.2f", $pct),
+          label => $pct >= 4 ? $n : "",
+        };
+    }
+    $vars->{overview} = { count => $count, segments => $segments };
+  }
+
   method generate_html {
     my ($d) = $self->made_res_dir;
     chdir $d or die "Can't chdir $d: $!\n";
@@ -514,6 +548,7 @@ class Devel::Cover::Collection {
 
     $self->resolve_log_links($d, \@mods, $vars);
     $self->add_metacpan_links($vars);
+    $self->add_overview($vars);
 
     # print "vars ", Dumper $vars;
     $self->write_summary($vars);
@@ -899,6 +934,15 @@ $Templates{summary} = <<'EOT';
 [% WRAPPER html %]
 
 <h2>Distributions</h2>
+
+<p class="dist-count">[% overview.count %] distributions</p>
+<div class="dist-bar">
+[% FOREACH seg = overview.segments %]
+  <div class="dist-bar-seg [% seg.class %]" style="width: [% seg.pct %]%">
+    [%- seg.label -%]
+  </div>
+[% END %]
+</div>
 
 <p>Search for distributions by first character:</p>
 
@@ -1399,6 +1443,17 @@ modules.
 Writes C<search.json>, a sorted list of the module directories that have
 report pages. The header search on the collection pages fetches it to
 offer direct links to module reports.
+
+=head3 add_overview ($vars)
+
+  $collection->add_overview($vars);
+
+Builds the front-page overview from the collected module data: the
+distribution count and a list of coverage-band segments for the
+distribution bar. Only the latest version of each distribution counts,
+so the bar reflects the current state of CPAN. Bands with no
+distributions are omitted, and a segment too narrow to fit its count
+drops its label.
 
 =head2 Status Tracking
 

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -14,7 +14,7 @@ use 5.42.0;
 use Devel::Cover::Criterion    ();
 use Devel::Cover::DB::IO::JSON ();
 use Devel::Cover::Dumper       qw( Dumper );
-use Devel::Cover::Html_Common  ();               ## no perlimports
+use Devel::Cover::Html_Common  qw( scar_class );  ## no perlimports
 use Devel::Cover::Inc          ();
 use Devel::Cover::Web          qw( write_file );
 
@@ -305,7 +305,7 @@ class Devel::Cover::Collection {
       if (defined $name && defined $version) {
         $results->{$name}{$version}{coverage}{total} = {
           map { $_ => $m->{$_}{pc} } grep $m->{$_}{pc} ne "n/a",
-          grep !/link|log|module/,
+          grep !/link|log|module|^(?:cc|scar)$/,
           keys %$m,
         };
       } else {
@@ -484,6 +484,21 @@ class Devel::Cover::Collection {
         $m->{$criterion}{class} = $self->coverage_class($pc);
         $m->{$criterion}{details}
           = ($summary->{covered} || 0) . " / " . ($summary->{total} || 0);
+      }
+
+      my $s = $json->{summary}{Total}{scar};
+      if ($s && defined $s->{file_scar}) {
+        $m->{cc}   = { val => $s->{file_cc}, class => "cc-val" };
+        $m->{scar} = {
+          val   => sprintf("%.1f", $s->{file_scar}),
+          class => "scar-val scar-" . scar_class($s->{file_scar}),
+          tip   => sprintf(
+            "CC %d &middot; cov %.0f%% &middot; CRAP %.1f",
+            $s->{file_cc}, $s->{file_cov}, $s->{file_crap},
+          ),
+        };
+      } else {
+        $m->{$_} = { val => "n/a", class => "na" } for qw( cc scar );
       }
 
       print "." if !($n++ % 1000) && !$verbose;
@@ -956,7 +971,7 @@ $Templates{module_by_start} = <<'EOT';
 
 <h2>Distributions - [% module_start %]</h2>
 
-[% crit_w = 76 / col_headers.size %]
+[% crit_w = 66 / col_headers.size %]
 <table>
 <colgroup>
 <col style="width:12%">
@@ -965,6 +980,8 @@ $Templates{module_by_start} = <<'EOT';
 [% FOREACH h = col_headers %]
 <col style="width:[% crit_w %]%">
 [% END %]
+<col style="width:5%">
+<col style="width:5%">
 </colgroup>
 
   [% IF modules.$module_start %]
@@ -978,6 +995,8 @@ $Templates{module_by_start} = <<'EOT';
           <span class="name-short">[% h.short %]</span>
         </th>
       [% END %]
+      <th>CC</th>
+      <th>SCAR</th>
     </tr>
   [% END %]
 
@@ -1017,6 +1036,15 @@ $Templates{module_by_start} = <<'EOT';
           [% END %]
           <span class="glass-tip">[%- vals.$m.$criterion.details -%]</span>
         </td>
+      [% END %]
+      <td class="[%- vals.$m.cc.class -%]">[%- vals.$m.cc.val -%]</td>
+      [% IF vals.$m.scar.tip %]
+        <td class="[%- vals.$m.scar.class %] tip-hover">
+          [%- vals.$m.scar.val -%]
+          <span class="glass-tip">[%- vals.$m.scar.tip -%]</span>
+        </td>
+      [% ELSE %]
+        <td class="[%- vals.$m.scar.class -%]">[%- vals.$m.scar.val -%]</td>
       [% END %]
     </tr>
   [% END %]

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -904,7 +904,7 @@ https://pjcj.net
 <h1><a href="[% root %]index.html">CPANCover</a></h1>
 <div class="search">
 <input type="search" id="module-search" data-root="[% root %]"
-  placeholder="Search modules" autocomplete="off">
+  placeholder="Search distributions" autocomplete="off">
 <div class="search-results" hidden></div>
 </div>
 <div class="header-stats">

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -321,6 +321,13 @@ class Devel::Cover::Collection {
     say "Wrote json output to $f";
   }
 
+  method write_search_index ($vars) {
+    my @names  = sort grep $vars->{vals}{$_}{link}, keys $vars->{vals}->%*;
+    my $io     = Devel::Cover::DB::IO::JSON->new;
+    my ($rdir) = $self->made_res_dir;
+    $io->write(\@names, "$rdir/search.json");
+  }
+
   method coverage_class ($pc) {
     Devel::Cover::Html_Common::coverage_class($pc)
   }
@@ -364,6 +371,7 @@ class Devel::Cover::Collection {
 
     # print Dumper $vars;
     $self->write_json($vars);
+    $self->write_search_index($vars);
 
     say "Wrote collection output to $f";
   }
@@ -859,6 +867,11 @@ https://pjcj.net
 <header class="header">
 <div class="header-inner">
 <h1><a href="[% root %]index.html">CPANCover</a></h1>
+<div class="search">
+<input type="search" id="module-search" data-root="[% root %]"
+  placeholder="Search modules" autocomplete="off">
+<div class="search-results" hidden></div>
+</div>
 <div class="header-stats">
 <button class="theme-toggle" aria-label="Toggle dark mode">&#x263e;</button>
 </div>
@@ -1378,6 +1391,14 @@ C<generate_html>.
 
 Writes a JSON file (C<cpancover.json>) containing coverage data for all
 modules.
+
+=head3 write_search_index ($vars)
+
+  $collection->write_search_index($vars);
+
+Writes C<search.json>, a sorted list of the module directories that have
+report pages. The header search on the collection pages fetches it to
+offer direct links to module reports.
 
 =head2 Status Tracking
 

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -12,10 +12,9 @@ use 5.42.0;
 # VERSION
 
 use Devel::Cover::Criterion    ();
-use Devel::Cover::DB           ();
 use Devel::Cover::DB::IO::JSON ();
 use Devel::Cover::Dumper       qw( Dumper );
-use Devel::Cover::Html_Common  ();
+use Devel::Cover::Html_Common  ();               ## no perlimports
 use Devel::Cover::Inc          ();
 use Devel::Cover::Web          qw( write_file );
 

--- a/lib/Devel/Cover/Html_Common.pm
+++ b/lib/Devel/Cover/Html_Common.pm
@@ -14,7 +14,7 @@ use HTML::Entities ();
 
 our @EXPORT_OK = qw(
   launch highlight $Have_highlighter
-  coverage_class default_thresholds unique_filenames
+  coverage_class default_thresholds scar_class unique_filenames
   decode_guess escape_html source_layer
 );
 
@@ -35,6 +35,11 @@ sub coverage_class ($pc, $t = undef) {
   $t //= default_thresholds;
   return "na" if !defined $pc || $pc eq "n/a";
   $pc < $t->{c0} ? "c0" : $pc < $t->{c1} ? "c1" : $pc < $t->{c2} ? "c2" : "c3"
+}
+
+sub scar_class ($scar) {
+  return "" unless defined $scar;
+  $scar < 16 ? "c3" : $scar < 34 ? "c2" : $scar < 41 ? "c1" : "c0"
 }
 
 sub unique_filenames (@files) {
@@ -200,6 +205,12 @@ points. It defaults to the values from C<default_thresholds> when omitted.
 Return a fresh hashref of the default band cut-off points (C<c0> 75,
 C<c1> 90, C<c2> 100). A new copy is returned each call so callers may
 mutate their own thresholds without affecting the defaults.
+
+=item scar_class ($scar)
+
+Map a SCAR value to a CSS band name (C<c0>, C<c1>, C<c2> or C<c3>), with
+lower values in the better bands. An undefined value maps to the empty
+string.
 
 =item unique_filenames (@files)
 

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -22,7 +22,7 @@ BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
 ## no perlimports
 use Devel::Cover::Html_Common qw(
   $Have_highlighter highlight launch
-  coverage_class default_thresholds unique_filenames
+  coverage_class default_thresholds scar_class unique_filenames
   decode_guess escape_html source_layer
 );
 use Devel::Cover::Web             qw( $Cov $Crisp_base_css $Crisp_theme_js );
@@ -448,11 +448,6 @@ HTML
     title        => "Coverage Summary",
     content      => $o,
   )
-}
-
-sub scar_class ($scar) {
-  return "" unless defined $scar;
-  $scar < 16 ? "c3" : $scar < 34 ? "c2" : $scar < 41 ? "c1" : "c0"
 }
 
 sub _summary_text ($covered, $total, $error = undef, $criterion = "condition") {
@@ -1673,14 +1668,6 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
   text-decoration: none;
 }
 .file-table .cell-link:hover { opacity: 0.85; }
-
-/* SCAR colouring: coloured text/outline by risk, never a full fill */
-td.cc-val   { color: var(--fg-muted); }
-td.scar-val { font-weight: 600; }
-.scar-c0 { color: var(--tip-c0); }
-.scar-c1 { color: var(--tip-c1); }
-.scar-c2 { color: var(--tip-c2); }
-.scar-c3 { color: var(--tip-c3); }
 
 .worst-item.scar-c0 { border-color: var(--tip-c0); }
 .worst-item.scar-c1 { border-color: var(--tip-c1); }

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -656,6 +656,10 @@ my $Collection_extra_css = <<'CSS';
   text-decoration: underline;
 }
 
+.header {
+  z-index: 20;
+}
+
 table {
   border-collapse: collapse;
   margin: 0 0 24px;
@@ -671,6 +675,9 @@ th, td {
 }
 
 th {
+  position: sticky;
+  top: calc(var(--header-height, 0px) - 2px);
+  z-index: 10;
   background: var(--header-bg);
   font-weight: 600;
   color: var(--fg);
@@ -830,6 +837,21 @@ ul {
 .search-empty { color: var(--fg-muted); }
 CSS
 
+my $Collection_header_js = <<'JS';
+/* Sticky table headers stack below the page header */
+(function() {
+  var header = document.querySelector(".header");
+  if (!header) return;
+  function set() {
+    document.documentElement.style.setProperty(
+      "--header-height", header.getBoundingClientRect().height + "px");
+  }
+  set();
+  if (window.ResizeObserver) new ResizeObserver(set).observe(header);
+  else window.addEventListener("resize", set);
+})();
+JS
+
 my $Collection_search_js = <<'JS';
 /* CPANCover module search */
 (function() {
@@ -912,8 +934,9 @@ my $Collection_search_js = <<'JS';
 JS
 
 $Files{"collection.css"} = $Crisp_base_css . $Collection_extra_css;
-$Files{"collection.js"}  = $Crisp_theme_js . $Collection_search_js;
-$Files{"cover.css"}      = $Common_css . $Extra_css;
+$Files{"collection.js"}
+  = $Crisp_theme_js . $Collection_header_js . $Collection_search_js;
+$Files{"cover.css"} = $Common_css . $Extra_css;
 
 $Files{"common.js"} = <<'EOF';
 /**

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -683,7 +683,7 @@ tr:hover td:not(.c0):not(.c1):not(.c2):not(.c3) {
   background: var(--bg-alt);
 }
 
-td.c0, td.c1, td.c2, td.c3 {
+td.c0, td.c1, td.c2, td.c3, td.na {
   border-color: var(--border);
   white-space: nowrap;
   text-align: center;

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -780,10 +780,139 @@ ul {
 .about-key td:last-child {
   text-align: left;
 }
+
+/* Module search */
+
+.search {
+  position: relative;
+  margin-left: auto;
+}
+
+.search input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  color: var(--fg);
+  font-size: var(--font-size-small);
+  width: 180px;
+}
+
+.search-results {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  min-width: 220px;
+  max-height: 60vh;
+  overflow-y: auto;
+  background: var(--tip-glass-bg);
+  border: 1px solid var(--tip-glass-border);
+  border-radius: 4px;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 40;
+}
+
+.search-results a, .search-empty {
+  display: block;
+  padding: 4px 10px;
+  font-size: var(--font-size-small);
+  color: var(--tip-glass-fg);
+  white-space: nowrap;
+}
+
+.search-results a:hover, .search-results a.selected {
+  background: var(--bg-alt);
+  text-decoration: none;
+}
+
+.search-empty { color: var(--fg-muted); }
 CSS
 
+my $Collection_search_js = <<'JS';
+/* CPANCover module search */
+(function() {
+  var input = document.getElementById("module-search");
+  if (!input) return;
+  var root = input.getAttribute("data-root") || "";
+  var box = input.parentNode.querySelector(".search-results");
+  var names = null;
+  var sel = -1;
+
+  function load() {
+    if (names) return;
+    names = [];
+    fetch(root + "search.json")
+      .then(function(r) { return r.json(); })
+      .then(function(data) { names = data; render(); });
+  }
+
+  function tier(name, q) {
+    var i = name.toLowerCase().indexOf(q);
+    if (i < 0) return -1;
+    if (i === 0) return 0;
+    return name.charAt(i - 1) === "-" ? 1 : 2;
+  }
+
+  function matches(q) {
+    var tiers = [[], [], []];
+    for (var i = 0; i < names.length; i++) {
+      var t = tier(names[i], q);
+      if (t >= 0) tiers[t].push(names[i]);
+    }
+    return tiers[0].concat(tiers[1], tiers[2]).slice(0, 10);
+  }
+
+  function render() {
+    var q = input.value.toLowerCase();
+    sel = -1;
+    box.innerHTML = "";
+    if (!q) { box.hidden = true; return; }
+    var found = matches(q);
+    if (!found.length) {
+      var d = document.createElement("div");
+      d.className = "search-empty";
+      d.textContent = "no matches";
+      box.appendChild(d);
+    }
+    found.forEach(function(name) {
+      var a = document.createElement("a");
+      a.href = root + encodeURIComponent(name) + "/index.html";
+      a.textContent = name;
+      box.appendChild(a);
+    });
+    box.hidden = false;
+  }
+
+  function move(delta) {
+    var items = box.querySelectorAll("a");
+    if (!items.length) return;
+    sel = (sel + delta + items.length) % items.length;
+    items.forEach(function(el, i) {
+      el.classList.toggle("selected", i === sel);
+    });
+  }
+
+  input.addEventListener("focus", load);
+  input.addEventListener("input", render);
+  input.addEventListener("keydown", function(e) {
+    if (e.key === "ArrowDown") { move(1); e.preventDefault(); }
+    else if (e.key === "ArrowUp") { move(-1); e.preventDefault(); }
+    else if (e.key === "Enter") {
+      var items = box.querySelectorAll("a");
+      var target = items[sel >= 0 ? sel : 0];
+      if (target) location.href = target.href;
+    } else if (e.key === "Escape") { box.hidden = true; }
+  });
+  document.addEventListener("click", function(e) {
+    if (!e.target.closest(".search")) box.hidden = true;
+  });
+})();
+JS
+
 $Files{"collection.css"} = $Crisp_base_css . $Collection_extra_css;
-$Files{"collection.js"}  = $Crisp_theme_js;
+$Files{"collection.js"}  = $Crisp_theme_js . $Collection_search_js;
 $Files{"cover.css"}      = $Common_css . $Extra_css;
 
 $Files{"common.js"} = <<'EOF';

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -549,6 +549,34 @@ td.scar-val { font-weight: 600; }
 .scar-c2 { color: var(--tip-c2); }
 .scar-c3 { color: var(--tip-c3); }
 
+/* Coverage distribution bar */
+
+.dist-bar {
+  display: flex;
+  width: 100%;
+  height: 24px;
+  margin: 0 0 24px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.dist-bar-seg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-small);
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.dist-bar-seg.c0 { background: var(--cov-none-bg); color: var(--cov-none-fg); }
+.dist-bar-seg.c1 { background: var(--cov-low-bg);  color: var(--cov-low-fg);  }
+.dist-bar-seg.c2 { background: var(--cov-good-bg); color: var(--cov-good-fg); }
+.dist-bar-seg.c3 { background: var(--cov-full-bg); color: var(--cov-full-fg); }
+.dist-bar-seg.na { background: var(--bg-alt);      color: var(--fg-muted);    }
+
 /* Main content */
 
 .content {

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -541,6 +541,14 @@ a:visited { color: var(--link-visited); }
   color: var(--fg-muted);
 }
 
+/* SCAR colouring: coloured text/outline by risk, never a full fill */
+td.cc-val   { color: var(--fg-muted); }
+td.scar-val { font-weight: 600; }
+.scar-c0 { color: var(--tip-c0); }
+.scar-c1 { color: var(--tip-c1); }
+.scar-c2 { color: var(--tip-c2); }
+.scar-c3 { color: var(--tip-c3); }
+
 /* Main content */
 
 .content {
@@ -683,7 +691,7 @@ tr:hover td:not(.c0):not(.c1):not(.c2):not(.c3) {
   background: var(--bg-alt);
 }
 
-td.c0, td.c1, td.c2, td.c3, td.na {
+td.c0, td.c1, td.c2, td.c3, td.na, td.cc-val, td.scar-val {
   border-color: var(--border);
   white-space: nowrap;
   text-align: center;

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -108,6 +108,17 @@ sub setup_results_dir {
   # $Dist5 has coverage totals but its report page was never written
   write_dist($dir, $Dist5, "No-Page", "5.00", undef, 0);
 
+  # An older version of $Dist, which the overview must not count
+  write_dist($dir, "Foo-Bar-0.50", "Foo-Bar", "0.50");
+
+  # A dist with no coverage percentages, for the overview's n/a band
+  make_path("$dir/Zero-Data-6.00");
+  my $empty = {
+    runs    => [{ name => "Zero-Data", version => "6.00", dir => "/tmp/x" }],
+    summary => { Total => {} },
+  };
+  write_file("$dir/Zero-Data-6.00/cover.json", JSON::PP->new->encode($empty));
+
   make_path("$dir/dist");
   seed_page($dir, $_) for qw( index.html dist/F.html about.html );
 
@@ -202,9 +213,46 @@ like $Css, qr{th[^{}]*\{[^{}]*top:\s*calc\(var\(--header-height}s,
 like slurp("$Dir/collection.js"), qr{--header-height},
   "collection.js measures the page header height";
 
+like $Page{index}, qr{<p class="dist-count">6 distributions</p>},
+  "index page counts distributions once per name";
+like $Page{index},
+  qr{<div class="dist-bar-seg c1" style="width: 83\.33%">\s*5\s*</div>},
+  "index page bar has a c1 segment counting latest versions only";
+like $Page{index},
+  qr{<div class="dist-bar-seg na" style="width: 16\.67%">\s*1\s*</div>},
+  "index page bar has an n/a segment";
+like $Page{index}, qr{dist-bar-seg c1.*dist-bar-seg na}s,
+  "bar segments run from best to worst";
+unlike $Page{index}, qr{dist-bar-seg c[023]}, "empty bands are omitted";
+like $Page{index},   qr{dist-bar.*az-nav}s,   "bar appears above the A-Z nav";
+like $Css, qr{\.dist-bar\b[^{}]*\{[^{}]*display:\s*flex}s,
+  "bar segments lay out in a row";
+like $Css,
+  qr{\.dist-bar-seg\.c1[^{}]*\{[^{}]*background:\s*var\(--cov-low-bg\)}s,
+  "bar segments use the shared coverage colours";
+
+my $Overview_vars = {
+  vals => {
+    (
+      map { ("Dist$_-1.00" => {
+        module => { name => "Dist$_", version => "1.00" },
+        total  => { pc   => "100.00" },
+      }) } 1 .. 30
+    ),
+    "Low-1.00" => {
+      module => { name => "Low", version => "1.00" },
+      total  => { pc   => "50.00" },
+    },
+  },
+};
+$Collection->add_overview($Overview_vars);
+my $Segments = $Overview_vars->{overview}{segments};
+is $Segments->[-1]{label}, "",
+  "segments too narrow for their count drop the label";
+
 my $Search = JSON::PP->new->decode(slurp("$Dir/search.json"));
 is join(",", sort @$Search),
-  "Baz-Qux-2.00,Dangle-Ref-3.00,Dep-Only-4.00,Foo-Bar-1.00",
+  "Baz-Qux-2.00,Dangle-Ref-3.00,Dep-Only-4.00,Foo-Bar-0.50,Foo-Bar-1.00",
   "search.json lists only modules with report pages";
 like $Page{index}, qr{<input[^>]*id="module-search"[^>]*data-root=""},
   "index page has the search input";

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -197,6 +197,17 @@ my $Css = slurp("$Dir/collection.css");
 like $Css, qr{td\.na[^{}]*\{[^{}]*text-align:\s*center}s,
   "n/a cells are centred";
 
+my $Search = JSON::PP->new->decode(slurp("$Dir/search.json"));
+is join(",", sort @$Search),
+  "Baz-Qux-2.00,Dangle-Ref-3.00,Dep-Only-4.00,Foo-Bar-1.00",
+  "search.json lists only modules with report pages";
+like $Page{index}, qr{<input[^>]*id="module-search"[^>]*data-root=""},
+  "index page has the search input";
+like $Page{dist}, qr{<input[^>]*id="module-search"[^>]*data-root="\.\./"},
+  "dist page search input carries the root prefix";
+like slurp("$Dir/collection.js"), qr{module-search},
+  "collection.js wires up the search";
+
 my $Cpancover = JSON::PP->new->decode(slurp("$Dir/cpancover.json"));
 my $Coverage  = $Cpancover->{"Foo-Bar"}{"1.00"}{coverage}{total};
 is join(",", sort keys %$Coverage), "statement,total",

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -60,13 +60,18 @@ sub slurp ($path) {
   $content
 }
 
-sub write_dist ($dir, $dist, $name, $version, $log = undef, $page = 1) {
+sub write_dist (
+  $dir, $dist, $name, $version, $log = undef,
+  $page = 1, $scar = undef,
+) {
   make_path("$dir/$dist");
 
   my $criterion = { percentage => 85.5, covered => 10, total => 12 };
-  my $cover     = {
+  my $total     = { total => $criterion, statement => $criterion };
+  $total->{scar} = $scar if $scar;
+  my $cover = {
     runs    => [{ name => $name, version => $version, dir => "/tmp/x" }],
-    summary => { Total => { total => $criterion, statement => $criterion } },
+    summary => { Total => $total },
   };
   write_file("$dir/$dist/cover.json", JSON::PP->new->encode($cover));
   write_file("$dir/$dist/index.html", "report\n") if $page;
@@ -79,9 +84,12 @@ sub seed_page ($dir, $file) {
     or plan skip_all => "hardlinks not supported";
 }
 
+my $Scar
+  = { file_cc => 12, file_cov => 90, file_crap => 14.3, file_scar => 26.6 };
+
 sub setup_results_dir {
   my $dir = File::Temp->newdir;
-  write_dist($dir, $Dist,  "Foo-Bar", "1.00", $Log);
+  write_dist($dir, $Dist, "Foo-Bar", "1.00", $Log, 1, $Scar);
   write_dist($dir, $Dist2, "Baz-Qux", "2.00", $Log2);
 
   # $Dist was rebuilt: .log_ref names the newer log, both logs remain
@@ -173,6 +181,26 @@ like $Page{dist_d}, qr{href="https://metacpan\.org/dist/Dep-Only"},
   "dependency dist falls back to the metacpan dist link";
 unlike $Page{dist_d}, qr{href="https://metacpan\.org/release/\w+/\Q$Dist4\E"},
   "dependency dist gets no release link from its target's log";
+
+like $Page{dist}, qr{<th>CC</th>},                "dist page has a CC header";
+like $Page{dist}, qr{<th>SCAR</th>},              "dist page has a SCAR header";
+like $Page{dist}, qr{<td class="cc-val">12</td>}, "dist page shows CC";
+my $Tip = quotemeta
+  '<span class="glass-tip">CC 12 &middot; cov 90% &middot; CRAP 14.3</span>';
+like $Page{dist},
+  qr{<td class="scar-val scar-c2 tip-hover">26\.6\s*$Tip\s*</td>},
+  "dist page shows SCAR with class and tip";
+my @Na_cells = $Page{dist_b} =~ m{(<td class="na">n/a</td>)}g;
+is @Na_cells, 2, "dist without scar data shows n/a for CC and SCAR";
+
+my $Css = slurp("$Dir/collection.css");
+like $Css, qr{td\.na[^{}]*\{[^{}]*text-align:\s*center}s,
+  "n/a cells are centred";
+
+my $Cpancover = JSON::PP->new->decode(slurp("$Dir/cpancover.json"));
+my $Coverage  = $Cpancover->{"Foo-Bar"}{"1.00"}{coverage}{total};
+is join(",", sort keys %$Coverage), "statement,total",
+  "cpancover.json has no cc or scar keys";
 
 my $Version = $Devel::Cover::Inc::VERSION . $Devel::Cover::Inc::Dev;
 for my $name (sort keys %Page) {

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -256,6 +256,8 @@ is join(",", sort @$Search),
   "search.json lists only modules with report pages";
 like $Page{index}, qr{<input[^>]*id="module-search"[^>]*data-root=""},
   "index page has the search input";
+like $Page{index}, qr{<input[^>]*placeholder="Search distributions"},
+  "search placeholder says distributions";
 like $Page{dist}, qr{<input[^>]*id="module-search"[^>]*data-root="\.\./"},
   "dist page search input carries the root prefix";
 like slurp("$Dir/collection.js"), qr{module-search},

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -196,6 +196,11 @@ is @Na_cells, 2, "dist without scar data shows n/a for CC and SCAR";
 my $Css = slurp("$Dir/collection.css");
 like $Css, qr{td\.na[^{}]*\{[^{}]*text-align:\s*center}s,
   "n/a cells are centred";
+like $Css, qr{th[^{}]*\{[^{}]*position:\s*sticky}s, "table headers are sticky";
+like $Css, qr{th[^{}]*\{[^{}]*top:\s*calc\(var\(--header-height}s,
+  "table headers stick below the page header";
+like slurp("$Dir/collection.js"), qr{--header-height},
+  "collection.js measures the page header height";
 
 my $Search = JSON::PP->new->decode(slurp("$Dir/search.json"));
 is join(",", sort @$Search),


### PR DESCRIPTION
## Summary

Add CC and SCAR columns to the cpancover letter tables after Total, using the same presentation as the crisp per-module reports - integer CC, SCAR as coloured text by the shared thresholds, with a tooltip carrying CC, coverage and CRAP. Modules whose reports predate the SCAR summary data show n/a. Also centre n/a cells, which fell back to the default right alignment. The public `cpancover.json` output is unchanged.

Add a module search to every collection page header. Type a few characters, pick from the ranked dropdown (prefix, then word-start, then substring matches) and jump straight to that module's report. Generate the searchable module index as `search.json`, fetched lazily on first focus.

## Ticket

Closes #689