### PR TITLE
GH-691 Fix collection HTML generation

### DIFF
--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -528,8 +528,9 @@ class Devel::Cover::Collection {
           = ($summary->{covered} || 0) . " / " . ($summary->{total} || 0);
       }
 
-      my $s = $json->{summary}{Total}{scar};
-      if ($s && defined $s->{file_scar}) {
+      my $s      = $json->{summary}{Total}{scar};
+      my @fields = qw( file_scar file_cc file_cov file_crap );
+      if ($s && @fields == grep defined, @$s{@fields}) {
         $m->{cc}   = { val => $s->{file_cc}, class => "cc-val" };
         $m->{scar} = {
           val   => sprintf("%.1f", $s->{file_scar}),

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -322,9 +322,22 @@ class Devel::Cover::Collection {
     say "Wrote json output to $f";
   }
 
+  method _newer ($va, $vb) {
+    my ($pa, $pb) = map { eval { version->parse($_) } } $va, $vb;
+    return $pa > $pb if $pa && $pb;
+    ($va // "") gt($vb // "")
+  }
+
   method write_search_index ($vars) {
-    my @names  = sort grep $vars->{vals}{$_}{link}, keys $vars->{vals}->%*;
-    my $io     = Devel::Cover::DB::IO::JSON->new;
+    my $v     = $vars->{vals};
+    my @names = sort {
+      my ($ma, $mb) = ($v->{$a}{module}, $v->{$b}{module});
+      ($ma->{name} // $a) cmp ($mb->{name} // $b)
+        || ($self->_newer($ma->{version}, $mb->{version}) ? -1
+          : $self->_newer($mb->{version}, $ma->{version}) ? 1
+          :                                                 $a cmp $b)
+    } grep $v->{$_}{link}, keys %$v;
+    my $io = Devel::Cover::DB::IO::JSON->new;
     my ($rdir) = $self->made_res_dir;
     $io->write(\@names, "$rdir/search.json");
   }
@@ -421,12 +434,6 @@ class Devel::Cover::Collection {
         }
       }
     }
-  }
-
-  method _newer ($va, $vb) {
-    my ($pa, $pb) = map { eval { version->parse($_) } } $va, $vb;
-    return $pa > $pb if $pa && $pb;
-    ($va // "") gt($vb // "")
   }
 
   method add_overview ($vars) {
@@ -1441,9 +1448,10 @@ modules.
 
   $collection->write_search_index($vars);
 
-Writes C<search.json>, a sorted list of the module directories that have
-report pages. The header search on the collection pages fetches it to
-offer direct links to module reports.
+Writes C<search.json>, a list of the module directories that have report
+pages, sorted by distribution name with the newest version of each
+distribution first. The header search on the collection pages fetches it
+to offer direct links to module reports.
 
 =head3 add_overview ($vars)
 

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -262,9 +262,9 @@ is $Segments->[-1]{label}, "",
   "segments too narrow for their count drop the label";
 
 my $Search = JSON::PP->new->decode(slurp("$Dir/search.json"));
-is join(",", sort @$Search),
-  "Baz-Qux-2.00,Dangle-Ref-3.00,Dep-Only-4.00,Foo-Bar-0.50,Foo-Bar-1.00",
-  "search.json lists only modules with report pages";
+is join(",", @$Search),
+  "Baz-Qux-2.00,Dangle-Ref-3.00,Dep-Only-4.00,Foo-Bar-1.00,Foo-Bar-0.50",
+  "search.json lists newest versions first, report pages only";
 like $Page{index}, qr{<input[^>]*id="module-search"[^>]*data-root=""},
   "index page has the search input";
 like $Page{index}, qr{<input[^>]*placeholder="Search distributions"},

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -90,7 +90,9 @@ my $Scar
 sub setup_results_dir {
   my $dir = File::Temp->newdir;
   write_dist($dir, $Dist, "Foo-Bar", "1.00", $Log, 1, $Scar);
-  write_dist($dir, $Dist2, "Baz-Qux", "2.00", $Log2);
+
+  # $Dist2's report predates the file_cc/file_cov/file_crap summary fields
+  write_dist($dir, $Dist2, "Baz-Qux", "2.00", $Log2, 1, { file_scar => 26.6 });
 
   # $Dist was rebuilt: .log_ref names the newer log, both logs remain
   write_file("$dir/$Log_new",       "log\n");
@@ -129,8 +131,15 @@ my $Cwd = getcwd;
 my $Dir = setup_results_dir;
 
 my $Collection = Devel::Cover::Collection->new(results_dir => "$Dir");
-$Collection->generate_html;
+my @Warnings;
+{
+  local $SIG{__WARN__} = sub { push @Warnings, @_ };
+  $Collection->generate_html;
+}
 chdir $Cwd or die "Can't chdir $Cwd: $!";
+
+is grep(/uninitialized/, @Warnings), 0,
+  "generate_html emits no uninitialized warnings";
 
 my %Page = (
   index  => slurp("$Dir/index.html"),
@@ -202,7 +211,9 @@ like $Page{dist},
   qr{<td class="scar-val scar-c2 tip-hover">26\.6\s*$Tip\s*</td>},
   "dist page shows SCAR with class and tip";
 my @Na_cells = $Page{dist_b} =~ m{(<td class="na">n/a</td>)}g;
-is @Na_cells, 2, "dist without scar data shows n/a for CC and SCAR";
+is @Na_cells, 2, "dist with incomplete scar data shows n/a for CC and SCAR";
+my @Na_cells_n = $Page{dist_n} =~ m{(<td class="na">n/a</td>)}g;
+is @Na_cells_n, 2, "dist without scar data shows n/a for CC and SCAR";
 
 my $Css = slurp("$Dir/collection.css");
 like $Css, qr{td\.na[^{}]*\{[^{}]*text-align:\s*center}s,

--- a/utils/dc
+++ b/utils/dc
@@ -638,7 +638,7 @@ cpancover_controller_command() {
     --mount "type=bind,source=$results_dir,target=/remote_staging" \
     ${env_flags[@]:+"${env_flags[@]}"} \
     --label "cpancover.env=$env" \
-    --rm=false --memory=1g --name="$(docker_name "$name")" \
+    --rm=false --memory=8g --name="$(docker_name "$name")" \
     "$docker_image" "${cmd[@]}"
 }
 

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -341,6 +341,8 @@ sub controller_rebuild_module_recipe () {
   my $calls = slurp("$work/calls");
   like $calls, qr{\brun\b.* pjcj/cpancover_dev }, "runs the dev image";
   like $calls, qr{--label cpancover\.env=dev},    "container is labelled";
+  like $calls, qr{--memory=8g},
+    "controller gets enough memory for HTML generation";
   like $calls, qr{source=\Q$dir\E,target=/remote_staging},
     "results dir is mounted";
   like $calls, qr{ dc --env dev cpancover-rebuild-module \Q$module\E},


### PR DESCRIPTION
## Summary

- Raise the controller container's memory limit from 1 GB to 8 GB. Regenerating the dev-tree index reads every module's `cover.json`, and the memory cgroup counts that page cache along with the perl process, so the OOM killer ended HTML generation partway through. The per-module build containers keep their own 1 GB limit.
- Show n/a in the CC and SCAR columns for reports that predate the CC, coverage and CRAP summary fields. These rendered broken cells and warned three times per module, swamping the log.
- Sort `search.json` by distribution name with the newest version first, so the header search dropdown offers the current release before older ones.

## Ticket

Closes #691