### PR TITLE
GH-697 Fix uninitialised warning in dir_summary.t

### DIFF
--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -1168,7 +1168,7 @@ sub objectify_cover ($self) {
 }
 
 sub _derive_mcdc ($self, $cover, $uncoverable = {}) {
-  require Devel::Cover::Condition_table;
+  require Devel::Cover::Condition_table;  ## no perlimports
   require Devel::Cover::Mcdc::Analyser;
 
   # Sorted iteration keeps the too-wide warnings deterministic
@@ -1355,7 +1355,7 @@ sub _uncoverable_mark_warnings ($criterion, $slot, $entry, $file, $line, $n) {
   my $patterns;
   my $rows = sub {
     $patterns //= do {
-      require Devel::Cover::Condition_table;
+      require Devel::Cover::Condition_table;  ## no perlimports
       Devel::Cover::Condition_table->input_patterns($entry->[1]{type}) // []
     }
   };

--- a/t/internal/dir_summary.t
+++ b/t/internal/dir_summary.t
@@ -46,7 +46,8 @@ sub test_all_criteria_aggregated () {
     },
   };
   my $dir_files = { "lib/A" => ["lib/A/Foo.pm", "lib/A/Bar.pm"] };
-  my $dir_stats = { "lib/A" => { cc_sum => 6, cc_count => 3 } };
+  my $dir_stats
+    = { "lib/A" => { cc_sum => 6, cc_count => 3, wcrap_sum => 12 } };
 
   $db->_summarise_dir_complexity($s, $dir_files, $dir_stats);
 
@@ -63,7 +64,9 @@ sub test_all_criteria_aggregated () {
   is $d->{total}{covered},        23, "total aggregated";
   ok !exists $d->{time},       "time not aggregated";
   ok !exists $d->{complexity}, "complexity not treated as a criterion";
-  is $d->{scar}{file_cc}, 4, "dir SCAR computed from dir stats";
+  is $d->{scar}{file_cc},   4, "dir SCAR computed from dir stats";
+  is $d->{scar}{file_crap}, 2, "dir CRAP is complexity-weighted mean";
+  ok $d->{scar}{file_scar} > 0, "dir SCAR derived from dir CRAP";
 }
 
 sub main () {


### PR DESCRIPTION
## Summary

The test's hand-built directory stats predate the complexity-weighted SCAR aggregation and lacked `wcrap_sum`, so computing the directory CRAP warned about an undefined value under `make prove`. Complete the fixture and assert the weighted mean, which nothing previously checked.

Also quieten perlimports on the repeated lazy requires in `DB.pm`, which are deliberate.

## Ticket

Closes #697