### PR TITLE
GH-313 Fix pod coverage after delete_package

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Fix pod coverage dying after Symbol::delete_package - subs in the deleted
+  package have no stash left to name (jkahrman) (GH-313)
 - Cover files first seen at runtime under -replace_ops 0, such as AutoLoader
   .al subs - they were never classified so their coverage was lost (GH-683)
 - Fix coverage collection hanging when a multiconcat expression is followed

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -1066,7 +1066,7 @@ sub _parse_pod_options {
 
 sub _add_pod_cover ($cv) {
   my $gv = $cv->GV;
-  return if !$gv || $gv->isa("B::SPECIAL");
+  return if !$gv || $gv->isa("B::SPECIAL") || $gv->STASH->isa("B::SPECIAL");
 
   my $pkg  = $gv->STASH->NAME;
   my %opts = _parse_pod_options();

--- a/test_output/cover/delete_package.5.020000
+++ b/test_output/cover/delete_package.5.020000
@@ -1,0 +1,88 @@
+cover: Reading database from ...
+-------------------- ------ ------ ------ ------ ------ ------ ------
+File                   stmt   bran   cond    sub    pod  total   scar
+-------------------- ------ ------ ------ ------ ------ ------ ------
+tests/delete_package   92.3    n/a    n/a   80.0    n/a   88.8    1.8
+Total                  92.3    n/a    n/a   80.0    n/a   88.8    1.8
+-------------------- ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/delete_package
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 1 92.3  1.2  1.8
+
+Worst Subroutines
+-----------------
+
+Subroutine CC SCAR  Location               
+---------- -- ----  -----------------------
+__ANON__    1  6.9  tests/delete_package:30
+
+line  err   stmt   bran   cond    sub    pod   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10                                             # Test for Symbol::delete_package breaking pod coverage
+11                                             # See GH-313
+12                                             
+13                                             # __COVER__ criteria statement branch condition subroutine pod
+14                                             # __COVER__ skip_test eval "use Pod::Coverage 0.06"; $@
+15                                             # __COVER__ skip_reason Pod::Coverage unavailable
+16                                             
+17             1                    1          use strict;
+               1                               
+               1                               
+18             1                    1          use warnings;
+               1                               
+               1                               
+19                                             
+20             1                    1          use Symbol;
+               1                               
+               1                               
+21                                             
+22             1                               Symbol::delete_package("Foo");
+23                                             
+24             1                    1          sub bar { 1 }
+25                                             
+26             1                               bar();
+27                                             
+28                                             package Foo;
+29                                             
+30    ***     *0                   *0          sub foo { 2 }
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location               
+---------- ----- --- ----- -----------------------
+BEGIN          1   1   0.0 tests/delete_package:17
+BEGIN          1   1   0.0 tests/delete_package:18
+BEGIN          1   1   0.0 tests/delete_package:20
+bar            1   1   0.0 tests/delete_package:24
+
+Uncovered Subroutines
+---------------------
+
+Subroutine Count  CC  SCAR Location               
+---------- ----- --- ----- -----------------------
+__ANON__       0   1   6.9 tests/delete_package:30
+
+

--- a/tests/delete_package
+++ b/tests/delete_package
@@ -1,0 +1,30 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Test for Symbol::delete_package breaking pod coverage
+# See GH-313
+
+# __COVER__ criteria statement branch condition subroutine pod
+# __COVER__ skip_test eval "use Pod::Coverage 0.06"; $@
+# __COVER__ skip_reason Pod::Coverage unavailable
+
+use strict;
+use warnings;
+
+use Symbol;
+
+Symbol::delete_package("Foo");
+
+sub bar { 1 }
+
+bar();
+
+package Foo;
+
+sub foo { 2 }


### PR DESCRIPTION
## Summary

`Symbol::delete_package` leaves subs whose GV stash is `B::SPECIAL`. Writing pod coverage asked that stash for a package name, and the resulting die aborted the whole coverage write, losing all data for the run. Skip pod coverage for such subs, since with the package gone there is nothing for `Pod::Coverage` to look up, and add an e2e fixture with the ticket's reproduction.

## Ticket

Closes #313