### PR TITLE
GH-152 Don't invoke overload in condition coverage

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Don't invoke overload when recording condition coverage - programs using
+  overloaded objects could die or run bool overloads under coverage only
+  (dolmen) (GH-152)
 - Fix pod coverage dying after Symbol::delete_package - subs in the deleted
   package have no stash left to name (jkahrman) (GH-313)
 - Cover files first seen at runtime under -replace_ops 0, such as AutoLoader

--- a/Cover.xs
+++ b/Cover.xs
@@ -1203,6 +1203,17 @@ static OP *find_skipped_conditional(pTHX_ OP *o) {
   return next;
 }
 
+/*
+ * Truth of an SV without invoking overload.  The program may never boolify
+ * this value itself, so calling a bool overload here would run user code the
+ * program didn't, or die when fallback => 0 forbids autogenerating bool.
+ * An overloaded ref counts as true.
+ */
+static int sv_true_no_overload(pTHX_ SV *sv) {
+  if (SvROK(sv) && SvAMAGIC(sv)) return 1;
+  return SvTRUE(sv) ? 1 : 0;
+}
+
 /* NOTE: caller must protect get_condition* calls by locking DC_mutex */
 static OP *get_condition(pTHX) {
   SV **pc = hv_fetch(Pending_conditionals, get_key(PL_op), KEY_SZ, 0);
@@ -1214,7 +1225,7 @@ static OP *get_condition(pTHX) {
     /* dump_conditions(aTHX); */
     NDEB(svdump(Pending_conditionals));
     true_ish = (PL_op->op_type == OP_DOR || PL_op->op_type == OP_DORASSIGN)
-      ? SvOK(TOPs) : SvTRUE(TOPs);
+      ? SvOK(TOPs) : sv_true_no_overload(aTHX_ TOPs);
     NDEB(D(L, "   get_condition true_ish=%d\n", true_ish));
     add_condition(aTHX_ *pc, true_ish ? 2 : 1);
   } else {
@@ -1297,7 +1308,7 @@ static void resolve_deferred_conditionals(pTHX_ AV *dc, I32 base) {
   dMY_CXT;
   if (av_len(dc) >= base) {
     dSP;
-    int true_ish = SvTRUE(TOPs);
+    int true_ish = sv_true_no_overload(aTHX_ TOPs);
 
     if (collecting(Mcdc)) {
       I32 i;

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -641,6 +641,21 @@ runs cannot be reported on - its code is freed before any coverage could
 attach to it - so its statements are absent from the report rather than
 shown as uncovered.
 
+=head2 Overloaded objects in conditions
+
+When the result of C<||> or C<&&> is used as a value, perl returns the
+right operand without testing its truth.  Condition coverage needs that
+truth, but asking an overloaded object for it would run code the
+program never ran, and would die outright for an object with
+C<< fallback => 0 >> and no C<bool> overload.  Devel::Cover therefore
+counts any overloaded object as true there without invoking its
+overloads.  For an object whose C<bool> overload would have returned
+false, the report shows the true row for that operand.
+
+Where the program does test an operand's truth, as with the left
+operand of C<||> or C<&&>, Devel::Cover tests it again to record the
+result, so a C<bool> overload may be called twice there.
+
 =head1 BUGS
 
 Almost certainly.

--- a/test_output/cover/cond_overload.5.020000
+++ b/test_output/cover/cond_overload.5.020000
@@ -1,0 +1,142 @@
+cover: Reading database from ...
+------------------- ------ ------ ------ ------ ------ ------ ------
+File                  stmt   bran   cond   mcdc    sub  total   scar
+------------------- ------ ------ ------ ------ ------ ------ ------
+tests/cond_overload   84.6   50.0   33.3    0.0   66.6   61.5    1.1
+Total                 84.6   50.0   33.3    0.0   66.6   61.5    1.1
+------------------- ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/cond_overload
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 1 70.3  1.1  1.1
+
+Worst Subroutines
+-----------------
+
+Subroutine CC SCAR  Location              
+---------- -- ----  ----------------------
+__ANON__    1  6.9  tests/cond_overload:24
+BEGIN       1  0.2  tests/cond_overload:19
+__ANON__    1  0.2  tests/cond_overload:19
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10                                             # Test for overloaded objects as logop right operands
+11                                             # See GH-152 and GH-175
+12                                             
+13             1                           1   use strict;
+               1                               
+               1                               
+14             1                           1   use warnings;
+               1                               
+               1                               
+15                                             
+16             1                               my $bool_calls;
+17                                             
+18                                             package NoBool;
+19             1                           1   use overload '""' => sub { "nobool" }, fallback => 0;
+      ***      1                          *0   
+               1                               
+      ***     *0                               
+20             1                           1   sub new { bless {}, shift }
+21                                             
+22                                             package CountBool;
+23                                             use overload
+24    ***     *0                          *0     bool => sub { $bool_calls++; 1 },
+      ***     *0                               
+25             1                           1     '""' => sub { "countbool" };
+      ***      1                          *0   
+               1                               
+      ***     *0                               
+26             1                           1   sub new { bless {}, shift }
+27                                             
+28                                             package main;
+29                                             
+30             1                               my $nb = NoBool->new;
+31             1                               my $cb = CountBool->new;
+32             1                               my $t  = 1;
+33                                             
+34    ***      1          * 33   *  0          my $x = undef || $nb;
+35    ***      1          * 33   *  0          my $y = $t && $nb;
+36    ***      1          * 33   *  0          my $z = undef || $cb;
+37                                             
+38    ***      1   * 50                        print "bool overload invoked\n" if $bool_calls;
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+38    ***     50      0      1   if $bool_calls
+
+
+Conditions
+----------
+
+and 3 conditions
+
+line  err      %     !l  l&&!r   l&&r   expr
+----- --- ------ ------ ------ ------   ----
+35    ***     33      0      0      1   $t && $nb
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+34    ***     33      0      1      0   undef || $nb
+36    ***     33      0      1      0   undef || $cb
+
+
+MC/DC
+-----
+
+line  err      %  cov  tot   missing                expr
+----- --- ------ ---- ----   --------------------   ----
+34    ***      0    0    2   undef, $nb             undef || $nb
+35    ***      0    0    2   $t, $nb                $t && $nb
+36    ***      0    0    2   undef, $cb             undef || $cb
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location              
+---------- ----- --- ----- ----------------------
+BEGIN          1   1   0.0 tests/cond_overload:13
+BEGIN          1   1   0.0 tests/cond_overload:14
+BEGIN          1   1   0.2 tests/cond_overload:19
+BEGIN          1   1   0.2 tests/cond_overload:25
+new            1   1   0.0 tests/cond_overload:20
+new            1   1   0.0 tests/cond_overload:26
+
+Uncovered Subroutines
+---------------------
+
+Subroutine Count  CC  SCAR Location              
+---------- ----- --- ----- ----------------------
+__ANON__       0   1   0.2 tests/cond_overload:19
+__ANON__       0   1   6.9 tests/cond_overload:24
+__ANON__       0   1   0.2 tests/cond_overload:25
+
+

--- a/tests/cond_overload
+++ b/tests/cond_overload
@@ -1,0 +1,38 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Test for overloaded objects as logop right operands
+# See GH-152 and GH-175
+
+use strict;
+use warnings;
+
+my $bool_calls;
+
+package NoBool;
+use overload '""' => sub { "nobool" }, fallback => 0;
+sub new { bless {}, shift }
+
+package CountBool;
+use overload
+  bool => sub { $bool_calls++; 1 },
+  '""' => sub { "countbool" };
+sub new { bless {}, shift }
+
+package main;
+
+my $nb = NoBool->new;
+my $cb = CountBool->new;
+my $t  = 1;
+
+my $x = undef || $nb;
+my $y = $t && $nb;
+my $z = undef || $cb;
+
+print "bool overload invoked\n" if $bool_calls;


### PR DESCRIPTION
## Summary

Condition coverage evaluated the truth of the right operand of `||` and `&&`, which the program itself never does in value context. An object with `fallback => 0` and no `bool` overload died "Operation bool: no method found" under coverage only, and objects that do overload `bool` had it invoked where a plain run never called it (#175). Count any overloaded ref as true without invoking overload, and document the trade-off under LIMITATIONS - an object whose `bool` overload would have returned false records the true row.

The remaining double call on left operands, which perl itself also boolifies, is GH-700.

## Ticket

Closes #152
Closes #175