### PR TITLE
GH-700 Read operand truth from the path perl took

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ make test
 make out TEST=empty_else
 
 # Run all tests on all Perl versions
+# You are not allowed to run this without approval since it takes too long.
 make all_test
 
 # Generate HTML report for a single test
@@ -56,6 +57,9 @@ make gold TEST=empty_else
 
 # Generate golden results for a single test, ALL Perl versions
 make all_gold TEST=empty_else
+
+# You are not allowed to run a plain `make all_gold` without approval since it
+# takes too long.
 ```
 
 ### Coverage Analysis

--- a/Changes
+++ b/Changes
@@ -7,6 +7,10 @@ Devel::Cover history
 - Evaluate xor operands, and the condition of an if/else or ternary with
   both branches empty, in perl's stead when collecting coverage, so a
   bool overload there no longer runs twice either (GH-700)
+- Read a logop right operand's truth from the path of the op consuming
+  its value, when an if/else, ternary, && or || tests it directly, so
+  condition coverage records an overloaded object's real truth there
+  (GH-152, GH-700)
 - Don't invoke overload when recording condition coverage (Olivier Mengué, Diab
   Jerius) (GH-152, GH-175)
 - Fix pod coverage dying after Symbol::delete_package - subs in the deleted

--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Devel::Cover history
 - Read a logop left operand's truth, and an if/else or ternary
   condition's truth, from the path perl took instead of testing the value
   again, so a bool overload no longer runs twice under coverage (GH-700)
+- Evaluate xor operands in perl's stead when collecting condition
+  coverage, so a bool overload there no longer runs twice either (GH-700)
 - Don't invoke overload when recording condition coverage (Olivier Mengué, Diab
   Jerius) (GH-152, GH-175)
 - Fix pod coverage dying after Symbol::delete_package - subs in the deleted

--- a/Changes
+++ b/Changes
@@ -4,8 +4,9 @@ Devel::Cover history
 - Read a logop left operand's truth, and an if/else or ternary
   condition's truth, from the path perl took instead of testing the value
   again, so a bool overload no longer runs twice under coverage (GH-700)
-- Evaluate xor operands in perl's stead when collecting condition
-  coverage, so a bool overload there no longer runs twice either (GH-700)
+- Evaluate xor operands, and the condition of an if/else or ternary with
+  both branches empty, in perl's stead when collecting coverage, so a
+  bool overload there no longer runs twice either (GH-700)
 - Don't invoke overload when recording condition coverage (Olivier Mengué, Diab
   Jerius) (GH-152, GH-175)
 - Fix pod coverage dying after Symbol::delete_package - subs in the deleted

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Read a logop left operand's truth, and an if/else or ternary
+  condition's truth, from the path perl took instead of testing the value
+  again, so a bool overload no longer runs twice under coverage (GH-700)
 - Don't invoke overload when recording condition coverage (Olivier Mengué, Diab
   Jerius) (GH-152, GH-175)
 - Fix pod coverage dying after Symbol::delete_package - subs in the deleted

--- a/Cover.xs
+++ b/Cover.xs
@@ -1267,8 +1267,10 @@ static void finalise_conditions(pTHX) {
  * op_other when the condition is true, so we read the condition's truth
  * from control flow rather than boolifying the value again.  When both
  * branches are empty rpeep leaves op_other equal to op_next and the path
- * cannot decide, so the caller runs this BEFORE the op with next_op NULL
- * and we test the value as pp_cond_expr itself will.
+ * cannot decide, so the caller runs this BEFORE the op with next_op
+ * NULL, and we boolify the condition exactly once, as pp_cond_expr
+ * would, then replace it with the plain boolean so pp_cond_expr does
+ * not call an overloaded bool a second time.
  */
 static void cover_cond(pTHX_ OP *next_op)
 {
@@ -1279,7 +1281,8 @@ static void cover_cond(pTHX_ OP *next_op)
       val = next_op == cLOGOP->op_other;
     } else {
       dSP;
-      val = SvTRUE(TOPs);
+      val  = SvTRUE(TOPs);
+      TOPs = boolSV(val);
     }
     add_branch(aTHX_ PL_op, !val);
   }

--- a/Cover.xs
+++ b/Cover.xs
@@ -940,16 +940,16 @@ static void set_conditional(pTHX_ OP *op, int cond, int value) {
   /*
    * The conditional array is composed of six elements:
    *
-   * 0 - 1 iff we are in an xor and the right operand was true
+   * 0 - unused
    * 1 - not short circuited - second operand is false
    * 2 - not short circuited - second operand is true
-   * 3 - short circuited, or for xor right operand true, result false
-   * 4 - for xor right operand true, result true
+   * 3 - short circuited
+   * 4 - unused for and, or and dor
    * 5 - 1 iff we are in void context
    *
-   * xor does not short circuit, so the value observed at the next op is
-   * the decision result rather than the right operand; slots 1 and 2
-   * carry a false right operand with a false or true result.
+   * xor cannot short circuit, so cover_xor records its slots directly
+   * as the four operand combinations: 1 = !l&&!r, 2 = l&&!r, 3 = l&&r,
+   * 4 = !l&&r.
    */
 
   SV **count = av_fetch(get_conditional_array(aTHX_ op), cond, 1);
@@ -1028,27 +1028,16 @@ static void add_condition(pTHX_ SV *cond_ref, int value) {
   NDEB(D(L, "Looking through %zd conditionals at %p\n",
          av_len(conds) - 1, PL_op));
   for (; i <= av_len(conds); i++) {
-    OP  *op    = INT2PTR(OP *, SvIV(*av_fetch(conds, i, 0)));
-    SV **count = av_fetch(get_conditional_array(aTHX_ op), 0, 1);
-    int true_ish = (op->op_type == OP_DOR || op->op_type == OP_DORASSIGN)
-      ? SvOK(*count) : SvTRUE(*count);
-    int type  = true_ish ? SvIV(*count) : 0;
-    sv_setiv(*count, 0);
+    OP *op = INT2PTR(OP *, SvIV(*av_fetch(conds, i, 0)));
 
-    /* Check if we have come from an xor with a true right operand */
-    if (final)     value  = 1;
-    if (type == 1) value += 2;
+    if (final) value = 1;
 
-    NDEB(D(L, "Found %p (trueish=%d): %d, %d\n", op, true_ish, type, value));
+    NDEB(D(L, "Found %p: %d\n", op, value));
     add_conditional(aTHX_ op, value);
 
     /*
-     * MC/DC: write this logop's leaf column(s).  For and/or the observed
-     * value is the right operand: 1 = false, 2 = true.  For xor it is the
-     * decision result and the +2 flag records a true right operand, so
-     * both operands are recovered: right = value >= 3, left = right xor
-     * result.  The left column is written here because at the xor op the
-     * stack top was the right operand, not the left.
+     * MC/DC: write this logop's right-operand leaf column.  The observed
+     * value is the right operand: 1 = false, 2 = true.
      */
     if (!final && collecting(Mcdc)) {
       HV *m;
@@ -1059,20 +1048,8 @@ static void add_condition(pTHX_ SV *cond_ref, int value) {
           INT2PTR(OP *, dc_meta_iv(aTHX_ m, "root_addr", 9));
         int      leaf_right = dc_meta_iv(aTHX_ m, "leaf_col_right", 14);
         dc_dctx *d          = dc_stack_find_root(aTHX_ root_addr);
-        int      right_val  = (value == 2 || value == 4)
-                                ? DC_VECTOR_TRUE
-                                : DC_VECTOR_FALSE;
-
-        if (op->op_type == OP_XOR) {
-          int leaf_left = dc_meta_iv(aTHX_ m, "leaf_col_left", 13);
-          int right     = value >= 3;
-          int result    = value == 2 || value == 4;
-
-          right_val = right ? DC_VECTOR_TRUE : DC_VECTOR_FALSE;
-          if (d && leaf_left >= 0 && leaf_left < d->width)
-            d->vector[leaf_left] = right != result ? DC_VECTOR_TRUE
-                                                   : DC_VECTOR_FALSE;
-        }
+        int      right_val  = value == 2 ? DC_VECTOR_TRUE
+                                         : DC_VECTOR_FALSE;
 
         if (d && leaf_right >= 0 && leaf_right < d->width)
           d->vector[leaf_right] = right_val;
@@ -1996,6 +1973,40 @@ static void dc_snapshot_on_short_circuit(pTHX) {
 }
 
 /*
+ * Find or push the MC/DC frame for the decision this op belongs to.
+ * Returns NULL when the decision records nothing (too wide, or no
+ * frame to attach to).
+ */
+static dc_dctx *dc_mcdc_frame(pTHX_ HV *meta) {
+  OP      *root_addr = INT2PTR(OP *, dc_meta_iv(aTHX_ meta, "root_addr", 9));
+  int      width     = dc_meta_iv(aTHX_ meta, "width",    5);
+  int      is_entry  = dc_meta_iv(aTHX_ meta, "is_entry", 8) == 1;
+  dc_dctx *d;
+
+  /* A too-wide decision records nothing - never push a frame */
+  if (width > DC_MAX_DECISION_WIDTH) width = 0;
+
+  dc_stack_discard_stale(aTHX);
+  d = dc_stack_find_root(aTHX_ root_addr);
+
+  if (is_entry && width > 0) {
+    /*
+     * A fresh evaluation of this decision starts here.  A leftover
+     * frame at the same or deeper context depth was abandoned by a
+     * non-local exit - discard it.  A shallower frame belongs to an
+     * outer invocation still in flight (recursion) and is kept; the
+     * fresh frame shadows it until resolution.
+     */
+    if (d && d->cx_ix >= cxstack_ix) dc_stack_remove(aTHX_ d);
+    d = dc_stack_push(aTHX_ root_addr, width);
+  } else if (!d && width > 0) {
+    d = dc_stack_push(aTHX_ root_addr, width);
+  }
+
+  return d;
+}
+
+/*
  * Discard any DCs left over at program end.  A frame still on the stack
  * here belongs to an evaluation that never completed (die / exit / goto
  * out of a decision); recording its partial vector would fabricate an
@@ -2030,18 +2041,11 @@ static void cover_logop(pTHX_ OP *next_op, SSize_t depth) {
    * For OP_OR, if the first operand is true, we have short circuited the
    * second, otherwise the value of the op is the value of the second operand.
    *
-   * For and, or and dor and their assign forms this runs AFTER the op's pp
-   * function, with PL_op still the logop, next_op the op it returned and
-   * depth the stack depth before it ran.  The path the pp function took
-   * encodes the first operand's truth, so we read it from control flow.
-   * Boolifying the value here instead would invoke an overloaded bool a
-   * second time.
-   *
-   * For OP_XOR this runs BEFORE the pp function, with next_op NULL.  xor
-   * does not short circuit or branch, and after execution both operands
-   * are gone, so we test the second operand here at the stack top, as
-   * pp_xor itself will, and flag a true second operand so the next op can
-   * recover both operands from the result.
+   * This runs AFTER the op's pp function, with PL_op still the logop,
+   * next_op the op it returned and depth the stack depth before it ran.
+   * The path the pp function took encodes the first operand's truth, so
+   * we read it from control flow.  Boolifying the value here instead
+   * would invoke an overloaded bool a second time.
    *
    * To check the second operand we note the location of the next op after
    * this logop.  When we get there, we look at the stack and store the
@@ -2091,16 +2095,10 @@ static void cover_logop(pTHX_ OP *next_op, SSize_t depth) {
                        PL_op->op_type != OP_ANDASSIGN &&
                        PL_op->op_type != OP_ORASSIGN;
 
-    if (PL_op->op_type == OP_XOR) {
-      dSP;
-      no_short_circuit = 1;
-      leftval_true_ish = SvTRUE(TOPs);
-    } else {
-      no_short_circuit = logop_no_short_circuit(aTHX_ next_op, depth);
-      leftval_true_ish =
-        (PL_op->op_type == OP_AND || PL_op->op_type == OP_ANDASSIGN)
-          ? no_short_circuit : !no_short_circuit;
-    }
+    no_short_circuit = logop_no_short_circuit(aTHX_ next_op, depth);
+    leftval_true_ish =
+      (PL_op->op_type == OP_AND || PL_op->op_type == OP_ANDASSIGN)
+        ? no_short_circuit : !no_short_circuit;
     NDEB(D(L, "leftval_true_ish: %d, void_context: %d at %p\n",
            leftval_true_ish, void_context, PL_op));
     NDEB(op_dump(PL_op));
@@ -2121,39 +2119,10 @@ static void cover_logop(pTHX_ OP *next_op, SSize_t depth) {
       HV *meta = dc_lookup_or_build_decision_meta(aTHX_ PL_op,
                                                   find_runcv(NULL));
       if (meta) {
-        OP      *root_addr =
-          INT2PTR(OP *, dc_meta_iv(aTHX_ meta, "root_addr", 9));
-        int      width     = dc_meta_iv(aTHX_ meta, "width",         5);
         int      leaf_left = dc_meta_iv(aTHX_ meta, "leaf_col_left", 13);
-        int      is_entry  = dc_meta_iv(aTHX_ meta, "is_entry",      8) == 1;
-        dc_dctx *d;
+        dc_dctx *d         = dc_mcdc_frame(aTHX_ meta);
 
-        /* A too-wide decision records nothing - never push a frame */
-        if (width > DC_MAX_DECISION_WIDTH) width = 0;
-
-        dc_stack_discard_stale(aTHX);
-        d = dc_stack_find_root(aTHX_ root_addr);
-
-        if (is_entry && width > 0) {
-          /*
-           * A fresh evaluation of this decision starts here.  A leftover
-           * frame at the same or deeper context depth was abandoned by a
-           * non-local exit - discard it.  A shallower frame belongs to an
-           * outer invocation still in flight (recursion) and is kept; the
-           * fresh frame shadows it until resolution.
-           */
-          if (d && d->cx_ix >= cxstack_ix) dc_stack_remove(aTHX_ d);
-          d = dc_stack_push(aTHX_ root_addr, width);
-        } else if (!d && width > 0) {
-          d = dc_stack_push(aTHX_ root_addr, width);
-        }
-
-        /*
-         * For xor the stack top here is the right operand, not the left;
-         * the left column is written when the result is observed.
-         */
-        if (d && leaf_left >= 0 && leaf_left < d->width &&
-            PL_op->op_type != OP_XOR)
+        if (d && leaf_left >= 0 && leaf_left < d->width)
           d->vector[leaf_left] = leftval_true_ish ? DC_VECTOR_TRUE
                                                   : DC_VECTOR_FALSE;
       }
@@ -2194,21 +2163,8 @@ static void cover_logop(pTHX_ OP *next_op, SSize_t depth) {
              *cond;
         OP   *next;
 
-        if (PL_op->op_type == OP_XOR && leftval_true_ish) {
-          /*
-           * This is an xor.  It does not short circuit, so both operands
-           * have been evaluated and the top of the stack is the right
-           * operand.  At next the stack holds the xor result, so we flag
-           * a true right operand here to recover both operands there.
-           */
-
-          set_conditional(aTHX_ PL_op, 0, 1);
-        }
-
         NDEB(D(L, "Getting next\n"));
-        next = (PL_op->op_type == OP_XOR)
-          ? PL_op->op_next
-          : right->op_next;
+        next = right->op_next;
         while (next &&
                (next->op_type == OP_NULL || next->op_type == OP_LINESEQ))
           next = next->op_next;
@@ -2272,6 +2228,52 @@ static void cover_logop(pTHX_ OP *next_op, SSize_t depth) {
       dc_snapshot_on_short_circuit(aTHX);
     }
   }
+}
+
+/*
+ * Record an xor.  This runs BEFORE pp_xor, with both operands still on
+ * the stack.  xor does not branch, so operand truth cannot be read from
+ * control flow.  Instead we boolify each operand exactly once, exactly
+ * as pp_xor would, record the outcome, and replace the operands with
+ * the plain booleans so pp_xor does not call an overloaded bool a
+ * second time.
+ */
+static void cover_xor(pTHX) {
+  dMY_CXT;
+  dSP;
+  int lt, rt;
+
+  if (!collecting(Condition)) return;
+  /* A future xor-assign writes to its left operand - leave it alone */
+  if (PL_op->op_flags & OPf_STACKED) return;
+
+  lt     = SvTRUE(TOPm1s);
+  rt     = SvTRUE(TOPs);
+  TOPm1s = boolSV(lt);
+  TOPs   = boolSV(rt);
+
+  set_conditional(aTHX_ PL_op, 5, GIMME_V == G_VOID);
+
+  if (collecting(Mcdc)) {
+    HV *meta = dc_lookup_or_build_decision_meta(aTHX_ PL_op,
+                                                find_runcv(NULL));
+    if (meta) {
+      int      leaf_left  = dc_meta_iv(aTHX_ meta, "leaf_col_left",  13);
+      int      leaf_right = dc_meta_iv(aTHX_ meta, "leaf_col_right", 14);
+      dc_dctx *d          = dc_mcdc_frame(aTHX_ meta);
+
+      if (d && leaf_left >= 0 && leaf_left < d->width)
+        d->vector[leaf_left]  = lt ? DC_VECTOR_TRUE : DC_VECTOR_FALSE;
+      if (d && leaf_right >= 0 && leaf_right < d->width)
+        d->vector[leaf_right] = rt ? DC_VECTOR_TRUE : DC_VECTOR_FALSE;
+      if (d && dc_meta_iv(aTHX_ meta, "is_root", 7) == 1) {
+        dc_snapshot(aTHX_ d);
+        if (dc_stack_top(aTHX) == d) dc_stack_pop(aTHX);
+      }
+    }
+  }
+
+  add_conditional(aTHX_ PL_op, lt ? (rt ? 3 : 2) : (rt ? 4 : 1));
 }
 
 /*
@@ -2494,7 +2496,7 @@ OP *dc_xor(pTHX) {
   dMY_CXT;
   check_if_collecting(aTHX_ PL_curcop);
   NDEB(D(L, "dc_xor() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  if (MY_CXT.covering && collecting_here(aTHX)) cover_logop(aTHX_ NULL, 0);
+  if (MY_CXT.covering && collecting_here(aTHX)) cover_xor(aTHX);
   return MY_CXT.ppaddr[OP_XOR](aTHX);
 }
 
@@ -2839,7 +2841,7 @@ static int runops_cover(pTHX) {
       }
 
       case OP_XOR: {
-        cover_logop(aTHX_ NULL, 0);
+        cover_xor(aTHX);
         break;
       }
 

--- a/Cover.xs
+++ b/Cover.xs
@@ -2407,90 +2407,22 @@ static OP *dc_cond_expr(pTHX) {
   return next;
 }
 
-/* Capture collect first - an overloaded bool can flip collecting_here */
-static OP *dc_and(pTHX) {
-  dMY_CXT;
-  OP *next;
-  int collect;
-  SSize_t depth;
-  NDEB(D(L, "dc_and() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  check_if_collecting(aTHX_ PL_curcop);
-  NDEB(D(L, "dc_and() at %p (%d)\n", PL_curcop, collecting_here(aTHX)));
-  NDEB(D(L, "PL_curcop: %s:%ld\n",
-         CopFILE(PL_curcop), (long)CopLINE(PL_curcop)));
-  collect = MY_CXT.covering && collecting_here(aTHX);
-  depth   = PL_stack_sp - PL_stack_base;
-  next    = MY_CXT.ppaddr[OP_AND](aTHX);
-  if (collect) cover_logop(aTHX_ next, depth);
-  return next;
-}
-
-static OP *dc_andassign(pTHX) {
+/*
+ * Shared wrapper for and, or and dor and their assign forms.  Capture
+ * collect first - an overloaded bool can flip collecting_here.  The
+ * depth only decides the path for the plain forms, but capturing it
+ * unconditionally is cheaper than distinguishing the op types here.
+ */
+static OP *dc_logop(pTHX) {
   dMY_CXT;
   OP *next;
   int collect;
   SSize_t depth;
   check_if_collecting(aTHX_ PL_curcop);
-  NDEB(D(L, "dc_andassign() at %p (%d)\n", PL_op, collecting_here(aTHX)));
+  NDEB(D(L, "dc_logop() at %p (%d)\n", PL_op, collecting_here(aTHX)));
   collect = MY_CXT.covering && collecting_here(aTHX);
   depth   = PL_stack_sp - PL_stack_base;
-  next    = MY_CXT.ppaddr[OP_ANDASSIGN](aTHX);
-  if (collect) cover_logop(aTHX_ next, depth);
-  return next;
-}
-
-static OP *dc_or(pTHX) {
-  dMY_CXT;
-  OP *next;
-  int collect;
-  SSize_t depth;
-  check_if_collecting(aTHX_ PL_curcop);
-  NDEB(D(L, "dc_or() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  collect = MY_CXT.covering && collecting_here(aTHX);
-  depth   = PL_stack_sp - PL_stack_base;
-  next    = MY_CXT.ppaddr[OP_OR](aTHX);
-  if (collect) cover_logop(aTHX_ next, depth);
-  return next;
-}
-
-static OP *dc_orassign(pTHX) {
-  dMY_CXT;
-  OP *next;
-  int collect;
-  SSize_t depth;
-  check_if_collecting(aTHX_ PL_curcop);
-  NDEB(D(L, "dc_orassign() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  collect = MY_CXT.covering && collecting_here(aTHX);
-  depth   = PL_stack_sp - PL_stack_base;
-  next    = MY_CXT.ppaddr[OP_ORASSIGN](aTHX);
-  if (collect) cover_logop(aTHX_ next, depth);
-  return next;
-}
-
-static OP *dc_dor(pTHX) {
-  dMY_CXT;
-  OP *next;
-  int collect;
-  SSize_t depth;
-  check_if_collecting(aTHX_ PL_curcop);
-  NDEB(D(L, "dc_dor() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  collect = MY_CXT.covering && collecting_here(aTHX);
-  depth   = PL_stack_sp - PL_stack_base;
-  next    = MY_CXT.ppaddr[OP_DOR](aTHX);
-  if (collect) cover_logop(aTHX_ next, depth);
-  return next;
-}
-
-static OP *dc_dorassign(pTHX) {
-  dMY_CXT;
-  OP *next;
-  int collect;
-  SSize_t depth;
-  check_if_collecting(aTHX_ PL_curcop);
-  NDEB(D(L, "dc_dorassign() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  collect = MY_CXT.covering && collecting_here(aTHX);
-  depth   = PL_stack_sp - PL_stack_base;
-  next    = MY_CXT.ppaddr[OP_DORASSIGN](aTHX);
+  next    = MY_CXT.ppaddr[PL_op->op_type](aTHX);
   if (collect) cover_logop(aTHX_ next, depth);
   return next;
 }
@@ -2654,12 +2586,12 @@ static void replace_ops (pTHX) {
   PL_ppaddr[OP_ENTERSUB]  = dc_entersub;
   PL_ppaddr[OP_PADRANGE]  = dc_padrange;
   PL_ppaddr[OP_COND_EXPR] = dc_cond_expr;
-  PL_ppaddr[OP_AND]       = dc_and;
-  PL_ppaddr[OP_ANDASSIGN] = dc_andassign;
-  PL_ppaddr[OP_OR]        = dc_or;
-  PL_ppaddr[OP_ORASSIGN]  = dc_orassign;
-  PL_ppaddr[OP_DOR]       = dc_dor;
-  PL_ppaddr[OP_DORASSIGN] = dc_dorassign;
+  PL_ppaddr[OP_AND]       = dc_logop;
+  PL_ppaddr[OP_ANDASSIGN] = dc_logop;
+  PL_ppaddr[OP_OR]        = dc_logop;
+  PL_ppaddr[OP_ORASSIGN]  = dc_logop;
+  PL_ppaddr[OP_DOR]       = dc_logop;
+  PL_ppaddr[OP_DORASSIGN] = dc_logop;
   PL_ppaddr[OP_XOR]       = dc_xor;
   PL_ppaddr[OP_REQUIRE]   = dc_require;
   PL_ppaddr[OP_LEAVEEVAL] = dc_leaveeval;

--- a/Cover.xs
+++ b/Cover.xs
@@ -2021,6 +2021,15 @@ static void finalise_decisions(pTHX) {
     dc_stack_pop(aTHX);
 }
 
+/* Both path rules below depend on per-version pp behaviour - warn once */
+static void logop_invariant_warn(pTHX) {
+  static int warned;
+  if (warned++) return;
+  warn("Devel::Cover: logop path detection disagrees at %s line %ld - "
+       "coverage data may be wrong, please report this\n",
+       CopFILE(PL_curcop), (long)CopLINE(PL_curcop));
+}
+
 /*
  * Whether the logop at PL_op continued into its right operand, given the
  * op it returned and the stack depth before it ran.  and, or and dor pop
@@ -2031,8 +2040,14 @@ static void finalise_decisions(pTHX) {
  */
 static int logop_no_short_circuit(pTHX_ OP *next_op, SSize_t depth) {
   if (PL_op->op_type == OP_AND || PL_op->op_type == OP_OR ||
-      PL_op->op_type == OP_DOR)
-    return PL_stack_sp - PL_stack_base < depth;
+      PL_op->op_type == OP_DOR) {
+    int continued = PL_stack_sp - PL_stack_base < depth;
+    if (cLOGOP->op_other != PL_op->op_next &&
+        continued != (next_op == cLOGOP->op_other))
+      logop_invariant_warn(aTHX);
+    return continued;
+  }
+  if (cLOGOP->op_other == PL_op->op_next) logop_invariant_warn(aTHX);
   return next_op == cLOGOP->op_other;
 }
 

--- a/Cover.xs
+++ b/Cover.xs
@@ -202,6 +202,9 @@ typedef struct {
   dc_stack_t    dc_stack;              /* active decisions awaiting
                                         * resolution; top entry is the
                                         * decision currently being filled */
+  SV           *chained_cond;          /* pending conditions whose truth
+                                        * the consuming op's path gives */
+  OP           *chained_target;        /* the consuming op */
   Perl_ppaddr_t ppaddr[MAXO];
 } my_cxt_t;
 
@@ -1201,6 +1204,27 @@ static OP *get_condition(pTHX) {
           PL_op, (void *)PL_op->op_targ, pc, hex_key(get_key(PL_op))));
     /* dump_conditions(aTHX); */
     NDEB(svdump(Pending_conditionals));
+
+    /*
+     * When this op will itself test the pending value's truth and
+     * branch on it, defer resolution and read the truth from the path
+     * it takes.  That truth is exact for an overloaded value, where
+     * the stack read below counts the object as true regardless of
+     * its bool overload.  An ambiguous cond_expr (op_other equal to
+     * op_next) gives no path, so it resolves from the stack as before.
+     */
+    if (PL_op->op_type == OP_AND || PL_op->op_type == OP_OR ||
+        (PL_op->op_type == OP_COND_EXPR &&
+         cLOGOP->op_other != PL_op->op_next)) {
+      dMY_CXT;
+      AV *conds = (AV *)SvRV(*pc);
+      PL_op->op_ppaddr =
+        INT2PTR(OP *(*)(pTHX), SvIV(*av_fetch(conds, 1, 0)));
+      MY_CXT.chained_cond   = *pc;
+      MY_CXT.chained_target = PL_op;
+      return PL_op;
+    }
+
     true_ish = (PL_op->op_type == OP_DOR || PL_op->op_type == OP_DORASSIGN)
       ? SvOK(TOPs) : sv_true_no_overload(aTHX_ TOPs);
     NDEB(D(L, "   get_condition true_ish=%d\n", true_ish));
@@ -2051,6 +2075,26 @@ static int logop_no_short_circuit(pTHX_ OP *next_op, SSize_t depth) {
   return next_op == cLOGOP->op_other;
 }
 
+/*
+ * Resolve pending conditions chained to the op at PL_op, which tested
+ * the pending value's truth itself and took a path that encodes it.
+ * The tested value is true when a cond_expr took op_other, when an and
+ * continued into its right operand, or when an or short-circuited.
+ */
+static void resolve_chained_condition(pTHX_ OP *next_op, SSize_t depth) {
+  dMY_CXT;
+  SV *cond = MY_CXT.chained_cond;
+  int truth;
+  if (!cond) return;
+  MY_CXT.chained_cond = NULL;
+  if (MY_CXT.chained_target != PL_op) return;
+  truth = PL_op->op_type == OP_COND_EXPR
+    ? next_op == cLOGOP->op_other
+    : logop_no_short_circuit(aTHX_ next_op, depth)
+        == (PL_op->op_type == OP_AND);
+  add_condition(aTHX_ cond, truth ? 2 : 1);
+}
+
 static void cover_logop(pTHX_ OP *next_op, SSize_t depth) {
   /*
    * For OP_AND, if the first operand is false, we have short circuited the
@@ -2418,6 +2462,7 @@ static OP *dc_cond_expr(pTHX) {
   ambiguous = cLOGOP->op_other == PL_op->op_next;
   if (collect && ambiguous) cover_cond(aTHX_ NULL);
   next = MY_CXT.ppaddr[OP_COND_EXPR](aTHX);
+  if (MY_CXT.chained_cond) resolve_chained_condition(aTHX_ next, 0);
   if (collect && !ambiguous) cover_cond(aTHX_ next);
   return next;
 }
@@ -2438,6 +2483,7 @@ static OP *dc_logop(pTHX) {
   collect = MY_CXT.covering && collecting_here(aTHX);
   depth   = PL_stack_sp - PL_stack_base;
   next    = MY_CXT.ppaddr[PL_op->op_type](aTHX);
+  if (MY_CXT.chained_cond) resolve_chained_condition(aTHX_ next, depth);
   if (collect) cover_logop(aTHX_ next, depth);
   return next;
 }
@@ -2682,6 +2728,8 @@ static void initialise(pTHX) {
     Zero(&MY_CXT.av_cache, 1, dc_av_cache);
     Zero(&MY_CXT.dc_stack,  1, dc_stack_t);
     MY_CXT.deferred_conditionals      = newAV();
+    MY_CXT.chained_cond               = NULL;
+    MY_CXT.chained_target             = NULL;
     MY_CXT.decision_meta              = newHV();
     MY_CXT.decision_walked_cvs        = newHV();
     HvSHAREKEYS_off(MY_CXT.decision_meta);
@@ -2814,6 +2862,8 @@ static int runops_cover(pTHX) {
       OP *next = PL_op->op_ppaddr(aTHX);
       if (pending_op) {
         PL_op = pending_op;
+        if (MY_CXT.chained_cond)
+          resolve_chained_condition(aTHX_ next, pending_depth);
         if (PL_op->op_type == OP_COND_EXPR)
           cover_cond(aTHX_ next);
         else

--- a/Cover.xs
+++ b/Cover.xs
@@ -1284,12 +1284,26 @@ static void finalise_conditions(pTHX) {
   MUTEX_UNLOCK(&DC_mutex);
 }
 
-static void cover_cond(pTHX)
+/*
+ * Record the branch a cond_expr took.  This runs AFTER the op's pp
+ * function, with next_op the op it returned, and pp_cond_expr returns
+ * op_other when the condition is true, so we read the condition's truth
+ * from control flow rather than boolifying the value again.  When both
+ * branches are empty rpeep leaves op_other equal to op_next and the path
+ * cannot decide, so the caller runs this BEFORE the op with next_op NULL
+ * and we test the value as pp_cond_expr itself will.
+ */
+static void cover_cond(pTHX_ OP *next_op)
 {
   dMY_CXT;
   if (collecting(Branch)) {
-    dSP;
-    int val = SvTRUE(TOPs);
+    int val;
+    if (next_op) {
+      val = next_op == cLOGOP->op_other;
+    } else {
+      dSP;
+      val = SvTRUE(TOPs);
+    }
     add_branch(aTHX_ PL_op, !val);
   }
 }
@@ -1993,7 +2007,22 @@ static void finalise_decisions(pTHX) {
     dc_stack_pop(aTHX);
 }
 
-static void cover_logop(pTHX) {
+/*
+ * Whether the logop at PL_op continued into its right operand, given the
+ * op it returned and the stack depth before it ran.  and, or and dor pop
+ * the tested value only on that path, so depth decides - rpeep can leave
+ * op_other equal to op_next when the right side is a nulled constant.
+ * The assign forms never pop, but their right side always holds an
+ * assignment, so the returned op decides for them.
+ */
+static int logop_no_short_circuit(pTHX_ OP *next_op, SSize_t depth) {
+  if (PL_op->op_type == OP_AND || PL_op->op_type == OP_OR ||
+      PL_op->op_type == OP_DOR)
+    return PL_stack_sp - PL_stack_base < depth;
+  return next_op == cLOGOP->op_other;
+}
+
+static void cover_logop(pTHX_ OP *next_op, SSize_t depth) {
   /*
    * For OP_AND, if the first operand is false, we have short circuited the
    * second, otherwise the value of the op is the value of the second operand.
@@ -2001,13 +2030,22 @@ static void cover_logop(pTHX) {
    * For OP_OR, if the first operand is true, we have short circuited the
    * second, otherwise the value of the op is the value of the second operand.
    *
-   * We check the value of the first operand by simply looking on the stack.  To
-   * check the second operand it is necessary to note the location of the next
-   * op after this logop.  When we get there, we look at the stack and store the
-   * coverage information indexed to this op.
+   * For and, or and dor and their assign forms this runs AFTER the op's pp
+   * function, with PL_op still the logop, next_op the op it returned and
+   * depth the stack depth before it ran.  The path the pp function took
+   * encodes the first operand's truth, so we read it from control flow.
+   * Boolifying the value here instead would invoke an overloaded bool a
+   * second time.
    *
-   * This scheme also works for OP_XOR with a small modification because it
-   * doesn't short circuit.  See the comment below.
+   * For OP_XOR this runs BEFORE the pp function, with next_op NULL.  xor
+   * does not short circuit or branch, and after execution both operands
+   * are gone, so we test the second operand here at the stack top, as
+   * pp_xor itself will, and flag a true second operand so the next op can
+   * recover both operands from the result.
+   *
+   * To check the second operand we note the location of the next op after
+   * this logop.  When we get there, we look at the stack and store the
+   * coverage information indexed to this op.
    *
    * To find out when we get to the next op we change the op_ppaddr to point to
    * get_condition(), which will do the necessary work and then reset and run
@@ -2034,30 +2072,35 @@ static void cover_logop(pTHX) {
     if (!collecting(Branch)) return;
     if (PL_op->op_type != OP_AND && PL_op->op_type != OP_OR) return;
     if (cLOGOP->op_first->op_type == OP_ITER) return;
-    {
-      dSP;
-      if (PL_op->op_type == OP_AND ? SvTRUE(TOPs) : !SvTRUE(TOPs))
-        add_conditional(aTHX_ PL_op, 2);
-      else
-        credit_short_circuit(aTHX);
-    }
+    if (logop_no_short_circuit(aTHX_ next_op, depth))
+      add_conditional(aTHX_ PL_op, 2);
+    else
+      credit_short_circuit(aTHX);
     return;
   }
 
   if (cLOGOP->op_first->op_type == OP_ITER) {
     /* loop - ignore it for now */
   } else {
-    dSP;
-
-    int leftval_true_ish = (PL_op->op_type == OP_DOR ||
-                            PL_op->op_type == OP_DORASSIGN)
-      ? SvOK(TOPs) : SvTRUE(TOPs);
+    int no_short_circuit;
+    int leftval_true_ish;
     /* We don't count X= as void context because we care about the value
      * of the RHS */
     int void_context = GIMME_V == G_VOID &&
                        PL_op->op_type != OP_DORASSIGN &&
                        PL_op->op_type != OP_ANDASSIGN &&
                        PL_op->op_type != OP_ORASSIGN;
+
+    if (PL_op->op_type == OP_XOR) {
+      dSP;
+      no_short_circuit = 1;
+      leftval_true_ish = SvTRUE(TOPs);
+    } else {
+      no_short_circuit = logop_no_short_circuit(aTHX_ next_op, depth);
+      leftval_true_ish =
+        (PL_op->op_type == OP_AND || PL_op->op_type == OP_ANDASSIGN)
+          ? no_short_circuit : !no_short_circuit;
+    }
     NDEB(D(L, "leftval_true_ish: %d, void_context: %d at %p\n",
            leftval_true_ish, void_context, PL_op));
     NDEB(op_dump(PL_op));
@@ -2116,14 +2159,7 @@ static void cover_logop(pTHX) {
       }
     }
 
-    if ((PL_op->op_type == OP_AND       &&  leftval_true_ish) ||
-        (PL_op->op_type == OP_ANDASSIGN &&  leftval_true_ish) ||
-        (PL_op->op_type == OP_OR        && !leftval_true_ish) ||
-        (PL_op->op_type == OP_ORASSIGN  && !leftval_true_ish) ||
-        (PL_op->op_type == OP_DOR       && !leftval_true_ish) ||
-        (PL_op->op_type == OP_DORASSIGN && !leftval_true_ish) ||
-        (PL_op->op_type == OP_XOR)) {
-      /* no short circuit */
+    if (no_short_circuit) {
 
       OP *right = OpSIBLING(cLOGOP->op_first);
 
@@ -2353,68 +2389,112 @@ static OP *dc_entersub(pTHX) {
 
 static OP *dc_cond_expr(pTHX) {
   dMY_CXT;
+  OP *next;
+  int collect,
+      ambiguous;
   check_if_collecting(aTHX_ PL_curcop);
   NDEB(D(L, "dc_cond_expr() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  if (MY_CXT.covering && collecting_here(aTHX)) cover_cond(aTHX);
-  return MY_CXT.ppaddr[OP_COND_EXPR](aTHX);
+  collect   = MY_CXT.covering && collecting_here(aTHX);
+  ambiguous = cLOGOP->op_other == PL_op->op_next;
+  if (collect && ambiguous) cover_cond(aTHX_ NULL);
+  next = MY_CXT.ppaddr[OP_COND_EXPR](aTHX);
+  if (collect && !ambiguous) cover_cond(aTHX_ next);
+  return next;
 }
 
+/* Capture collect first - an overloaded bool can flip collecting_here */
 static OP *dc_and(pTHX) {
   dMY_CXT;
+  OP *next;
+  int collect;
+  SSize_t depth;
   NDEB(D(L, "dc_and() at %p (%d)\n", PL_op, collecting_here(aTHX)));
   check_if_collecting(aTHX_ PL_curcop);
   NDEB(D(L, "dc_and() at %p (%d)\n", PL_curcop, collecting_here(aTHX)));
   NDEB(D(L, "PL_curcop: %s:%ld\n",
          CopFILE(PL_curcop), (long)CopLINE(PL_curcop)));
-  if (MY_CXT.covering && collecting_here(aTHX)) cover_logop(aTHX);
-  return MY_CXT.ppaddr[OP_AND](aTHX);
+  collect = MY_CXT.covering && collecting_here(aTHX);
+  depth   = PL_stack_sp - PL_stack_base;
+  next    = MY_CXT.ppaddr[OP_AND](aTHX);
+  if (collect) cover_logop(aTHX_ next, depth);
+  return next;
 }
 
 static OP *dc_andassign(pTHX) {
   dMY_CXT;
+  OP *next;
+  int collect;
+  SSize_t depth;
   check_if_collecting(aTHX_ PL_curcop);
   NDEB(D(L, "dc_andassign() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  if (MY_CXT.covering && collecting_here(aTHX)) cover_logop(aTHX);
-  return MY_CXT.ppaddr[OP_ANDASSIGN](aTHX);
+  collect = MY_CXT.covering && collecting_here(aTHX);
+  depth   = PL_stack_sp - PL_stack_base;
+  next    = MY_CXT.ppaddr[OP_ANDASSIGN](aTHX);
+  if (collect) cover_logop(aTHX_ next, depth);
+  return next;
 }
 
 static OP *dc_or(pTHX) {
   dMY_CXT;
+  OP *next;
+  int collect;
+  SSize_t depth;
   check_if_collecting(aTHX_ PL_curcop);
   NDEB(D(L, "dc_or() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  if (MY_CXT.covering && collecting_here(aTHX)) cover_logop(aTHX);
-  return MY_CXT.ppaddr[OP_OR](aTHX);
+  collect = MY_CXT.covering && collecting_here(aTHX);
+  depth   = PL_stack_sp - PL_stack_base;
+  next    = MY_CXT.ppaddr[OP_OR](aTHX);
+  if (collect) cover_logop(aTHX_ next, depth);
+  return next;
 }
 
 static OP *dc_orassign(pTHX) {
   dMY_CXT;
+  OP *next;
+  int collect;
+  SSize_t depth;
   check_if_collecting(aTHX_ PL_curcop);
   NDEB(D(L, "dc_orassign() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  if (MY_CXT.covering && collecting_here(aTHX)) cover_logop(aTHX);
-  return MY_CXT.ppaddr[OP_ORASSIGN](aTHX);
+  collect = MY_CXT.covering && collecting_here(aTHX);
+  depth   = PL_stack_sp - PL_stack_base;
+  next    = MY_CXT.ppaddr[OP_ORASSIGN](aTHX);
+  if (collect) cover_logop(aTHX_ next, depth);
+  return next;
 }
 
 static OP *dc_dor(pTHX) {
   dMY_CXT;
+  OP *next;
+  int collect;
+  SSize_t depth;
   check_if_collecting(aTHX_ PL_curcop);
   NDEB(D(L, "dc_dor() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  if (MY_CXT.covering && collecting_here(aTHX)) cover_logop(aTHX);
-  return MY_CXT.ppaddr[OP_DOR](aTHX);
+  collect = MY_CXT.covering && collecting_here(aTHX);
+  depth   = PL_stack_sp - PL_stack_base;
+  next    = MY_CXT.ppaddr[OP_DOR](aTHX);
+  if (collect) cover_logop(aTHX_ next, depth);
+  return next;
 }
 
 static OP *dc_dorassign(pTHX) {
   dMY_CXT;
+  OP *next;
+  int collect;
+  SSize_t depth;
   check_if_collecting(aTHX_ PL_curcop);
   NDEB(D(L, "dc_dorassign() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  if (MY_CXT.covering && collecting_here(aTHX)) cover_logop(aTHX);
-  return MY_CXT.ppaddr[OP_DORASSIGN](aTHX);
+  collect = MY_CXT.covering && collecting_here(aTHX);
+  depth   = PL_stack_sp - PL_stack_base;
+  next    = MY_CXT.ppaddr[OP_DORASSIGN](aTHX);
+  if (collect) cover_logop(aTHX_ next, depth);
+  return next;
 }
 
 OP *dc_xor(pTHX) {
   dMY_CXT;
   check_if_collecting(aTHX_ PL_curcop);
   NDEB(D(L, "dc_xor() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  if (MY_CXT.covering && collecting_here(aTHX)) cover_logop(aTHX);
+  if (MY_CXT.covering && collecting_here(aTHX)) cover_logop(aTHX_ NULL, 0);
   return MY_CXT.ppaddr[OP_XOR](aTHX);
 }
 
@@ -2670,7 +2750,9 @@ static void initialise(pTHX) {
 
 static int runops_cover(pTHX) {
   dMY_CXT;
-  I32 deferred_base = av_len(MY_CXT.deferred_conditionals) + 1;
+  I32     deferred_base = av_len(MY_CXT.deferred_conditionals) + 1;
+  OP     *pending_op    = NULL;
+  SSize_t pending_depth = 0;
 
   NDEB(D(L, "entering runops_cover\n"));
 
@@ -2737,7 +2819,10 @@ static int runops_cover(pTHX) {
       }
 
       case OP_COND_EXPR: {
-        cover_cond(aTHX);
+        if (cLOGOP->op_other == PL_op->op_next)
+          cover_cond(aTHX_ NULL);
+        else
+          pending_op = PL_op;
         break;
       }
 
@@ -2746,9 +2831,15 @@ static int runops_cover(pTHX) {
       case OP_OR:
       case OP_ORASSIGN:
       case OP_DOR:
-      case OP_DORASSIGN:
+      case OP_DORASSIGN: {
+        /* Record coverage after the op runs, from the path it took */
+        pending_op    = PL_op;
+        pending_depth = PL_stack_sp - PL_stack_base;
+        break;
+      }
+
       case OP_XOR: {
-        cover_logop(aTHX);
+        cover_logop(aTHX_ NULL, 0);
         break;
       }
 
@@ -2767,10 +2858,21 @@ static int runops_cover(pTHX) {
     }
 
     call_fptr:
-    if (!(PL_op = PL_op->op_ppaddr(aTHX))) {
-      resolve_deferred_conditionals(aTHX_
-        MY_CXT.deferred_conditionals, deferred_base);
-      break;
+    {
+      OP *next = PL_op->op_ppaddr(aTHX);
+      if (pending_op) {
+        PL_op = pending_op;
+        if (PL_op->op_type == OP_COND_EXPR)
+          cover_cond(aTHX_ next);
+        else
+          cover_logop(aTHX_ next, pending_depth);
+        pending_op = NULL;
+      }
+      if (!(PL_op = next)) {
+        resolve_deferred_conditionals(aTHX_
+          MY_CXT.deferred_conditionals, deferred_base);
+        break;
+      }
     }
 
     PERL_ASYNC_CHECK();

--- a/docs/technical/branches_and_conditions.md
+++ b/docs/technical/branches_and_conditions.md
@@ -195,9 +195,19 @@ Index   Meaning
 
 ### How the XS code collects data
 
-1. **`cover_logop`** runs when a logical op (`OP_AND`, `OP_OR`, `OP_XOR`,
-   `OP_DOR`, and their assign variants) is about to execute. It checks the truth
-   value of the left operand on the stack.
+1. **`cover_logop`** runs after the pp function of a logical op (`OP_AND`,
+   `OP_OR`, `OP_DOR`, or one of their assign variants) has executed. It receives
+   the op the pp function returned and the stack depth from before the op ran,
+   and derives the left operand's truth from the path perl took rather than
+   testing the value itself, which would call an overloaded `bool` a second
+   time. `logop_no_short_circuit` decides the path. The plain forms pop the
+   tested value only when they continue into the right operand, so stack depth
+   decides for them (rpeep can leave `op_other` equal to `op_next` when the
+   right side is a nulled constant, so the returned op alone cannot). The assign
+   forms never pop, but their right side always holds an assignment, so
+   comparing the returned op with `op_other` decides for them. `OP_XOR` neither
+   branches nor short-circuits, so for it `cover_logop` still runs before the pp
+   function and tests the operand at the stack top, as `pp_xor` itself will.
 
 2. If the op short-circuits (left is false for `and`, true for `or`),
    `add_conditional` immediately records the outcome at index 3 (left determined
@@ -230,8 +240,12 @@ Index   Meaning
 ### `cover_cond` - branch data from `cond_expr`
 
 The `cond_expr` op (`?:` / `if-else`) uses a simpler mechanism. `cover_cond`
-runs at the `cond_expr` op and records which branch (true or false) was taken,
-using `add_branch` directly.
+runs after `pp_cond_expr` and reads the condition's truth from the op it
+returned - `op_other` means true, `op_next` means false. `add_branch` records
+the outcome directly. An if/else with both branches empty, or a void
+`$c ? 1 : 0`, leaves `op_other` equal to `op_next` after rpeep, so the returned
+op cannot decide. For exactly those forms `cover_cond` runs before the op
+instead and tests the value at the stack top, as `pp_cond_expr` itself will.
 
 ## How the Perl Layer Interprets Raw Data
 

--- a/docs/technical/branches_and_conditions.md
+++ b/docs/technical/branches_and_conditions.md
@@ -250,7 +250,9 @@ returned - `op_other` means true, `op_next` means false. `add_branch` records
 the outcome directly. An if/else with both branches empty, or a void
 `$c ? 1 : 0`, leaves `op_other` equal to `op_next` after rpeep, so the returned
 op cannot decide. For exactly those forms `cover_cond` runs before the op
-instead and tests the value at the stack top, as `pp_cond_expr` itself will.
+instead, boolifies the condition exactly once as `pp_cond_expr` would, and
+replaces it on the stack with the plain boolean so the pp function does not
+invoke an overloaded `bool` a second time - the same technique `cover_xor` uses.
 
 ## How the Perl Layer Interprets Raw Data
 

--- a/docs/technical/branches_and_conditions.md
+++ b/docs/technical/branches_and_conditions.md
@@ -170,7 +170,7 @@ assign the result), so condition coverage is appropriate.
 walker dispatches both to `_walk_xor`, which calls `add_condition_cover`. The
 label is rendered as `^^` when the op is used at high precedence (`$cx > 2`) and
 `xor` otherwise. The raw 4-outcome counts come from the runtime (`dc_xor` /
-`cover_logop`).
+`cover_xor`).
 
 ## Runtime Data Collection (Cover.xs)
 
@@ -185,13 +185,16 @@ by op address. The indices track different outcomes:
 ```text
 Index   Meaning
 -----   -------
-  0     Flag: first operand of xor was true (internal bookkeeping)
-  1     Count: left false, right not evaluated (short-circuited)
-  2     Count: left true, right false (not short-circuited)
-  3     Count: left true, right true (not short-circuited)
-  4     Count: left true, right true (xor-specific)
-  5     Flag: void context (the RHS is a control flow op)
+  0     Unused
+  1     Count: not short-circuited, right operand false
+  2     Count: not short-circuited, right operand true
+  3     Count: short-circuited (left determined the result)
+  4     Unused for and/or/dor
+  5     Flag: void context
 ```
+
+`xor` cannot short-circuit, so `cover_xor` records its slots directly as the
+four operand combinations: 1 = `!l&&!r`, 2 = `l&&!r`, 3 = `l&&r`, 4 = `!l&&r`.
 
 ### How the XS code collects data
 
@@ -206,8 +209,10 @@ Index   Meaning
    right side is a nulled constant, so the returned op alone cannot). The assign
    forms never pop, but their right side always holds an assignment, so
    comparing the returned op with `op_other` decides for them. `OP_XOR` neither
-   branches nor short-circuits, so for it `cover_logop` still runs before the pp
-   function and tests the operand at the stack top, as `pp_xor` itself will.
+   branches nor short-circuits, so `cover_xor` handles it instead - it runs
+   before the pp function, boolifies each operand exactly once as `pp_xor`
+   would, replaces the operands on the stack with the plain booleans, and
+   records the outcome immediately with no hook.
 
 2. If the op short-circuits (left is false for `and`, true for `or`),
    `add_conditional` immediately records the outcome at index 3 (left determined

--- a/docs/technical/branches_and_conditions.md
+++ b/docs/technical/branches_and_conditions.md
@@ -222,7 +222,11 @@ four operand combinations: 1 = `!l&&!r`, 2 = `l&&!r`, 3 = `l&&r`, 4 = `!l&&r`.
    operand's value too. It installs a temporary hook (`get_condition`) at the op
    that follows the right operand. When execution reaches that op,
    `get_condition` examines the stack and records the outcome at index 1 (right
-   was false) or 2 (right was true).
+   was false) or 2 (right was true). When that op is itself about to test the
+   value's truth - a non-ambiguous `cond_expr`, an `and` or an `or` - resolution
+   is deferred past its pp function instead and the truth is read from the path
+   it takes, which is exact for an overloaded value; see
+   `pending-and-deferred-conditionals.md`.
 
 4. **Void context shortcut**: if the op is in void context, or the right operand
    is a control flow op (`next`, `last`, `redo`, `goto`, `return`, `die`), the

--- a/docs/technical/mcdc.md
+++ b/docs/technical/mcdc.md
@@ -229,9 +229,9 @@ populated.
 MC/DC reuses the data and structural machinery Devel::Cover already collects for
 condition coverage:
 
-1. **Per-logop truth value collection** in `Cover.xs`'s `cover_logop`. See
-   `docs/technical/branches_and_conditions.md` for the layout of the condition
-   array.
+1. **Per-logop truth value collection** in `Cover.xs`'s `cover_logop` and
+   `cover_xor`. See `docs/technical/branches_and_conditions.md` for the layout
+   of the condition array.
 
 2. **Composite truth tables** built by `lib/Devel/Cover/Condition_table.pm`
    (added in GH-446). Given a tree of nested logops, this module synthesises a
@@ -308,25 +308,25 @@ analyser reports the buggy implementation as MC/DC-satisfied.
 
 Audit-grade MC/DC therefore needs per-execution combined-input data. `Cover.xs`
 records each decision's input vector at runtime: a small stack
-(`MY_CXT.dc_stack`) tracks the decisions in flight; `cover_logop` and
-`add_condition` write each leaf's observed truth value into the current vector,
-and snapshot it into `MY_CXT.decision_inputs` on short-circuit-at-root, on the
-same-type chain reaching the root, or - for decisions ending a sort comparator -
-per invocation from `resolve_deferred_conditionals`. The chain walk follows each
-right operand's `op_next`, stepping through nulled ops (the tree roots of
-element accesses, which are not executed but whose `op_next` still leads on) to
-reach the enclosing logop. Each evaluation of a decision gets its own frame: the
-decision's entry logop (the first to fire on every evaluation) always pushes a
-fresh one, so recursive invocations record separately. Frames record
-`cxstack_ix` at push; a frame abandoned by a non-local exit (`die`, `goto`,
-`last`) is detected by its now-too-deep context depth and discarded without
-recording - an abandoned evaluation must record nothing, since a partial vector
-would fabricate an observation no execution produced. Column metadata (which
-logop is a decision root, which leaf maps to which column index) is computed
-lazily on first encounter of each CV by walking the optree from `CvROOT`. The
-walk uses `op_first` / `OpSIBLING` chains rather than `op_sibparent` to preserve
-the 5.20 minimum (`op_sibparent` requires `PERL_OP_PARENT`, added in 5.22 and
-made default in 5.26).
+(`MY_CXT.dc_stack`) tracks the decisions in flight; `cover_logop`, `cover_xor`
+and `add_condition` write each leaf's observed truth value into the current
+vector, and snapshot it into `MY_CXT.decision_inputs` on short-circuit-at-root,
+on the same-type chain reaching the root, or - for decisions ending a sort
+comparator - per invocation from `resolve_deferred_conditionals`. The chain walk
+follows each right operand's `op_next`, stepping through nulled ops (the tree
+roots of element accesses, which are not executed but whose `op_next` still
+leads on) to reach the enclosing logop. Each evaluation of a decision gets its
+own frame: the decision's entry logop (the first to fire on every evaluation)
+always pushes a fresh one, so recursive invocations record separately. Frames
+record `cxstack_ix` at push; a frame abandoned by a non-local exit (`die`,
+`goto`, `last`) is detected by its now-too-deep context depth and discarded
+without recording - an abandoned evaluation must record nothing, since a partial
+vector would fabricate an observation no execution produced. Column metadata
+(which logop is a decision root, which leaf maps to which column index) is
+computed lazily on first encounter of each CV by walking the optree from
+`CvROOT`. The walk uses `op_first` / `OpSIBLING` chains rather than
+`op_sibparent` to preserve the 5.20 minimum (`op_sibparent` requires
+`PERL_OP_PARENT`, added in 5.22 and made default in 5.26).
 
 Root identification must agree with condition coverage on what "the decision"
 is. The joining logop of an `if`, `unless` or `while` statement or statement

--- a/docs/technical/pending-and-deferred-conditionals.md
+++ b/docs/technical/pending-and-deferred-conditionals.md
@@ -68,6 +68,18 @@ When `cover_logop()` handles the non-short-circuit path:
    pending logical op, restores the original `op_ppaddr`, and returns `PL_op` so
    the hijacked op runs normally.
 
+When the hijacked op is itself going to test that value's truth and branch on it
+\- a non-ambiguous `cond_expr`, an `and` or an `or` - `get_condition()` instead
+restores the `op_ppaddr`, stashes the pending entry in `MY_CXT.chained_cond`,
+and lets the op run. The after-exec sites (the `dc_cond_expr` and `dc_logop`
+wrappers, and the pending block in `runops_cover`) then call
+`resolve_chained_condition()`, which derives the value's truth from the path the
+consuming op took and resolves the pending entry with it. The stack read counts
+an overloaded object as true regardless of its `bool` overload, so the
+path-derived truth is exact where the stack read is not. A consumer that never
+records - a die inside the op, or collection turned off - leaves the members in
+`Pending_conditionals` for `finalise_conditions()` as usual.
+
 Multiple logical ops can share the same target. For example, in
 `$a || $b || $c`, when `$a` is false and `$b` is also false, both `||` ops are
 waiting on the same `next` op (the one after `$c`). They are all stored in the

--- a/docs/technical/pending-and-deferred-conditionals.md
+++ b/docs/technical/pending-and-deferred-conditionals.md
@@ -26,12 +26,14 @@ Each logical op has a 6-element condition array (see
 [3]  short-circuited (left operand determined the result)
 ```
 
-The short-circuit path (slot [3]) is straightforward: `cover_logop()` records it
-immediately via `add_conditional(op, 3)` because the left operand's value is
-known at the time the logical op is despatched. No deferred work is needed.
+The short-circuit path (slot [3]) is simple. `cover_logop()` runs after the
+logical op's pp function and derives the left operand's truth from the path perl
+took (see `branches_and_conditions.md`), so it records the outcome immediately
+via `add_conditional(op, 3)`. No deferred work is needed.
 
-The non-short-circuit path (slots [1] and [2]) is harder: the right operand
-hasn't been evaluated yet. Devel::Cover must wait until the right operand
+The non-short-circuit path (slots [1] and [2]) is harder. The pp function has
+continued into the right operand, but that operand has not yet run when
+`cover_logop()` records the path. Devel::Cover must wait until the right operand
 finishes, then read its value to decide between slot [1] (false) and slot [2]
 (true).
 
@@ -88,11 +90,10 @@ NULL, which happens in two known cases:
 
 ### Where to find it in Cover.xs
 
-- Declaration: line ~148 (`static HV *Pending_conditionals`)
-- Setup in `cover_logop()`: lines ~1248-1278 (hv_fetch, av_push, ppaddr
-  replacement)
-- Resolution in `get_condition()`: lines ~1048-1069
-- End-of-run cleanup in `finalise_conditions()`: lines ~1092-1115
+- Declaration: `static HV *Pending_conditionals`
+- Setup in `cover_logop()`: hv_fetch, av_push, ppaddr replacement
+- Resolution in `get_condition()`
+- End-of-run cleanup in `finalise_conditions()`
 
 ## deferred_conditionals: the runops-exit mechanism
 
@@ -132,9 +133,9 @@ reads the result directly from `*PL_stack_sp`. There is nowhere for the ops to
    av_push(MY_CXT.deferred_conditionals, newSViv(PTR2IV(PL_op)));
    ```
 
-2. The original `pp_or` then executes, falls through to the right operand, and
-   the right operand runs. When the right operand's final op returns NULL, the
-   runops loop exits.
+2. `pp_or` has already fallen through to the right operand by the time
+   `cover_logop()` runs, so the right operand runs next. When the right
+   operand's final op returns NULL, the runops loop exits.
 
 3. At the runops loop exit (in both `runops_cover` and `runops_orig`),
    `resolve_deferred_conditionals()` is called. It checks for entries pushed
@@ -233,14 +234,13 @@ so that it works regardless of mode. In replace_ops mode, `PL_runops` is set to
 
 ### Where to find it in Cover.xs
 
-- Field declaration: `my_cxt_t.deferred_conditionals` (line ~140)
+- Field declaration: `my_cxt_t.deferred_conditionals`
 - Initialisation in `initialise()`: `MY_CXT.deferred_conditionals = newAV()`
-  (line ~1537)
-- Push in `cover_logop()`: the `if (!next)` block (lines ~1253-1260)
-- Helper: `resolve_deferred_conditionals()` (line ~1134)
-- Call from `runops_cover()`: loop exit (line ~1657)
-- Call from `runops_orig()`: after the while loop (line ~1687)
-- Boot: `PL_runops = runops_orig` in replace_ops branch (line ~1967)
+- Push in `cover_logop()`: the `if (!next)` block
+- Helper: `resolve_deferred_conditionals()`
+- Call from `runops_cover()`: loop exit
+- Call from `runops_orig()`: after the while loop
+- Boot: `PL_runops = runops_orig` in replace_ops branch
 
 ## Comparison
 

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -654,10 +654,10 @@ false, the report shows the true row for that operand.
 
 Devel::Cover reads the truth of the left operand of C<||> or C<&&>, and
 of an C<if> or ternary condition, from the path perl took rather than
-from the value, and it evaluates the operands of C<xor> in perl's stead,
-so it makes no extra call there.  It still tests a value's truth itself
-in one place - the condition of an C<if>/C<else> or ternary whose
-branches are both empty - so a C<bool> overload there may run twice.
+from the value.  Where the path holds no answer - the operands of
+C<xor>, and the condition of an C<if>/C<else> or ternary whose branches
+are both empty - it evaluates the truth in perl's stead.  A C<bool>
+overload therefore runs exactly as often under coverage as without it.
 
 =head1 BUGS
 

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -644,9 +644,13 @@ shown as uncovered.
 =head2 Overloaded objects in conditions
 
 When the result of C<||> or C<&&> is used as a value, perl returns the
-right operand without testing its truth.  Condition coverage needs that
-truth, but asking an overloaded object for it would run code the
-program never ran, and would die outright for an object with
+right operand without testing its truth.  When the program tests that
+value straight away - as an C<if> or ternary condition, or as an
+operand of another C<&&> or C<||> - Devel::Cover reads the operand's
+truth from the path that test takes, which is exact for an overloaded
+object.  When the program never tests the value, condition coverage
+still needs a truth, but asking an overloaded object for it would run
+code the program never ran, and would die outright for an object with
 C<< fallback => 0 >> and no C<bool> overload.  Devel::Cover therefore
 counts any overloaded object as true there without invoking its
 overloads.  For an object whose C<bool> overload would have returned

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -654,10 +654,10 @@ false, the report shows the true row for that operand.
 
 Devel::Cover reads the truth of the left operand of C<||> or C<&&>, and
 of an C<if> or ternary condition, from the path perl took rather than
-from the value, so it makes no extra call there.  It still tests a
-value's truth itself in two places - the right operand of C<xor>, and
-the condition of an C<if>/C<else> or ternary whose branches are both
-empty - so a C<bool> overload there may run twice.
+from the value, and it evaluates the operands of C<xor> in perl's stead,
+so it makes no extra call there.  It still tests a value's truth itself
+in one place - the condition of an C<if>/C<else> or ternary whose
+branches are both empty - so a C<bool> overload there may run twice.
 
 =head1 BUGS
 

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -652,9 +652,12 @@ counts any overloaded object as true there without invoking its
 overloads.  For an object whose C<bool> overload would have returned
 false, the report shows the true row for that operand.
 
-Where the program does test an operand's truth, as with the left
-operand of C<||> or C<&&>, Devel::Cover tests it again to record the
-result, so a C<bool> overload may be called twice there.
+Devel::Cover reads the truth of the left operand of C<||> or C<&&>, and
+of an C<if> or ternary condition, from the path perl took rather than
+from the value, so it makes no extra call there.  It still tests a
+value's truth itself in two places - the right operand of C<xor>, and
+the condition of an C<if>/C<else> or ternary whose branches are both
+empty - so a C<bool> overload there may run twice.
 
 =head1 BUGS
 

--- a/test_output/cover/cond_expr_overload.5.020000
+++ b/test_output/cover/cond_expr_overload.5.020000
@@ -2,8 +2,8 @@ cover: Reading database from ...
 ------------------------ ------ ------ ------ ------ ------ ------ ------
 File                       stmt   bran   cond   mcdc    sub  total   scar
 ------------------------ ------ ------ ------ ------ ------ ------ ------
-tests/cond_expr_overload   86.6   50.0    n/a    n/a   85.7   76.3    0.0
-Total                      86.6   50.0    n/a    n/a   85.7   76.3    0.0
+tests/cond_expr_overload   88.2   50.0    n/a    n/a   85.7   76.1    0.0
+Total                      88.2   50.0    n/a    n/a   85.7   76.1    0.0
 ------------------------ ------ ------ ------ ------ ------ ------ ------
 
 
@@ -20,7 +20,7 @@ File Summary
 
 CC  Cov CRAP SCAR
 -- ---- ---- ----
- 1 75.4  1.0  0.0
+ 1 75.3  1.0  0.0
 
 Worst Subroutines
 -----------------
@@ -54,9 +54,9 @@ line  err   stmt   bran   cond   mcdc    sub   code
 17                                             
 18                                             package CountBool;
 19                                             use overload
-20             7                           7     bool => sub { $bool_calls++; ${ $_[0] } },
-               7                               
-               7                               
+20            10                          10     bool => sub { $bool_calls++; ${ $_[0] } },
+              10                               
+              10                               
 21             1                           1     '""' => sub { "countbool" };
       ***      1                          *0   
                1                               
@@ -109,8 +109,20 @@ line  err   stmt   bran   cond   mcdc    sub   code
 62    ***      1   * 50                        if   ($q) { }
 63                                             else      { }
 64                                             
-65                                             # Extra bool calls under coverage make this branch take its true leg
-66    ***      1   * 50                        print "extra bool calls\n" if $bool_calls != $expected;
+65                                             # both branches empty with an overloaded condition - tested exactly once
+66    ***      1   * 50                        if   ($true) { }
+67                                             else         { }
+68             1                               $expected++;
+69    ***      1   * 50                        if   ($false) { }
+70                                             else          { }
+71             1                               $expected++;
+72                                             
+73                                             # void ternary with constant legs - the same ambiguous form
+74    ***      1   * 50                        $true ? 1 : 0;
+75             1                               $expected++;
+76                                             
+77                                             # Extra bool calls under coverage make this branch take its true leg
+78    ***      1   * 50                        print "extra bool calls\n" if $bool_calls != $expected;
 
 
 Branches
@@ -127,7 +139,10 @@ line  err      %   true  false   branch
 53    ***     50      1      0   if (not $false) { }
 59    ***     50      1      0   if ($p) { }
 62    ***     50      0      1   if ($q) { }
-66    ***     50      0      1   if $bool_calls != $expected
+66    ***     50      1      0   if ($true) { }
+69    ***     50      0      1   if ($false) { }
+74    ***     50      1      0   if ($true) { }
+78    ***     50      0      1   if $bool_calls != $expected
 
 
 Covered Subroutines
@@ -138,7 +153,7 @@ Subroutine Count  CC  SCAR Location
 BEGIN          1   1   0.0 tests/cond_expr_overload:13
 BEGIN          1   1   0.0 tests/cond_expr_overload:14
 BEGIN          1   1   0.2 tests/cond_expr_overload:21
-__ANON__       7   1   0.0 tests/cond_expr_overload:20
+__ANON__      10   1   0.0 tests/cond_expr_overload:20
 new            2   1   0.0 tests/cond_expr_overload:22
 noop           4   1   0.0 tests/cond_expr_overload:26
 

--- a/test_output/cover/cond_expr_overload.5.020000
+++ b/test_output/cover/cond_expr_overload.5.020000
@@ -1,0 +1,152 @@
+cover: Reading database from ...
+------------------------ ------ ------ ------ ------ ------ ------ ------
+File                       stmt   bran   cond   mcdc    sub  total   scar
+------------------------ ------ ------ ------ ------ ------ ------ ------
+tests/cond_expr_overload   86.6   50.0    n/a    n/a   85.7   76.3    0.0
+Total                      86.6   50.0    n/a    n/a   85.7   76.3    0.0
+------------------------ ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/cond_expr_overload
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 1 75.4  1.0  0.0
+
+Worst Subroutines
+-----------------
+
+Subroutine CC SCAR  Location                   
+---------- -- ----  ---------------------------
+BEGIN       1  0.2  tests/cond_expr_overload:21
+__ANON__    1  0.2  tests/cond_expr_overload:21
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10                                             # Test for overloaded objects as ternary and if/else conditions
+11                                             # See GH-700
+12                                             
+13             1                           1   use strict;
+               1                               
+               1                               
+14             1                           1   use warnings;
+               1                               
+               1                               
+15                                             
+16             1                               my $bool_calls;
+17                                             
+18                                             package CountBool;
+19                                             use overload
+20             7                           7     bool => sub { $bool_calls++; ${ $_[0] } },
+               7                               
+               7                               
+21             1                           1     '""' => sub { "countbool" };
+      ***      1                          *0   
+               1                               
+      ***     *0                               
+22             2                           2   sub new { my ($class, $val) = @_; bless \$val, $class }
+               2                               
+23                                             
+24                                             package main;
+25                                             
+26                                         4   sub noop { }
+27                                             
+28             1                               my $true     = CountBool->new(1);
+29             1                               my $false    = CountBool->new(0);
+30             1                               my $expected = 0;
+31                                             
+32                                             # ternary in value context, both directions
+33    ***      1   * 50                        my $a = $true ? "t" : "f";
+34             1                               $expected++;
+35    ***      1   * 50                        my $b = $false ? "t" : "f";
+36             1                               $expected++;
+37                                             
+38                                             # if/else, both directions
+39    ***      1   * 50                        if   ($true) { noop() }
+               1                               
+40    ***     *0                               else         { noop() }
+41             1                               $expected++;
+42    ***      1   * 50                        if   ($false) { noop() }
+      ***     *0                               
+43             1                               else          { noop() }
+44             1                               $expected++;
+45                                             
+46                                             # elsif tests its condition only when the first is false
+47    ***      1   * 50                        if    ($false) { noop() }
+      ***     *0   * 50                        
+48             1                               elsif ($true)  { noop() }
+49    ***     *0                               else           { noop() }
+50             1                               $expected += 2;
+51                                             
+52                                             # unless/else
+53    ***      1   * 50                        unless ($false) { noop() }
+               1                               
+54    ***     *0                               else            { noop() }
+55             1                               $expected++;
+56                                             
+57                                             # both branches empty - op_other equals op_next, no overload involved
+58             1                               my $p = 1;
+59    ***      1   * 50                        if   ($p) { }
+60                                             else      { }
+61             1                               my $q = 0;
+62    ***      1   * 50                        if   ($q) { }
+63                                             else      { }
+64                                             
+65                                             # Extra bool calls under coverage make this branch take its true leg
+66    ***      1   * 50                        print "extra bool calls\n" if $bool_calls != $expected;
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+33    ***     50      1      0   $true ? :
+35    ***     50      0      1   $false ? :
+39    ***     50      1      0   if ($true) { }
+42    ***     50      0      1   if ($false) { }
+47    ***     50      0      1   if ($false) { }
+      ***     50      1      0   elsif ($true) { }
+53    ***     50      1      0   if (not $false) { }
+59    ***     50      1      0   if ($p) { }
+62    ***     50      0      1   if ($q) { }
+66    ***     50      0      1   if $bool_calls != $expected
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location                   
+---------- ----- --- ----- ---------------------------
+BEGIN          1   1   0.0 tests/cond_expr_overload:13
+BEGIN          1   1   0.0 tests/cond_expr_overload:14
+BEGIN          1   1   0.2 tests/cond_expr_overload:21
+__ANON__       7   1   0.0 tests/cond_expr_overload:20
+new            2   1   0.0 tests/cond_expr_overload:22
+noop           4   1   0.0 tests/cond_expr_overload:26
+
+Uncovered Subroutines
+---------------------
+
+Subroutine Count  CC  SCAR Location                   
+---------- ----- --- ----- ---------------------------
+__ANON__       0   1   0.2 tests/cond_expr_overload:21
+
+

--- a/test_output/cover/cond_expr_overload.5.024000
+++ b/test_output/cover/cond_expr_overload.5.024000
@@ -1,0 +1,152 @@
+cover: Reading database from ...
+------------------------ ------ ------ ------ ------ ------ ------ ------
+File                       stmt   bran   cond   mcdc    sub  total   scar
+------------------------ ------ ------ ------ ------ ------ ------ ------
+tests/cond_expr_overload   86.6   50.0    n/a    n/a   85.7   76.3    0.0
+Total                      86.6   50.0    n/a    n/a   85.7   76.3    0.0
+------------------------ ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/cond_expr_overload
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 1 75.4  1.0  0.0
+
+Worst Subroutines
+-----------------
+
+Subroutine CC SCAR  Location                   
+---------- -- ----  ---------------------------
+BEGIN       1  0.2  tests/cond_expr_overload:21
+__ANON__    1  0.2  tests/cond_expr_overload:21
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10                                             # Test for overloaded objects as ternary and if/else conditions
+11                                             # See GH-700
+12                                             
+13             1                           1   use strict;
+               1                               
+               1                               
+14             1                           1   use warnings;
+               1                               
+               1                               
+15                                             
+16             1                               my $bool_calls;
+17                                             
+18                                             package CountBool;
+19                                             use overload
+20             7                           7     bool => sub { $bool_calls++; ${ $_[0] } },
+               7                               
+               7                               
+21             1                           1     '""' => sub { "countbool" };
+      ***      1                          *0   
+               1                               
+      ***     *0                               
+22             2                           2   sub new { my ($class, $val) = @_; bless \$val, $class }
+               2                               
+23                                             
+24                                             package main;
+25                                             
+26                                         4   sub noop { }
+27                                             
+28             1                               my $true     = CountBool->new(1);
+29             1                               my $false    = CountBool->new(0);
+30             1                               my $expected = 0;
+31                                             
+32                                             # ternary in value context, both directions
+33    ***      1   * 50                        my $a = $true ? "t" : "f";
+34             1                               $expected++;
+35    ***      1   * 50                        my $b = $false ? "t" : "f";
+36             1                               $expected++;
+37                                             
+38                                             # if/else, both directions
+39    ***      1   * 50                        if   ($true) { noop() }
+               1                               
+40    ***     *0                               else         { noop() }
+41             1                               $expected++;
+42    ***      1   * 50                        if   ($false) { noop() }
+      ***     *0                               
+43             1                               else          { noop() }
+44             1                               $expected++;
+45                                             
+46                                             # elsif tests its condition only when the first is false
+47    ***      1   * 50                        if    ($false) { noop() }
+      ***     *0   * 50                        
+48             1                               elsif ($true)  { noop() }
+49    ***     *0                               else           { noop() }
+50             1                               $expected += 2;
+51                                             
+52                                             # unless/else
+53    ***      1   * 50                        unless ($false) { noop() }
+               1                               
+54    ***     *0                               else            { noop() }
+55             1                               $expected++;
+56                                             
+57                                             # both branches empty - op_other equals op_next, no overload involved
+58             1                               my $p = 1;
+59    ***      1   * 50                        if   ($p) { }
+60                                             else      { }
+61             1                               my $q = 0;
+62    ***      1   * 50                        if   ($q) { }
+63                                             else      { }
+64                                             
+65                                             # Extra bool calls under coverage make this branch take its true leg
+66    ***      1   * 50                        print "extra bool calls\n" if $bool_calls != $expected;
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+33    ***     50      1      0   $true ? :
+35    ***     50      0      1   $false ? :
+39    ***     50      1      0   if ($true) { }
+42    ***     50      0      1   if ($false) { }
+47    ***     50      0      1   if ($false) { }
+      ***     50      1      0   elsif ($true) { }
+53    ***     50      0      1   if ($false) { }
+59    ***     50      1      0   if ($p) { }
+62    ***     50      0      1   if ($q) { }
+66    ***     50      0      1   if $bool_calls != $expected
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location                   
+---------- ----- --- ----- ---------------------------
+BEGIN          1   1   0.0 tests/cond_expr_overload:13
+BEGIN          1   1   0.0 tests/cond_expr_overload:14
+BEGIN          1   1   0.2 tests/cond_expr_overload:21
+__ANON__       7   1   0.0 tests/cond_expr_overload:20
+new            2   1   0.0 tests/cond_expr_overload:22
+noop           4   1   0.0 tests/cond_expr_overload:26
+
+Uncovered Subroutines
+---------------------
+
+Subroutine Count  CC  SCAR Location                   
+---------- ----- --- ----- ---------------------------
+__ANON__       0   1   0.2 tests/cond_expr_overload:21
+
+

--- a/test_output/cover/cond_expr_overload.5.044000
+++ b/test_output/cover/cond_expr_overload.5.044000
@@ -141,7 +141,7 @@ line  err      %   true  false   branch
 62    ***     50      0      1   if ($q) { }
 66    ***     50      1      0   if ($true) { }
 69    ***     50      0      1   if ($false) { }
-74    ***     50      1      0   if ($true) { }
+74    ***     50      1      0   $true ? :
 78    ***     50      0      1   if $bool_calls != $expected
 
 

--- a/test_output/cover/cond_left_overload.5.020000
+++ b/test_output/cover/cond_left_overload.5.020000
@@ -170,7 +170,7 @@ or 3 conditions
 
 line  err      %      l  !l&&r !l&&!r   expr
 ----- --- ------ ------ ------ ------   ----
-74    ***     33      0      1      0   $false or $false
+74    ***     33      0      0      1   $false or $false
 
 xor 4 conditions
 

--- a/test_output/cover/cond_left_overload.5.020000
+++ b/test_output/cover/cond_left_overload.5.020000
@@ -1,0 +1,183 @@
+cover: Reading database from ...
+------------------------ ------ ------ ------ ------ ------ ------ ------
+File                       stmt   bran   cond   mcdc    sub  total   scar
+------------------------ ------ ------ ------ ------ ------ ------ ------
+tests/cond_left_overload   97.7   50.0   50.0    0.0   85.7   74.1    0.0
+Total                      97.7   50.0   50.0    0.0   85.7   74.1    0.0
+------------------------ ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/cond_left_overload
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 1 80.3  1.0  0.0
+
+Worst Subroutines
+-----------------
+
+Subroutine CC SCAR  Location                   
+---------- -- ----  ---------------------------
+BEGIN       1  0.2  tests/cond_left_overload:21
+__ANON__    1  0.2  tests/cond_left_overload:21
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10                                             # Test for overloaded objects as logop left operands
+11                                             # See GH-700 and GH-175
+12                                             
+13             1                           1   use strict;
+               1                               
+               1                               
+14             1                           1   use warnings;
+               1                               
+               1                               
+15                                             
+16             1                               my $bool_calls;
+17                                             
+18                                             package CountBool;
+19                                             use overload
+20            11                          11     bool => sub { $bool_calls++; ${ $_[0] } },
+              11                               
+              11                               
+21             1                           1     '""' => sub { "countbool" };
+      ***      1                          *0   
+               1                               
+      ***     *0                               
+22             4                           4   sub new { my ($class, $val) = @_; bless \$val, $class }
+               4                               
+23                                             
+24                                             package main;
+25                                             
+26                                         1   sub noop { }
+27                                             
+28             1                               my $true     = CountBool->new(1);
+29             1                               my $false    = CountBool->new(0);
+30             1                               my $expected = 0;
+31                                             
+32                                             # or - short circuit and fall through
+33    ***      1          * 50   *  0          my $a = $true || "right";
+34             1                               $expected++;
+35    ***      1          * 50   *  0          my $b = $false || "right";
+36             1                               $expected++;
+37                                             
+38                                             # and - fall through and short circuit
+39    ***      1          * 50   *  0          my $c = $true && "right";
+40             1                               $expected++;
+41    ***      1          * 50   *  0          my $d = $false && "right";
+42             1                               $expected++;
+43                                             
+44                                             # assign forms
+45             1                               my $e = CountBool->new(0);
+46    ***      1          * 50   *  0          $e ||= "right";
+47             1                               $expected++;
+48             1                               my $f = CountBool->new(1);
+49    ***      1          * 50   *  0          $f &&= "right";
+50             1                               $expected++;
+51                                             
+52                                             # void context
+53    ***      1   * 50                        $true || noop();
+54             1                               $expected++;
+55    ***      1   * 50                        $false && noop();
+56             1                               $expected++;
+57    ***      1   * 50                        noop() if $true;
+58             1                               $expected++;
+59                                             
+60                                             # void context with a nulled constant right side - op_other equals op_next
+61    ***      1   * 50                        1 if $true;
+62             1                               $expected++;
+63    ***      1   * 50                        1 if $false;
+64             1                               $expected++;
+65                                             
+66                                             # dor tests definedness, not truth, so never calls bool
+67    ***      1          * 50   *  0          my $g = $true // "right";
+68                                             
+69                                             # Extra bool calls under coverage make this branch take its true leg
+70    ***      1   * 50                        print "extra bool calls\n" if $bool_calls != $expected;
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+53    ***     50      0      1   unless $true
+55    ***     50      0      1   if $false
+57    ***     50      1      0   if $true
+61    ***     50      1      0   if $true
+63    ***     50      0      1   if $false
+70    ***     50      0      1   if $bool_calls != $expected
+
+
+Conditions
+----------
+
+and 2 conditions
+
+line  err      %     !l      l   expr
+----- --- ------ ------ ------   ----
+39    ***     50      0      1   $true && 'right'
+41    ***     50      1      0   $false && 'right'
+49    ***     50      0      1   $f &&= "right"
+
+or 2 conditions
+
+line  err      %      l     !l   expr
+----- --- ------ ------ ------   ----
+33    ***     50      1      0   $true || 'right'
+35    ***     50      0      1   $false || 'right'
+46    ***     50      0      1   $e ||= "right"
+67    ***     50      1      0   $true // "right"
+
+
+MC/DC
+-----
+
+line  err      %  cov  tot   missing                expr
+----- --- ------ ---- ----   --------------------   ----
+33    ***      0    0    1   $true                  $true || 'right'
+35    ***      0    0    1   $false                 $false || 'right'
+39    ***      0    0    1   $true                  $true && 'right'
+41    ***      0    0    1   $false                 $false && 'right'
+46    ***      0    0    1   $e                     $e ||= "right"
+49    ***      0    0    1   $f                     $f &&= "right"
+67    ***      0    0    1   $true                  $true // "right"
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location                   
+---------- ----- --- ----- ---------------------------
+BEGIN          1   1   0.0 tests/cond_left_overload:13
+BEGIN          1   1   0.0 tests/cond_left_overload:14
+BEGIN          1   1   0.2 tests/cond_left_overload:21
+__ANON__      11   1   0.0 tests/cond_left_overload:20
+new            4   1   0.0 tests/cond_left_overload:22
+noop           1   1   0.0 tests/cond_left_overload:26
+
+Uncovered Subroutines
+---------------------
+
+Subroutine Count  CC  SCAR Location                   
+---------- ----- --- ----- ---------------------------
+__ANON__       0   1   0.2 tests/cond_left_overload:21
+
+

--- a/test_output/cover/cond_left_overload.5.020000
+++ b/test_output/cover/cond_left_overload.5.020000
@@ -2,8 +2,8 @@ cover: Reading database from ...
 ------------------------ ------ ------ ------ ------ ------ ------ ------
 File                       stmt   bran   cond   mcdc    sub  total   scar
 ------------------------ ------ ------ ------ ------ ------ ------ ------
-tests/cond_left_overload   97.7   50.0   50.0    0.0   85.7   74.1    0.0
-Total                      97.7   50.0   50.0    0.0   85.7   74.1    0.0
+tests/cond_left_overload   98.0   50.0   42.8    0.0   85.7   66.6    0.0
+Total                      98.0   50.0   42.8    0.0   85.7   66.6    0.0
 ------------------------ ------ ------ ------ ------ ------ ------ ------
 
 
@@ -20,7 +20,7 @@ File Summary
 
 CC  Cov CRAP SCAR
 -- ---- ---- ----
- 1 80.3  1.0  0.0
+ 1 74.7  1.0  0.0
 
 Worst Subroutines
 -----------------
@@ -54,9 +54,9 @@ line  err   stmt   bran   cond   mcdc    sub   code
 17                                             
 18                                             package CountBool;
 19                                             use overload
-20            11                          11     bool => sub { $bool_calls++; ${ $_[0] } },
-              11                               
-              11                               
+20            17                          17     bool => sub { $bool_calls++; ${ $_[0] } },
+              17                               
+              17                               
 21             1                           1     '""' => sub { "countbool" };
       ***      1                          *0   
                1                               
@@ -109,8 +109,20 @@ line  err   stmt   bran   cond   mcdc    sub   code
 66                                             # dor tests definedness, not truth, so never calls bool
 67    ***      1          * 50   *  0          my $g = $true // "right";
 68                                             
-69                                             # Extra bool calls under coverage make this branch take its true leg
-70    ***      1   * 50                        print "extra bool calls\n" if $bool_calls != $expected;
+69                                             # xor boolifies both operands exactly once each
+70    ***      1          * 25   *  0          my $h = ($true xor $false);
+71             1                               $expected += 2;
+72                                             
+73                                             # chained logops add no extra calls
+74    ***      1          * 50   *  0          my $i = $false || $false || "right";
+      ***                 * 33                 
+75             1                               $expected += 2;
+76    ***      1          * 50   *  0          my $j = $true && $true && "right";
+      ***                 * 33                 
+77             1                               $expected += 2;
+78                                             
+79                                             # Extra bool calls under coverage make this branch take its true leg
+80    ***      1   * 50                        print "extra bool calls\n" if $bool_calls != $expected;
 
 
 Branches
@@ -123,7 +135,7 @@ line  err      %   true  false   branch
 57    ***     50      1      0   if $true
 61    ***     50      1      0   if $true
 63    ***     50      0      1   if $false
-70    ***     50      0      1   if $bool_calls != $expected
+80    ***     50      0      1   if $bool_calls != $expected
 
 
 Conditions
@@ -136,6 +148,13 @@ line  err      %     !l      l   expr
 39    ***     50      0      1   $true && 'right'
 41    ***     50      1      0   $false && 'right'
 49    ***     50      0      1   $f &&= "right"
+76    ***     50      0      1   $true && $true && 'right'
+
+and 3 conditions
+
+line  err      %     !l  l&&!r   l&&r   expr
+----- --- ------ ------ ------ ------   ----
+76    ***     33      0      0      1   $true and $true
 
 or 2 conditions
 
@@ -145,6 +164,19 @@ line  err      %      l     !l   expr
 35    ***     50      0      1   $false || 'right'
 46    ***     50      0      1   $e ||= "right"
 67    ***     50      1      0   $true // "right"
+74    ***     50      0      1   $false || $false || 'right'
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+74    ***     33      0      1      0   $false or $false
+
+xor 4 conditions
+
+line  err      %   l&&r  l&&!r  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------ ------   ----
+70    ***     25      0      1      0      0   $true xor $false
 
 
 MC/DC
@@ -159,6 +191,9 @@ line  err      %  cov  tot   missing                expr
 46    ***      0    0    1   $e                     $e ||= "right"
 49    ***      0    0    1   $f                     $f &&= "right"
 67    ***      0    0    1   $true                  $true // "right"
+70    ***      0    0    2   $true, $false          $true xor $false
+74    ***      0    0    2   $false, $false         $false || $false || 'right'
+76    ***      0    0    2   $true, $true           $true && $true && 'right'
 
 
 Covered Subroutines
@@ -169,7 +204,7 @@ Subroutine Count  CC  SCAR Location
 BEGIN          1   1   0.0 tests/cond_left_overload:13
 BEGIN          1   1   0.0 tests/cond_left_overload:14
 BEGIN          1   1   0.2 tests/cond_left_overload:21
-__ANON__      11   1   0.0 tests/cond_left_overload:20
+__ANON__      17   1   0.0 tests/cond_left_overload:20
 new            4   1   0.0 tests/cond_left_overload:22
 noop           1   1   0.0 tests/cond_left_overload:26
 

--- a/test_output/cover/cond_left_overload.5.040000
+++ b/test_output/cover/cond_left_overload.5.040000
@@ -170,7 +170,7 @@ or 3 conditions
 
 line  err      %      l  !l&&r !l&&!r   expr
 ----- --- ------ ------ ------ ------   ----
-74    ***     33      0      1      0   $false or $false
+74    ***     33      0      0      1   $false or $false
 
 xor 4 conditions
 

--- a/test_output/cover/cond_left_overload.5.040000
+++ b/test_output/cover/cond_left_overload.5.040000
@@ -130,8 +130,8 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-53    ***     50      0      1   $true or noop()
-55    ***     50      0      1   $false and noop()
+53    ***     50      0      1   unless $true
+55    ***     50      0      1   if $false
 57    ***     50      1      0   if $true
 61    ***     50      1      0   if $true
 63    ***     50      0      1   if $false

--- a/test_output/cover/cond_left_overload.5.044000
+++ b/test_output/cover/cond_left_overload.5.044000
@@ -170,7 +170,7 @@ or 3 conditions
 
 line  err      %      l  !l&&r !l&&!r   expr
 ----- --- ------ ------ ------ ------   ----
-74    ***     33      0      1      0   $false or $false
+74    ***     33      0      0      1   $false or $false
 
 xor 4 conditions
 

--- a/test_output/cover/cond_left_overload.5.044000
+++ b/test_output/cover/cond_left_overload.5.044000
@@ -1,0 +1,183 @@
+cover: Reading database from ...
+------------------------ ------ ------ ------ ------ ------ ------ ------
+File                       stmt   bran   cond   mcdc    sub  total   scar
+------------------------ ------ ------ ------ ------ ------ ------ ------
+tests/cond_left_overload   97.7   50.0   50.0    0.0   85.7   74.1    0.0
+Total                      97.7   50.0   50.0    0.0   85.7   74.1    0.0
+------------------------ ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/cond_left_overload
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 1 80.3  1.0  0.0
+
+Worst Subroutines
+-----------------
+
+Subroutine CC SCAR  Location                   
+---------- -- ----  ---------------------------
+BEGIN       1  0.2  tests/cond_left_overload:21
+__ANON__    1  0.2  tests/cond_left_overload:21
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10                                             # Test for overloaded objects as logop left operands
+11                                             # See GH-700 and GH-175
+12                                             
+13             1                           1   use strict;
+               1                               
+               1                               
+14             1                           1   use warnings;
+               1                               
+               1                               
+15                                             
+16             1                               my $bool_calls;
+17                                             
+18                                             package CountBool;
+19                                             use overload
+20            11                          11     bool => sub { $bool_calls++; ${ $_[0] } },
+              11                               
+              11                               
+21             1                           1     '""' => sub { "countbool" };
+      ***      1                          *0   
+               1                               
+      ***     *0                               
+22             4                           4   sub new { my ($class, $val) = @_; bless \$val, $class }
+               4                               
+23                                             
+24                                             package main;
+25                                             
+26                                         1   sub noop { }
+27                                             
+28             1                               my $true     = CountBool->new(1);
+29             1                               my $false    = CountBool->new(0);
+30             1                               my $expected = 0;
+31                                             
+32                                             # or - short circuit and fall through
+33    ***      1          * 50   *  0          my $a = $true || "right";
+34             1                               $expected++;
+35    ***      1          * 50   *  0          my $b = $false || "right";
+36             1                               $expected++;
+37                                             
+38                                             # and - fall through and short circuit
+39    ***      1          * 50   *  0          my $c = $true && "right";
+40             1                               $expected++;
+41    ***      1          * 50   *  0          my $d = $false && "right";
+42             1                               $expected++;
+43                                             
+44                                             # assign forms
+45             1                               my $e = CountBool->new(0);
+46    ***      1          * 50   *  0          $e ||= "right";
+47             1                               $expected++;
+48             1                               my $f = CountBool->new(1);
+49    ***      1          * 50   *  0          $f &&= "right";
+50             1                               $expected++;
+51                                             
+52                                             # void context
+53    ***      1   * 50                        $true || noop();
+54             1                               $expected++;
+55    ***      1   * 50                        $false && noop();
+56             1                               $expected++;
+57    ***      1   * 50                        noop() if $true;
+58             1                               $expected++;
+59                                             
+60                                             # void context with a nulled constant right side - op_other equals op_next
+61    ***      1   * 50                        1 if $true;
+62             1                               $expected++;
+63    ***      1   * 50                        1 if $false;
+64             1                               $expected++;
+65                                             
+66                                             # dor tests definedness, not truth, so never calls bool
+67    ***      1          * 50   *  0          my $g = $true // "right";
+68                                             
+69                                             # Extra bool calls under coverage make this branch take its true leg
+70    ***      1   * 50                        print "extra bool calls\n" if $bool_calls != $expected;
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+53    ***     50      0      1   $true or noop()
+55    ***     50      0      1   $false and noop()
+57    ***     50      1      0   if $true
+61    ***     50      1      0   if $true
+63    ***     50      0      1   if $false
+70    ***     50      0      1   if $bool_calls != $expected
+
+
+Conditions
+----------
+
+and 2 conditions
+
+line  err      %     !l      l   expr
+----- --- ------ ------ ------   ----
+39    ***     50      0      1   $true && 'right'
+41    ***     50      1      0   $false && 'right'
+49    ***     50      0      1   $f &&= "right"
+
+or 2 conditions
+
+line  err      %      l     !l   expr
+----- --- ------ ------ ------   ----
+33    ***     50      1      0   $true || 'right'
+35    ***     50      0      1   $false || 'right'
+46    ***     50      0      1   $e ||= "right"
+67    ***     50      1      0   $true // "right"
+
+
+MC/DC
+-----
+
+line  err      %  cov  tot   missing                expr
+----- --- ------ ---- ----   --------------------   ----
+33    ***      0    0    1   $true                  $true || 'right'
+35    ***      0    0    1   $false                 $false || 'right'
+39    ***      0    0    1   $true                  $true && 'right'
+41    ***      0    0    1   $false                 $false && 'right'
+46    ***      0    0    1   $e                     $e ||= "right"
+49    ***      0    0    1   $f                     $f &&= "right"
+67    ***      0    0    1   $true                  $true // "right"
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location                   
+---------- ----- --- ----- ---------------------------
+BEGIN          1   1   0.0 tests/cond_left_overload:13
+BEGIN          1   1   0.0 tests/cond_left_overload:14
+BEGIN          1   1   0.2 tests/cond_left_overload:21
+__ANON__      11   1   0.0 tests/cond_left_overload:20
+new            4   1   0.0 tests/cond_left_overload:22
+noop           1   1   0.0 tests/cond_left_overload:26
+
+Uncovered Subroutines
+---------------------
+
+Subroutine Count  CC  SCAR Location                   
+---------- ----- --- ----- ---------------------------
+__ANON__       0   1   0.2 tests/cond_left_overload:21
+
+

--- a/test_output/cover/cond_right_overload.5.020000
+++ b/test_output/cover/cond_right_overload.5.020000
@@ -1,0 +1,188 @@
+cover: Reading database from ...
+------------------------- ------ ------ ------ ------ ------ ------ ------
+File                        stmt   bran   cond   mcdc    sub  total   scar
+------------------------- ------ ------ ------ ------ ------ ------ ------
+tests/cond_right_overload   88.3   50.0   34.7    0.0   85.7   58.5    0.0
+Total                       88.3   50.0   34.7    0.0   85.7   58.5    0.0
+------------------------- ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/cond_right_overload
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 1 66.7  1.0  0.0
+
+Worst Subroutines
+-----------------
+
+Subroutine CC SCAR  Location                    
+---------- -- ----  ----------------------------
+BEGIN       1  0.2  tests/cond_right_overload:21
+__ANON__    1  0.2  tests/cond_right_overload:21
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10                                             # Test for overloaded objects as logop right operands
+11                                             # See GH-700 and GH-152
+12                                             
+13             1                           1   use strict;
+               1                               
+               1                               
+14             1                           1   use warnings;
+               1                               
+               1                               
+15                                             
+16             1                               my $bool_calls;
+17                                             
+18                                             package CountBool;
+19                                             use overload
+20             6                           6     bool => sub { $bool_calls++; ${ $_[0] } },
+               6                               
+               6                               
+21             1                           1     '""' => sub { "countbool" };
+      ***      1                          *0   
+               1                               
+      ***     *0                               
+22             2                           2   sub new { my ($class, $val) = @_; bless \$val, $class }
+               2                               
+23                                             
+24                                             package main;
+25                                             
+26                                         4   sub noop { }
+27                                             
+28             1                               my $true     = CountBool->new(1);
+29             1                               my $false    = CountBool->new(0);
+30             1                               my $zero     = 0;
+31             1                               my $one      = 1;
+32             1                               my $expected = 0;
+33                                             
+34                                             # The right operand's truth is read from the path the consumer takes, so
+35                                             # the overload runs exactly once and the recorded row is exact
+36                                             
+37                                             # if/else consumer, all four operand combinations
+38    ***      1   * 50   * 33   *  0          if   ($zero || $false) { noop() }
+      ***     *0                               
+39             1                               else                   { noop() }
+40             1                               $expected++;
+41    ***      1   * 50   * 33   *  0          if   ($zero || $true) { noop() }
+               1                               
+42    ***     *0                               else                  { noop() }
+43             1                               $expected++;
+44    ***      1   * 50   * 33   *  0          if   ($one && $true) { noop() }
+               1                               
+45    ***     *0                               else                 { noop() }
+46             1                               $expected++;
+47    ***      1   * 50   * 33   *  0          if   ($one && $false) { noop() }
+      ***     *0                               
+48             1                               else                  { noop() }
+49             1                               $expected++;
+50                                             
+51                                             # ternary consumer
+52    ***      1   * 50   * 33   *  0          my $t = ($zero || $false) ? "t" : "f";
+53             1                               $expected++;
+54                                             
+55                                             # logop consumer - the or's value is the outer and's left operand
+56    ***      1          * 50   *  0          my $r = ($zero || $true) && "right";
+      ***                 * 33                 
+57             1                               $expected++;
+58                                             
+59                                             # value context - the program never tests the value, so no truth can be
+60                                             # read and the object counts as true without invoking its overloads
+61    ***      1          * 33   *  0          my $v = $zero || $false;
+62                                             
+63                                             # Extra bool calls under coverage make this branch take its true leg
+64    ***      1   * 50                        print "extra bool calls\n" if $bool_calls != $expected;
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+38    ***     50      0      1   if ($zero or $false) { }
+41    ***     50      1      0   if ($zero or $true) { }
+44    ***     50      1      0   if ($one and $true) { }
+47    ***     50      0      1   if ($one and $false) { }
+52    ***     50      0      1   $zero || $false ? :
+64    ***     50      0      1   if $bool_calls != $expected
+
+
+Conditions
+----------
+
+and 2 conditions
+
+line  err      %     !l      l   expr
+----- --- ------ ------ ------   ----
+56    ***     50      0      1   ($zero || $true) && 'right'
+
+and 3 conditions
+
+line  err      %     !l  l&&!r   l&&r   expr
+----- --- ------ ------ ------ ------   ----
+44    ***     33      0      0      1   $one and $true
+47    ***     33      0      1      0   $one and $false
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+38    ***     33      0      0      1   $zero or $false
+41    ***     33      0      1      0   $zero or $true
+52    ***     33      0      0      1   $zero or $false
+56    ***     33      0      1      0   $zero or $true
+61    ***     33      0      1      0   $zero || $false
+
+
+MC/DC
+-----
+
+line  err      %  cov  tot   missing                expr
+----- --- ------ ---- ----   --------------------   ----
+38    ***      0    0    2   $zero, $false          $zero or $false
+41    ***      0    0    2   $zero, $true           $zero or $true
+44    ***      0    0    2   $one, $true            $one and $true
+47    ***      0    0    2   $one, $false           $one and $false
+52    ***      0    0    2   $zero, $false          $zero or $false
+56    ***      0    0    2   $zero, $true           ($zero || $true) && 'right'
+61    ***      0    0    2   $zero, $false          $zero || $false
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location                    
+---------- ----- --- ----- ----------------------------
+BEGIN          1   1   0.0 tests/cond_right_overload:13
+BEGIN          1   1   0.0 tests/cond_right_overload:14
+BEGIN          1   1   0.2 tests/cond_right_overload:21
+__ANON__       6   1   0.0 tests/cond_right_overload:20
+new            2   1   0.0 tests/cond_right_overload:22
+noop           4   1   0.0 tests/cond_right_overload:26
+
+Uncovered Subroutines
+---------------------
+
+Subroutine Count  CC  SCAR Location                    
+---------- ----- --- ----- ----------------------------
+__ANON__       0   1   0.2 tests/cond_right_overload:21
+
+

--- a/tests/cond_expr_overload
+++ b/tests/cond_expr_overload
@@ -1,0 +1,66 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Test for overloaded objects as ternary and if/else conditions
+# See GH-700
+
+use strict;
+use warnings;
+
+my $bool_calls;
+
+package CountBool;
+use overload
+  bool => sub { $bool_calls++; ${ $_[0] } },
+  '""' => sub { "countbool" };
+sub new { my ($class, $val) = @_; bless \$val, $class }
+
+package main;
+
+sub noop { }
+
+my $true     = CountBool->new(1);
+my $false    = CountBool->new(0);
+my $expected = 0;
+
+# ternary in value context, both directions
+my $a = $true ? "t" : "f";
+$expected++;
+my $b = $false ? "t" : "f";
+$expected++;
+
+# if/else, both directions
+if   ($true) { noop() }
+else         { noop() }
+$expected++;
+if   ($false) { noop() }
+else          { noop() }
+$expected++;
+
+# elsif tests its condition only when the first is false
+if    ($false) { noop() }
+elsif ($true)  { noop() }
+else           { noop() }
+$expected += 2;
+
+# unless/else
+unless ($false) { noop() }
+else            { noop() }
+$expected++;
+
+# both branches empty - op_other equals op_next, no overload involved
+my $p = 1;
+if   ($p) { }
+else      { }
+my $q = 0;
+if   ($q) { }
+else      { }
+
+# Extra bool calls under coverage make this branch take its true leg
+print "extra bool calls\n" if $bool_calls != $expected;

--- a/tests/cond_expr_overload
+++ b/tests/cond_expr_overload
@@ -62,5 +62,17 @@ my $q = 0;
 if   ($q) { }
 else      { }
 
+# both branches empty with an overloaded condition - tested exactly once
+if   ($true) { }
+else         { }
+$expected++;
+if   ($false) { }
+else          { }
+$expected++;
+
+# void ternary with constant legs - the same ambiguous form
+$true ? 1 : 0;
+$expected++;
+
 # Extra bool calls under coverage make this branch take its true leg
 print "extra bool calls\n" if $bool_calls != $expected;

--- a/tests/cond_left_overload
+++ b/tests/cond_left_overload
@@ -66,5 +66,15 @@ $expected++;
 # dor tests definedness, not truth, so never calls bool
 my $g = $true // "right";
 
+# xor boolifies both operands exactly once each
+my $h = ($true xor $false);
+$expected += 2;
+
+# chained logops add no extra calls
+my $i = $false || $false || "right";
+$expected += 2;
+my $j = $true && $true && "right";
+$expected += 2;
+
 # Extra bool calls under coverage make this branch take its true leg
 print "extra bool calls\n" if $bool_calls != $expected;

--- a/tests/cond_left_overload
+++ b/tests/cond_left_overload
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Test for overloaded objects as logop left operands
+# See GH-700 and GH-175
+
+use strict;
+use warnings;
+
+my $bool_calls;
+
+package CountBool;
+use overload
+  bool => sub { $bool_calls++; ${ $_[0] } },
+  '""' => sub { "countbool" };
+sub new { my ($class, $val) = @_; bless \$val, $class }
+
+package main;
+
+sub noop { }
+
+my $true     = CountBool->new(1);
+my $false    = CountBool->new(0);
+my $expected = 0;
+
+# or - short circuit and fall through
+my $a = $true || "right";
+$expected++;
+my $b = $false || "right";
+$expected++;
+
+# and - fall through and short circuit
+my $c = $true && "right";
+$expected++;
+my $d = $false && "right";
+$expected++;
+
+# assign forms
+my $e = CountBool->new(0);
+$e ||= "right";
+$expected++;
+my $f = CountBool->new(1);
+$f &&= "right";
+$expected++;
+
+# void context
+$true || noop();
+$expected++;
+$false && noop();
+$expected++;
+noop() if $true;
+$expected++;
+
+# void context with a nulled constant right side - op_other equals op_next
+1 if $true;
+$expected++;
+1 if $false;
+$expected++;
+
+# dor tests definedness, not truth, so never calls bool
+my $g = $true // "right";
+
+# Extra bool calls under coverage make this branch take its true leg
+print "extra bool calls\n" if $bool_calls != $expected;

--- a/tests/cond_right_overload
+++ b/tests/cond_right_overload
@@ -1,0 +1,64 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Test for overloaded objects as logop right operands
+# See GH-700 and GH-152
+
+use strict;
+use warnings;
+
+my $bool_calls;
+
+package CountBool;
+use overload
+  bool => sub { $bool_calls++; ${ $_[0] } },
+  '""' => sub { "countbool" };
+sub new { my ($class, $val) = @_; bless \$val, $class }
+
+package main;
+
+sub noop { }
+
+my $true     = CountBool->new(1);
+my $false    = CountBool->new(0);
+my $zero     = 0;
+my $one      = 1;
+my $expected = 0;
+
+# The right operand's truth is read from the path the consumer takes, so
+# the overload runs exactly once and the recorded row is exact
+
+# if/else consumer, all four operand combinations
+if   ($zero || $false) { noop() }
+else                   { noop() }
+$expected++;
+if   ($zero || $true) { noop() }
+else                  { noop() }
+$expected++;
+if   ($one && $true) { noop() }
+else                 { noop() }
+$expected++;
+if   ($one && $false) { noop() }
+else                  { noop() }
+$expected++;
+
+# ternary consumer
+my $t = ($zero || $false) ? "t" : "f";
+$expected++;
+
+# logop consumer - the or's value is the outer and's left operand
+my $r = ($zero || $true) && "right";
+$expected++;
+
+# value context - the program never tests the value, so no truth can be
+# read and the object counts as true without invoking its overloads
+my $v = $zero || $false;
+
+# Extra bool calls under coverage make this branch take its true leg
+print "extra bool calls\n" if $bool_calls != $expected;


### PR DESCRIPTION
## Summary

Devel::Cover used to test the truth of logop left operands, and of `if` and ternary conditions, before the op ran - alongside the test perl itself performs - so a `bool` overload ran twice under coverage where a plain run calls it once, and a stateful overload could record the opposite leg from the one perl took.

- Read the truth from the path perl took, after the pp function runs. The plain `and`/`or`/`dor` forms decide by stack depth, since rpeep can leave `op_other` equal to `op_next` when the right side is a nulled constant. The assign forms decide by the returned op.
- Where the path holds no answer - the operands of `xor`, and the condition of an `if`/`else` or ternary with both branches empty - boolify the value exactly once, as the pp would, and hand the pp the plain boolean. This is sound because those ops consume the tested value. The ticket assumed `xor` could not be improved, but this technique covers it, and removes the flag and hook machinery that reconstructed its left operand.
- Read a right operand's truth from the path of the op consuming its value when an `if`/`else`, ternary, `&&` or `||` tests it directly. Perl never tests a logop's right operand itself, so coverage counted an overloaded object there as true regardless of its `bool` overload (GH-152).
- Warn once if the depth and returned-op signals disagree, so a future perl changing pp behaviour fails its test run loudly instead of silently misrecording.

No place now remains where coverage double-calls a `bool` overload, and the LIMITATIONS section says so. The note remaining there covers overloaded right operands of `&&`/`||` whose value the program never tests - they are counted true without invoking overloads (GH-152) because no path exists to read.

Covering xor-heavy code is roughly twice as fast without the hook machinery, and logop-heavy code is a few percent faster. New fixtures `cond_left_overload`, `cond_expr_overload` and `cond_right_overload` assert the exact call counts and condition rows in both dispatch modes.

## Ticket

Closes #700