### PR TITLE
Match or-branch polarity to the displayed text

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Devel::Cover history
 
 {{$NEXT}}
+- BREAKING: Swap branch true and false for an "or" statement displayed
+  as written, e.g. my $x = get() or die, so "true" now means the left
+  side was true. Uncoverable branch comments on such lines must swap
+  too. Only perl 5.43.8 and later displays this form (GH-173)
 - Read a logop left operand's truth, and an if/else or ternary
   condition's truth, from the path perl took instead of testing the value
   again, so a bool overload no longer runs twice under coverage (GH-700)

--- a/Changes
+++ b/Changes
@@ -4,7 +4,8 @@ Devel::Cover history
 - BREAKING: Swap branch true and false for an "or" statement displayed
   as written, e.g. my $x = get() or die, so "true" now means the left
   side was true. Uncoverable branch comments on such lines must swap
-  too. Only perl 5.43.8 and later displays this form (GH-173)
+  too. Only perl 5.43.8 and later displays this form (Kevin Brannen)
+  (GH-173)
 - Read a logop left operand's truth, and an if/else or ternary
   condition's truth, from the path perl took instead of testing the value
   again, so a bool overload no longer runs twice under coverage (GH-700)

--- a/Contributors
+++ b/Contributors
@@ -94,6 +94,7 @@ Lukas Mai                      https://github.com/mauke
 Marc-Philip                    mpw96@gmx.de
 Marcel Grünauer                marcel@cpan.org
 Mark Stosberg                  mark@summersault.com
+Martin Becker                  https://github.com/mhasch
 martinvonwittich               https://github.com/martinvonwittich
 Mathieu Arnold                 https://github.com/mat813
 Matthew Horsfall               wolfsage@gmail.com
@@ -141,6 +142,7 @@ Steve Sanbeg                   sanbeg@cpan.org
 Sullivan Beck                  sbeck@cpan.org
 Sébastien Aperghis-Tramoni     saper@cpan.org
 Tatsuhiko Miyagawa             miyagawa@bulknews.net
+thairman                       https://github.com/thairman
 Thomas Dorner                  dorner (AT) cpan.org
 Tina Müller                    tinita at cpan.org
 Todd Rinaldo                   toddr@cpan.org

--- a/docs/technical/branches_and_conditions.md
+++ b/docs/technical/branches_and_conditions.md
@@ -270,10 +270,29 @@ data), the function reads from `$Coverage->{condition}{$key}` and collapses the
 6-element array into 2 values:
 
 ```perl
-# True path = left true and right evaluated (indices 1 + 2)
-# False path = short-circuited (index 3)
 $c = [ $c->[1] + $c->[2], $c->[3] ];
 ```
+
+The index meanings differ by operator. For `and`, index 1 is `l && !r`, index 2
+is `l && r` and index 3 is `!l`, so the collapse gives `[l, !l]` - "true" means
+the left operand was true. For `or`, index 1 is `!l && !r`, index 2 is `!l && r`
+and index 3 is `l`, so the same collapse gives `[!l, l]` - "true" means the left
+operand was false. That reading matches the `if`/`unless` text these types
+display, where "true" means the guarded code ran.
+
+The `or_expr` type is passed by `_walk_logop` for a statement-level `or` whose
+text displays as written (`A or B`), which perl distinguishes from the modifier
+spelling via `OPpSTATEMENT` from 5.43.8. Its collapse is mirrored so "true"
+follows the displayed text, meaning the left operand was true:
+
+```perl
+$c = [ $c->[3], $c->[1] + $c->[2] ];
+```
+
+The `and` type needs no mirror because its standard collapse already reads
+correctly for both the `if` and `A and B` texts. On perls before 5.43.8 the
+statement-level path is never taken for `and`/`or`, so `or_expr` does not arise
+there.
 
 For `if`/`elsif` type branches, the function reads from
 `$Coverage->{branch}{$key}`, which is populated directly by `cover_cond` in the

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -928,6 +928,8 @@ sub add_branch_cover ($op, $type, $text, $file, $line) {
     || ($type eq "elsif" && !exists $Coverage->{branch}{$key})
   ) {
     $c = [$c->[1] + $c->[2], $c->[3]];
+  } elsif ($type eq "or_expr") {
+    $c = [$c->[3], $c->[1] + $c->[2]];
   } else {
     $c = $Coverage->{branch}{$key} || [0, 0];
   }
@@ -1419,9 +1421,10 @@ sub _walk_logop ($cv, $op) {
     _record_logop_condition($cv, $op, $highop, $left, $right, $highprec, 0);
   } elsif ($is_branch) {
     # From 5.43.8 OPpSTATEMENT routes statement-level expression joins here
-    my $l = _deparse_binop_left($cv, $op, $left, $lowprec);
-    my $r = _deparse_expr($cv, $right, $lowprec);
-    add_branch_cover($op, $lowop, "$l $lowop $r", $file, $line)
+    my $l    = _deparse_binop_left($cv, $op, $left, $lowprec);
+    my $r    = _deparse_expr($cv, $right, $lowprec);
+    my $type = $lowop eq "or" ? "or_expr" : $lowop;
+    add_branch_cover($op, $type, "$l $lowop $r", $file, $line)
       unless $Seen{branch}{$$op}++;
     _record_compound_join(
       $cv,   $op,    $highop   // $lowop,

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -404,6 +404,25 @@ A condition inside any of these, such as C<unless ($a && $b)> or C<while
 ($a && $b)>, is instrumented on its own terms, with the same truth-table
 rows as anywhere else.
 
+=head4 Statement-level and/or
+
+C<B unless A> and C<A or B> compile to the same logop, as do C<B if A>
+and C<A and B>.  In every case the "true" and "false" elements follow
+the text the report displays.  From perl 5.43.8 a statement written
+C<A or B>, including the common C<my $x = A or die>, displays as
+written, and its "true" element means C<A> was true so C<B> did not
+run.  A C<die> or other escape which can never fire is therefore the
+"false" element:
+
+  # uncoverable branch false
+  my $x = get_thing() or die "no thing\n";
+
+Earlier perls do not record the source spelling, so the report
+renormalises the statement to the modifier text - here C<unless my $x =
+get_thing()> - and, as described above, its "true" element means the
+right side ran.  A comment on such a line therefore names opposite
+outcomes on either side of 5.43.8.
+
 =head3 Conditions
 
 Because Perl short-circuits boolean operations, a condition has several

--- a/t/internal/select_dir.t
+++ b/t/internal/select_dir.t
@@ -160,7 +160,7 @@ sub test_text_report () {
       "Uncovered/Calc.pm  0.0  0.0  0.0  0.0  0.0  18.4",
       "Uncovered/Full.pm  0.0  0.0  0.0  0.0  0.0  17.2",
       "Uncovered/Logic.pm  0.0  0.0  0.0  0.0  0.0  16.1",
-      "Uncovered/Markers.pm  0.0  0.0  0.0  0.0  0.0  12.0",
+      "Uncovered/Markers.pm  0.0  0.0  0.0  0.0  0.0  15.0",
       "Uncovered/Trivial.pm  0.0  n/a  n/a  0.0  0.0  6.9",
       "Uncovered/Utils.pm  0.0  0.0  n/a  0.0  0.0  12.8",
     ]

--- a/t/lib/Devel/Cover/Test/Showcase.pm
+++ b/t/lib/Devel/Cover/Test/Showcase.pm
@@ -279,6 +279,64 @@ my $Markers_body = <<'BODY' =~ s/^  //gmr;
     # uncoverable statement
     die "emergency stop";
   }
+
+  =head2 require_value
+
+  Return the value, dying if it is false.
+
+  =cut
+
+  sub require_value {
+    my ($v) = @_;
+    # uncoverable branch false
+    my $ok = $v or die "no value";
+    return $ok;
+  }
+
+  =head2 require_value_unless
+
+  The same guard written with the unless modifier.
+
+  =cut
+
+  sub require_value_unless {
+    my ($v) = @_;
+    # uncoverable branch true
+    die "no value" unless $v;
+    return $v;
+  }
+
+  =head2 require_value_if
+
+  The same guard written with a negated block if.
+
+  =cut
+
+  sub require_value_if {
+    my ($v) = @_;
+    # uncoverable branch true
+    if (!$v) {
+      # uncoverable statement
+      die "no value";
+    }
+    return $v;
+  }
+
+  =head2 require_value_unless_block
+
+  The same guard written with a block unless.
+
+  =cut
+
+  sub require_value_unless_block {
+    my ($v) = @_;
+    # uncoverable branch true
+    unless ($v) {
+      # uncoverable statement
+      die "no value";
+    }
+    return $v;
+  }
 BODY
 
 my $Trivial_body = <<'BODY' =~ s/^  //gmr;
@@ -398,6 +456,10 @@ sub create_cover_db ($tmpdir, $libdir) {
   Covered::Markers::fetch(\\%c, q(k), 2);
   Covered::Markers::audit(1);
   Covered::Markers::audit(0);
+  Covered::Markers::require_value(5);
+  Covered::Markers::require_value_unless(5);
+  Covered::Markers::require_value_if(5);
+  Covered::Markers::require_value_unless_block(5);
   Covered::Utils::greet(q(world));
   Covered::Utils::upper(q(hi));
   Covered::Full::double(5);

--- a/test_output/cover/cond_branch.5.044000
+++ b/test_output/cover/cond_branch.5.044000
@@ -384,7 +384,7 @@ line  err      %   true  false   branch
 29    ***     50      0      4   if $y
 31           100      2      2   $z and ++$x[6]
 32           100      2      2   if $z
-34    ***     50      4      0   $y or ++$x[7]
+34    ***     50      0      4   $y or ++$x[7]
 35    ***     50      4      0   unless $y
 37           100      2      2   $z or ++$x[8]
 38           100      2      2   unless $z
@@ -399,11 +399,11 @@ line  err      %   true  false   branch
 64           100      1      1   $y or next
 69           100      1      1   $y and next
 74           100      1      1   $y and next
-92    ***     50      1      0   $y or last
+92    ***     50      0      1   $y or last
 97           100      1      1   $y or last
 102          100      1      1   $y and last
 107   ***     50      1      0   $y and last
-125   ***     50      1      0   $y or goto G1
+125   ***     50      0      1   $y or goto G1
 131          100      1      1   $y or goto G2
 137          100      1      1   $y and goto G3
 143   ***     50      1      0   $y and goto G4

--- a/test_output/cover/cond_left_overload.5.044000
+++ b/test_output/cover/cond_left_overload.5.044000
@@ -130,7 +130,7 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-53    ***     50      0      1   $true or noop()
+53    ***     50      1      0   $true or noop()
 55    ***     50      0      1   $false and noop()
 57    ***     50      1      0   if $true
 61    ***     50      1      0   if $true

--- a/test_output/cover/cond_or.5.044000
+++ b/test_output/cover/cond_or.5.044000
@@ -146,8 +146,8 @@ line  err      %   true  false   branch
 27    ***      0      0      0   if $@
 28    ***      0      0      0   unless defined $return
 29    ***      0      0      0   unless $return
-33    ***     50      0     11   $y or ++$x[1]
-36    ***     50      0     11   $y or $x[0]++ or ++$x[1]
+33    ***     50     11      0   $y or ++$x[1]
+36    ***     50     11      0   $y or $x[0]++ or ++$x[1]
 40    ***     50     11      0   unless $z
 47    ***     50      0     11   if ($z) { }
 80    ***     50     11      0   if exists &main::cond_dor

--- a/test_output/cover/mcdc_final_chain.5.044000
+++ b/test_output/cover/mcdc_final_chain.5.044000
@@ -149,10 +149,10 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-19           100      2      1   $p or $q
+19           100      1      2   $p or $q
 24           100      2      2   $p and $q and $r
-29           100      4      2   $p // $q or $r
-34           100      5      3   ($p // $q) // $s or $r
+29           100      2      4   $p // $q or $r
+34           100      3      5   ($p // $q) // $s or $r
 
 
 Conditions

--- a/test_output/cover/mcdc_signatures.5.044000
+++ b/test_output/cover/mcdc_signatures.5.044000
@@ -119,8 +119,8 @@ Branches
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
 23           100      2      1   $p and $q
-24           100      2      1   $p or $q
-25           100      3      1   $a and $b or $c and $d
+24           100      1      2   $p or $q
+25           100      1      3   $a and $b or $c and $d
 
 
 Conditions

--- a/test_output/cover/or_branch_polarity.5.020000
+++ b/test_output/cover/or_branch_polarity.5.020000
@@ -1,0 +1,123 @@
+cover: Reading database from ...
+------------------------ ------ ------ ------ ------ ------
+File                       stmt   bran   cond  total   scar
+------------------------ ------ ------ ------ ------ ------
+tests/or_branch_polarity  100.0   91.6  100.0   97.7    6.3
+Total                     100.0   91.6  100.0   97.7    6.3
+------------------------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/or_branch_polarity
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 8 97.7  1.9  6.3
+
+Worst Subroutines
+-----------------
+
+Subroutine      CC SCAR  Location                   
+--------------- -- ----  ---------------------------
+or_die           2  7.1  tests/or_branch_polarity:18
+or_void          2  6.9  tests/or_branch_polarity:24
+unless_modifier  2  6.9  tests/or_branch_polarity:29
+
+line  err   stmt   bran   cond   code
+1                                #!/usr/bin/env perl
+2                                
+3                                # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                
+5                                # This software is free.  It is licensed under the same terms as Perl itself.
+6                                
+7                                # The latest version of this software should be available from my homepage:
+8                                # https://pjcj.net
+9                                
+10                               # __COVER__ criteria statement branch condition
+11                               
+12             1                 use strict;
+               1                 
+               1                 
+13             1                 use warnings;
+               1                 
+               1                 
+14                               
+15             1                 my $side_effect;
+16                               
+17                               sub or_die {
+18             3                   my $x = shift;
+19    ***      3   * 50            my $v = $x or die "no value\n";
+20             3                   $v
+21                               }
+22                               
+23                               sub or_void {
+24             3                   my $x = shift;
+25             3    100            $x or $side_effect = "or";
+26                               }
+27                               
+28                               sub unless_modifier {
+29             3                   my $x = shift;
+30             3    100            $side_effect = "unless" unless $x;
+31                               }
+32                               
+33                               sub unless_block {
+34             3                   my $x = shift;
+35             3    100            unless ($x) { $side_effect = "block" }
+               2                 
+36                               }
+37                               
+38                               sub if_modifier {
+39             3                   my $x = shift;
+40             3    100            $side_effect = "if" if $x;
+41                               }
+42                               
+43                               sub and_void {
+44             3                   my $x = shift;
+45             3    100            $x and $side_effect = "and";
+46                               }
+47                               
+48                               sub dor_void {
+49             3                   my $x = shift;
+50             3           100     $x // ($side_effect = "dor");
+51                               }
+52                               
+53             1                 or_die($_)          for 1,     2, 3;
+54             1                 or_void($_)         for 0,     1, 2;
+55             1                 unless_modifier($_) for 0,     1, 1;
+56             1                 unless_block($_)    for 0,     0, 1;
+57             1                 if_modifier($_)     for 0,     1, 1;
+58             1                 and_void($_)        for 0,     1, 1;
+59             1                 dor_void($_)        for undef, 1, 2;
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+19    ***     50      0      3   unless my $v = $x
+25           100      1      2   unless $x
+30           100      1      2   unless $x
+35           100      2      1   unless ($x)
+40           100      2      1   if $x
+45           100      2      1   if $x
+
+
+Conditions
+----------
+
+or 2 conditions
+
+line  err      %      l     !l   expr
+----- --- ------ ------ ------   ----
+50           100      2      1   $x // ($side_effect = "dor")
+
+

--- a/test_output/cover/or_branch_polarity.5.044000
+++ b/test_output/cover/or_branch_polarity.5.044000
@@ -1,0 +1,123 @@
+cover: Reading database from ...
+------------------------ ------ ------ ------ ------ ------
+File                       stmt   bran   cond  total   scar
+------------------------ ------ ------ ------ ------ ------
+tests/or_branch_polarity  100.0   91.6  100.0   97.7    6.3
+Total                     100.0   91.6  100.0   97.7    6.3
+------------------------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/or_branch_polarity
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 8 97.7  1.9  6.3
+
+Worst Subroutines
+-----------------
+
+Subroutine      CC SCAR  Location                   
+--------------- -- ----  ---------------------------
+or_die           2  7.1  tests/or_branch_polarity:18
+or_void          2  6.9  tests/or_branch_polarity:24
+unless_modifier  2  6.9  tests/or_branch_polarity:29
+
+line  err   stmt   bran   cond   code
+1                                #!/usr/bin/env perl
+2                                
+3                                # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                
+5                                # This software is free.  It is licensed under the same terms as Perl itself.
+6                                
+7                                # The latest version of this software should be available from my homepage:
+8                                # https://pjcj.net
+9                                
+10                               # __COVER__ criteria statement branch condition
+11                               
+12             1                 use strict;
+               1                 
+               1                 
+13             1                 use warnings;
+               1                 
+               1                 
+14                               
+15             1                 my $side_effect;
+16                               
+17                               sub or_die {
+18             3                   my $x = shift;
+19    ***      3   * 50            my $v = $x or die "no value\n";
+20             3                   $v
+21                               }
+22                               
+23                               sub or_void {
+24             3                   my $x = shift;
+25             3    100            $x or $side_effect = "or";
+26                               }
+27                               
+28                               sub unless_modifier {
+29             3                   my $x = shift;
+30             3    100            $side_effect = "unless" unless $x;
+31                               }
+32                               
+33                               sub unless_block {
+34             3                   my $x = shift;
+35             3    100            unless ($x) { $side_effect = "block" }
+               2                 
+36                               }
+37                               
+38                               sub if_modifier {
+39             3                   my $x = shift;
+40             3    100            $side_effect = "if" if $x;
+41                               }
+42                               
+43                               sub and_void {
+44             3                   my $x = shift;
+45             3    100            $x and $side_effect = "and";
+46                               }
+47                               
+48                               sub dor_void {
+49             3                   my $x = shift;
+50             3           100     $x // ($side_effect = "dor");
+51                               }
+52                               
+53             1                 or_die($_)          for 1,     2, 3;
+54             1                 or_void($_)         for 0,     1, 2;
+55             1                 unless_modifier($_) for 0,     1, 1;
+56             1                 unless_block($_)    for 0,     0, 1;
+57             1                 if_modifier($_)     for 0,     1, 1;
+58             1                 and_void($_)        for 0,     1, 1;
+59             1                 dor_void($_)        for undef, 1, 2;
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+19    ***     50      3      0   my $v = $x or die "no value\n"
+25           100      2      1   $x or $side_effect = "or"
+30           100      1      2   unless $x
+35           100      2      1   unless ($x)
+40           100      2      1   if $x
+45           100      2      1   $x and $side_effect = "and"
+
+
+Conditions
+----------
+
+or 2 conditions
+
+line  err      %      l     !l   expr
+----- --- ------ ------ ------   ----
+50           100      2      1   $x // ($side_effect = "dor")
+
+

--- a/test_output/cover/sort_or.5.044000
+++ b/test_output/cover/sort_or.5.044000
@@ -103,15 +103,15 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-19    ***     50      2      0   $main::b->{"cnt"} <=> $main::a->{"cnt"} or $main::a->{"val"} cmp $main::b->{"val"}
-27           100      1      2   $main::b->{"cnt"} <=> $main::a->{"cnt"} or $main::a->{"val"} cmp $main::b->{"val"}
+19    ***     50      0      2   $main::b->{"cnt"} <=> $main::a->{"cnt"} or $main::a->{"val"} cmp $main::b->{"val"}
+27           100      2      1   $main::b->{"cnt"} <=> $main::a->{"cnt"} or $main::a->{"val"} cmp $main::b->{"val"}
 33           100      2      1   $r ? :
-42    ***     50      1      0   $main::a->{"a"} <=> $main::b->{"a"} or $main::a->{"b"} cmp $main::b->{"b"}
-44    ***     50      1      0   $main::a->{"a"} <=> $main::b->{"a"} or $main::a->{"b"} cmp $main::b->{"b"}
-45    ***     50      1      0   $main::a->{"key"} <=> $main::b->{"key"} or +(sort {$main::a->{"a"} <=> $main::b->{"a"} or $main::a->{"b"} cmp $main::b->{"b"};} @{$$a{"inner"};})[0]->{"b"} cmp +(sort {$main::a->{"a"} <=> $main::b->{"a"} or $main::a->{"b"} cmp $main::b->{"b"};} @{$$b{"inner"};})[0]->{"b"}
+42    ***     50      0      1   $main::a->{"a"} <=> $main::b->{"a"} or $main::a->{"b"} cmp $main::b->{"b"}
+44    ***     50      0      1   $main::a->{"a"} <=> $main::b->{"a"} or $main::a->{"b"} cmp $main::b->{"b"}
+45    ***     50      0      1   $main::a->{"key"} <=> $main::b->{"key"} or +(sort {$main::a->{"a"} <=> $main::b->{"a"} or $main::a->{"b"} cmp $main::b->{"b"};} @{$$a{"inner"};})[0]->{"b"} cmp +(sort {$main::a->{"a"} <=> $main::b->{"a"} or $main::a->{"b"} cmp $main::b->{"b"};} @{$$b{"inner"};})[0]->{"b"}
 53    ***      0      0      0   $main::b->{"cnt"} <=> $main::a->{"cnt"} or boom()
-58           100      1      2   $main::b->{"cnt"} <=> $main::a->{"cnt"} or $main::a->{"val"} cmp $main::b->{"val"}
-61           100      1      2   $main::b->{"cnt"} <=> $main::a->{"cnt"} or $main::a->{"val"} cmp $main::b->{"val"}
+58           100      2      1   $main::b->{"cnt"} <=> $main::a->{"cnt"} or $main::a->{"val"} cmp $main::b->{"val"}
+61           100      2      1   $main::b->{"cnt"} <=> $main::a->{"cnt"} or $main::a->{"val"} cmp $main::b->{"val"}
 
 
 Covered Subroutines

--- a/test_output/cover/uncoverable_guards.5.020000
+++ b/test_output/cover/uncoverable_guards.5.020000
@@ -1,0 +1,103 @@
+cover: Reading database from ...
+------------------------ ------ ------ ------ ------
+File                       stmt   bran  total   scar
+------------------------ ------ ------ ------ ------
+tests/uncoverable_guards  100.0   75.0   93.7    6.2
+Total                     100.0   75.0   93.7    6.2
+------------------------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/uncoverable_guards
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 5 93.8  1.9  6.2
+
+Worst Subroutines
+-----------------
+
+Subroutine           CC SCAR  Location                   
+-------------------- -- ----  ---------------------------
+require_value         2  8.1  tests/uncoverable_guards:16
+require_value_unless  2  6.9  tests/uncoverable_guards:23
+require_value_if      2  6.9  tests/uncoverable_guards:30
+
+line  err   stmt   bran   code
+1                         #!/usr/bin/env perl
+2                         
+3                         # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                         
+5                         # This software is free.  It is licensed under the same terms as Perl itself.
+6                         
+7                         # The latest version of this software should be available from my homepage:
+8                         # https://pjcj.net
+9                         
+10                        # __COVER__ criteria statement branch
+11                        
+12             1          use strict;
+               1          
+               1          
+13             1          use warnings;
+               1          
+               1          
+14                        
+15                        sub require_value {
+16             1            my ($v) = @_;
+17                          # uncoverable branch false
+18    ***      1  *- 50     my $ok = $v or die "no value";
+19             1            return $ok;
+20                        }
+21                        
+22                        sub require_value_unless {
+23             1            my ($v) = @_;
+24                          # uncoverable branch true
+25             1   - 50     die "no value" unless $v;
+26             1            return $v;
+27                        }
+28                        
+29                        sub require_value_if {
+30             1            my ($v) = @_;
+31                          # uncoverable branch true
+32             1   - 50     if (!$v) {
+33                            # uncoverable statement
+34            -0              die "no value";
+35                          }
+36             1            return $v;
+37                        }
+38                        
+39                        sub require_value_unless_block {
+40             1            my ($v) = @_;
+41                          # uncoverable branch true
+42             1   - 50     unless ($v) {
+43                            # uncoverable statement
+44            -0              die "no value";
+45                          }
+46             1            return $v;
+47                        }
+48                        
+49             1          require_value(5);
+50             1          require_value_unless(5);
+51             1          require_value_if(5);
+52             1          require_value_unless_block(5);
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+18    ***   - 50      0     -1   unless my $ok = $v
+25          - 50     -0      1   unless $v
+32          - 50     -0      1   unless ($v)
+42          - 50     -0      1   unless ($v)
+
+

--- a/test_output/cover/uncoverable_guards.5.044000
+++ b/test_output/cover/uncoverable_guards.5.044000
@@ -1,0 +1,103 @@
+cover: Reading database from ...
+------------------------ ------ ------ ------ ------
+File                       stmt   bran  total   scar
+------------------------ ------ ------ ------ ------
+tests/uncoverable_guards  100.0  100.0  100.0    5.9
+Total                     100.0  100.0  100.0    5.9
+------------------------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/uncoverable_guards
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+ 5 100.0  1.8  5.9
+
+Worst Subroutines
+-----------------
+
+Subroutine           CC SCAR  Location                   
+-------------------- -- ----  ---------------------------
+require_value         2  6.9  tests/uncoverable_guards:16
+require_value_unless  2  6.9  tests/uncoverable_guards:23
+require_value_if      2  6.9  tests/uncoverable_guards:30
+
+line  err   stmt   bran   code
+1                         #!/usr/bin/env perl
+2                         
+3                         # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                         
+5                         # This software is free.  It is licensed under the same terms as Perl itself.
+6                         
+7                         # The latest version of this software should be available from my homepage:
+8                         # https://pjcj.net
+9                         
+10                        # __COVER__ criteria statement branch
+11                        
+12             1          use strict;
+               1          
+               1          
+13             1          use warnings;
+               1          
+               1          
+14                        
+15                        sub require_value {
+16             1            my ($v) = @_;
+17                          # uncoverable branch false
+18             1   - 50     my $ok = $v or die "no value";
+19             1            return $ok;
+20                        }
+21                        
+22                        sub require_value_unless {
+23             1            my ($v) = @_;
+24                          # uncoverable branch true
+25             1   - 50     die "no value" unless $v;
+26             1            return $v;
+27                        }
+28                        
+29                        sub require_value_if {
+30             1            my ($v) = @_;
+31                          # uncoverable branch true
+32             1   - 50     if (!$v) {
+33                            # uncoverable statement
+34            -0              die "no value";
+35                          }
+36             1            return $v;
+37                        }
+38                        
+39                        sub require_value_unless_block {
+40             1            my ($v) = @_;
+41                          # uncoverable branch true
+42             1   - 50     unless ($v) {
+43                            # uncoverable statement
+44            -0              die "no value";
+45                          }
+46             1            return $v;
+47                        }
+48                        
+49             1          require_value(5);
+50             1          require_value_unless(5);
+51             1          require_value_if(5);
+52             1          require_value_unless_block(5);
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+18          - 50      1     -0   my $ok = $v or die "no value"
+25          - 50     -0      1   unless $v
+32          - 50     -0      1   unless ($v)
+42          - 50     -0      1   unless ($v)
+
+

--- a/tests/or_branch_polarity
+++ b/tests/or_branch_polarity
@@ -1,0 +1,59 @@
+#!/usr/bin/env perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# __COVER__ criteria statement branch condition
+
+use strict;
+use warnings;
+
+my $side_effect;
+
+sub or_die {
+  my $x = shift;
+  my $v = $x or die "no value\n";
+  $v
+}
+
+sub or_void {
+  my $x = shift;
+  $x or $side_effect = "or";
+}
+
+sub unless_modifier {
+  my $x = shift;
+  $side_effect = "unless" unless $x;
+}
+
+sub unless_block {
+  my $x = shift;
+  unless ($x) { $side_effect = "block" }
+}
+
+sub if_modifier {
+  my $x = shift;
+  $side_effect = "if" if $x;
+}
+
+sub and_void {
+  my $x = shift;
+  $x and $side_effect = "and";
+}
+
+sub dor_void {
+  my $x = shift;
+  $x // ($side_effect = "dor");
+}
+
+or_die($_)          for 1,     2, 3;
+or_void($_)         for 0,     1, 2;
+unless_modifier($_) for 0,     1, 1;
+unless_block($_)    for 0,     0, 1;
+if_modifier($_)     for 0,     1, 1;
+and_void($_)        for 0,     1, 1;
+dor_void($_)        for undef, 1, 2;

--- a/tests/uncoverable_guards
+++ b/tests/uncoverable_guards
@@ -1,0 +1,52 @@
+#!/usr/bin/env perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# __COVER__ criteria statement branch
+
+use strict;
+use warnings;
+
+sub require_value {
+  my ($v) = @_;
+  # uncoverable branch false
+  my $ok = $v or die "no value";
+  return $ok;
+}
+
+sub require_value_unless {
+  my ($v) = @_;
+  # uncoverable branch true
+  die "no value" unless $v;
+  return $v;
+}
+
+sub require_value_if {
+  my ($v) = @_;
+  # uncoverable branch true
+  if (!$v) {
+    # uncoverable statement
+    die "no value";
+  }
+  return $v;
+}
+
+sub require_value_unless_block {
+  my ($v) = @_;
+  # uncoverable branch true
+  unless ($v) {
+    # uncoverable statement
+    die "no value";
+  }
+  return $v;
+}
+
+require_value(5);
+require_value_unless(5);
+require_value_if(5);
+require_value_unless_block(5);


### PR DESCRIPTION
Closes #173
Closes #114

## Summary

- From perl 5.43.8 a statement-level `or` displays as written, such as `my $x = get() or die`, but the branch counts kept the `unless` reading where "true" meant the left side was false, so a run in which `get` always succeeded reported true 0 and false 1 with no textual hint of the inversion.
- Pass a distinct `or_expr` type from the statement-level branch path and mirror the count collapse so "true" means the left side was true, matching the displayed text. Uncoverable branch comments on such lines must swap true and false.
- Earlier perls cannot know the source spelling and still display the `unless` form, which reads coherently, so their behaviour and golden results are unchanged.
- Add showcase examples and an e2e test of the same guard written four ways to compare the branch display of each form.
- Also close #114, whose de Morgan condition miscounting was fixed between 1.18 and 1.29 - verified on current code together with RT 78801, which it duplicates.