### PR TITLE
GH-276 Fix assignment through a ref to a do-block

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Fix taking a ref to a do-block, \do { $var = undef } - under coverage
+  the ref pointed at a mortal copy of the block's value, so assignment
+  through it never reached the variable (Felipe Gasper) (GH-276)
 - BREAKING: Swap branch true and false for an "or" statement displayed
   as written, e.g. my $x = get() or die, so "true" now means the left
   side was true. Uncoverable branch comments on such lines must swap

--- a/Cover.xs
+++ b/Cover.xs
@@ -2784,9 +2784,18 @@ static int runops_cover(pTHX) {
     NDEB(D(L, "running func %p from %p (%s)\n",
            PL_op->op_ppaddr, PL_op, OP_NAME(PL_op)));
 
-    /* Semantics, not collection, so it must not honour the vetoes below */
-    if (PL_op->op_type == OP_LEAVE)
-      leave_set_lvalue(aTHX);
+    /* Semantics, not collection, so it must not honour the vetoes below.
+       But leave a hijacked op alone - the pending-conditional key hashes
+       op_private, so changing it here would break the key lookup. */
+    if (PL_op->op_type == OP_LEAVE) {
+      int hijacked;
+      MUTEX_LOCK(&DC_mutex);
+      hijacked = PL_op->op_ppaddr == get_condition
+              || PL_op->op_ppaddr == get_condition_dor;
+      MUTEX_UNLOCK(&DC_mutex);
+      if (!hijacked)
+        leave_set_lvalue(aTHX);
+    }
 
     if (!MY_CXT.covering)
       goto call_fptr;

--- a/Cover.xs
+++ b/Cover.xs
@@ -2628,6 +2628,23 @@ static OP *dc_leaveeval(pTHX) {
   return MY_CXT.ppaddr[OP_LEAVEEVAL](aTHX);
 }
 
+/*
+ * PERLDBf_NOOPT keeps a real enter/leave pair for every block, and pp_leave
+ * copies the block's value unless OPpLVALUE is set, so \do { $var } refs a
+ * copy.  Restore plain perl semantics by setting the flag under op_scope's
+ * own condition - OPf_PARENS marks the blocks plain perl copies too.
+ */
+static void leave_set_lvalue(pTHX) {
+  if (!(PL_op->op_flags & OPf_PARENS) && !TAINTING_get)
+    PL_op->op_private |= OPpLVALUE;
+}
+
+static OP *dc_leave(pTHX) {
+  dMY_CXT;
+  leave_set_lvalue(aTHX);
+  return MY_CXT.ppaddr[OP_LEAVE](aTHX);
+}
+
 static OP *dc_exec(pTHX) {
   dMY_CXT;
   NDEB(D(L, "dc_exec() at %p (%d)\n", PL_op, collecting_here(aTHX)));
@@ -2657,6 +2674,7 @@ static void replace_ops (pTHX) {
   PL_ppaddr[OP_REQUIRE]   = dc_require;
   PL_ppaddr[OP_LEAVEEVAL] = dc_leaveeval;
   PL_ppaddr[OP_RETURN]    = dc_return;
+  PL_ppaddr[OP_LEAVE]     = dc_leave;
   PL_ppaddr[OP_EXEC]      = dc_exec;
 }
 
@@ -2765,6 +2783,10 @@ static int runops_cover(pTHX) {
   for (;;) {
     NDEB(D(L, "running func %p from %p (%s)\n",
            PL_op->op_ppaddr, PL_op, OP_NAME(PL_op)));
+
+    /* Semantics, not collection, so it must not honour the vetoes below */
+    if (PL_op->op_type == OP_LEAVE)
+      leave_set_lvalue(aTHX);
 
     if (!MY_CXT.covering)
       goto call_fptr;

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -29,3 +29,5 @@ tags
 .perl-version
 \.db
 ^\.build\b
+CLAUDE\.md$
+\.autoenv\.zsh$

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -155,7 +155,7 @@ BEGIN {
   @Inc     = map { -d () ? ($_ eq "." ? $_ : abs_path($_)) : () } @Inc;
   @Inc     = remove_contained_paths(getcwd, @Inc);
   @Ignore  = ("/Devel/Cover[./]") unless $Self_cover = $ENV{DEVEL_COVER_SELF};
-  $^P     |= 0x004 | 0x100;  # save source lines; evals report file info
+  $^P     |= 0x004 | 0x100;  # switch off optimisations; evals report file info
 }
 
 sub version    { $VERSION }

--- a/t/internal/ref_do_block.t
+++ b/t/internal/ref_do_block.t
@@ -97,11 +97,15 @@ sub run_program ($label, $taint, $cover_options, $expected) {
   is $out, $expected, "$label: refs to do-blocks match plain perl";
 }
 
-run_program "no coverage",         "",    undef,            $Expected;
-run_program "default",             "",    "",               $Expected;
-run_program "replace_ops 0",       "",    "-replace_ops,0", $Expected;
-run_program "taint no coverage",   " -T", undef,            $Expected_taint;
-run_program "taint default",       " -T", "",               $Expected_taint;
-run_program "taint replace_ops 0", " -T", "-replace_ops,0", $Expected_taint;
+run_program "no coverage",       "",    undef,            $Expected;
+run_program "default",           "",    "",               $Expected;
+run_program "replace_ops 0",     "",    "-replace_ops,0", $Expected;
+run_program "taint no coverage", " -T", undef,            $Expected_taint;
+run_program "taint default",     " -T", "",               $Expected_taint;
+
+# On Windows Cwd chdirs inside abs_path, which taint forbids, killing the
+# child at CHECK time under -replace_ops 0
+run_program "taint replace_ops 0", " -T", "-replace_ops,0", $Expected_taint
+  unless $^O eq "MSWin32";
 
 done_testing;

--- a/t/internal/ref_do_block.t
+++ b/t/internal/ref_do_block.t
@@ -1,0 +1,107 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( realpath );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is )];
+
+# Taking a reference to a do-block, "\do { $var = undef }", must return a
+# reference to $var itself, as it does in plain perl.  Devel::Cover sets
+# $^P & 0x004 (PERLDBf_NOOPT), which keeps a real enter/leave pair for the
+# block, and pp_leave mortal-copies the block's value, so the reference
+# points at a copy and assignment through it never reaches $var.  With more
+# than one statement in the block plain perl also copies, and that must be
+# preserved.  See GH-276.
+
+my $Program = <<'PERL';
+my $var;
+my $foo_sr = \do { $var = undef };
+$$foo_sr = "3:4:5";
+print "ticket: ", (defined $var && $var eq $$foo_sr ? "set" : "unset"), "\n";
+
+my $x;
+my $rx = \do { $x = undef };
+print "single: ", (\$x == $rx ? "same" : "copy"), "\n";
+
+my $y;
+my $ry = \do { $y = undef; };
+print "trailing: ", (\$y == $ry ? "same" : "copy"), "\n";
+
+my $z;
+my $rz = \do { $z };
+print "plain: ", (\$z == $rz ? "same" : "copy"), "\n";
+
+my $d;
+my $rd = \$d;
+print "direct: ", (\$d == $rd ? "same" : "copy"), "\n";
+
+my $m;
+my $rm = \do { 1; $m = undef };
+$$rm = "changed";
+print "multi: ", (defined $m ? "set" : "unset"), "\n";
+PERL
+
+my $Expected = <<'TEXT';
+ticket: set
+single: same
+trailing: same
+plain: same
+direct: same
+multi: unset
+TEXT
+
+# Under taint mode perl keeps a real leave and copies even when optimising,
+# so Devel::Cover must copy too.
+my $Expected_taint = <<'TEXT';
+ticket: unset
+single: copy
+trailing: copy
+plain: copy
+direct: same
+multi: unset
+TEXT
+
+sub run_program ($label, $taint, $cover_options, $expected) {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+  my $prog   = File::Spec->catfile($tmpdir, "prog.pl");
+  open my $fh, ">", $prog or die "Cannot write $prog: $!";
+  print $fh $Program;
+  close $fh or die "Cannot close $prog: $!";
+
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my $cover = "";
+  if (defined $cover_options) {
+    my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+    $cover = " -MDevel::Cover=-db,$cover_db,-silent,1,-merge,0,-ignore,."
+      . ($cover_options ? ",$cover_options" : "");
+  }
+  my $out = `$^X$taint -Iblib/lib -Iblib/arch$cover $prog 2>&1`;
+  is $?,   0,         "$label: run exits 0" or diag $out;
+  is $out, $expected, "$label: refs to do-blocks match plain perl";
+}
+
+run_program "no coverage",         "",    undef,            $Expected;
+run_program "default",             "",    "",               $Expected;
+run_program "replace_ops 0",       "",    "-replace_ops,0", $Expected;
+run_program "taint no coverage",   " -T", undef,            $Expected_taint;
+run_program "taint default",       " -T", "",               $Expected_taint;
+run_program "taint replace_ops 0", " -T", "-replace_ops,0", $Expected_taint;
+
+done_testing;

--- a/t/internal/ref_do_block.t
+++ b/t/internal/ref_do_block.t
@@ -77,11 +77,23 @@ direct: same
 multi: unset
 TEXT
 
-sub run_program ($label, $taint, $cover_options, $expected) {
+# A logop inside a do-block whose value is consumed by the block's leave
+# makes Devel::Cover hijack the leave op for condition coverage.  Setting
+# OPpLVALUE on a hijacked leave changes the pending-conditional key, which
+# hashes op_private, so resolution fails and the run aborts.
+my $Cond_program = <<'PERL';
+my $q = 0;
+my $r = do { $q || "default" };
+print "r=$r\n";
+PERL
+
+my $Cond_expected = "r=default\n";
+
+sub run_program ($label, $taint, $cover_options, $program, $expected) {
   my $tmpdir = realpath(tempdir(CLEANUP => 1));
   my $prog   = File::Spec->catfile($tmpdir, "prog.pl");
   open my $fh, ">", $prog or die "Cannot write $prog: $!";
-  print $fh $Program;
+  print $fh $program;
   close $fh or die "Cannot close $prog: $!";
 
   local $ENV{DEVEL_COVER_SELF};
@@ -97,15 +109,20 @@ sub run_program ($label, $taint, $cover_options, $expected) {
   is $out, $expected, "$label: refs to do-blocks match plain perl";
 }
 
-run_program "no coverage",       "",    undef,            $Expected;
-run_program "default",           "",    "",               $Expected;
-run_program "replace_ops 0",     "",    "-replace_ops,0", $Expected;
-run_program "taint no coverage", " -T", undef,            $Expected_taint;
-run_program "taint default",     " -T", "",               $Expected_taint;
+run_program "no coverage",       "",    undef,            $Program, $Expected;
+run_program "default",           "",    "",               $Program, $Expected;
+run_program "replace_ops 0",     "",    "-replace_ops,0", $Program, $Expected;
+run_program "taint no coverage", " -T", undef, $Program, $Expected_taint;
+run_program "taint default",     " -T", "",    $Program, $Expected_taint;
 
 # On Windows Cwd chdirs inside abs_path, which taint forbids, killing the
 # child at CHECK time under -replace_ops 0
-run_program "taint replace_ops 0", " -T", "-replace_ops,0", $Expected_taint
+run_program "taint replace_ops 0", " -T", "-replace_ops,0", $Program,
+  $Expected_taint
   unless $^O eq "MSWin32";
+
+run_program "cond default", "", "+select,prog", $Cond_program, $Cond_expected;
+run_program "cond replace_ops 0", "", "-replace_ops,0,+select,prog",
+  $Cond_program, $Cond_expected;
 
 done_testing;

--- a/test_output/cover/ref_do_block.5.020000
+++ b/test_output/cover/ref_do_block.5.020000
@@ -1,0 +1,114 @@
+cover: Reading database from ...
+------------------ ------ ------ ------ ------ ------ ------ ------
+File                 stmt   bran   cond   mcdc    sub  total   scar
+------------------ ------ ------ ------ ------ ------ ------ ------
+tests/ref_do_block   89.4   50.0   33.3    0.0   50.0   68.7    4.1
+Total                89.4   50.0   33.3    0.0   50.0   68.7    4.1
+------------------ ------ ------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+tests/ref_do_block
+
+File Summary
+------------
+
+CC  Cov CRAP SCAR
+-- ---- ---- ----
+ 1 76.9  1.5  4.1
+
+Worst Subroutines
+-----------------
+
+Subroutine     CC SCAR  Location             
+-------------- -- ----  ---------------------
+not_referenced  1  6.9  tests/ref_do_block:16
+not_copied      1  6.9  tests/ref_do_block:17
+
+line  err   stmt   bran   cond   mcdc    sub   code
+1                                              #!/usr/bin/perl
+2                                              
+3                                              # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                              
+5                                              # This software is free.  It is licensed under the same terms as Perl itself.
+6                                              
+7                                              # The latest version of this software should be available from my homepage:
+8                                              # https://pjcj.net
+9                                              
+10                                             # A ref to a single-statement do-block must point at the real variable, and
+11                                             # a ref to a multi-statement do-block must still point at a copy.
+12                                             
+13             1                           1   use strict;
+               1                               
+               1                               
+14             1                           1   use warnings;
+               1                               
+               1                               
+15                                             
+16    ***     *0                          *0   sub not_referenced { print "assignment did not reach the variable\n" }
+17    ***     *0                          *0   sub not_copied     { print "multi-statement do-block was not copied\n" }
+18                                             
+19             1                               my $var;
+20             1                               my $foo_sr = \do { $var = undef };
+               1                               
+21             1                               $$foo_sr = "3:4:5";
+22    ***      1   * 50   * 33   *  0          not_referenced() if !defined $var || $var ne $$foo_sr;
+23                                             
+24             1                               my $multi;
+25                                             my $keep;
+26             1                               my $multi_sr = \do { $keep = 1; $multi = undef };
+               1                               
+               1                               
+27             1                               $$multi_sr = "changed";
+28    ***      1   * 50                        not_copied() if defined $multi;
+
+
+Branches
+--------
+
+line  err      %   true  false   branch
+----- --- ------ ------ ------   ------
+22    ***     50      0      1   if not defined $var or $var ne $$foo_sr
+28    ***     50      0      1   if defined $multi
+
+
+Conditions
+----------
+
+or 3 conditions
+
+line  err      %      l  !l&&r !l&&!r   expr
+----- --- ------ ------ ------ ------   ----
+22    ***     33      0      0      1   not defined $var or $var ne $$foo_sr
+
+
+MC/DC
+-----
+
+line  err      %  cov  tot   missing                              expr
+----- --- ------ ---- ----   ----------------------------------   ----
+22    ***      0    0    2   not defined $var, $var ne $$foo_sr   not defined $var or $var ne $$foo_sr
+
+
+Covered Subroutines
+-------------------
+
+Subroutine     Count  CC  SCAR Location             
+-------------- ----- --- ----- ---------------------
+BEGIN              1   1   0.0 tests/ref_do_block:13
+BEGIN              1   1   0.0 tests/ref_do_block:14
+
+Uncovered Subroutines
+---------------------
+
+Subroutine     Count  CC  SCAR Location             
+-------------- ----- --- ----- ---------------------
+not_copied         0   1   6.9 tests/ref_do_block:17
+not_referenced     0   1   6.9 tests/ref_do_block:16
+
+

--- a/tests/ref_do_block
+++ b/tests/ref_do_block
@@ -1,0 +1,28 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# A ref to a single-statement do-block must point at the real variable, and
+# a ref to a multi-statement do-block must still point at a copy.
+
+use strict;
+use warnings;
+
+sub not_referenced { print "assignment did not reach the variable\n" }
+sub not_copied     { print "multi-statement do-block was not copied\n" }
+
+my $var;
+my $foo_sr = \do { $var = undef };
+$$foo_sr = "3:4:5";
+not_referenced() if !defined $var || $var ne $$foo_sr;
+
+my $multi;
+my $keep;
+my $multi_sr = \do { $keep = 1; $multi = undef };
+$$multi_sr = "changed";
+not_copied() if defined $multi;


### PR DESCRIPTION
## Summary

- Under coverage `\do { $var = undef }` returned a ref to a mortal copy, so assignment through it never reached the variable. Devel::Cover sets `$^P & 0x004` for statement coverage, which makes perl keep a real leave op for every block, and `pp_leave` copies the block's value unless the op carries `OPpLVALUE`.
- Set `OPpLVALUE` on each leave op at runtime, in both collection modes, under the same condition `op_scope` uses, so multi-statement blocks and taint mode still copy exactly as plain perl does.

## Ticket

Fixes #276