### PR TITLE
GH-703 Render uncoverable constructs consistently

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,8 @@ Devel::Cover history
   reporting excused statements, subroutines and pod as failures (GH-703)
 - Show uncoverable markers in the crisp HTML report as a diagonal stripe
   over the outcome colour (GH-703)
+- Show uncoverable markers in the basic HTML report the same way, and
+  fix its branch and condition cells' banding (GH-703)
 - Add a third, grey, sign state to the Vim and Nvim reports for excused
   lines (GH-703)
 - BREAKING: Rebuild the JSON report's condition truth tables from observed

--- a/Changes
+++ b/Changes
@@ -1,6 +1,22 @@
 Devel::Cover history
 
 {{$NEXT}}
+- BREAKING: Base each construct's displayed percentage on errors, matching
+  the summary definition, so excused constructs read -100 instead of
+  dragging the number down (GH-703)
+- List excused subroutines under an Uncoverable Subroutines heading in the
+  text report, and flag covered subroutines whose marker is stale (GH-703)
+- Report stale uncoverable markers in the compilation report, and stop
+  reporting excused statements, subroutines and pod as failures (GH-703)
+- Show uncoverable markers in the crisp HTML report as a diagonal stripe
+  over the outcome colour (GH-703)
+- Add a third, grey, sign state to the Vim and Nvim reports for excused
+  lines (GH-703)
+- BREAKING: Rebuild the JSON report's condition truth tables from observed
+  vectors - rows carry an uncoverable flag, unproven rows read as
+  uncovered, and over-wide tables are omitted (GH-703)
+- Record the error rule in the JSON report's top-level ignore_covered_err
+  key (GH-703)
 - Fix taking a ref to a do-block, \do { $var = undef } - under coverage
   the ref pointed at a mortal copy of the block's value, so assignment
   through it never reached the variable (Felipe Gasper) (GH-276)

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -583,6 +583,13 @@ code which ran despite its marker is striped red, and a partially covered
 line carrying a marker is striped amber.  Tooltips give the uncoverable
 counts and the help panel shows a legend.
 
+=item * B<html_basic> follows the same design with a C<cx> class for excused
+cells, striped green, and an C<mk> class adding a red stripe to cells whose
+marker no longer tells the truth.  Cell tooltips carry "marked uncoverable"
+or "marked uncoverable but covered" notes, summary tooltips give the
+uncoverable counts, and MC/DC atomics keep the "-" prefix of the text
+reports.
+
 =item * B<vim> and B<nvim> add a third sign state per criterion, grey by
 default, for lines whose constructs are excused.
 

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -503,8 +503,8 @@ comments when a particular outcome cannot occur, for example an error state
 that cannot be simulated.  If a pair could still be formed from rows not
 marked uncoverable, the atomic condition is reported missing - a test gap, not
 an excuse.  For a decision that can never execute at all, such as code inside
-a branch that can never be taken, mark the whole decision with the bare
-C<uncoverable mcdc> comment.
+a branch that can never be taken, mark the whole decision with
+C<uncoverable mcdc all>.
 
 As for conditions, the "count" value selects between several decisions on one
 line.
@@ -541,6 +541,56 @@ The parameter for -add_uncoverable_point is a string composed of up to seven
 space separated elements: "$file $criterion $line $count $type $class $note".
 
 The contents of the uncoverable file is the same, with one point per line.
+
+=head2 Presentation in reports
+
+Combining coverage with the uncoverable flag leaves each construct in one of
+four states:
+
+  covered  uncoverable  error  state
+        1            0      0  covered
+        0            0      1  uncovered
+        0            1      0  excused
+        1            1      1  marked uncoverable but covered
+
+An excused construct is not an error - that is the point of the marker.  A
+construct which runs despite its marker is an error, because the marker no
+longer tells the truth and should be removed.  The global
+L<-ignore_covered_err> flag, or the per-point L<ignore_covered_err> class,
+forgives that state, which is then treated as covered.
+
+Percentages measure freedom from errors, computed as 100 - errors * 100 /
+total.  An excused outcome therefore counts towards 100% just as a covered
+one does, and a construct whose outcomes are all covered or excused reports
+100%.  Raw hit counts remain available in the detail tables of each report.
+
+Each report renders the states in its own vocabulary:
+
+=over 4
+
+=item * B<text> prefixes a value with "-" when an uncoverable marker is
+involved and with "*" when the construct is in error, and flags erroring
+lines with "***" in the err column.  Excused subroutines appear under the
+"Uncoverable Subroutines" heading.
+
+=item * B<compilation> reports errors only.  Excused constructs produce no
+output, and a stale marker produces a "marked uncoverable but covered"
+message.
+
+=item * B<html> (html_crisp) keeps colour for the coverage outcome and adds
+a diagonal stripe where a marker is present.  Excused code is striped green,
+code which ran despite its marker is striped red, and a partially covered
+line carrying a marker is striped amber.  Tooltips give the uncoverable
+counts and the help panel shows a legend.
+
+=item * B<vim> and B<nvim> add a third sign state per criterion, grey by
+default, for lines whose constructs are excused.
+
+=item * B<json> emits explicit C<covered>, C<uncoverable> and C<error>
+fields per construct and records the error rule in the top-level
+C<ignore_covered_err> key.
+
+=back
 
 =head1 ENVIRONMENT
 

--- a/lib/Devel/Cover/Branch.pm
+++ b/lib/Devel/Cover/Branch.pm
@@ -40,7 +40,7 @@ sub sign_letter      ($class) { "B" }
 
 sub percentage ($self) {
   my $t = $self->total;
-  $t ? int($self->covered / $t * 100) : 0;
+  $t ? int(($t - $self->error) / $t * 100) : 0;
 }
 
 sub error ($self, $c = undef) {

--- a/lib/Devel/Cover/Mcdc.pm
+++ b/lib/Devel/Cover/Mcdc.pm
@@ -46,7 +46,7 @@ sub missing ($self) {
 
 sub percentage ($self) {
   my $t = $self->total;
-  $t ? int($self->covered / $t * 100) : 0
+  $t ? int(($t - $self->error) / $t * 100) : 0
 }
 
 sub error ($self, $c = undef) {

--- a/lib/Devel/Cover/Pod.pm
+++ b/lib/Devel/Cover/Pod.pm
@@ -21,7 +21,7 @@ BEGIN { eval "use Pod::Coverage 0.06" }  # We'll use this if it is available.
 sub uncoverable ($self) { $self->[2] }
 sub covered     ($self) { $self->[0] ? 1 : 0 }
 sub total       ($self) { 1 }
-sub percentage  ($self) { $self->[0] ? 100 : 0 }
+sub percentage  ($self) { $self->error ? 0 : 100 }
 sub error       ($self) { $self->simple_error }
 sub criterion   ($self) { "pod" }
 
@@ -31,12 +31,7 @@ sub sign_letter      ($class) { "P" }
 
 sub calculate_summary ($self, $db, $file) {
   return unless $INC{"Pod/Coverage.pm"};
-
-  my $s = $db->{summary};
-
-  $self->aggregate($s, $file, "total",   $self->total);
-  $self->aggregate($s, $file, "covered", 1) if $self->covered;
-  $self->aggregate($s, $file, "error",   $self->error);
+  $self->SUPER::calculate_summary($db, $file)
 }
 
 1

--- a/lib/Devel/Cover/Report/Compilation.pm
+++ b/lib/Devel/Cover/Report/Compilation.pm
@@ -14,15 +14,15 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
-# TODO - uncoverable code?
-
 sub print_statement ($db, $file, $) {
   my $statements = $db->cover->file($file)->statement or return;
 
   for my $location (sort { $a <=> $b } $statements->items) {
     for my $statement ($statements->location($location)->@*) {
-      next if $statement->covered;
-      print "Uncovered statement at $file line $location\n";
+      next unless $statement->error;
+      print $statement->covered
+        ? "Statement marked uncoverable but covered at $file line $location\n"
+        : "Uncovered statement at $file line $location\n";
     }
   }
 }
@@ -34,19 +34,21 @@ sub print_branches ($db, $file, $) {
     for my $b ($branches->location($location)->@*) {
       next unless $b->error;
 
-      # One or both paths from this branch weren't reached. $b->covered(0) and
-      # (1) say whether the first and second paths were reached.  If the branch
-      # condition text begins with "unless" then the meanings of 0 and 1 are
-      # swapped. The output is easier to understand if we strip off "unless" and
-      # say whether the remaining condition was true or false.
-
+      # Path 0 is the true path for "if", swapped for "unless". Strip the
+      # keyword and report on the truth of the remaining condition.
       my $text = $b->text;
-      my ($t, $f) = map $b->covered($_),
-        $text =~ s/^(if|unless) // && $1 eq "unless" ? (1, 0) : (0, 1);
-      # TODO - uncoverable code?
-      print "Branch never ",
-        $t ? ($f ? "???" : "false") : ($f ? "true" : "reached"),
-        " at $file line $location: $text\n";
+      my @path = $text =~ s/^(if|unless) // && $1 eq "unless" ? (1, 0) : (0, 1);
+      my ($t, $f) = map $b->error($_) && !$b->covered($_), @path;
+      print "Branch never ", $t ? ($f ? "reached" : "true") : "false",
+        " at $file line $location: $text\n"
+        if $t || $f;
+      my ($ts, $fs) = map $b->error($_) && $b->covered($_), @path;
+      print "Branch true marked uncoverable but covered",
+        " at $file line $location: $text\n"
+        if $ts;
+      print "Branch false marked uncoverable but covered",
+        " at $file line $location: $text\n"
+        if $fs;
     }
   }
 }
@@ -67,9 +69,17 @@ sub print_conditions ($db, $file, $) {
       my ($c, $location) = @$_;
       next unless $c->error;
       my @headers = $c->headers->@*;
-      print "Uncovered condition (",
-        join(", ", map !$c->covered($_) ? $headers[$_] : (),
-          0 .. $c->total - 1), ") at $file line $location: ", $c->text, "\n";
+      my @missed  = grep !$c->covered($_) && !$c->uncoverable($_),
+        0 .. $c->total - 1;
+      my @stale = grep $c->covered($_) && $c->uncoverable($_),
+        0 .. $c->total - 1;
+      print "Uncovered condition (", join(", ", @headers[@missed]),
+        ") at $file line $location: ", $c->text, "\n"
+        if @missed;
+      print "Condition (", join(", ", @headers[@stale]),
+        ") marked uncoverable but covered at $file line $location: ", $c->text,
+        "\n"
+        if @stale;
     }
   }
 }
@@ -85,8 +95,17 @@ sub print_mcdc ($db, $file, $) {
           "at $file line $location: ", $m->text, "\n";
         next;
       }
-      print "Uncovered MC/DC pair (", join(", ", $m->missing->@*),
-        ") at $file line $location: ", $m->text, "\n";
+      my $missing = $m->missing;
+      print "Uncovered MC/DC pair (", join(", ", @$missing),
+        ") at $file line $location: ", $m->text, "\n"
+        if @$missing;
+      my $labels = $m->labels;
+      my @stale  = map $labels->[$_],
+        grep $m->covered($_) && $m->uncoverable($_), 0 .. $m->total - 1;
+      print "MC/DC pair (", join(", ", @stale),
+        ") marked uncoverable but covered at $file line $location: ", $m->text,
+        "\n"
+        if @stale;
     }
   }
 }
@@ -96,8 +115,13 @@ sub print_subroutines ($db, $file, $) {
 
   for my $location (sort { $a <=> $b } $subroutines->items) {
     for my $sub ($subroutines->location($location)->@*) {
-      next if $sub->covered;
-      print "Uncovered subroutine ", $sub->name, " at $file line $location\n";
+      next unless $sub->error;
+      print $sub->covered
+        ? (
+          "Subroutine ", $sub->name,
+          " marked uncoverable but covered at $file line $location\n",
+        )
+        : ("Uncovered subroutine ", $sub->name, " at $file line $location\n");
     }
   }
 }
@@ -107,8 +131,10 @@ sub print_pod ($db, $file, $) {
 
   for my $location (sort { $a <=> $b } $pod->items) {
     for my $p ($pod->location($location)->@*) {
-      next if $p->covered;
-      print "Uncovered pod at $file line $location\n";
+      next unless $p->error;
+      print $p->covered
+        ? "Pod marked uncoverable but covered at $file line $location\n"
+        : "Uncovered pod at $file line $location\n";
     }
   }
 }
@@ -160,31 +186,43 @@ The compilation report generates output in the following formats:
 
 =item * Statements
 
-  Uncovered statement at filename.pm line 42:
+  Uncovered statement at filename.pm line 42
+  Statement marked uncoverable but covered at filename.pm line 42
 
 =item * Branches
 
   Branch never true at filename.pm line 15: condition
   Branch never false at filename.pm line 20: unless condition
   Branch never reached at filename.pm line 25: condition
+  Branch true marked uncoverable but covered at filename.pm line 15: condition
 
 =item * Conditions
 
   Uncovered condition (left, right) at filename.pm line 30: expr && expr
+  Condition (left) marked uncoverable but covered at filename.pm line 30: expr
 
 =item * MC/DC
 
   Uncovered MC/DC pair ($q) at filename.pm line 22: $p || $q
+  MC/DC pair ($q) marked uncoverable but covered at filename.pm line 22: $p
 
 =item * Subroutines
 
   Uncovered subroutine function_name at filename.pm line 50
+  Subroutine function_name marked uncoverable but covered at filename.pm line 50
 
 =item * POD Documentation
 
   Uncovered pod at filename.pm line 60
+  Pod marked uncoverable but covered at filename.pm line 60
 
 =back
+
+Only errors are reported. A construct marked uncoverable and not covered is
+excused, so it produces no output. A construct marked uncoverable but covered
+carries a stale marker, so it is reported with a "marked uncoverable but
+covered" message. Branch directions and condition outcomes which are excused
+are omitted from "never" messages and header lists.
 
 =head1 USAGE WITH DEVELOPMENT TOOLS
 
@@ -234,39 +272,42 @@ Use the standard C<cover> command options to select which types to report:
 
 =head2 print_statement ($db, $file, $options)
 
-Prints uncovered statement coverage information for the specified file. Outputs
-one line per uncovered statement in the format:
-
-  "Uncovered statement at $file line $line_number:"
+Prints statement coverage errors for the specified file. Outputs one line per
+uncovered statement and one line per statement with a stale uncoverable
+marker.
 
 =head2 print_branches ($db, $file, $options)
 
-Prints uncovered branch coverage information for the specified file. Reports
-branches where one or both execution paths were not taken. Outputs detailed
-information about which branch condition was never true, false, or reached.
+Prints branch coverage errors for the specified file. Reports branches where
+an execution path was neither taken nor excused, saying whether the branch
+condition was never true, false, or reached, and reports paths with stale
+uncoverable markers.
 
 =head2 print_conditions ($db, $file, $options)
 
-Prints uncovered condition coverage information for the specified file. Reports
-logical conditions that were not fully exercised, showing which parts of complex
-boolean expressions were not tested.
+Prints condition coverage errors for the specified file. Reports logical
+conditions that were not fully exercised, naming the outcomes that were
+neither tested nor excused, and reports outcomes with stale uncoverable
+markers.
 
 =head2 print_mcdc ($db, $file, $options)
 
-Prints uncovered MC/DC pair information for the specified file.  Reports each
-decision whose independence pairs were not all observed, listing the atomic
-conditions whose pair is missing.
+Prints MC/DC coverage errors for the specified file. Reports each decision
+whose independence pairs were not all observed, listing the atomic conditions
+whose pair is missing and not excused, and reports atomic conditions with
+stale uncoverable markers.
 
 =head2 print_subroutines ($db, $file, $options)
 
-Prints uncovered subroutine coverage information for the specified file. Reports
-subroutines that were never called during testing.
+Prints subroutine coverage errors for the specified file. Reports subroutines
+that were never called during testing and subroutines with stale uncoverable
+markers.
 
 =head2 print_pod ($db, $file, $options)
 
-Prints uncovered POD (Plain Old Documentation) coverage information for the
-specified file. Reports sections of POD documentation that do not have
-corresponding tested code.
+Prints POD (Plain Old Documentation) coverage errors for the specified file.
+Reports subroutines without documentation and documented subroutines with
+stale uncoverable markers.
 
 =head2 report ($pkg, $db, $options)
 

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -36,15 +36,39 @@ my $Template;
 my %R;
 
 sub oclass ($o, $criterion) {
-  $o ? class($o->percentage, $o->error, $criterion) : ""
+  $o ? class($o->percentage, $o->error, $criterion, $o->uncoverable) : ""
 }
 
 my $Threshold = default_thresholds;
 
-sub class ($pc, $err, $criterion) {
+sub class ($pc, $err, $criterion, $unc = 0) {
   return "" if $criterion eq "time";
-  !$err ? "c3" : coverage_class($pc // 0, $Threshold)
+  return $unc ? "cx" : "c3" unless $err;
+  coverage_class($pc // 0, $Threshold) . ($unc ? " mk" : "")
 }
+
+sub marker_title ($unc, $err) {
+  $unc ? $err ? "marked uncoverable but covered" : "marked uncoverable" : ""
+}
+
+sub _stale ($o, $criterion) {
+  return $o->uncoverable && $o->covered
+    if $criterion =~ /^(?:statement|subroutine|pod)$/;
+  grep $o->uncoverable($_) && $o->covered($_), 0 .. $o->total - 1
+}
+
+sub otitle ($o, $criterion) {
+  return "" unless $o && $criterion ne "time" && $o->uncoverable;
+  _stale($o, $criterion)
+    ? "marked uncoverable but covered"
+    : "marked uncoverable"
+}
+
+sub part_entry ($text, $unc, $err, $criterion) { {
+  text  => $text,
+  class => class(0, $err, $criterion, $unc),
+  title => marker_title($unc, $err),
+} }
 
 sub get_summary ($file, $criterion) {
   my $vals = { pc => "n/a", class => "" };
@@ -56,9 +80,10 @@ sub get_summary ($file, $criterion) {
 
   return $vals unless defined $c->{percentage};
   $vals->{pc} = do { my $x = sprintf "%5.2f", $c->{percentage}; chop $x; $x };
-  $vals->{covered} = $c->{covered} || 0;
-  $vals->{total}   = $c->{total};
-  $vals->{details} = "$vals->{covered} / $vals->{total}";
+  $vals->{covered}  = $c->{covered} || 0;
+  $vals->{total}    = $c->{total};
+  $vals->{details}  = "$vals->{covered} / $vals->{total}";
+  $vals->{details} .= " ($c->{uncoverable} uncoverable)" if $c->{uncoverable};
 
   my $cr
     = $criterion eq "total"
@@ -90,11 +115,12 @@ sub _build_coverage_criteria ($criteria, $n, $count) {
     my $o   = shift $criteria->{$c}->@*;
     $more ||= $criteria->{$c}->@*;
 
-    my $meta      = Devel::Cover::Criterion->criterion_class($c);
-    my $cr        = $meta->detail_criterion;
-    my $pc        = $meta->display_mode eq "percentage";
-    my $text      = $o ? $pc ? $o->percentage : $o->covered : "&nbsp;";
-    my $criterion = { text => $text, class => oclass($o, $c) };
+    my $meta = Devel::Cover::Criterion->criterion_class($c);
+    my $cr   = $meta->detail_criterion;
+    my $pc   = $meta->display_mode eq "percentage";
+    my $text = $o ? $pc ? $o->percentage : $o->covered : "&nbsp;";
+    my $criterion
+      = { text => $text, class => oclass($o, $c), title => otitle($o, $c) };
 
     $criterion->{link} = "$R{filenames}{$R{file}}--$cr.html#$n-$count"
       if $o && defined $cr;
@@ -105,7 +131,7 @@ sub _build_coverage_criteria ($criteria, $n, $count) {
 
 sub _add_uncovered_links ($lines) {
   my @unc = grep {
-    $_->{criteria}[0]{class} eq "c0" && $_->{criteria}[0]{text} eq "0"
+    $_->{criteria}[0]{class} =~ /^c0\b/ && $_->{criteria}[0]{text} =~ /^\d+$/
   } @$lines;
   while (@unc) {
     my $u    = pop @unc;
@@ -193,16 +219,16 @@ sub print_branches () {
       my $text = _highlight_text($br->text);
 
       push @branches, {
-        number => $count == 1 ? $location : "",
-        parts  => [
-          map {
-            text    => $br->value($_),
-              class => class($br->value($_), $br->error($_), "branch")
-          },
-          0 .. $br->total - 1,
-        ],
-        text => $text,
-      };
+          number => $count == 1 ? $location : "",
+          parts  => [
+            map part_entry(
+              $br->value($_), $br->uncoverable($_),
+              $br->error($_), "branch",
+            ),
+            0 .. $br->total - 1,
+          ],
+          text => $text,
+        };
     }
   }
 
@@ -226,17 +252,16 @@ sub print_conditions () {
       my $text = _highlight_text($c->text);
 
       push $r->{ $c->type }->@*, {
-        number    => $count->{ $c->type } == 1 ? $location : "",
-        condition => $c,
-        parts     => [
-          map {
-            text    => $c->value($_),
-              class => class($c->value($_), $c->error($_), "condition")
-          },
-          0 .. $c->total - 1,
-        ],
-        text => $text,
-      };
+          number    => $count->{ $c->type } == 1 ? $location : "",
+          condition => $c,
+          parts     => [
+            map part_entry(
+              $c->value($_), $c->uncoverable($_), $c->error($_), "condition"
+            ),
+            0 .. $c->total - 1,
+          ],
+          text => $text,
+        };
     }
   }
 
@@ -274,15 +299,16 @@ sub print_mcdc () {
         number     => $count == 1 ? $location : "",
         ref        => "$location-$count",
         percentage => $m->percentage,
-        class      => class($m->percentage, $m->error, "mcdc"),
+        class      => class($m->percentage, $m->error, "mcdc", $m->uncoverable),
+        title      => otitle($m, "mcdc"),
         note       => $m->unanalysed ? "too many conditions" : "",
         atomics    => $m->unanalysed ? []                    : [
           map {
-            my $unc = $m->uncoverable($_);
-            +{
-              label => escape_html(($unc ? "-" : "") . ($labels[$_] // "")),
-              class => $vals[$_] || $unc ? "c3" : "c0",
-            }
+            my $unc  = $m->uncoverable($_);
+            my $part = part_entry("", $unc, $m->error($_), "mcdc");
+            $part->{label}
+              = escape_html(($unc ? "-" : "") . ($labels[$_] // ""));
+            $part
           } 0 .. $#vals,
         ],
         text => $text,
@@ -319,8 +345,10 @@ sub print_subroutines () {
           name   => decode_guess($o->name),
           count  => $s ? $o->covered              : "",
           class  => $s ? oclass($o, "subroutine") : "",
+          title  => $s ? otitle($o, "subroutine") : "",
           pod    => $p ? $p->covered ? "Yes" : "No" : "n/a",
           pclass => $p ? oclass($p, "pod") : "",
+          ptitle => $p ? otitle($p, "pod") : "",
         };
     }
   }
@@ -660,7 +688,8 @@ $Templates{file} = <<'HTML';
         [% END %]>[% line.number %]</a>
       </td>
       [% FOREACH cr = line.criteria %]
-        <td [% IF cr.class %] class="[% cr.class %]" [% END %]>
+        <td[% IF cr.class %] class="[% cr.class %]"[% END -%]
+        [% IF cr.title %] title="[% cr.title %]"[% END %]>
           [% IF cr.link.defined %] <a href="[% cr.link %]"> [% END %]
           [% cr.text %]
           [% IF cr.link.defined %] </a> [% END %]
@@ -697,7 +726,9 @@ $Templates{branches} = <<'HTML';
           [% branch.number %]</a>
       </td>
       [% FOREACH part = branch.parts %]
-        <td class="[% part.class %]"> [% part.text %] </td>
+        <td class="[% part.class %]"
+        [%- IF part.title %] title="[% part.title %]"[% END %]>
+          [% part.text %] </td>
       [% END %]
       <td class="s"> [% branch.text %] </td>
     </tr>
@@ -734,7 +765,9 @@ $Templates{conditions} = <<'HTML';
             [% condition.number %]</a>
         </td>
         [% FOREACH part = condition.parts %]
-          <td class="[% part.class %]"> [% part.text %] </td>
+          <td class="[% part.class %]"
+          [%- IF part.title %] title="[% part.title %]"[% END %]>
+            [% part.text %] </td>
         [% END %]
         <td class="s"> [% condition.text %] </td>
       </tr>
@@ -767,13 +800,17 @@ $Templates{mcdc} = <<'HTML';
         <a href="[% R.file_link %]#[% decision.number %]">
           [% decision.number %]</a>
       </td>
-      <td class="[% decision.class %]"> [% decision.percentage %] </td>
+      <td class="[% decision.class %]"
+      [%- IF decision.title %] title="[% decision.title %]"[% END %]>
+        [% decision.percentage %] </td>
       <td>
         [% IF decision.note %]
           <em> [% decision.note %] </em>
         [% ELSE %]
           [% FOREACH atom = decision.atomics %]
-            <span class="[% atom.class %]"> [% atom.label %] </span>
+            <span class="[% atom.class %]"
+            [%- IF atom.title %] title="[% atom.title %]"[% END %]>
+              [% atom.label %] </span>
           [% END %]
         [% END %]
       </td>
@@ -814,10 +851,14 @@ $Templates{subroutines} = <<'HTML';
         <a href="[% R.file_link %]#[% sub.line %]">[% sub.line %]</a>
       </td>
       [% IF R.options.show.subroutine %]
-        <td class="[% sub.class %]"> [% sub.count %] </td>
+        <td class="[% sub.class %]"
+        [%- IF sub.title %] title="[% sub.title %]"[% END %]>
+          [% sub.count %] </td>
       [% END %]
       [% IF R.options.show.pod %]
-        <td class="[% sub.pclass %]"> [% sub.pod %] </td>
+        <td class="[% sub.pclass %]"
+        [%- IF sub.ptitle %] title="[% sub.ptitle %]"[% END %]>
+          [% sub.pod %] </td>
       [% END %]
       <td> [% sub.name | html %] </td>
     </tr>
@@ -849,6 +890,13 @@ Devel::Cover::Report::Html_basic - HTML backend for Devel::Cover
 This module provides a HTML reporting mechanism for coverage data.  It
 is designed to be called from the C<cover> program. It will add syntax
 highlighting if C<PPI::HTML> or C<Perl::Tidy> is installed.
+
+Colour shows the coverage outcome and a diagonal stripe shows that an
+uncoverable marker is present.  Excused code is striped green with a
+"marked uncoverable" tooltip, and code which ran despite its marker is
+striped red with a "marked uncoverable but covered" tooltip.  Summary
+tooltips give the uncoverable counts and MC/DC atomics keep the "-"
+prefix of the text reports.
 
 =head1 OPTIONS
 

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -2888,6 +2888,12 @@ with inline branch, condition, and subroutine detail.
 Features include dark mode support, keyboard navigation, sortable columns,
 inline condition truth tables, and deep-linkable filters.
 
+Colour shows the coverage outcome and a diagonal stripe shows that an
+uncoverable marker is present.  Excused code is striped green, code which ran
+despite its marker is striped red, and a partially covered line carrying a
+marker is striped amber.  Tooltips give the uncoverable counts and the help
+panel shows a legend of the colours.
+
 It is designed to be called from the C<cover> program.  It will add syntax
 highlighting if C<PPI::HTML> or C<Perl::Tidy> is installed.
 

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -94,6 +94,12 @@ sub untested_badge () {
 sub glass_tip ($text) { qq(<span class="glass-tip">$text</span>) }
 sub is_na     ($v)    { !defined $v || $v eq "n/a" || $v eq "-" }
 
+sub tip_text ($s) {
+  my $t = "$s->{covered} / $s->{total}";
+  $t .= " ($s->{uncoverable} uncoverable)" if $s->{uncoverable};
+  $t
+}
+
 sub scar_tip ($f) {
   return "" if is_na($f->{file_scar});
   my $cov_cls = class($f->{file_cov}, $f->{file_cov} < 100, "total");
@@ -137,10 +143,10 @@ sub cov_cell ($s, $uncompiled, $data_value = undef, $link = undef) {
   my $dv      = $data_value // (is_na($s->{pc}) ? -1 : $s->{pc});
   my $no_data = $uncompiled && !$R{have_ppi};
   my $no_tip  = $no_data || ($s->{total} // 0) == 0;
-  my $cls   = $no_tip ? $s->{class} : "$s->{class} tip-hover";
-  my $tip   = $no_tip ? ""          : glass_tip("$s->{covered} / $s->{total}");
-  my $bar   = cov_bar($s->{pc}, $uncompiled);
-  my $inner = "$s->{pc} $bar";
+  my $cls     = $no_tip ? $s->{class} : "$s->{class} tip-hover";
+  my $tip     = $no_tip ? ""          : glass_tip(tip_text($s));
+  my $bar     = cov_bar($s->{pc}, $uncompiled);
+  my $inner   = "$s->{pc} $bar";
 
   $inner = qq(<a class="cell-link" href="$link">$inner</a>) if $link;
   qq(<td class="$cls" data-value="$dv">$inner $tip</td>)
@@ -267,7 +273,7 @@ sub stat_badge ($c, $s) {
   my $suf    = is_na($pct) ? "" : "%";
   my $no_tip = ($s->{total} // 0) == 0;
   my $cls    = $no_tip ? $s->{class} : "$s->{class} tip-hover";
-  my $tip    = $no_tip ? ""          : glass_tip("$s->{covered} / $s->{total}");
+  my $tip    = $no_tip ? ""          : glass_tip(tip_text($s));
 
   <<HTML
 <span class="stat-badge $cls">
@@ -450,9 +456,14 @@ HTML
   )
 }
 
-sub _summary_text ($covered, $total, $error = undef, $criterion = "condition") {
+sub _summary_text (
+  $covered, $total,
+  $error     = undef,
+  $criterion = "condition",
+  $pc        = undef,
+) {
   return "" unless $total;
-  my $pc  = int(100 * $covered / $total);
+  $pc //= int(100 * $covered / $total);
   my $cls = class($pc, $error // $covered != $total, $criterion);
   qq(<span class="summary-text $cls">$pc%)
     . qq(<span class="count">$covered/$total</span></span>)
@@ -460,17 +471,19 @@ sub _summary_text ($covered, $total, $error = undef, $criterion = "condition") {
 
 sub _render_cond_cells ($line) {
   my $cells = $line->{condition_cells} or return "";
-  my ($cov, $tot) = (0, 0);
+  my ($cov, $err, $tot) = (0, 0, 0);
   for my $cell (@$cells) {
     for my $part ($cell->{parts}->@*) {
       $tot++;
-      $cov++ if ($part->{class} // "") ne "c0";
+      $cov++ if $part->{covered};
+      $err++ if $part->{error};
     }
   }
+  my $pc = $tot ? int(($tot - $err) / $tot * 100) : 0;
   my $o
     = qq(<div class="detail cond-cells">\n)
     . '<div class="head"><span>Condition</span>'
-    . _summary_text($cov, $tot)
+    . _summary_text($cov, $tot, $err ? 1 : 0, "condition", $pc)
     . qq(</div>\n<div class="body">\n);
   for my $cell (@$cells) {
     $o .= qq(<div class="item">\n);
@@ -493,10 +506,12 @@ sub _render_truth_tables ($line) {
   for my $tt (@$tts) {
     my $tot = $tt->{rows}->@*;
     my $cov = grep $_->{covered}, $tt->{rows}->@*;
+    my $err = grep $_->{error},   $tt->{rows}->@*;
+    my $pc  = $tot ? int(($tot - $err) / $tot * 100) : 0;
     $o
       .= qq(<div class="detail decision-vectors">\n)
       . '<div class="head"><span>Truth table</span>'
-      . _summary_text($cov, $tot)
+      . _summary_text($cov, $tot, $err ? 1 : 0, "condition", $pc)
       . qq(</div>\n<div class="body">\n)
       . qq(<div class="expr">$tt->{short_expr}</div>\n);
     if ($tt->{legend} && $tt->{legend}->@*) {
@@ -522,7 +537,12 @@ sub render_line_detail ($line) {
 
   if ($line->{subroutines}) {
     for my $s ($line->{subroutines}->@*) {
-      my $status  = $s->{covered} ? "called" : "not called";
+      my $status
+        = $s->{excused}
+        ? "not called (uncoverable)"
+        : $s->{covered}
+        ? ($s->{error} ? "called (marked uncoverable but covered)" : "called")
+        : "not called";
       my $cc_info = "";
       if (defined $s->{cc}) {
         my $cls  = scar_class($s->{scar});
@@ -540,7 +560,13 @@ HTML
 
   if ($line->{pod}) {
     for my $p ($line->{pod}->@*) {
-      my $status = $p->{covered} ? "documented" : "undocumented";
+      my $status
+        = $p->{excused}
+        ? "undocumented (uncoverable)"
+        : $p->{covered} ? ($p->{error}
+          ? "documented (marked uncoverable but covered)"
+          : "documented")
+        : "undocumented";
       $o .= <<HTML;
 <div class="detail">
 <span class="detail-heading">Pod</span>
@@ -584,7 +610,9 @@ sub render_mcdc_detail ($mcdc) {
     $o
       .= qq(<div class="detail mcdc-detail">\n)
       . '<div class="head"><span>MC/DC</span>'
-      . _summary_text($m->{covered}, $m->{total}, $m->{error}, "mcdc")
+      . _summary_text(
+        $m->{covered}, $m->{total}, $m->{error}, "mcdc", $m->{percentage},
+      )
       . qq(</div>\n<div class="body">\n)
       . qq(<div class="expr">$m->{text}</div>\n);
     if ($m->{unanalysed}) {
@@ -592,7 +620,12 @@ sub render_mcdc_detail ($mcdc) {
     } else {
       $o .= qq(<div class="mcdc-atomics">\n);
       for my $a ($m->{atomics}->@*) {
-        $o .= qq(<span class="mcdc-pill $a->{class}">$a->{label}</span>\n);
+        my $title
+          = $a->{excused} ? ' title="marked uncoverable"'
+          : $a->{stale}   ? ' title="marked uncoverable but covered"'
+          :                 "";
+        $o
+          .= qq(<span class="mcdc-pill $a->{class}"$title>$a->{label}</span>\n);
       }
       $o .= "</div>\n";
     }
@@ -602,27 +635,44 @@ sub render_mcdc_detail ($mcdc) {
 }
 
 sub count_cell ($line, $cov_defined) {
-  my $cls = "count";
-  if ($line->{partial}) {
-    $cls .= " exec-partial";
-  } else {
-    $cls .= " $line->{exec_class}" if $line->{exec_class};
-    $cls .= " c0"                  if $line->{pod_uncovered};
+  my $exec = $line->{exec_class} // "";
+  my $cls  = "count";
+  if ($exec eq "exec-0" || $line->{stale}) {
+    $cls .= " exec-0";
+    $cls .= " mk" if $line->{stale};
+  } elsif ($line->{partial}) {
+    $cls .= " exec-partial"
+  } elsif ($line->{pod_uncovered}) {
+    $cls .= " c0"
+  } elsif ($line->{excused}) {
+    $cls .= " exec-excused"
+  } elsif ($exec) {
+    $cls .= " $exec"
   }
   my $aria
-    = $cov_defined ? "executed $line->{count} times" : "no coverage data";
+    = !$cov_defined         ? "no coverage data"
+    : $line->{stmt_excused} ? "marked uncoverable"
+    : $line->{stmt_stale}
+    ? "executed $line->{count} times, marked uncoverable but covered"
+    : "executed $line->{count} times";
   my $count = $cov_defined ? $line->{count} : "";
   <<HTML
 <td role="cell" class="$cls" aria-label="$aria">$count</td>
 HTML
 }
 
+sub line_data_cov ($line, $is_uncov) {
+      $is_uncov           ? "0"
+    : $line->{partial}    ? "2"
+    : $line->{excused}    ? "3"
+    : $line->{count} == 0 ? "0"
+    : "1"
+}
+
 sub render_source_line ($line) {
   my $cov_defined = defined $line->{count};
   my $is_uncov
-    = $cov_defined
-    && $line->{count} == 0
-    && ($line->{count_class} // "") eq "c0";
+    = $cov_defined && (($line->{count_class} // "") eq "c0" || $line->{stale});
   my $has_detail
     = $line->{branches}
     || $line->{condition_cells}
@@ -638,7 +688,7 @@ sub render_source_line ($line) {
 
   my $o = '<tr role="row"';
   if ($cov_defined) {
-    my $dcov = $line->{count} == 0 ? "0" : $line->{partial} ? "2" : "1";
+    my $dcov = line_data_cov($line, $is_uncov);
     $o .= qq(\n    data-cov="$dcov");
   }
   $o .= qq(\n    class="$tr_cls")          if $tr_cls;
@@ -653,7 +703,7 @@ sub render_source_line ($line) {
   my $chevron = $has_detail ? "&#x25b6;" : "";
   my $src_cls = "src";
   $src_cls .= " src-c0"      if $is_uncov;
-  $src_cls .= " src-partial" if $line->{partial};
+  $src_cls .= " src-partial" if $line->{partial} && !$is_uncov;
   $src_cls .= " src-c1"      if ($line->{count_class} // "") eq "c1";
   my $text  = $line->{text} // "";
   $o .= qq(<td role="cell" class="chevron">$chevron</td>)
@@ -682,7 +732,7 @@ HTML
     my $suf  = is_na($s->{pc})   ? ""              : "%";
     my $no_tip = ($s->{total} // 0) == 0;
     my $cls    = $no_tip ? $base : "$base tip-hover";
-    my $tip    = $no_tip ? ""    : glass_tip("$s->{covered} / $s->{total}");
+    my $tip    = $no_tip ? ""    : glass_tip(tip_text($s));
 
     $o .= <<HTML;
 <span class="stat-badge $cls" data-criterion="$c">
@@ -699,7 +749,7 @@ HTML
 <span class="stat-badge $tt_cls tip-hover" data-criterion="total">
 <span class="badge-label">@{[ crit_name("total") ]} $tt->{pc}%</span>
 @{[ cov_bar($tt->{pc}, $fd->{uncompiled}) ]}
-@{[ glass_tip("$tt->{covered} / $tt->{total}") ]}</span>
+@{[ glass_tip(tip_text($tt)) ]}</span>
 HTML
   }
   my $cc = $fd->{file_cc};
@@ -736,9 +786,23 @@ line that has any error. Click again to close.</dd>
 <dt>Line details</dt>
 <dd>Click any line with a &#x25b6; chevron to expand branch,
 condition, or subroutine detail.</dd>
+<dt>Colours</dt>
+<dd>
+<span class="legend-swatch c3"></span> covered<br>
+<span class="legend-swatch c1"></span> partial - ran, but a construct
+on the line is uncovered<br>
+<span class="legend-swatch c0"></span> uncovered<br>
+<span class="legend-swatch cx"></span> excused - marked uncoverable<br>
+<span class="legend-swatch c0 mk"></span> marked uncoverable but ran
+</dd>
 <dt>Minimap</dt>
 <dd>The strip on the right shows coverage at a glance. Click to
 jump to that line.</dd>
+<dt>Uncoverable</dt>
+<dd>Constructs marked uncoverable are excused - not counted as
+errors, and skipped by <kbd>j</kbd> / <kbd>k</kbd>. Diagonal stripes
+mean an uncoverable marker is present. A striped red cell means
+marked code actually ran, so the marker needs removing.</dd>
 <dt>Tooltips</dt>
 <dd>Hover badges for covered/total counts. Hover SCAR for a
 breakdown.</dd>
@@ -810,15 +874,23 @@ sub fmt_pc ($pc) {
 }
 
 sub _format_criterion ($part, $criterion) {
-  return { pc => "n/a", class => "na", covered => 0, total => 0, error => 0 }
+  return {
+    pc          => "n/a",
+    class       => "na",
+    covered     => 0,
+    total       => 0,
+    uncoverable => 0,
+    error       => 0,
+    }
     unless $part && exists $part->{$criterion};
   my $c = $part->{$criterion};
   {
-    pc      => fmt_pc($c->{percentage}),
-    class   => class($c->{percentage}, $c->{error}, $criterion),
-    covered => $c->{covered} || 0,
-    total   => $c->{total}   || 0,
-    error   => $c->{error}   || 0,
+    pc          => fmt_pc($c->{percentage}),
+    class       => class($c->{percentage}, $c->{error}, $criterion),
+    covered     => $c->{covered}     || 0,
+    total       => $c->{total}       || 0,
+    uncoverable => $c->{uncoverable} || 0,
+    error       => $c->{error}       || 0,
   }
 }
 
@@ -877,7 +949,13 @@ sub build_one_file ($file) {
 
   my $no_data = $uncompiled && !$R{have_ppi};
   my $na      = sub { {
-    pc => "-", class => "na", covered => 0, total => 0, error => 0 } };
+    pc          => "-",
+    class       => "na",
+    covered     => 0,
+    total       => 0,
+    uncoverable => 0,
+    error       => 0,
+  } };
 
   for my $c ($R{showing}->@*) {
     $f{criteria}{$c} = $no_data ? $na->() : get_summary($file, $c);
@@ -934,21 +1012,36 @@ sub line_subroutines ($f, $n) {
   my $loc  = $subs->location($n);
   return unless $loc && @$loc;
   my $cl = $R{scar_subs} || {};
-  map { {
-    name    => escape_html($_->name),
-    covered => $_->covered,
-    class   => oclass($_, "subroutine"),
-    cc      => ($cl->{ "$n\0" . $_->name } // {})->{cc},
-    crap    => ($cl->{ "$n\0" . $_->name } // {})->{crap},
-    scar    => ($cl->{ "$n\0" . $_->name } // {})->{scar},
-  } } @$loc
+  map {
+    my $excused = $_->uncoverable && !$_->covered;
+    {
+      name    => escape_html($_->name),
+      covered => $_->covered,
+      error   => $_->error ? 1    : 0,
+      excused => $excused  ? 1    : 0,
+      class   => $excused  ? "cx" : $_->covered
+        && $_->error ? "c0 mk" : oclass($_, "subroutine"),
+      cc   => ($cl->{ "$n\0" . $_->name } // {})->{cc},
+      crap => ($cl->{ "$n\0" . $_->name } // {})->{crap},
+      scar => ($cl->{ "$n\0" . $_->name } // {})->{scar},
+    }
+  } @$loc
 }
 
 sub line_pod ($f, $n) {
   my $pod = $f->pod or return;
   my $loc = $pod->location($n);
   return unless $loc && @$loc;
-  map { { covered => $_->covered, class => oclass($_, "pod") } } @$loc
+  map {
+    my $excused = $_->uncoverable && !$_->covered;
+    {
+      covered => $_->covered,
+      error   => $_->error ? 1    : 0,
+      excused => $excused  ? 1    : 0,
+      class   => $excused  ? "cx" : $_->covered
+        && $_->error ? "c0 mk" : oclass($_, "pod"),
+    }
+  } @$loc
 }
 
 sub line_branches ($f, $n) {
@@ -956,14 +1049,25 @@ sub line_branches ($f, $n) {
   my $loc      = $branches->location($n);
   return unless $loc && @$loc;
   map {
-    my $t = $_->value(0);
-    my $f = $_->value(1);
+    my $t         = $_->value(0);
+    my $f         = $_->value(1);
+    my $arm_class = sub ($i, $v) {
+      $_->uncoverable($i)
+        && !$v                ? "cx"
+        : $v && $_->error($i) ? "c0 mk"
+        : class($v, $_->error($i), "branch")
+    };
+    my $true_class  = $arm_class->(0, $t);
+    my $false_class = $arm_class->(1, $f);
     {
       true_count  => $t,
       false_count => $f,
       total_count => $t + $f,
-      true_class  => class($t, $_->error(0), "branch"),
-      false_class => class($f, $_->error(1), "branch"),
+      has_error   => $_->error ? 1 : 0,
+      has_excused => $true_class eq "cx"  || $false_class eq "cx" ? 1 : 0,
+      has_stale   => ($_->error(0) && $t) || ($_->error(1) && $f) ? 1 : 0,
+      true_class  => $true_class,
+      false_class => $false_class,
       text        => escape_html($_->text // ""),
     }
   } @$loc
@@ -1001,10 +1105,19 @@ sub line_condition_cells ($f, $n) {
       text    => _cond_expr($c),
       headers => [map escape_html($_), ($c->headers // [])->@*],
       parts   => [
-        map { {
-          count => $c->value($_),
-          class => class($c->value($_), $c->error($_), "condition"),
-        } } 0 .. $c->total - 1
+        map {
+          my $excused = $c->uncoverable($_) && !$c->value($_);
+          {
+            count   => $c->value($_),
+            covered => $c->value($_) ? 1 : 0,
+            error   => $c->error($_) ? 1 : 0,
+            excused => $excused      ? 1 : 0,
+            class   => $excused      ? "cx"
+            : $c->value($_)
+              && $c->error($_) ? "c0 mk"
+            : class($c->value($_), $c->error($_), "condition"),
+          }
+        } 0 .. $c->total - 1
       ],
     }
   } @$loc
@@ -1019,11 +1132,17 @@ sub line_truth_tables ($f, $n) {
     my $proven = $_->proven;
     my @rows   = map {
       my $covered = $proven && $_->covered;
+      my $error
+        = Devel::Cover::Criterion->err_chk($covered, $_->uncoverable) ? 1 : 0;
       {
         inputs  => $_->inputs,
         result  => $_->result,
         covered => $covered,
-        class   => $covered ? "c3" : "c0",
+        error   => $error,
+        excused => !$error && !$covered ? 1 : 0,
+        class   => $error               ? ($covered ? "c0 mk" : "c0")
+        : $covered ? "c3"
+        :            "cx",
       }
     } $_->rows;
     my @labels  = $_->labels;
@@ -1059,11 +1178,17 @@ sub line_mcdc ($f, $n) {
       class      => class($m->percentage, $m->error, "mcdc"),
       atomics    => $m->unanalysed ? [] : [
         map {
-          my $unc = $m->uncoverable($_);
+          my $stale = $m->error($_) && $vals[$_];
+          my $cls
+            = $m->error($_) ? ($stale ? "c0 mk" : "c0")
+            : $vals[$_]     ? "c3"
+            :                 "cx";
           {
-            label   => escape_html(($unc ? "-" : "") . ($labels[$_] // "")),
-            covered => $vals[$_]         ? 1    : 0,
-            class   => $vals[$_] || $unc ? "c3" : "c0",
+            label   => escape_html($labels[$_] // ""),
+            covered => $vals[$_]    ? 1 : 0,
+            excused => $cls eq "cx" ? 1 : 0,
+            stale   => $stale       ? 1 : 0,
+            class   => $cls,
           }
         } 0 .. $#vals
       ],
@@ -1071,8 +1196,10 @@ sub line_mcdc ($f, $n) {
   } @$loc
 }
 
-sub exec_class ($count) {
-  defined $count && $count > 0 ? "exec-covered" : "exec-0"
+sub exec_class ($s) {
+      $s->uncoverable && !$s->covered ? "exec-excused"
+    : $s->error                       ? "exec-0"
+    : "exec-covered"
 }
 
 sub line_statement ($f, $n, $line) {
@@ -1080,20 +1207,52 @@ sub line_statement ($f, $n, $line) {
   my $loc  = $stmt->location($n);
   return unless $loc && @$loc;
   my $s = $loc->[0];
-  $line->{count}       = $s->covered;
-  $line->{count_class} = oclass($s, "statement");
-  $line->{exec_class}  = exec_class($s->covered);
+  $line->{count}        = $s->covered;
+  $line->{count_class}  = oclass($s, "statement");
+  $line->{exec_class}   = exec_class($s);
+  $line->{stmt_excused} = 1 if $s->uncoverable && !$s->covered;
+  $line->{stmt_stale}   = 1 if $s->uncoverable && $s->covered && $s->error;
 }
 
 sub line_partial ($line, $bd, $cd, $tts, $sd, $md) {
   return unless defined $line->{count} && $line->{count} > 0;
   my $p;
-  $p ||= any { $_->{true_count} == 0 || $_->{false_count} == 0 } @$bd;
-  $p ||= any { any { ($_->{class} // "") eq "c0" } $_->{parts}->@* } @$cd;
-  $p ||= any { !$_->{covered} } @$sd;
+  $p ||= any { $_->{has_error} } @$bd;
+  $p ||= any { any { $_->{error} } $_->{parts}->@* } @$cd;
+  $p ||= any { $_->{error} } @$sd;
   $p ||= any { $_->{error} } @$md;
   $p ||= $line->{pod_uncovered};
   $line->{partial} = 1 if $p;
+}
+
+sub line_excused ($line, $bd, $cd, $tts, $sd, $md) {
+  my $e;
+  $e ||= $line->{stmt_excused} || $line->{pod_excused};
+  $e ||= any { $_->{has_excused} } @$bd;
+  $e ||= any { any { $_->{excused} } $_->{parts}->@* } @$cd;
+  $e ||= any { any { $_->{excused} } $_->{rows}->@* } @$tts;
+  $e ||= any { any { $_->{excused} } ($_->{atomics} // [])->@* } @$md;
+  $e ||= any { $_->{excused} } @$sd;
+  $line->{excused} = 1 if $e;
+}
+
+sub line_pod_flags ($line, $pd) {
+  return unless @$pd;
+  $line->{pod}           = $pd;
+  $line->{pod_uncovered} = 1 if any { $_->{error} } @$pd;
+  $line->{pod_excused}   = 1 if any { $_->{excused} } @$pd;
+  $line->{pod_stale}     = 1 if any { $_->{covered} && $_->{error} } @$pd;
+}
+
+sub line_stale ($line, $bd, $cd, $tts, $sd, $md) {
+  my $s;
+  $s ||= $line->{stmt_stale} || $line->{pod_stale};
+  $s ||= any { $_->{has_stale} } @$bd;
+  $s ||= any { any { $_->{covered} && $_->{error} } $_->{parts}->@* } @$cd;
+  $s ||= any { any { $_->{covered} && $_->{error} } $_->{rows}->@* } @$tts;
+  $s ||= any { any { $_->{stale} } ($_->{atomics} // [])->@* } @$md;
+  $s ||= any { $_->{covered} && $_->{error} } @$sd;
+  $line->{stale} = 1 if $s;
 }
 
 sub read_source ($file) {
@@ -1137,22 +1296,20 @@ sub build_source_lines ($file) {
     $line{subroutines} = \@sd if @sd;
 
     my @pd = line_pod($f, $n);
-    if (@pd) {
-      $line{pod}           = \@pd;
-      $line{pod_uncovered} = 1 if any { !$_->{covered} } @pd;
-    }
+    line_pod_flags(\%line, \@pd);
 
     line_partial(\%line, \@bd, \@cd, \@tts, \@sd, \@md);
+    line_excused(\%line, \@bd, \@cd, \@tts, \@sd, \@md);
+    line_stale(\%line, \@bd, \@cd, \@tts, \@sd, \@md);
 
     my @errors;
-    push @errors, "branch"
-      if any { $_->{true_count} == 0 || $_->{false_count} == 0 } @bd;
+    push @errors, "branch" if any { $_->{has_error} } @bd;
     push @errors, "condition" if any {
-      any { !$_->{covered} }
+      any { $_->{error} }
         $_->{rows}->@*
     } @tts;
     push @errors, "mcdc"       if any { $_->{error} } @md;
-    push @errors, "subroutine" if any { !$_->{covered} } @sd;
+    push @errors, "subroutine" if any { $_->{error} } @sd;
     push @errors, "pod"        if $line{pod_uncovered};
     $line{errors} = join ",", @errors if @errors;
 
@@ -1535,6 +1692,16 @@ $Assets{css} = $Crisp_base_css . <<'CSS';
 
 .help-panel .help-close:hover { color: var(--fg); }
 
+.help-panel .legend-swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 1px solid;
+  border-radius: 3px;
+  vertical-align: -2px;
+  margin-right: 6px;
+}
+
 /* Common prefix */
 
 .common-prefix {
@@ -1856,6 +2023,7 @@ tr.dir-file td:first-child a {
 .exec-0 { background: var(--cov-none-bg); }
 .exec-partial { background: var(--cov-low-bg); }
 .exec-covered { background: var(--cov-full-bg); }
+.exec-excused { background: var(--cov-excused-bg); }
 
 .src {
   white-space: pre;
@@ -1932,6 +2100,21 @@ td.chevron {
 .detail th { background: var(--header-bg); }
 .detail .c0 { background: var(--cov-none-bg); }
 .detail .c3 { background: var(--cov-full-bg); }
+.detail .cx { background: var(--cov-excused-bg); }
+
+/* Hatch marks a construct carrying an uncoverable marker */
+.exec-excused,
+.detail td.cx, .detail span.cx, .detail tr.cx > td,
+.mcdc-pill.cx, .legend-swatch.cx {
+  background-image: repeating-linear-gradient(45deg, transparent 0 5px,
+    color-mix(in srgb, var(--cov-excused-border) 30%, transparent) 5px 7px);
+}
+.count.mk,
+.detail td.mk, .detail span.mk, .detail tr.mk > td,
+.mcdc-pill.mk, .legend-swatch.mk {
+  background-image: repeating-linear-gradient(45deg, transparent 0 5px,
+    color-mix(in srgb, var(--cov-none-border) 30%, transparent) 5px 7px);
+}
 
 .detail.cond-cells { border-left: 3px solid var(--panel-cond); }
 .detail.mcdc-detail { border-left: 3px solid var(--panel-mcdc); }
@@ -2636,6 +2819,8 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
             ctx.fillStyle = gp("--cov-good-border");
           else if (cov === "1")
             ctx.fillStyle = gp("--cov-full-border");
+          else if (cov === "3")
+            ctx.fillStyle = gp("--cov-excused-border");
           else continue;
           var y = Math.floor(i * scale);
           ctx.fillRect(0, y, 12, Math.max(1, Math.ceil(scale)));

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -639,7 +639,6 @@ sub count_cell ($line, $cov_defined) {
   my $cls  = "count";
   if ($exec eq "exec-0" || $line->{stale}) {
     $cls .= " exec-0";
-    $cls .= " mk" if $line->{stale};
   } elsif ($line->{partial}) {
     $cls .= " exec-partial"
   } elsif ($line->{pod_uncovered}) {
@@ -649,6 +648,10 @@ sub count_cell ($line, $cov_defined) {
   } elsif ($exec) {
     $cls .= " $exec"
   }
+
+  # exec-excused hatches via its own CSS rule
+  $cls .= " mk" if ($line->{stale} || $line->{excused}) && $cls !~ /excused/;
+
   my $aria
     = !$cov_defined         ? "no coverage data"
     : $line->{stmt_excused} ? "marked uncoverable"
@@ -793,6 +796,8 @@ condition, or subroutine detail.</dd>
 on the line is uncovered<br>
 <span class="legend-swatch c0"></span> uncovered<br>
 <span class="legend-swatch cx"></span> excused - marked uncoverable<br>
+<span class="legend-swatch c1 mk"></span> partial, with an uncoverable
+marker on the line<br>
 <span class="legend-swatch c0 mk"></span> marked uncoverable but ran
 </dd>
 <dt>Minimap</dt>
@@ -2114,6 +2119,11 @@ td.chevron {
 .mcdc-pill.mk, .legend-swatch.mk {
   background-image: repeating-linear-gradient(45deg, transparent 0 5px,
     color-mix(in srgb, var(--cov-none-border) 30%, transparent) 5px 7px);
+}
+.count.exec-partial.mk,
+.legend-swatch.c1.mk {
+  background-image: repeating-linear-gradient(45deg, transparent 0 5px,
+    color-mix(in srgb, var(--cov-low-border) 30%, transparent) 5px 7px);
 }
 
 .detail.cond-cells { border-left: 3px solid var(--panel-cond); }

--- a/lib/Devel/Cover/Report/Json.pm
+++ b/lib/Devel/Cover/Report/Json.pm
@@ -14,12 +14,13 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
-use Devel::Cover::Criterion    ();
-use Devel::Cover::DB::IO::JSON ();
-use Devel::Cover::Inc          ();
-use Devel::Cover::Log          qw( dcinfo );
-use Devel::Cover::Truth_Table  ();
-use Getopt::Long               qw( GetOptions );
+use Devel::Cover::Condition_table ();
+use Devel::Cover::Criterion       ();
+use Devel::Cover::DB              ();
+use Devel::Cover::DB::IO::JSON    ();
+use Devel::Cover::Inc             ();
+use Devel::Cover::Log             qw( dcinfo );
+use Getopt::Long                  qw( GetOptions );
 
 sub _runs ($db) {
   my @runs;
@@ -97,29 +98,36 @@ sub _conditions ($f) {
   \%out
 }
 
+sub _truth_table ($table) {
+  # An unproven synthesis may not present its rows as covered
+  my $proven = $table->proven;
+  my @rows   = map +{
+    inputs      => $_->inputs,
+    result      => $_->result + 0,
+    covered     => $proven && $_->covered ? 1 : 0,
+    uncoverable => $_->uncoverable        ? 1 : 0,
+    },
+    $table->rows;
+  my $errors = grep {
+    Devel::Cover::Criterion->err_chk($_->{covered}, $_->{uncoverable})
+  } @rows;
+  +{
+    expr       => $table->expr,
+    percentage => @rows ? 100 - $errors * 100 / @rows : 100,
+    rows       => \@rows,
+  }
+}
+
 sub _condition_truth_tables ($f) {
   my $criterion = $f->condition or return undef;
   my %out;
   for my $line (sort { $a <=> $b } $criterion->items) {
-    my @tables = $criterion->truth_table($line);
-    next unless @tables;
-    $out{$line} = [
-      map {
-        my ($tt, $expr) = $_->@*;
-        +{
-          expr       => $expr,
-          percentage => $tt->percentage + 0,
-          rows       => [
-            map +{
-              inputs  => [$_->inputs],
-              result  => $_->result + 0,
-              covered => $_->covered ? 1 : 0,
-            },
-            @$tt,
-          ],
-        };
-      } @tables
-    ];
+    my $loc = $criterion->location($line);
+    next unless $loc && @$loc;
+    my @observed = map Devel::Cover::DB::observed_vectors($_), @$loc;
+    my @tables   = map _truth_table($_), grep !$_->too_wide,
+      Devel::Cover::Condition_table->for_line($loc, \@observed);
+    $out{$line} = \@tables if @tables;
   }
   \%out
 }
@@ -221,8 +229,10 @@ sub report ($pkg, $db, $options) {
     $files{$file} = $entry;
   }
 
+  no warnings "once";
   my $data = {
     devel_cover_version => $Devel::Cover::Inc::VERSION,
+    ignore_covered_err  => $Devel::Cover::Ignore_covered_err ? 1 : 0,
     runs                => _runs($db),
     summary             => $db->{summary},
     files               => \%files,
@@ -289,6 +299,12 @@ C<cover_db/>). The top-level keys are:
 
 The version of Devel::Cover that produced the file.
 
+=item ignore_covered_err
+
+Whether the C<-ignore_covered_err> option was in force, as 1 or 0.  It
+records the rule behind every C<error> field, so consumers can interpret
+them (see below).
+
 =item runs
 
 Array of run metadata objects, identical to the C<json_summary> report output.
@@ -310,6 +326,31 @@ C<condition_truth_tables>, C<mcdc>, C<subroutines>, C<pod>, C<time>.  Within
 each criterion, keys are source line numbers and values are arrays of coverage
 objects for that line.
 
+Each coverage object carries C<covered>, C<uncoverable> and C<error> fields.
+For statements, subroutines and pod these are single values.  For branches,
+conditions and mcdc, C<covered> and C<uncoverable> are arrays with one entry
+per direction, outcome or atomic condition, and C<error> is 1 when any entry
+errors.  A construct is in one of four states:
+
+  covered  uncoverable  error  state
+  -------  -----------  -----  ------------------------------------
+        1            0      0  covered
+        0            0      1  uncovered
+        0            1      0  excused (marked uncoverable)
+        1            1      1  marked uncoverable but ran
+
+Under C<-ignore_covered_err> the last combination is forgiven and its
+C<error> is 0 - the top-level C<ignore_covered_err> key says which rule was
+used.
+
+A C<condition_truth_tables> row carries C<inputs> (C<0>, C<1>, or C<"X"> for
+an operand never evaluated because an earlier operand short-circuited),
+the decision C<result>, C<covered>, and C<uncoverable> for a row excused by
+an uncoverable marker.  Rows synthesised for a compound decision whose input
+combinations were never observed together read as uncovered.  The table
+C<percentage> is error-based, so an excused row does not count against it.
+A decision too wide to analyse has no truth table.
+
 An C<mcdc> entry for a decision too wide to analyse (more conditions than the
 per-decision limit) carries C<"unanalysed": 1>; its C<covered> array is all
 zeroes.  The key is absent for analysed decisions, distinguishing "too wide
@@ -321,6 +362,7 @@ Example structure:
 
   {
     "devel_cover_version": "1.53",
+    "ignore_covered_err": 0,
     "runs": [ { "run": "...", "perl": "5.38.0", ... } ],
     "summary": {
       "Total":          { "statement": { "covered": 95, "total": 100,
@@ -341,8 +383,9 @@ Example structure:
                                     "error": 1 } ] },
         "condition_truth_tables": {
           "30": [ { "expr": "$x && $y", "percentage": 50,
-                    "rows": [ { "inputs": [0,0], "result": 0,
-                                "covered": 1 } ] } ] },
+                    "rows": [ { "inputs": [0,"X"], "result": 0,
+                                "covered": 1,
+                                "uncoverable": 0 } ] } ] },
         "mcdc":        { "30": [ { "text": "$x && $y",
                                     "labels": ["$x","$y"],
                                     "covered": [1,0], "uncoverable": [0,0],

--- a/lib/Devel/Cover/Report/Nvim.pm
+++ b/lib/Devel/Cover/Report/Nvim.pm
@@ -60,8 +60,10 @@ local M = {}
 local config = {
   -- Colours
   cover_fg = vim.g.devel_cover_fg or "Green",
+  uncoverable_fg = vim.g.devel_cover_uncoverable_fg or "Grey",
   error_fg = vim.g.devel_cover_error_fg or "Red",
   cover_bg = vim.g.devel_cover_bg or nil,
+  uncoverable_bg = vim.g.devel_cover_uncoverable_bg or nil,
   error_bg = vim.g.devel_cover_error_bg or nil,
   valid_bg = vim.g.devel_cover_valid_bg or nil,
   old_bg = vim.g.devel_cover_old_bg or nil,
@@ -78,6 +80,7 @@ local config = {
 
   -- Line highlight groups
   linehl_cover = vim.g.devel_cover_linehl or "cov",
+  linehl_uncoverable = vim.g.devel_cover_linehl_uncoverable or "unc",
   linehl_error = vim.g.devel_cover_linehl_error or "err",
 
   -- Additional highlight options
@@ -105,6 +108,16 @@ local function create_highlight_groups()
     end
     vim.api.nvim_set_hl(0, "cov_" .. type_name, hl_opts)
 
+    -- Uncoverable (excused) highlight
+    local unc_hl_opts = {
+      fg = config.uncoverable_fg,
+      bold = config.cterm == "bold" or config.gui == "bold",
+    }
+    if config.uncoverable_bg then
+      unc_hl_opts.bg = config.uncoverable_bg
+    end
+    vim.api.nvim_set_hl(0, "cov_" .. type_name .. "_uncoverable", unc_hl_opts)
+
     -- Error coverage highlight
     local err_hl_opts = {
       fg = config.error_fg,
@@ -120,9 +133,14 @@ end
 -- Create highlight groups
 create_highlight_groups()
 
--- Create line highlight groups for covered/error lines
+-- Create line highlight groups for covered/uncoverable/error lines
 if config.cover_bg then
   vim.api.nvim_set_hl(0, config.linehl_cover, { bg = config.cover_bg })
+end
+if config.uncoverable_bg then
+  vim.api.nvim_set_hl(
+    0, config.linehl_uncoverable, { bg = config.uncoverable_bg }
+  )
 end
 if config.error_bg then
   vim.api.nvim_set_hl(0, config.linehl_error, { bg = config.error_bg })
@@ -139,6 +157,13 @@ local function create_sign_definitions()
       text = config.signs[type_name],
       linehl = config.linehl_cover,
       texthl = "cov_" .. type_name
+    })
+
+    -- Uncoverable (excused) sign
+    vim.fn.sign_define(type_name .. "_uncoverable", {
+      text = config.signs[type_name],
+      linehl = config.linehl_uncoverable,
+      texthl = "cov_" .. type_name .. "_uncoverable"
     })
 
     -- Error coverage sign
@@ -186,6 +211,18 @@ function M.set_background(bg)
     }
     vim.api.nvim_set_hl(0, "cov_" .. type_name, new_hl)
 
+    -- Get existing highlight and create new options table for uncoverable
+    local unc_hl =
+      vim.api.nvim_get_hl(0, { name = "cov_" .. type_name .. "_uncoverable" })
+    local new_unc_hl = {
+      fg = unc_hl.fg,
+      bg = bg,
+      bold = unc_hl.bold,
+      italic = unc_hl.italic,
+      underline = unc_hl.underline,
+    }
+    vim.api.nvim_set_hl(0, "cov_" .. type_name .. "_uncoverable", new_unc_hl)
+
     -- Get existing highlight and create new options table for error coverage
     local err_hl =
       vim.api.nvim_get_hl(0, { name = "cov_" .. type_name .. "_error" })
@@ -206,6 +243,13 @@ function M.set_background(bg)
       text = config.signs[type_name],
       linehl = config.linehl_cover,
       texthl = "cov_" .. type_name
+    })
+
+    -- Uncoverable (excused) sign
+    vim.fn.sign_define(type_name .. "_uncoverable", {
+      text = config.signs[type_name],
+      linehl = config.linehl_uncoverable,
+      texthl = "cov_" .. type_name .. "_uncoverable"
     })
 
     -- Error coverage sign
@@ -230,16 +274,23 @@ end
 
 local types = {
 [%- FOREACH type = types -%] "[%- type -%]",[%- END -%]
+[%- FOREACH type = types -%] "[%- type -%]_uncoverable",[%- END -%]
 [%- FOREACH type = types -%] "[%- type -%]_error",[%- END -%]
 }
 
-[%- MACRO criterion(file, crit, error) BLOCK %]
-      [% crit %][% error ? "_error" : "" %] = {
+[%- MACRO criterion(file, crit, state) BLOCK -%]
+[%- suffix = state == "error"       ? "_error"
+           : state == "uncoverable" ? "_uncoverable"
+           :                          "" %]
+      [% crit %][% suffix %] = {
     [%- criteria = cover.file("$file").$crit -%]
     [%- FOREACH loc = criteria.items.nsort -%]
         [%- cov = 0 -%]
         [%- FOREACH l = criteria.location("$loc") -%]
-            [%- IF error ? l.error : l.covered -%]
+            [%- hit = state == "error"       ? l.error
+                    : state == "uncoverable" ? l.uncoverable && !l.error
+                    :                          l.covered -%]
+            [%- IF hit -%]
                 [% loc -%],[%- cov = 1; LAST -%]
             [%- END -%]
         [%- LAST IF cov; END -%]
@@ -251,8 +302,9 @@ local coverage = {
 [% FOREACH file = files %]
   ["[% file %]"] = {
 [%- FOREACH type = types -%]
-[%- criterion(file, type, 0) -%]
-[%- criterion(file, type, 1) -%]
+[%- criterion(file, type, "covered") -%]
+[%- criterion(file, type, "uncoverable") -%]
+[%- criterion(file, type, "error") -%]
 [%- END %]
   },
 [% END %]
@@ -456,8 +508,10 @@ The signs are as follows:
 
 The last of the criteria, in the order given above, is the one which is
 displayed.  Correctly covered criteria are shown in green.  Incorrectly
-covered criteria are shown in red.  Any incorrectly covered criterion will
-override a correctly covered criterion.
+covered criteria are shown in red.  Criteria marked uncoverable which did
+not run are shown in grey.  A red criterion overrides a grey one, and a
+grey one overrides a green one.  Code which runs despite an uncoverable
+marker is an error and is shown in red.
 
 If the coverage for the file being displayed is out of date the function
 called coverage_old() is called and passed the name of the file.  Similarly,
@@ -468,19 +522,22 @@ your init.lua or init.vim file before loading the coverage script.
 
 Available configuration variables:
 
- vim.g.devel_cover_fg            -- Covered foreground (default: "Green")
- vim.g.devel_cover_error_fg      -- Uncovered foreground (default: "Red")
- vim.g.devel_cover_bg            -- Covered background (default: nil)
- vim.g.devel_cover_error_bg      -- Uncovered background (default: nil)
- vim.g.devel_cover_valid_bg      -- Current-coverage background (default: nil)
- vim.g.devel_cover_old_bg        -- Old-coverage background (default: nil)
- vim.g.devel_cover_cterm         -- Terminal styling (default: "bold")
- vim.g.devel_cover_gui           -- GUI styling (default: "bold")
- vim.g.devel_cover_linehl        -- Covered line highlight (default: "cov")
- vim.g.devel_cover_linehl_error  -- Error line highlight (default: "err")
- vim.g.devel_cover_signs         -- Custom sign text table
- vim.g.devel_cover_sign_group    -- Sign group name (default: "DevelCover")
- vim.g.devel_cover_sign_priority -- Sign priority (default: 1)
+ vim.g.devel_cover_fg             -- Covered foreground (default: "Green")
+ vim.g.devel_cover_uncoverable_fg -- Excused foreground (default: "Grey")
+ vim.g.devel_cover_error_fg       -- Uncovered foreground (default: "Red")
+ vim.g.devel_cover_bg             -- Covered background (default: nil)
+ vim.g.devel_cover_uncoverable_bg -- Excused background (default: nil)
+ vim.g.devel_cover_error_bg       -- Uncovered background (default: nil)
+ vim.g.devel_cover_valid_bg       -- Current-coverage background (default: nil)
+ vim.g.devel_cover_old_bg         -- Old-coverage background (default: nil)
+ vim.g.devel_cover_cterm          -- Terminal styling (default: "bold")
+ vim.g.devel_cover_gui            -- GUI styling (default: "bold")
+ vim.g.devel_cover_linehl         -- Covered line highlight (default: "cov")
+ vim.g.devel_cover_linehl_uncoverable -- Excused lines (default: "unc")
+ vim.g.devel_cover_linehl_error   -- Error line highlight (default: "err")
+ vim.g.devel_cover_signs          -- Custom sign text table
+ vim.g.devel_cover_sign_group     -- Sign group name (default: "DevelCover")
+ vim.g.devel_cover_sign_priority  -- Sign priority (default: 1)
 
 Example configuration for solarized theme in init.lua:
 

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -506,6 +506,14 @@ subroutine metrics with inline source listing.  When files share a long common
 directory prefix, the prefix is stripped and only the distinguishing suffixes
 are shown.
 
+A value is prefixed with "-" when an uncoverable marker is involved and with
+"*" when the construct is in error, and a line holding an error is flagged
+with "***" in the err column.  Percentages are error-based, computed as 100 -
+errors * 100 / total, so excused constructs do not reduce them.  Excused
+subroutines are listed under the "Uncoverable Subroutines" heading, and a
+covered subroutine whose marker is stale stays under "Covered Subroutines"
+with a "*" prefix on its counts.
+
 It is designed to be called from the C<cover> program.
 
 =head1 SUBROUTINES

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -385,6 +385,11 @@ sub _update_maxw ($maxw, %vals) {
   }
 }
 
+sub _flagged_count ($o) {
+  my $v = ($o->uncoverable ? "-" : "") . $o->covered;
+  $o->uncoverable && $o->error ? "*$v" : $v
+}
+
 sub _gather_subs ($dfile, $pods, $display_name, $scar_lookup) {
   my $subs = $dfile->subroutine or return;
   my %maxw = (h => 8, c => 5, p => 3, s => 10, cc => 3, cr => 5);
@@ -396,9 +401,9 @@ sub _gather_subs ($dfile, $pods, $display_name, $scar_lookup) {
     my $d = $pods && $pods->location($location);
     for my $sub (@$l) {
       my $h = "$display_name:$location";
-      my $c = ($sub->uncoverable ? "-" : "") . $sub->covered;
+      my $c = _flagged_count($sub);
       my $e = $pods && shift @$d;
-      my $p = $e ? ($e->uncoverable ? "-" : "") . $e->covered : "";
+      my $p = $e ? _flagged_count($e) : "";
       my $s = $sub->name;
 
       my $info = $scar_lookup->{"$location\0$s"};
@@ -408,7 +413,10 @@ sub _gather_subs ($dfile, $pods, $display_name, $scar_lookup) {
       _update_maxw(\%maxw, h => $h, c => $c, s => $s, cc => $cc, cr => $cr);
       $maxw{p} = length $p if $p && length $p > $maxw{p};
 
-      my $type = $sub->covered ? "covered" : "uncovered";
+      my $type
+        = $sub->covered     ? "covered"
+        : $sub->uncoverable ? "uncoverable"
+        :                     "uncovered";
       push $by_type{$type}{$s}->@*,
         [$c, $pods ? $p : (), $has_scar ? ($cc, $cr) : (), $h];
     }
@@ -537,8 +545,9 @@ decision's source text.
 
 =head2 print_subroutines ($db, $file, $options, $short)
 
-Print covered and uncovered subroutine tables for C<$file>, including call
-counts, pod coverage, and source location.
+Print subroutine tables for C<$file>, including call counts, pod coverage,
+and source location. Subroutines are bucketed by state: covered, uncoverable
+(uncovered but marked uncoverable), and uncovered.
 
 =head1 PRIVATE SUBROUTINES
 
@@ -573,12 +582,18 @@ output lines are produced when a single source line has several coverage points
 Update column-width hash C<$maxw> in place: for each key in C<%vals>, set
 C<< $maxw->{$k} >> to the value's length if it exceeds the current maximum.
 
+=head2 _flagged_count ($o)
+
+Format a subroutine or pod count, prefixing C<-> for uncoverable entries and
+C<*> when the uncoverable marker is stale - the construct is marked
+uncoverable yet covered.
+
 =head2 _gather_subs ($dfile, $pods, $display_name, $scar_lookup)
 
 Walk the subroutine and pod coverage data for a file, returning a hashref of
-covered/uncovered sub entries and a hashref of column widths for formatting.
-When C<$scar_lookup> is non-empty, CC and SCAR values are included in each
-entry.
+covered/uncoverable/uncovered sub entries and a hashref of column widths for
+formatting. When C<$scar_lookup> is non-empty, CC and SCAR values are included
+in each entry.
 
 =head1 SEE ALSO
 

--- a/lib/Devel/Cover/Report/Vim.pm
+++ b/lib/Devel/Cover/Report/Vim.pm
@@ -73,6 +73,13 @@ highlight cov_condition_error  ctermfg=Red   cterm=bold gui=bold guifg=Red
 highlight cov_mcdc             ctermfg=Green cterm=bold gui=bold guifg=Green
 highlight cov_mcdc_error       ctermfg=Red   cterm=bold gui=bold guifg=Red
 
+highlight cov_pod_uncoverable        ctermfg=Grey cterm=bold gui=bold guifg=Grey
+highlight cov_subroutine_uncoverable ctermfg=Grey cterm=bold gui=bold guifg=Grey
+highlight cov_statement_uncoverable  ctermfg=Grey cterm=bold gui=bold guifg=Grey
+highlight cov_branch_uncoverable     ctermfg=Grey cterm=bold gui=bold guifg=Grey
+highlight cov_condition_uncoverable  ctermfg=Grey cterm=bold gui=bold guifg=Grey
+highlight cov_mcdc_uncoverable       ctermfg=Grey cterm=bold gui=bold guifg=Grey
+
 sign define pod              linehl=cov texthl=cov_pod              text=P
 sign define pod_error        linehl=err texthl=cov_pod_error        text=P
 sign define subroutine       linehl=cov texthl=cov_subroutine       text=R
@@ -85,6 +92,19 @@ sign define condition        linehl=cov texthl=cov_condition        text=C
 sign define condition_error  linehl=err texthl=cov_condition_error  text=C
 sign define mcdc             linehl=cov texthl=cov_mcdc             text=M
 sign define mcdc_error       linehl=err texthl=cov_mcdc_error       text=M
+
+sign define pod_uncoverable
+    \ linehl=unc texthl=cov_pod_uncoverable text=P
+sign define subroutine_uncoverable
+    \ linehl=unc texthl=cov_subroutine_uncoverable text=R
+sign define statement_uncoverable
+    \ linehl=unc texthl=cov_statement_uncoverable text=S
+sign define branch_uncoverable
+    \ linehl=unc texthl=cov_branch_uncoverable text=B
+sign define condition_uncoverable
+    \ linehl=unc texthl=cov_condition_uncoverable text=C
+sign define mcdc_uncoverable
+    \ linehl=unc texthl=cov_mcdc_uncoverable text=M
 
 function! CoverageOld(filename)
 endfunction
@@ -101,6 +121,7 @@ endfunction
 "----------------------------------------------------------------------------
 "
 "  let s:fg_cover = "#859900"
+"  let s:fg_uncov = "#586e75"
 "  let s:fg_error = "#dc322f"
 "  let s:bg_valid = "#073642"
 "  let s:bg_old   = "#342a2a"
@@ -111,6 +132,8 @@ endfunction
 "  for s:type in s:types
 "    exe "highlight cov_" . s:type
 "      \ . " ctermbg=0 cterm=bold gui=NONE guifg=" . s:fg_cover
+"    exe "highlight cov_" . s:type . "_uncoverable"
+"      \ . " ctermbg=0 cterm=bold gui=NONE guifg=" . s:fg_uncov
 "    exe "highlight cov_" . s:type . "_error"
 "      \ . " ctermbg=0 cterm=bold gui=NONE guifg=" . s:fg_error
 "  endfor
@@ -122,6 +145,7 @@ endfunction
 "  function! s:set_bg(bg)
 "    for s:type in s:types
 "      exe "highlight cov_" . s:type .       " guibg=" . a:bg
+"      exe "highlight cov_" . s:type . "_uncoverable guibg=" . a:bg
 "      exe "highlight cov_" . s:type . "_error guibg=" . a:bg
 "    endfor
 "    exe "highlight SignColumn ctermbg=0 guibg=" . a:bg
@@ -145,16 +169,23 @@ endif
 
 let s:types = [
 [%- FOREACH type = types -%] "[%- type -%]",[%- END -%]
+[%- FOREACH type = types -%] "[%- type -%]_uncoverable",[%- END -%]
 [%- FOREACH type = types -%] "[%- type -%]_error",[%- END -%]
 ]
 
-[%- MACRO criterion(file, crit, error) BLOCK %]
-\    '[% crit %][% error ? "_error" : "" %]': [
+[%- MACRO criterion(file, crit, state) BLOCK -%]
+[%- suffix = state == "error"       ? "_error"
+           : state == "uncoverable" ? "_uncoverable"
+           :                          "" %]
+\    '[% crit %][% suffix %]': [
   [%- criteria = cover.file("$file").$crit -%]
   [%- FOREACH loc = criteria.items.nsort -%]
     [%- cov = 0 -%]
     [%- FOREACH l = criteria.location("$loc") -%]
-      [%- IF error ? l.error : l.covered -%]
+      [%- hit = state == "error"       ? l.error
+              : state == "uncoverable" ? l.uncoverable && !l.error
+              :                          l.covered -%]
+      [%- IF hit -%]
         [% loc -%],[%- cov = 1; LAST -%]
       [%- END -%]
     [%- LAST IF cov; END -%]
@@ -168,8 +199,9 @@ let s:coverage =
 \  '[% file %]':
 \  {
 [%- FOREACH type = types -%]
-[%- criterion(file, type, 0) -%]
-[%- criterion(file, type, 1) -%]
+[%- criterion(file, type, "covered") -%]
+[%- criterion(file, type, "uncoverable") -%]
+[%- criterion(file, type, "error") -%]
 [%- END %]
 \  },
 \[% END %]
@@ -306,8 +338,10 @@ The signs are as follows:
 
 The last of the criteria, in the order given above, is the one which is
 displayed.  Correctly covered criteria are shown in green.  Incorrectly
-covered criteria are shown in red.  Any incorrectly covered criterion will
-override a correctly covered criterion.
+covered criteria are shown in red.  Criteria marked uncoverable which did
+not run are shown in grey.  A red criterion overrides a grey one, and a
+grey one overrides a green one.  Code which runs despite an uncoverable
+marker is an error and is shown in red.
 
 If the coverage for the file being displayed is out of date the function
 called CoverageOld() is called and passed the name of the file.  Similarly,
@@ -320,6 +354,7 @@ For example, I use the solarized theme and keep the following commands in my
 local configuration file ~/.vim/local/devel-cover.vim:
 
  let s:fg_cover = "#859900"
+ let s:fg_uncov = "#586e75"
  let s:fg_error = "#dc322f"
  let s:bg_valid = "#073642"
  let s:bg_old   = "#342a2a"
@@ -330,6 +365,8 @@ local configuration file ~/.vim/local/devel-cover.vim:
  for s:type in s:types
    exe "highlight cov_" . s:type
        \ . " ctermbg=1 cterm=bold gui=NONE guifg=" . s:fg_cover
+   exe "highlight cov_" . s:type . "_uncoverable"
+       \ . " ctermbg=1 cterm=bold gui=NONE guifg=" . s:fg_uncov
    exe "highlight cov_" . s:type . "_error"
        \ . " ctermbg=1 cterm=bold gui=NONE guifg=" . s:fg_error
  endfor
@@ -341,6 +378,7 @@ local configuration file ~/.vim/local/devel-cover.vim:
  function! s:set_bg(bg)
    for s:type in s:types
      exe "highlight cov_" . s:type .       " guibg=" . a:bg
+     exe "highlight cov_" . s:type . "_uncoverable guibg=" . a:bg
      exe "highlight cov_" . s:type . "_error guibg=" . a:bg
    endfor
    exe "highlight SignColumn ctermbg=0 guibg=" . a:bg

--- a/lib/Devel/Cover/Statement.pm
+++ b/lib/Devel/Cover/Statement.pm
@@ -20,7 +20,7 @@ sub val         ($self) { $self->[0] }
 sub uncoverable ($self) { $self->[1] }
 sub covered     ($self) { $self->[0] }
 sub total       ($self) { 1 }
-sub percentage  ($self) { $self->[0] ? 100 : 0 }
+sub percentage  ($self) { $self->error ? 0 : 100 }
 sub error       ($self) { $self->simple_error }
 sub criterion   ($self) { "statement" }
 

--- a/lib/Devel/Cover/Subroutine.pm
+++ b/lib/Devel/Cover/Subroutine.pm
@@ -19,7 +19,7 @@ use base "Devel::Cover::Criterion";
 sub uncoverable ($self) { $self->[2] }
 sub covered     ($self) { $self->[0] }
 sub total       ($self) { 1 }
-sub percentage  ($self) { $self->[0] ? 100 : 0 }
+sub percentage  ($self) { $self->error ? 0 : 100 }
 sub error       ($self) { $self->simple_error }
 sub name        ($self) { $self->[1] }
 sub criterion   ($self) { "subroutine" }

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -26,14 +26,14 @@ our $Cov = {
     low     => { bg => "#f9dfa0", border => "#c08820", fg => "#7a5810" },
     good    => { bg => "#b3ddff", border => "#2f7db1", fg => "#164666" },
     full    => { bg => "#c0f1be", border => "#008800", fg => "#005500" },
-    excused => { bg => "#b3ddff", border => "#2f7db1", fg => "#164666" },
+    excused => { bg => "#c0f1be", border => "#008800", fg => "#005500" },
   },
   dark => {
     none    => { bg => "#7e0b12", border => "#ff4444", fg => "#ffcccc" },
     low     => { bg => "#5f4a08", border => "#e0a830", fg => "#f0d888" },
     good    => { bg => "#0d527c", border => "#64b7ef", fg => "#a0d6fa" },
     full    => { bg => "#0c5e0e", border => "#44dd44", fg => "#bbffbb" },
-    excused => { bg => "#0d527c", border => "#64b7ef", fg => "#a0d6fa" },
+    excused => { bg => "#0c5e0e", border => "#44dd44", fg => "#bbffbb" },
   },
 };
 

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -138,6 +138,8 @@ pre,.s {
  *   c1  : coverage >= 75%
  *   c2  : coverage >= 90%
  *   c3  : path covered or coverage = 100%
+ *   cx  : uncoverable code, not covered (excused)
+ *   mk  : uncoverable marker on covered code
  */
 .c0 {
   background-color :           #ff9999;
@@ -154,6 +156,18 @@ pre,.s {
 .c3 {
   background-color :           #99ff99;
   border           : solid 1px #009900;
+}
+.cx {
+  background-color :           #99ff99;
+  border           : solid 1px #009900;
+  background-image : repeating-linear-gradient(45deg,
+    transparent 0px, transparent 5px,
+    rgba(0, 153, 0, 0.3) 5px, rgba(0, 153, 0, 0.3) 7px);
+}
+.mk {
+  background-image : repeating-linear-gradient(45deg,
+    transparent 0px, transparent 5px,
+    rgba(204, 0, 0, 0.3) 5px, rgba(204, 0, 0, 0.3) 7px);
 }
 EOF
 

--- a/lib/Devel/Cover/Web.pm
+++ b/lib/Devel/Cover/Web.pm
@@ -22,16 +22,18 @@ our @EXPORT_OK = qw( write_file $Cov $Crisp_base_css $Crisp_theme_js );
 
 our $Cov = {
   light => {
-    none => { bg => "#fdd5d1", border => "#dd0000", fg => "#990000" },
-    low  => { bg => "#f9dfa0", border => "#c08820", fg => "#7a5810" },
-    good => { bg => "#b3ddff", border => "#2f7db1", fg => "#164666" },
-    full => { bg => "#c0f1be", border => "#008800", fg => "#005500" },
+    none    => { bg => "#fdd5d1", border => "#dd0000", fg => "#990000" },
+    low     => { bg => "#f9dfa0", border => "#c08820", fg => "#7a5810" },
+    good    => { bg => "#b3ddff", border => "#2f7db1", fg => "#164666" },
+    full    => { bg => "#c0f1be", border => "#008800", fg => "#005500" },
+    excused => { bg => "#b3ddff", border => "#2f7db1", fg => "#164666" },
   },
   dark => {
-    none => { bg => "#7e0b12", border => "#ff4444", fg => "#ffcccc" },
-    low  => { bg => "#5f4a08", border => "#e0a830", fg => "#f0d888" },
-    good => { bg => "#0d527c", border => "#64b7ef", fg => "#a0d6fa" },
-    full => { bg => "#0c5e0e", border => "#44dd44", fg => "#bbffbb" },
+    none    => { bg => "#7e0b12", border => "#ff4444", fg => "#ffcccc" },
+    low     => { bg => "#5f4a08", border => "#e0a830", fg => "#f0d888" },
+    good    => { bg => "#0d527c", border => "#64b7ef", fg => "#a0d6fa" },
+    full    => { bg => "#0c5e0e", border => "#44dd44", fg => "#bbffbb" },
+    excused => { bg => "#0d527c", border => "#64b7ef", fg => "#a0d6fa" },
   },
 };
 
@@ -40,7 +42,7 @@ sub _cov_vars ($theme, $indent) {
   join "", map {
     my $n = $_;
     map "$indent--cov-$n-$_: $c->{$n}{$_};\n", qw( bg border fg )
-  } qw( none low good full )
+  } qw( none low good full excused )
 }
 
 my %Files;
@@ -534,6 +536,11 @@ a:visited { color: var(--link-visited); }
   background: var(--cov-full-bg);
   border-color: var(--cov-full-border);
   color: var(--cov-full-fg);
+}
+.cx {
+  background: var(--cov-excused-bg);
+  border-color: var(--cov-excused-border);
+  color: var(--cov-excused-fg);
 }
 .na {
   background: var(--bg);

--- a/t/internal/compilation.t
+++ b/t/internal/compilation.t
@@ -17,7 +17,13 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
 use Test::More import => [qw( diag done_testing is is_deeply like )];
+use Devel::Cover::Branch              ();  ## no perlimports
+use Devel::Cover::Condition_and_2     ();  ## no perlimports
+use Devel::Cover::Mcdc                ();  ## no perlimports
+use Devel::Cover::Pod                 ();  ## no perlimports
 use Devel::Cover::Report::Compilation ();
+use Devel::Cover::Statement           ();  ## no perlimports
+use Devel::Cover::Subroutine          ();  ## no perlimports
 use Devel::Cover::Test::Showcase      qw(
   create_cover_db
   run_cover
@@ -58,17 +64,22 @@ sub test_compilation_report () {
 {
 
   package Mock::Item;
-  sub new     ($class) { bless {}, $class }
-  sub covered ($self)  { 0 }
-  sub name    ($self)  { "mock_sub" }
+  sub new         ($class) { bless {}, $class }
+  sub covered     ($self)  { 0 }
+  sub uncoverable ($self)  { 0 }
+  sub error       ($self)  { 1 }
+  sub name        ($self)  { "mock_sub" }
 }
 
 {
 
   package Mock::Criterion;
-  sub new   ($class, @locations) { bless { locations => \@locations }, $class }
-  sub items ($self)              { $self->{locations}->@* }
-  sub location ($self, $loc)     { [Mock::Item->new] }
+  sub new ($class, @locations) { bless { locations => \@locations }, $class }
+  sub items ($self) { map $_->[0], $self->{locations}->@* }
+
+  sub location ($self, $loc) {
+    [map $_->[1], grep { $_->[0] == $loc } $self->{locations}->@*]
+  }
 }
 
 {
@@ -76,6 +87,9 @@ sub test_compilation_report () {
   package Mock::File;
   sub new        ($class, $crit) { bless { crit => $crit }, $class }
   sub statement  ($self)         { $self->{crit} }
+  sub branch     ($self)         { $self->{crit} }
+  sub condition  ($self)         { $self->{crit} }
+  sub mcdc       ($self)         { $self->{crit} }
   sub subroutine ($self)         { $self->{crit} }
   sub pod        ($self)         { $self->{crit} }
 }
@@ -94,9 +108,8 @@ sub test_compilation_report () {
   sub cover ($self)          { $self->{cover} }
 }
 
-sub capture_lines ($print_sub) {
-  my $crit = Mock::Criterion->new(10, 2, 19, 7, 13);
-  my $db   = Mock::DB->new(Mock::Cover->new(Mock::File->new($crit)));
+sub capture_output ($print_sub, $crit) {
+  my $db = Mock::DB->new(Mock::Cover->new(Mock::File->new($crit)));
   my $output;
   {
     open my $fh, ">", \$output or die "Cannot open scalar ref: $!";
@@ -104,7 +117,12 @@ sub capture_lines ($print_sub) {
     $print_sub->($db, "Mock.pm", {});
     close $fh or die "Cannot close scalar ref: $!";
   }
-  [$output =~ /line (\d+)$/gm]
+  $output // ""
+}
+
+sub capture_lines ($print_sub) {
+  my $crit = Mock::Criterion->new(map [$_, Mock::Item->new], 10, 2, 19, 7, 13);
+  [capture_output($print_sub, $crit) =~ /line (\d+)$/gm]
 }
 
 # Hash order can coincidentally ascend, so feed a fixed non-ascending order.
@@ -121,9 +139,164 @@ sub test_lines_sorted () {
   }
 }
 
+sub stmt_obj ($covered, $uncoverable = 0) {
+  bless [$covered, $uncoverable], "Devel::Cover::Statement"
+}
+
+sub sub_obj ($covered, $name, $uncoverable = 0) {
+  bless [$covered, $name, $uncoverable], "Devel::Cover::Subroutine"
+}
+
+sub pod_obj ($covered, $uncoverable = 0) {
+  bless [$covered, undef, $uncoverable], "Devel::Cover::Pod"
+}
+
+sub branch_obj ($text, $values, $uncoverable = undef) {
+  bless [$values, { text => $text }, $uncoverable // [0, 0]],
+    "Devel::Cover::Branch"
+}
+
+sub cond_obj ($left, $right, $values, $uncoverable = undef) {
+  bless [
+    $values,
+    { left => $left, op => "&&", right => $right, type => "and_2" },
+    $uncoverable // [0, 0],
+    ],
+    "Devel::Cover::Condition_and_2"
+}
+
+sub mcdc_obj ($text, $values, $uncoverable = undef) {
+  bless [
+    $values,
+    { text => $text, labels => ["a", "b"] },
+    $uncoverable // [0, 0],
+    ],
+    "Devel::Cover::Mcdc"
+}
+
+sub lines (@lines) { join "", map "$_\n", @lines }
+
+# Each criterion has four states per construct: covered, uncovered, excused
+# (uncovered but marked uncoverable) and stale (covered but marked
+# uncoverable). Only uncovered and stale are errors and only they are
+# reported.
+sub test_statement_states () {
+  my $crit = Mock::Criterion->new(
+    [1, stmt_obj(1)],
+    [2, stmt_obj(0)],
+    [3, stmt_obj(0, 1)],
+    [4, stmt_obj(1, 1)],
+  );
+  is capture_output(\&Devel::Cover::Report::Compilation::print_statement,
+    $crit),
+    lines(
+      "Uncovered statement at Mock.pm line 2",
+      "Statement marked uncoverable but covered at Mock.pm line 4",
+    ),
+    "statement reports uncovered and stale, skips covered and excused";
+}
+
+sub test_subroutine_states () {
+  my $crit = Mock::Criterion->new(
+    [1, sub_obj(1, "alpha")],
+    [2, sub_obj(0, "beta")],
+    [3, sub_obj(0, "gamma", 1)],
+    [4, sub_obj(1, "delta", 1)],
+  );
+  is capture_output(
+    \&Devel::Cover::Report::Compilation::print_subroutines, $crit
+    ),
+    lines(
+      "Uncovered subroutine beta at Mock.pm line 2",
+      "Subroutine delta marked uncoverable but covered at Mock.pm line 4",
+    ),
+    "subroutine reports uncovered and stale, skips covered and excused";
+}
+
+sub test_pod_states () {
+  my $crit = Mock::Criterion->new(
+    [1, pod_obj(1)],
+    [2, pod_obj(0)],
+    [3, pod_obj(0, 1)],
+    [4, pod_obj(1, 1)],
+  );
+  is capture_output(\&Devel::Cover::Report::Compilation::print_pod, $crit),
+    lines(
+      "Uncovered pod at Mock.pm line 2",
+      "Pod marked uncoverable but covered at Mock.pm line 4",
+    ),
+    "pod reports uncovered and stale, skips covered and excused";
+}
+
+sub test_branch_states () {
+  my $crit = Mock::Criterion->new(
+    [1, branch_obj('if $a', [1, 1])],
+    [2, branch_obj('if $b', [1, 0])],
+    [3, branch_obj('if $c', [0, 0], [0, 1])],
+    [4, branch_obj('if $d', [0, 0])],
+    [5, branch_obj('if $e', [1, 1], [0, 1])],
+    [6, branch_obj('unless $f', [0, 1])],
+    [7, branch_obj('if $g', [0, 0], [1, 1])],
+  );
+  is capture_output(\&Devel::Cover::Report::Compilation::print_branches, $crit),
+    lines(
+      'Branch never false at Mock.pm line 2: $b',
+      'Branch never true at Mock.pm line 3: $c',
+      'Branch never reached at Mock.pm line 4: $d',
+      'Branch false marked uncoverable but covered at Mock.pm line 5: $e',
+      'Branch never false at Mock.pm line 6: $f',
+    ),
+    "branch skips excused directions and reports stale ones";
+}
+
+sub test_condition_states () {
+  my $crit = Mock::Criterion->new(
+    [1, cond_obj('$a', '$b', [1, 1])],
+    [2, cond_obj('$c', '$d', [0, 1])],
+    [3, cond_obj('$e', '$f', [0, 0], [1, 0])],
+    [4, cond_obj('$g', '$h', [1, 1], [1, 0])],
+    [5, cond_obj('$i', '$j', [0, 0], [1, 1])],
+  );
+  is capture_output(\&Devel::Cover::Report::Compilation::print_conditions,
+    $crit),
+    lines(
+      'Uncovered condition (!l) at Mock.pm line 2: $c && $d',
+      'Uncovered condition (l) at Mock.pm line 3: $e && $f',
+      "Condition (!l) marked uncoverable but covered at Mock.pm line 4: "
+      . '$g && $h',
+    ),
+    "condition names only genuinely missed outcomes and reports stale ones";
+}
+
+sub test_mcdc_states () {
+  my $crit = Mock::Criterion->new(
+    [1, mcdc_obj('$a || $b', [1, 1])],
+    [2, mcdc_obj('$c || $d', [1, 0])],
+    [3, mcdc_obj('$e || $f', [1, 0], [0, 1])],
+    [4, mcdc_obj('$g || $h', [1, 1], [0, 1])],
+    [5, mcdc_obj('$i || $j', [1, 0], [1, 0])],
+  );
+  is capture_output(\&Devel::Cover::Report::Compilation::print_mcdc, $crit),
+    lines(
+      'Uncovered MC/DC pair (b) at Mock.pm line 2: $c || $d',
+      "MC/DC pair (b) marked uncoverable but covered at Mock.pm line 4: "
+      . '$g || $h',
+      'Uncovered MC/DC pair (b) at Mock.pm line 5: $i || $j',
+      "MC/DC pair (a) marked uncoverable but covered at Mock.pm line 5: "
+      . '$i || $j',
+    ),
+    "mcdc skips excused atomics and reports stale ones";
+}
+
 sub main () {
   test_compilation_report;
   test_lines_sorted;
+  test_statement_states;
+  test_subroutine_states;
+  test_pod_states;
+  test_branch_states;
+  test_condition_states;
+  test_mcdc_states;
   done_testing;
 }
 

--- a/t/internal/crisp_uncoverable.t
+++ b/t/internal/crisp_uncoverable.t
@@ -73,6 +73,21 @@ sub stale_branch {
 1;
 PERL
 
+my $Mixed_fixture = <<'PERL';
+package Mixed;
+use strict;
+use warnings;
+
+sub mixed {
+  my ($x, $y) = @_;
+  # uncoverable mcdc all
+  my $r = $x || $y;
+  return $r;
+}
+
+1;
+PERL
+
 my $Pod_fixture = <<'PERL';
 package PodFix;
 use strict;
@@ -222,6 +237,8 @@ sub test_main ($tmpdir) {
     "legend shows the excused swatch";
   like $html, qr|<span class="legend-swatch c0 mk"></span> marked|,
     "legend shows the marked-but-ran swatch";
+  like $html, qr|<span class="legend-swatch c1 mk"></span> partial|,
+    "legend shows the partial-with-marker swatch";
 
   # Assets know the excused state
   like slurp("$outdir/assets/style.css"), qr|--cov-excused-bg|,
@@ -234,6 +251,34 @@ sub test_main ($tmpdir) {
     "stylesheet defines the marker hatch";
   like slurp("$outdir/assets/app.js"), qr|--cov-excused-border|,
     "minimap paints excused lines";
+}
+
+sub test_mixed ($tmpdir) {
+  my $cover_db = _collect(
+    $tmpdir,                    "cover_db_mixed",
+    "statement,condition,mcdc", "use Mixed; Mixed::mixed(1, 0)",
+  );
+  my ($outdir, $page) = _report($tmpdir, $cover_db, "html_crisp_mixed");
+  my $html = slurp($page);
+
+  # A partial line carrying an excused marker is hatched amber
+  my $mixed_cell = '<td role="cell" class="count exec-partial mk" '
+    . 'aria-label="executed 1 times">1</td>';
+  like $html, qr|\Q$mixed_cell\E|,
+    "partial line with an excused mcdc is amber and hatched";
+
+  like $html, qr|<span class="mcdc-pill cx"|,
+    "whole-decision mcdc marker excuses the pills";
+  unlike $html, qr|<span class="mcdc-pill c0"|, "no red mcdc pills";
+  unlike $html, qr|data-errors="[^"]*mcdc|, "excused mcdc not in error filter";
+
+  my $css = slurp("$outdir/assets/style.css");
+  like $css, qr|\.count\.exec-partial\.mk|,
+    "stylesheet hatches partial cells in their own colour";
+  like $css, qr|\.legend-swatch\.c1\.mk|,
+    "stylesheet hatches the partial legend swatch in amber";
+  like $css, qr|--cov-excused-bg: #c0f1be|,
+    "excused colour is the covered green";
 }
 
 sub test_pod ($tmpdir) {
@@ -267,9 +312,11 @@ sub main () {
   my $libdir = File::Spec->catdir($tmpdir, "lib");
   make_path($libdir);
   _write_module($libdir, "Fixture.pm", $Fixture);
+  _write_module($libdir, "Mixed.pm",   $Mixed_fixture);
   _write_module($libdir, "PodFix.pm",  $Pod_fixture);
 
   test_main($tmpdir);
+  test_mixed($tmpdir);
   test_pod($tmpdir) if eval "require Pod::Coverage; 1";
   done_testing;
 }

--- a/t/internal/crisp_uncoverable.t
+++ b/t/internal/crisp_uncoverable.t
@@ -1,0 +1,277 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( realpath );
+use File::Path qw( make_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is like plan unlike )];
+use Devel::Cover::Test::Showcase qw( run_cover slurp );
+
+eval "require HTML::Entities; 1" or do {
+  plan skip_all => "HTML::Entities not available";
+  exit;
+};
+
+my $Fixture = <<'PERL';
+package Fixture;
+use strict;
+use warnings;
+
+sub hit {
+  my ($x) = @_;
+  # uncoverable branch false
+  if ($x) {
+    return 1;
+  }
+  # uncoverable statement
+  return 0;
+}
+
+sub cond {
+  my ($x, $y) = @_;
+  # uncoverable condition when:0X
+  # uncoverable condition when:11
+  my $r = $x && !$y;
+  return $r;
+}
+
+# uncoverable subroutine
+# uncoverable statement
+sub never_called { 1 }
+
+sub stale {
+  # uncoverable subroutine
+  # uncoverable statement
+  return 42;
+}
+
+sub stale_branch {
+  my ($x) = @_;
+  # uncoverable branch true
+  if ($x) {
+    return 1;
+  }
+  return 0;
+}
+
+1;
+PERL
+
+my $Pod_fixture = <<'PERL';
+package PodFix;
+use strict;
+use warnings;
+
+=head1 NAME
+
+PodFix - pod fixture
+
+=cut
+
+# uncoverable pod
+sub undocumented { 1 }
+
+=head2 documented
+
+Documented sub.
+
+=cut
+
+# uncoverable pod
+sub documented { 1 }
+
+1;
+PERL
+
+sub _write_module ($libdir, $name, $content) {
+  my $path = File::Spec->catfile($libdir, $name);
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $content;
+  close $fh or die "Cannot close $path: $!";
+}
+
+sub _collect ($tmpdir, $db_name, $coverage, $code) {
+  my $libdir   = File::Spec->catdir($tmpdir, "lib");
+  my $cover_db = File::Spec->catdir($tmpdir, $db_name);
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my $cmd
+    = "$^X -Iblib/lib -Iblib/arch -I$libdir"
+    . " -MDevel::Cover=-db,$cover_db,-silent,1,-merge,0"
+    . ",-coverage,$coverage"
+    . qq( -e "$code" 2>&1);
+  my $out = `$cmd`;
+  die "Failed to create $db_name:\n$out\n" if $?;
+  $cover_db
+}
+
+sub _report ($tmpdir, $cover_db, $subdir) {
+  my $outdir = File::Spec->catdir($tmpdir, $subdir);
+  my ($out, $exit) = run_cover(
+    "--report", "html_crisp", "--outputdir", $outdir,
+    "--silent", $cover_db,
+  );
+  is $exit, 0, "cover --report html_crisp exits 0 ($subdir)" or diag $out;
+  my ($page) = grep !m|/coverage\.html$|, glob "$outdir/*.html";
+  ($outdir, $page)
+}
+
+sub test_main ($tmpdir) {
+  my $cover_db = _collect(
+    $tmpdir,
+    "cover_db",
+    "statement,branch,condition,mcdc,subroutine",
+    "use Fixture; Fixture::hit(1); Fixture::cond(1, 1); Fixture::stale();"
+      . " Fixture::stale_branch(1); Fixture::stale_branch(0)",
+  );
+  my ($outdir, $page) = _report($tmpdir, $cover_db, "html_crisp");
+  my $html = slurp($page);
+
+  # Excused statement: neutral cell, own minimap value, no red border
+  like $html, qr|data-cov="3">|, "excused statement row has data-cov 3";
+  my $excused_cell = '<td role="cell" class="count exec-excused" '
+    . 'aria-label="marked uncoverable">0</td>';
+  like $html, qr|\Q$excused_cell\E|, "excused statement count cell is neutral";
+
+  # Stale statement marker: explicit error rendering, hatched
+  my $stale_cell
+    = '<td role="cell" class="count exec-0 mk" aria-label="executed 1 times, '
+    . 'marked uncoverable but covered">1</td>';
+  like $html, qr|\Q$stale_cell\E|,
+    "stale statement count cell is red and hatched with its count";
+  like $html, qr|data-cov="0"\n    class="src-c0[^"]*"|,
+    "stale statement row is red in minimap and source";
+
+  # Branch: excused arm neutral, covered arm unchanged
+  like $html, qr|<td class="c3">1</td>\n<td class="cx">0</td>|,
+    "excused branch arm has the excused class";
+
+  # A marker on a construct which ran turns the whole line red
+  my $stale_branch_cell = '<td role="cell" class="count exec-0 mk" '
+    . 'aria-label="executed 2 times">2</td>';
+  like $html, qr|\Q$stale_branch_cell\E|,
+    "line with a run uncoverable branch marker is red and hatched";
+  like $html, qr|<td class="c0 mk">1</td>\n<td class="c3">1</td>|,
+    "the run-despite-marker arm is red and hatched in the detail";
+
+  # A covered line carrying an excused construct is excused, not plain green
+  my $excused_line_row
+    = qq(data-cov="3"\n    class="has-detail">\n)
+    . qq(<td role="cell" class="ln"><a id="L8" href="#L8">8</a></td>\n)
+    . '<td role="cell" class="count exec-excused" '
+    . 'aria-label="executed 1 times">1</td>';
+  like $html, qr|\Q$excused_line_row\E|,
+    "covered line with excused branch takes the excused state";
+
+  # Subroutines: excused gets its own class and wording, stale is red
+  like $html, qr|<span class="cx">never_called: not called \(uncoverable\)|,
+    "excused subroutine detail is neutral with uncoverable note";
+  like $html, qr|<span class="c3">hit: called|,
+    "covered subroutine detail unchanged";
+  like $html,
+    qr|<span class="c0 mk">stale: called \(marked uncoverable but covered\)|,
+    "stale subroutine detail is red and hatched with note";
+
+  # Condition: excused outcomes neutral, summary error-based
+  like $html,
+    qr|<span class="summary-text c3">100%<span class="count">1/3</span></span>|,
+    "condition summary percentage is error-based";
+  like $html, qr|<td class="cx">0</td>|,
+    "excused condition outcome has the excused class";
+
+  # Truth tables: excused rows neutral, no red rows
+  like $html,   qr|<tr class="cx">|, "excused truth table row is neutral";
+  like $html,   qr|<tr class="c3">|, "covered truth table row unchanged";
+  unlike $html, qr|<tr class="c0">|, "no red truth table rows";
+
+  # Excused constructs stay out of the error filter
+  my @branch_errs = $html =~ /(data-errors="[^"]*branch)/g;
+  is @branch_errs, 1, "only the stale branch is in the error filter";
+  my @sub_errs = $html =~ /(data-errors="[^"]*subroutine)/g;
+  is @sub_errs, 1, "only the stale subroutine is in the error filter";
+  unlike $html, qr|data-errors="[^"]*condition|,
+    "excused condition not in error filter";
+
+  # Summary tooltips name the uncoverable count
+  like $html, qr|\(\d+ uncoverable\)|, "tooltip shows uncoverable count";
+
+  # Help panel legend shows the four line states with live classes
+  like $html, qr|<span class="legend-swatch c3"></span> covered|,
+    "legend shows the covered swatch";
+  like $html, qr|<span class="legend-swatch c1"></span> partial|,
+    "legend shows the partial swatch";
+  like $html, qr|<span class="legend-swatch c0"></span> uncovered|,
+    "legend shows the uncovered swatch";
+  like $html, qr|<span class="legend-swatch cx"></span> excused|,
+    "legend shows the excused swatch";
+  like $html, qr|<span class="legend-swatch c0 mk"></span> marked|,
+    "legend shows the marked-but-ran swatch";
+
+  # Assets know the excused state
+  like slurp("$outdir/assets/style.css"), qr|--cov-excused-bg|,
+    "stylesheet defines the excused colour";
+  like slurp("$outdir/assets/style.css"), qr|\.legend-swatch|,
+    "stylesheet sizes the legend swatches";
+  like slurp("$outdir/assets/style.css"), qr|\.cx \{|,
+    "stylesheet defines the cx class";
+  like slurp("$outdir/assets/style.css"), qr|repeating-linear-gradient|,
+    "stylesheet defines the marker hatch";
+  like slurp("$outdir/assets/app.js"), qr|--cov-excused-border|,
+    "minimap paints excused lines";
+}
+
+sub test_pod ($tmpdir) {
+  my $cover_db = _collect(
+    $tmpdir, "cover_db_pod", "statement,subroutine,pod",
+    "use PodFix; PodFix::undocumented(); PodFix::documented()",
+  );
+  my (undef, $page) = _report($tmpdir, $cover_db, "html_crisp_pod");
+  my $html = slurp($page);
+
+  like $html, qr|class="count exec-excused"|,
+    "excused pod count cell is neutral";
+  like $html, qr|<span class="cx">undocumented \(uncoverable\)</span>|,
+    "excused pod detail is neutral with uncoverable note";
+
+  # A pod marker on a documented sub turns its line red
+  my $stale_pod_cell = '<td role="cell" class="count exec-0 mk" '
+    . 'aria-label="executed 1 times">1</td>';
+  like $html, qr|\Q$stale_pod_cell\E|,
+    "line with a run uncoverable pod marker is red and hatched";
+  like $html,
+    qr|<span class="c0 mk">documented \(marked uncoverable but covered\)|,
+    "run-despite-marker pod detail is red and hatched with note";
+
+  my @pod_errs = $html =~ /(data-errors="[^"]*pod)/g;
+  is @pod_errs, 1, "only the stale pod is in the error filter";
+}
+
+sub main () {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+  my $libdir = File::Spec->catdir($tmpdir, "lib");
+  make_path($libdir);
+  _write_module($libdir, "Fixture.pm", $Fixture);
+  _write_module($libdir, "PodFix.pm",  $Pod_fixture);
+
+  test_main($tmpdir);
+  test_pod($tmpdir) if eval "require Pod::Coverage; 1";
+  done_testing;
+}
+
+main;

--- a/t/internal/criterion_percentage.t
+++ b/t/internal/criterion_percentage.t
@@ -1,0 +1,127 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is is_deeply )];
+
+use Devel::Cover::Branch         ();  ## no perlimports
+use Devel::Cover::Condition_or_3 ();  ## no perlimports
+use Devel::Cover::Mcdc           ();  ## no perlimports
+use Devel::Cover::Pod            ();  ## no perlimports
+use Devel::Cover::Statement      ();  ## no perlimports
+use Devel::Cover::Subroutine     ();  ## no perlimports
+
+sub statement ($covered, $uncoverable = undef) {
+  bless [$covered, $uncoverable], "Devel::Cover::Statement"
+}
+
+sub subroutine ($covered, $uncoverable = undef) {
+  bless [$covered, "main::foo", $uncoverable], "Devel::Cover::Subroutine"
+}
+
+sub pod ($covered, $uncoverable = undef) {
+  bless [$covered, undef, $uncoverable], "Devel::Cover::Pod"
+}
+
+sub branch ($covered, $uncoverable = undef) {
+  bless [$covered, { text => '$a' }, $uncoverable], "Devel::Cover::Branch"
+}
+
+sub condition ($covered, $uncoverable = undef) {
+  bless [$covered, { left => '$a', op => "or", right => '$b' }, $uncoverable],
+    "Devel::Cover::Condition_or_3"
+}
+
+sub mcdc ($covered, $uncoverable = undef) {
+  bless [$covered, { text => '$a && $b' }, $uncoverable], "Devel::Cover::Mcdc"
+}
+
+sub test_single_construct_states () {
+  my @makers = ([\&statement, "statement"], [\&subroutine, "subroutine"],
+    [\&pod, "pod"]);
+  for my $maker (@makers) {
+    my ($make, $name) = @$maker;
+    is $make->(1)->percentage,    100, "covered $name is 100%";
+    is $make->(0)->percentage,    0,   "uncovered $name is 0%";
+    is $make->(0, 1)->percentage, 100, "excused $name is 100%";
+    is $make->(1, 1)->percentage, 0,   "covered but marked $name is 0%";
+  }
+}
+
+sub test_vector_states () {
+  my @makers
+    = ([\&branch, "branch"], [\&condition, "condition"], [\&mcdc, "mcdc"]);
+  for my $maker (@makers) {
+    my ($make, $name) = @$maker;
+    is $make->([1, 1])->percentage, 100, "fully covered $name is 100%";
+    is $make->([1, 0])->percentage, 50,  "half covered $name is 50%";
+    is $make->([0, 0])->percentage, 0,   "uncovered $name is 0%";
+    is $make->([0, 0], [0, 1])->percentage, 50,
+      "excused path counts as success for $name";
+    is $make->([0, 0], [1, 1])->percentage, 100, "fully excused $name is 100%";
+    is $make->([1, 1], [0, 1])->percentage, 50,
+      "covered but marked path counts as error for $name";
+    is $make->([0, 0, 0], [0, 0, 1])->percentage, 33,
+      "$name percentage truncates toward zero";
+  }
+}
+
+sub test_ignore_covered_err () {
+  no warnings "once";
+  local $Devel::Cover::Ignore_covered_err = 1;
+  is statement(1, 1)->percentage, 100,
+    "covered but marked statement is 100% under ignore_covered_err";
+  is branch([1, 1], [0, 1])->percentage, 100,
+    "covered but marked branch is 100% under ignore_covered_err";
+  is branch([0, 0], [0, 1])->percentage, 50,
+    "excused branch still credited under ignore_covered_err";
+}
+
+sub test_pod_summary_aggregates_uncoverable () {
+  local $INC{"Pod/Coverage.pm"} = $INC{"Pod/Coverage.pm"} // "mocked";
+  my $db = { summary => {} };
+  pod(0, 1)->calculate_summary($db, "file.pl");
+  my $counts = { total => 1, uncoverable => 1 };
+  is_deeply $db->{summary}, {
+      "file.pl" => { pod => $counts, total => $counts },
+      Total     => { pod => $counts, total => $counts },
+    },
+    "pod summary aggregates the uncoverable count";
+}
+
+sub test_pod_summary_covered_but_marked () {
+  local $INC{"Pod/Coverage.pm"} = $INC{"Pod/Coverage.pm"} // "mocked";
+  my $db = { summary => {} };
+  pod(1, 1)->calculate_summary($db, "file.pl");
+  my $counts = { total => 1, uncoverable => 1, covered => 1, error => 1 };
+  is_deeply $db->{summary}, {
+      "file.pl" => { pod => $counts, total => $counts },
+      Total     => { pod => $counts, total => $counts },
+    },
+    "pod summary flags a covered but marked subroutine as an error";
+}
+
+sub main () {
+  test_single_construct_states;
+  test_vector_states;
+  test_ignore_covered_err;
+  test_pod_summary_aggregates_uncoverable;
+  test_pod_summary_covered_but_marked;
+  done_testing;
+}
+
+main

--- a/t/internal/editor_types.t
+++ b/t/internal/editor_types.t
@@ -40,7 +40,7 @@ sub types_from_vim_report ($cover_db, $libdir, $seed) {
   my $vim = slurp("$cover_db/coverage.vim");
   my ($list) = $vim =~ /^let s:types = \[(.*?)\]/ms;
   ok defined $list, "types list found in coverage.vim (seed $seed)";
-  [grep !/_error$/, ($list // "") =~ /"(\w+)"/g]
+  [grep !/_uncoverable$|_error$/, ($list // "") =~ /"(\w+)"/g]
 }
 
 # Criteria must come out in canonical order, identical under any hash seed

--- a/t/internal/html_basic_uncoverable.t
+++ b/t/internal/html_basic_uncoverable.t
@@ -148,7 +148,8 @@ sub _report ($tmpdir, $cover_db, $subdir) {
     "--silent", $cover_db,
   );
   is $exit, 0, "cover --report html_basic exits 0 ($subdir)" or diag $out;
-  my ($page) = grep !m|/coverage\.html$| && !/--/, glob "$outdir/*.html";
+  my ($page) = grep !m|/coverage\.html$| && !m|--\w+\.html$|,
+    glob "$outdir/*.html";
   ($outdir, $page)
 }
 

--- a/t/internal/html_basic_uncoverable.t
+++ b/t/internal/html_basic_uncoverable.t
@@ -1,0 +1,264 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( realpath );
+use File::Path qw( make_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is like plan unlike )];
+use Devel::Cover::Test::Showcase qw( run_cover slurp );
+
+eval "require HTML::Entities; 1" or do {
+  plan skip_all => "HTML::Entities not available";
+  exit;
+};
+
+eval "require Template; 1" or do {
+  plan skip_all => "Template not available";
+  exit;
+};
+
+my $Fixture = <<'PERL';
+package Fixture;
+use strict;
+use warnings;
+
+sub hit {
+  my ($x) = @_;
+  # uncoverable branch false
+  if ($x) {
+    return 1;
+  }
+  # uncoverable statement
+  return 0;
+}
+
+sub cond {
+  my ($x, $y) = @_;
+  # uncoverable condition when:0X
+  # uncoverable condition when:11
+  my $r = $x && !$y;
+  return $r;
+}
+
+# uncoverable subroutine
+# uncoverable statement
+sub never_called { 1 }
+
+sub stale {
+  # uncoverable subroutine
+  # uncoverable statement
+  return 42;
+}
+
+sub stale_branch {
+  my ($x) = @_;
+  # uncoverable branch true
+  if ($x) {
+    return 1;
+  }
+  return 0;
+}
+
+1;
+PERL
+
+my $Mixed_fixture = <<'PERL';
+package Mixed;
+use strict;
+use warnings;
+
+sub mixed {
+  my ($x, $y) = @_;
+  # uncoverable mcdc all
+  my $r = $x || $y;
+  return $r;
+}
+
+1;
+PERL
+
+my $Pod_fixture = <<'PERL';
+package PodFix;
+use strict;
+use warnings;
+
+=head1 NAME
+
+PodFix - pod fixture
+
+=cut
+
+# uncoverable pod
+sub undocumented { 1 }
+
+=head2 documented
+
+Documented sub.
+
+=cut
+
+# uncoverable pod
+sub documented { 1 }
+
+1;
+PERL
+
+sub _write_module ($libdir, $name, $content) {
+  my $path = File::Spec->catfile($libdir, $name);
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $content;
+  close $fh or die "Cannot close $path: $!";
+}
+
+sub _collect ($tmpdir, $db_name, $coverage, $code) {
+  my $libdir   = File::Spec->catdir($tmpdir, "lib");
+  my $cover_db = File::Spec->catdir($tmpdir, $db_name);
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my $cmd
+    = "$^X -Iblib/lib -Iblib/arch -I$libdir"
+    . " -MDevel::Cover=-db,$cover_db,-silent,1,-merge,0"
+    . ",-coverage,$coverage"
+    . qq( -e "$code" 2>&1);
+  my $out = `$cmd`;
+  die "Failed to create $db_name:\n$out\n" if $?;
+  $cover_db
+}
+
+sub _report ($tmpdir, $cover_db, $subdir) {
+  my $outdir = File::Spec->catdir($tmpdir, $subdir);
+  my ($out, $exit) = run_cover(
+    "--report", "html_basic", "--outputdir", $outdir,
+    "--silent", $cover_db,
+  );
+  is $exit, 0, "cover --report html_basic exits 0 ($subdir)" or diag $out;
+  my ($page) = grep !m|/coverage\.html$| && !/--/, glob "$outdir/*.html";
+  ($outdir, $page)
+}
+
+sub test_main ($tmpdir) {
+  my $cover_db = _collect(
+    $tmpdir,
+    "cover_db",
+    "statement,branch,condition,subroutine",
+    "use Fixture; Fixture::hit(1); Fixture::cond(1, 1); Fixture::stale();"
+      . " Fixture::stale_branch(1); Fixture::stale_branch(0)",
+  );
+  my ($outdir, $page) = _report($tmpdir, $cover_db, "html_basic");
+  my $html = slurp($page);
+
+  my $cx = '<td class="cx" title="marked uncoverable">';
+  my $mk = '<td class="c0 mk" title="marked uncoverable but covered">';
+
+  # File page: excused cells are striped green, stale markers striped red
+  like $html, qr|\Q$cx\E\s*0\s*</td>|,
+    "excused statement cell has the excused class and note";
+  like $html, qr|\Q$mk\E\s*1\s*</td>|,
+    "stale statement cell is red and hatched with note";
+  like $html, qr|<a href="#30">|,
+    "stale statement is in the uncovered link chain";
+  like $html, qr|\Q$cx\E\s*<a href="[^"]*--branch\.html#8-1">\s*100|,
+    "branch with excused arm has the excused class on the file page";
+  like $html, qr|\Q$mk\E\s*<a href="[^"]*--branch\.html#36-1">\s*50|,
+    "branch with stale marker is red and hatched on the file page";
+
+  # Summary tooltips name the uncoverable count
+  like $html, qr|title="\d+ / \d+ \(\d+ uncoverable\)"|,
+    "header tooltip shows the uncoverable count";
+
+  # Branch page: per-direction four-state rendering
+  my ($branch_page) = glob "$outdir/*--branch.html";
+  my $branches = slurp($branch_page);
+  like $branches, qr|<td class="c3">\s*1\s*</td>\s*\Q$cx\E\s*0\s*</td>|,
+    "excused branch arm has the excused class";
+  like $branches, qr|\Q$mk\E\s*1\s*</td>\s*<td class="c3">\s*1\s*</td>|,
+    "stale branch arm is red and hatched";
+  unlike $branches, qr|<td class="c0">|, "no plain red branch arms";
+
+  # Condition page: excused outcomes are striped green
+  my ($cond_page) = glob "$outdir/*--condition.html";
+  my $conds = slurp($cond_page);
+  like $conds, qr|<td class="cx" title="marked uncoverable">|,
+    "excused condition outcome has the excused class";
+  unlike $conds, qr|<td class="c0">|, "no plain red condition outcomes";
+
+  # Subroutine page
+  my ($sub_page) = glob "$outdir/*--subroutine.html";
+  my $subs = slurp($sub_page);
+  like $subs, qr|\Q$cx\E\s*0\s*</td>\s*<td>\s*never_called\s*</td>|,
+    "excused subroutine count cell has the excused class";
+  like $subs, qr|\Q$mk\E\s*1\s*</td>\s*<td>\s*stale\s*</td>|,
+    "stale subroutine count cell is red and hatched";
+  like $subs, qr|<td class="c3">\s*1\s*</td>\s*<td>\s*hit\s*</td>|,
+    "covered subroutine count cell unchanged";
+
+  # The stylesheet defines the excused class and the marker hatch
+  my $css = slurp("$outdir/cover.css");
+  like $css, qr|\.cx \{|,                   "cover.css defines the cx class";
+  like $css, qr|\.mk \{|,                   "cover.css defines the mk class";
+  like $css, qr|repeating-linear-gradient|, "cover.css defines the hatch";
+}
+
+sub test_mixed ($tmpdir) {
+  my $cover_db = _collect(
+    $tmpdir,                    "cover_db_mixed",
+    "statement,condition,mcdc", "use Mixed; Mixed::mixed(1, 0)",
+  );
+  my ($outdir) = _report($tmpdir, $cover_db, "html_basic_mixed");
+
+  my ($mcdc_page) = glob "$outdir/*--mcdc.html";
+  my $mcdc = slurp($mcdc_page);
+  like $mcdc, qr|<td class="cx" title="marked uncoverable">\s*100\s*</td>|,
+    "excused mcdc decision has the excused class";
+  like $mcdc, qr|<span class="cx" title="marked uncoverable">\s*-\$x\s*</span>|,
+    "excused mcdc atomic keeps the - prefix with the excused class";
+  unlike $mcdc, qr|<span class="c0">|, "no red mcdc pills";
+}
+
+sub test_pod ($tmpdir) {
+  my $cover_db = _collect(
+    $tmpdir, "cover_db_pod", "statement,subroutine,pod",
+    "use PodFix; PodFix::undocumented(); PodFix::documented()",
+  );
+  my ($outdir) = _report($tmpdir, $cover_db, "html_basic_pod");
+
+  my ($sub_page) = glob "$outdir/*--subroutine.html";
+  my $subs = slurp($sub_page);
+  like $subs, qr|<td class="cx" title="marked uncoverable">\s*No\s*</td>|,
+    "excused pod cell has the excused class";
+  like $subs,
+    qr|<td class="c0 mk" title="marked uncoverable but covered">\s*Yes\s*</td>|,
+    "stale pod cell is red and hatched";
+}
+
+sub main () {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+  my $libdir = File::Spec->catdir($tmpdir, "lib");
+  make_path($libdir);
+  _write_module($libdir, "Fixture.pm", $Fixture);
+  _write_module($libdir, "Mixed.pm",   $Mixed_fixture);
+  _write_module($libdir, "PodFix.pm",  $Pod_fixture);
+
+  test_main($tmpdir);
+  test_mixed($tmpdir);
+  test_pod($tmpdir) if eval "require Pod::Coverage; 1";
+  done_testing;
+}
+
+main;

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -1076,12 +1076,11 @@ sub test_line_partial_ignores_tt_rows () {
     "partial: unobserved tt rows alone do not mark partial";
 
   my %with_cell = (count => 5);
-  my @cells
-    = ({ parts => [{ class => "c3" }, { class => "c0" }, { class => "c3" }] });
+  my @cells = ({ parts => [{ error => 0 }, { error => 1 }, { error => 0 }] });
   Devel::Cover::Report::Html_crisp::line_partial(
     \%with_cell, [], \@cells, [], [], [],
   );
-  ok $with_cell{partial}, "partial: c0 condition cell flags line partial";
+  ok $with_cell{partial}, "partial: condition cell error flags line partial";
 }
 
 sub test_class_accepts_criterion_percentage () {

--- a/t/internal/json.t
+++ b/t/internal/json.t
@@ -31,27 +31,37 @@ eval "require JSON::MaybeXS; 1" or do {
   exit;
 };
 
+sub markers_line ($libdir, $pattern) {
+  my @lines = split /\n/, slurp("$libdir/Covered/Markers.pm");
+  for my $i (0 .. $#lines) {
+    return $i + 1 if $lines[$i] =~ $pattern;
+  }
+  die "No line matching $pattern in Covered/Markers.pm";
+}
+
+sub markers_entry ($json) {
+  my $path = first { /Covered\W+Markers\.pm$/ } keys $json->{files}->%*;
+  ($path, $path ? $json->{files}{$path} : undef)
+}
+
+sub json_report ($tmpdir, $libdir, $cover_db, $subdir, @extra) {
+  my $outdir = File::Spec->catdir($tmpdir, $subdir);
+  my ($out, $exit) = run_cover(
+    "--select_dir", $libdir, "--report", "json",
+    "--outputdir",  $outdir, "--silent", @extra,
+    $cover_db,
+  );
+  is $exit, 0, "cover --report json exits 0 ($subdir)" or diag $out;
+  my $path = File::Spec->catfile($outdir, "cover.json");
+  ok -e $path, "cover.json was generated ($subdir)";
+  JSON::MaybeXS->new(utf8 => 1)->decode(slurp($path))
+}
+
 # The new `json` report emits full per-line detail (statements, branches,
 # conditions, condition_truth_tables, mcdc, subroutines, pod) plus per-file
 # meta and a top-level devel_cover_version.  It is the supersedes-everything
 # feed requested in GH-418.
-sub test_json_detailed_report () {
-  my ($tmpdir, $libdir) = setup_lib_dir;
-  my $cover_db = create_cover_db($tmpdir, $libdir);
-  my $outdir   = File::Spec->catdir($tmpdir, "json");
-
-  my ($out, $exit) = run_cover(
-    "--select_dir", $libdir, "--report", "json",
-    "--outputdir",  $outdir, "--silent", $cover_db,
-  );
-
-  is $exit, 0, "cover --report json exits 0" or diag $out;
-
-  my $path = File::Spec->catfile($outdir, "cover.json");
-  ok -e $path, "cover.json was generated";
-
-  my $json = JSON::MaybeXS->new(utf8 => 1)->decode(slurp($path));
-
+sub test_json_detailed_report ($json) {
   # Top-level structure.
   like $json->{devel_cover_version}, qr/^\d+\.\d+/,
     "devel_cover_version looks like a version number";
@@ -132,12 +142,63 @@ sub test_json_detailed_report () {
   ok defined $m->{error}, "mcdc has error";
 }
 
+# Excused and stale markers must be distinguishable in the output
+sub test_uncoverable_states ($json, $libdir) {
+  my ($path, $f) = markers_entry($json);
+  ok $path, "found Covered/Markers.pm in files" or return;
+
+  my $excused = markers_line($libdir, qr/die "emergency stop"/);
+  my $stale   = markers_line($libdir, qr/return "still called"/);
+
+  my $e = $f->{statements}{$excused}[0];
+  is $e->{covered},     0, "excused statement is not covered";
+  is $e->{uncoverable}, 1, "excused statement is marked uncoverable";
+  is $e->{error},       0, "excused statement is not an error";
+
+  my $s = $f->{statements}{$stale}[0];
+  ok $s->{covered} > 0, "stale-marked statement ran";
+  is $s->{uncoverable}, 1, "stale-marked statement keeps its marker";
+  is $s->{error},       1, "stale-marked statement is an error";
+}
+
+# Truth table rows carry the uncoverable flag and an error-based percentage
+sub test_truth_table_uncoverable ($json, $libdir) {
+  my ($path, $f) = markers_entry($json);
+  ok $path, "found Covered/Markers.pm in files" or return;
+
+  my $audit = markers_line($libdir, qr/my \$ok = \$active && \$value/);
+  my $tt    = ($f->{condition_truth_tables}{$audit} // [])->[0];
+  ok $tt, "audit line has a truth table" or return;
+
+  ok defined $_->{uncoverable}, "row has uncoverable flag" for $tt->{rows}->@*;
+  my $excused_row
+    = first { $_->{uncoverable} && !$_->{covered} } $tt->{rows}->@*;
+  ok $excused_row, "the excused outcome's row is flagged uncoverable";
+  is $tt->{percentage}, 100, "excused row does not drag the percentage down";
+}
+
+# The error rule must be recorded so consumers can interpret `error`
+sub test_error_rule_recorded ($json, $json_ignore, $libdir) {
+  is $json->{ignore_covered_err}, 0, "error rule recorded (default off)";
+  is $json_ignore->{ignore_covered_err}, 1,
+    "error rule recorded (-ignore_covered_err)";
+
+  my (undef, $f) = markers_entry($json_ignore);
+  my $stale = markers_line($libdir, qr/return "still called"/);
+  my $s     = $f->{statements}{$stale}[0];
+  is $s->{error}, 0, "stale marker is forgiven under -ignore_covered_err";
+}
+
+# Phase 0 made pod aggregate uncoverable like every other criterion
+sub test_summary_pod_uncoverable ($json) {
+  ok exists $json->{summary}{Total}{pod}{uncoverable},
+    "summary Total pod has an uncoverable count";
+}
+
 # json_summary should NOT have a files key - this protects against accidental
 # divergence in future where one reporter's output drifts into the other.
-sub test_summary_and_detailed_distinct () {
-  my ($tmpdir, $libdir) = setup_lib_dir;
-  my $cover_db = create_cover_db($tmpdir, $libdir);
-  my $outdir   = File::Spec->catdir($tmpdir, "json2");
+sub test_summary_and_detailed_distinct ($tmpdir, $libdir, $cover_db) {
+  my $outdir = File::Spec->catdir($tmpdir, "json_summary");
 
   my ($out, $exit) = run_cover(
     "--select_dir", $libdir, "--report", "json_summary",
@@ -154,8 +215,20 @@ sub test_summary_and_detailed_distinct () {
 }
 
 sub main () {
-  test_json_detailed_report;
-  test_summary_and_detailed_distinct;
+  my ($tmpdir, $libdir) = setup_lib_dir;
+  my $cover_db = create_cover_db($tmpdir, $libdir);
+
+  my $json        = json_report($tmpdir, $libdir, $cover_db, "json");
+  my $json_ignore = json_report(
+    $tmpdir, $libdir, $cover_db, "json_ignore", "-ignore_covered_err",
+  );
+
+  test_json_detailed_report($json);
+  test_uncoverable_states($json, $libdir);
+  test_truth_table_uncoverable($json, $libdir);
+  test_error_rule_recorded($json, $json_ignore, $libdir);
+  test_summary_pod_uncoverable($json);
+  test_summary_and_detailed_distinct($tmpdir, $libdir, $cover_db);
   done_testing;
 }
 

--- a/t/internal/mcdc_html_uncoverable.t
+++ b/t/internal/mcdc_html_uncoverable.t
@@ -45,9 +45,10 @@ sub left_always_true {
 1;
 PERL
 
-# An excused atomic must not render as a plain uncovered pill: it carries a
-# "-" prefix (matching the text reporters) and the satisfied colour class, so
-# the pills agree with the decision row's excused-as-covered state.
+# An excused atomic must not render as a plain uncovered pill. Crisp gives it
+# the excused class and a title, the other variants a "-" prefix (matching the
+# text reporters) and the satisfied colour class, so the pills agree with the
+# decision row's excused-as-covered state.
 sub _setup () {
   my $tmpdir = realpath(tempdir(CLEANUP => 1));
   my $libdir = File::Spec->catdir($tmpdir, "lib");
@@ -117,8 +118,8 @@ sub test_html_crisp ($tmpdir, $cover_db) {
   my ($outdir) = _report($tmpdir, $cover_db, "html_crisp");
   my ($page)   = grep !m|/coverage\.html$|, glob "$outdir/*.html";
   my $html     = slurp($page);
-  like $html, qr|mcdc-pill c3">-\$always</span>|,
-    "html_crisp: excused pill has - prefix and covered class";
+  like $html, qr|mcdc-pill cx" title="marked uncoverable">\$always</span>|,
+    "html_crisp: excused pill has the excused class and title";
   like $html, qr|mcdc-pill c3">\$b</span>|,
     "html_crisp: covered pill unchanged";
   unlike $html, qr|mcdc-pill c0|, "html_crisp: no uncovered pill";

--- a/t/internal/mcdc_html_uncoverable.t
+++ b/t/internal/mcdc_html_uncoverable.t
@@ -45,10 +45,11 @@ sub left_always_true {
 1;
 PERL
 
-# An excused atomic must not render as a plain uncovered pill. Crisp gives it
-# the excused class and a title, the other variants a "-" prefix (matching the
-# text reporters) and the satisfied colour class, so the pills agree with the
-# decision row's excused-as-covered state.
+# An excused atomic must not render as a plain uncovered pill. Crisp and basic
+# give it the excused class and a title (basic also keeps the "-" prefix,
+# matching the text reporters), minimal and subtle the "-" prefix and the
+# satisfied colour class, so the pills agree with the decision row's
+# excused-as-covered state.
 sub _setup () {
   my $tmpdir = realpath(tempdir(CLEANUP => 1));
   my $libdir = File::Spec->catdir($tmpdir, "lib");
@@ -96,8 +97,8 @@ sub test_html_minimal ($tmpdir, $cover_db) {
 sub test_html_basic ($tmpdir, $cover_db) {
   my (undef, $page) = _report($tmpdir, $cover_db, "html_basic");
   my $html = slurp($page);
-  like $html, qr|class="c3">\s*-\$always\s*</span>|,
-    "html_basic: excused pill has - prefix and covered class";
+  like $html, qr|class="cx" title="marked uncoverable">\s*-\$always\s*</span>|,
+    "html_basic: excused pill has - prefix and excused class";
   like $html, qr|class="c3">\s*\$b\s*</span>|,
     "html_basic: covered pill unchanged";
   like $html, qr|<a name="9-1">|,

--- a/t/internal/nvim_report.t
+++ b/t/internal/nvim_report.t
@@ -16,7 +16,8 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Test::More import => [qw( diag done_testing is like ok plan unlike )];
+use Test::More import =>
+  [qw( diag done_testing is is_deeply like ok plan unlike )];
 use Devel::Cover::Test::Showcase qw(
   create_cover_db
   run_cover
@@ -29,18 +30,22 @@ eval "require Template; 1" or do {
   exit;
 };
 
+sub markers_line ($libdir, $pattern) {
+  my @lines = split /\n/, slurp("$libdir/Covered/Markers.pm");
+  for my $i (0 .. $#lines) {
+    return $i + 1 if $lines[$i] =~ $pattern;
+  }
+  die "No line matching $pattern in Covered/Markers.pm";
+}
+
+sub markers_list ($lua, $name) {
+  my ($section) = $lua =~ m{Covered/Markers\.pm"\] = \{(.*?)\n  \},}s;
+  my ($list)    = ($section // "") =~ /\b\Q$name\E = \{([^}]*)\}/;
+  [($list // "") =~ /(\d+)/g]
+}
+
 # Stored file keys must be matched as literal text, not as Lua patterns
-sub test_nvim_report_literal_matching () {
-  my ($tmpdir, $libdir) = setup_lib_dir;
-  my $cover_db = create_cover_db($tmpdir, $libdir);
-
-  my ($out, $exit) = run_cover(
-    "--select_dir", $libdir, "--report", "nvim", "--silent", $cover_db,
-  );
-
-  is $exit, 0, "cover --report nvim exits 0" or diag $out;
-
-  my $lua     = slurp("$cover_db/coverage.lua");
+sub test_nvim_report_literal_matching ($lua) {
   my $pattern = 'string.find(filename, f .. "$")';
   my $literal = "string.sub(filename, -#f) == f";
   unlike $lua, qr/\Q$pattern\E/,
@@ -55,15 +60,72 @@ sub test_sign_priority_default_documented () {
   my ($code_default)
     = $src =~ /sign_priority = vim\.g\.devel_cover_sign_priority or (\d+),/;
   my ($pod_default)
-    = $src =~ /devel_cover_sign_priority -- Sign priority \(default: (\d+)\)/;
+    = $src =~ /devel_cover_sign_priority\s+-- Sign priority \(default: (\d+)\)/;
   ok defined $code_default, "template sign_priority default found";
   ok defined $pod_default,  "POD sign_priority default found";
   is $pod_default, $code_default, "POD documents the template default";
 }
 
+# Each criterion needs an uncoverable highlight and sign definition
+sub test_uncoverable_definitions ($lua) {
+  like $lua, qr/uncoverable_fg = vim\.g\.devel_cover_uncoverable_fg or "Grey"/,
+    "uncoverable foreground configurable, default grey";
+  like $lua, qr/"cov_" \.\. type_name \.\. "_uncoverable"/,
+    "uncoverable highlight groups created";
+  like $lua, qr/type_name \.\. "_uncoverable", \{/, "uncoverable signs defined";
+  like $lua, qr/linehl_uncoverable/, "uncoverable line highlight configured";
+}
+
+# Sign priority: error beats excused beats covered, so the types list
+# must run covered, uncoverable, error (placement is reversed first-wins)
+sub test_types_priority_order ($lua) {
+  my ($list) = $lua =~ /^local types = \{(.*?)\}/ms;
+  ok defined $list, "types list found in coverage.lua";
+  my @names = ($list // "") =~ /"(\w+)"/g;
+  my @base  = grep !/_error$|_uncoverable$/, @names;
+  ok @base >= 4, "several criteria collected" or diag "@base";
+  is_deeply \@names,
+    [@base, (map "${_}_uncoverable", @base), (map "${_}_error", @base)],
+    "types ordered covered, uncoverable, error";
+}
+
+# Excused constructs go in the uncoverable lists, stale markers stay errors
+sub test_excused_and_stale_lines ($lua, $libdir) {
+  # subroutine coverage is recorded on the first statement's line
+  my $excused = markers_line($libdir, qr/die "emergency stop"/);
+  my $stale   = markers_line($libdir, qr/return "still called"/);
+
+  my $st_unc = markers_list($lua, "statement_uncoverable");
+  my $st_err = markers_list($lua, "statement_error");
+  my $st_cov = markers_list($lua, "statement");
+
+  ok grep($_ == $excused, @$st_unc), "excused statement listed uncoverable";
+  is grep($_ == $excused, @$st_err), 0, "excused statement is not an error";
+  is grep($_ == $excused, @$st_cov), 0, "excused statement is not covered";
+  ok grep($_ == $stale,   @$st_err), "stale marker stays an error";
+  is grep($_ == $stale,   @$st_unc), 0, "stale marker is not excused";
+
+  my $sub_unc = markers_list($lua, "subroutine_uncoverable");
+  my $sub_err = markers_list($lua, "subroutine_error");
+  ok grep($_ == $excused, @$sub_unc), "excused subroutine listed uncoverable";
+  ok grep($_ == $stale,   @$sub_err), "stale subroutine marker stays an error";
+}
+
 sub main () {
-  test_nvim_report_literal_matching;
+  my ($tmpdir, $libdir) = setup_lib_dir;
+  my $cover_db = create_cover_db($tmpdir, $libdir);
+
+  my ($out, $exit) = run_cover(
+    "--select_dir", $libdir, "--report", "nvim", "--silent", $cover_db,
+  );
+  is $exit, 0, "cover --report nvim exits 0" or diag $out;
+  my $lua = slurp("$cover_db/coverage.lua");
+
+  test_nvim_report_literal_matching($lua);
   test_sign_priority_default_documented;
+  test_uncoverable_definitions($lua);
+  test_types_priority_order($lua);
+  test_excused_and_stale_lines($lua, $libdir);
   done_testing;
 }
 

--- a/t/internal/select_dir.t
+++ b/t/internal/select_dir.t
@@ -160,7 +160,7 @@ sub test_text_report () {
       "Uncovered/Calc.pm  0.0  0.0  0.0  0.0  0.0  18.4",
       "Uncovered/Full.pm  0.0  0.0  0.0  0.0  0.0  17.2",
       "Uncovered/Logic.pm  0.0  0.0  0.0  0.0  0.0  16.1",
-      "Uncovered/Markers.pm  0.0  0.0  0.0  0.0  0.0  15.0",
+      "Uncovered/Markers.pm  0.0  0.0  0.0  0.0  0.0  13.9",
       "Uncovered/Trivial.pm  0.0  n/a  n/a  0.0  0.0  6.9",
       "Uncovered/Utils.pm  0.0  0.0  n/a  0.0  0.0  12.8",
     ]

--- a/t/internal/text_sub_states.t
+++ b/t/internal/text_sub_states.t
@@ -1,0 +1,149 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is like unlike )];
+
+use Devel::Cover::Pod          ();  ## no perlimports
+use Devel::Cover::Report::Text ();  ## no perlimports
+use Devel::Cover::Subroutine   ();  ## no perlimports
+
+{
+
+  package Mock::Criterion;
+  sub new ($class, @locations) { bless { locations => \@locations }, $class }
+  sub items ($self) { map $_->[0], $self->{locations}->@* }
+
+  sub location ($self, $loc) {
+    [map $_->[1], grep { $_->[0] == $loc } $self->{locations}->@*]
+  }
+}
+
+{
+
+  package Mock::File;
+
+  sub new ($class, $subs, $pods = undef) {
+    bless { subs => $subs, pods => $pods }, $class
+  }
+  sub subroutine ($self) { $self->{subs} }
+  sub pod        ($self) { $self->{pods} }
+}
+
+{
+
+  package Mock::Cover;
+  sub new  ($class, $file) { bless { file => $file }, $class }
+  sub file ($self, $name)  { $self->{file} }
+}
+
+{
+
+  package Mock::DB;
+  sub new             ($class, $cover) { bless { cover => $cover }, $class }
+  sub cover           ($self)          { $self->{cover} }
+  sub scar_sub_lookup ($self, $)       { {} }
+}
+
+sub sub_obj ($covered, $name, $uncoverable = 0) {
+  bless [$covered, $name, $uncoverable], "Devel::Cover::Subroutine"
+}
+
+sub pod_obj ($covered, $uncoverable = 0) {
+  bless [$covered, undef, $uncoverable], "Devel::Cover::Pod"
+}
+
+sub run_report ($subs, $pods = undef, $show = {}) {
+  my $file = Mock::File->new($subs, $pods);
+  my $db   = Mock::DB->new(Mock::Cover->new($file));
+
+  my $output;
+  {
+    open my $fh, ">", \$output or die "Cannot open scalar ref: $!";
+    local *STDOUT = $fh;
+    Devel::Cover::Report::Text::print_subroutines(
+      $db, "Mock.pm",
+      { show      => $show },
+      { "Mock.pm" => "Mock.pm" },
+    );
+    close $fh or die "Cannot close scalar ref: $!";
+  }
+  $output
+}
+
+sub section ($output, $heading) {
+  $output =~ /^\Q$heading\E\n-+\n\n(.*?)(?:\n\n|\z)/ms ? $1 : ""
+}
+
+sub test_bucketing_by_state () {
+  my $subs = Mock::Criterion->new(
+    [5, sub_obj(1, "alpha")],
+    [6, sub_obj(0, "beta")],
+    [7, sub_obj(0, "gamma", 1)],
+    [8, sub_obj(1, "delta", 1)],
+  );
+  my $output = run_report($subs);
+
+  my $covered = section($output, "Covered Subroutines");
+  like $covered, qr/^alpha\s+1\s+Mock\.pm:5$/m,
+    "covered sub listed in the covered section";
+  like $covered, qr/^delta\s+\*-1\s+Mock\.pm:8$/m,
+    "covered but marked sub shows the error and uncoverable prefixes";
+
+  my $uncoverable = section($output, "Uncoverable Subroutines");
+  like $uncoverable, qr/^gamma\s+-0\s+Mock\.pm:7$/m,
+    "excused sub listed in the uncoverable section";
+
+  my $uncovered = section($output, "Uncovered Subroutines");
+  like $uncovered, qr/^beta\s+0\s+Mock\.pm:6$/m,
+    "uncovered sub keeps its bare count";
+  unlike $uncovered, qr/gamma/, "excused sub not listed as uncovered";
+}
+
+sub test_section_order () {
+  my $subs = Mock::Criterion->new(
+    [5, sub_obj(1, "alpha")],
+    [6, sub_obj(0, "beta")],
+    [7, sub_obj(0, "gamma", 1)],
+  );
+  my $output   = run_report($subs);
+  my @headings = $output =~ /^(\w+ Subroutines)$/mg;
+  is "@headings",
+    "Covered Subroutines Uncoverable Subroutines Uncovered Subroutines",
+    "sections appear in sorted order";
+}
+
+sub test_pod_states () {
+  my $subs
+    = Mock::Criterion->new([5, sub_obj(1, "alpha")], [6, sub_obj(1, "beta")]);
+  my $pods    = Mock::Criterion->new([5, pod_obj(0, 1)], [6, pod_obj(1, 1)]);
+  my $output  = run_report($subs, $pods, { pod => 1 });
+  my $covered = section($output, "Covered Subroutines");
+  like $covered, qr/^alpha\s+1\s+-0\s+Mock\.pm:5$/m,
+    "excused pod keeps the uncoverable prefix";
+  like $covered, qr/^beta\s+1\s+\*-1\s+Mock\.pm:6$/m,
+    "covered but marked pod shows the error and uncoverable prefixes";
+}
+
+sub main () {
+  test_bucketing_by_state;
+  test_section_order;
+  test_pod_states;
+  done_testing;
+}
+
+main

--- a/t/internal/vim_report.t
+++ b/t/internal/vim_report.t
@@ -16,7 +16,8 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Test::More import => [qw( diag done_testing is like plan unlike )];
+use Test::More import =>
+  [qw( diag done_testing is is_deeply like ok plan unlike )];
 use Devel::Cover::Test::Showcase qw(
   create_cover_db
   run_cover
@@ -29,18 +30,22 @@ eval "require Template; 1" or do {
   exit;
 };
 
+sub markers_line ($libdir, $pattern) {
+  my @lines = split /\n/, slurp("$libdir/Covered/Markers.pm");
+  for my $i (0 .. $#lines) {
+    return $i + 1 if $lines[$i] =~ $pattern;
+  }
+  die "No line matching $pattern in Covered/Markers.pm";
+}
+
+sub markers_list ($vim, $name) {
+  my ($section) = $vim             =~ m{Covered/Markers\.pm':(.*?)\n\\\s*\},}s;
+  my ($list)    = ($section // "") =~ /'\Q$name\E': \[([^\]]*)\]/;
+  [($list // "") =~ /(\d+)/g]
+}
+
 # Stored file keys must be matched as literal text, not as Vim regexes
-sub test_vim_report_literal_matching () {
-  my ($tmpdir, $libdir) = setup_lib_dir;
-  my $cover_db = create_cover_db($tmpdir, $libdir);
-
-  my ($out, $exit) = run_cover(
-    "--select_dir", $libdir, "--report", "vim", "--silent", $cover_db,
-  );
-
-  is $exit, 0, "cover --report vim exits 0" or diag $out;
-
-  my $vim     = slurp("$cover_db/coverage.vim");
+sub test_vim_report_literal_matching ($vim) {
   my $regex   = 'match(a:filename, s:f . "$")';
   my $literal = q[match(a:filename, '\V' . escape(s:f, '\') . '\$')];
   unlike $vim, qr/\Q$regex\E/,
@@ -49,8 +54,66 @@ sub test_vim_report_literal_matching () {
     "file matching uses a very-nomagic literal pattern";
 }
 
+# Each criterion needs an uncoverable highlight and sign definition
+sub test_uncoverable_definitions ($vim) {
+  for my $type (qw( pod subroutine statement branch condition mcdc )) {
+    like $vim, qr/^highlight cov_${type}_uncoverable\b.*Grey/m,
+      "grey highlight defined for $type";
+    my $sign = "sign define ${type}_uncoverable\n"
+      . "    \\ linehl=unc texthl=cov_${type}_uncoverable";
+    like $vim, qr/^\Q$sign\E/m, "sign defined for $type";
+  }
+}
+
+# Sign priority: error beats excused beats covered, so the types list
+# must run covered, uncoverable, error (placement is reversed first-wins)
+sub test_types_priority_order ($vim) {
+  my ($list) = $vim =~ /^let s:types = \[(.*?)\]/ms;
+  ok defined $list, "types list found in coverage.vim";
+  my @names = ($list // "") =~ /"(\w+)"/g;
+  my @base  = grep !/_error$|_uncoverable$/, @names;
+  ok @base >= 4, "several criteria collected" or diag "@base";
+  is_deeply \@names,
+    [@base, (map "${_}_uncoverable", @base), (map "${_}_error", @base)],
+    "types ordered covered, uncoverable, error";
+}
+
+# Excused constructs go in the uncoverable lists, stale markers stay errors
+sub test_excused_and_stale_lines ($vim, $libdir) {
+  # subroutine coverage is recorded on the first statement's line
+  my $excused = markers_line($libdir, qr/die "emergency stop"/);
+  my $stale   = markers_line($libdir, qr/return "still called"/);
+
+  my $st_unc = markers_list($vim, "statement_uncoverable");
+  my $st_err = markers_list($vim, "statement_error");
+  my $st_cov = markers_list($vim, "statement");
+
+  ok grep($_ == $excused, @$st_unc), "excused statement listed uncoverable";
+  is grep($_ == $excused, @$st_err), 0, "excused statement is not an error";
+  is grep($_ == $excused, @$st_cov), 0, "excused statement is not covered";
+  ok grep($_ == $stale,   @$st_err), "stale marker stays an error";
+  is grep($_ == $stale,   @$st_unc), 0, "stale marker is not excused";
+
+  my $sub_unc = markers_list($vim, "subroutine_uncoverable");
+  my $sub_err = markers_list($vim, "subroutine_error");
+  ok grep($_ == $excused, @$sub_unc), "excused subroutine listed uncoverable";
+  ok grep($_ == $stale,   @$sub_err), "stale subroutine marker stays an error";
+}
+
 sub main () {
-  test_vim_report_literal_matching;
+  my ($tmpdir, $libdir) = setup_lib_dir;
+  my $cover_db = create_cover_db($tmpdir, $libdir);
+
+  my ($out, $exit) = run_cover(
+    "--select_dir", $libdir, "--report", "vim", "--silent", $cover_db,
+  );
+  is $exit, 0, "cover --report vim exits 0" or diag $out;
+  my $vim = slurp("$cover_db/coverage.vim");
+
+  test_vim_report_literal_matching($vim);
+  test_uncoverable_definitions($vim);
+  test_types_priority_order($vim);
+  test_excused_and_stale_lines($vim, $libdir);
   done_testing;
 }
 

--- a/t/lib/Devel/Cover/Test/Showcase.pm
+++ b/t/lib/Devel/Cover/Test/Showcase.pm
@@ -250,7 +250,7 @@ my $Markers_body = <<'BODY' =~ s/^  //gmr;
 
   sub fetch {
     my ($cache, $key, $default) = @_;
-    # uncoverable mcdc
+    # uncoverable mcdc all
     return $cache->{$key} //= $default;
   }
 

--- a/t/lib/Devel/Cover/Test/Showcase.pm
+++ b/t/lib/Devel/Cover/Test/Showcase.pm
@@ -338,6 +338,47 @@ my $Markers_body = <<'BODY' =~ s/^  //gmr;
     return $v;
   }
 
+  =head2 legacy_guard
+
+  A guard whose branch marker is out of date - the false arm now runs.
+
+  =cut
+
+  sub legacy_guard {
+    my ($v) = @_;
+    # uncoverable branch false
+    return 1 if $v;
+    return 0;
+  }
+
+  =head2 legacy_filter
+
+  A filter whose condition marker is out of date - the marked outcome
+  is now seen.
+
+  =cut
+
+  sub legacy_filter {
+    my ($a, $b) = @_;
+    # uncoverable condition when:11
+    my $ok = $a > 0 && $b > 0;
+    return $ok;
+  }
+
+  =head2 legacy_pair
+
+  A check whose MC/DC marker is out of date - the marked pair is now
+  proven.
+
+  =cut
+
+  sub legacy_pair {
+    my ($a, $b) = @_;
+    # uncoverable mcdc pair:1
+    my $ok = $a && $b;
+    return $ok;
+  }
+
   =head2 retired_hook
 
   A hook that is still called - its uncoverable markers are stale.
@@ -488,6 +529,14 @@ sub create_cover_db ($tmpdir, $libdir) {
   Covered::Markers::require_value_unless(5);
   Covered::Markers::require_value_if(5);
   Covered::Markers::require_value_unless_block(5);
+  Covered::Markers::legacy_guard(1);
+  Covered::Markers::legacy_guard(0);
+  Covered::Markers::legacy_filter(1, 1);
+  Covered::Markers::legacy_filter(0, 1);
+  Covered::Markers::legacy_filter(1, 0);
+  Covered::Markers::legacy_pair(1, 1);
+  Covered::Markers::legacy_pair(0, 1);
+  Covered::Markers::legacy_pair(1, 0);
   Covered::Markers::retired_hook();
   Covered::Markers::internal_probe();
   Covered::Markers::documented_probe();

--- a/t/lib/Devel/Cover/Test/Showcase.pm
+++ b/t/lib/Devel/Cover/Test/Showcase.pm
@@ -337,6 +337,34 @@ my $Markers_body = <<'BODY' =~ s/^  //gmr;
     }
     return $v;
   }
+
+  =head2 retired_hook
+
+  A hook that is still called - its uncoverable markers are stale.
+
+  =cut
+
+  sub retired_hook {
+    # uncoverable subroutine
+    # uncoverable statement
+    return "still called";
+  }
+
+  sub internal_probe {
+    # uncoverable pod
+    return "internal";
+  }
+
+  =head2 documented_probe
+
+  A documented helper whose pod marker is stale.
+
+  =cut
+
+  sub documented_probe {
+    # uncoverable pod
+    return "documented";
+  }
 BODY
 
 my $Trivial_body = <<'BODY' =~ s/^  //gmr;
@@ -460,6 +488,9 @@ sub create_cover_db ($tmpdir, $libdir) {
   Covered::Markers::require_value_unless(5);
   Covered::Markers::require_value_if(5);
   Covered::Markers::require_value_unless_block(5);
+  Covered::Markers::retired_hook();
+  Covered::Markers::internal_probe();
+  Covered::Markers::documented_probe();
   Covered::Utils::greet(q(world));
   Covered::Utils::upper(q(hi));
   Covered::Full::double(5);
@@ -592,7 +623,8 @@ C<xor>, a 17-condition decision too wide to analyse, and a loop with postfix
 C<unless> and C<last>
 
 =item B<Markers> - uncoverable markers for statement, branch, condition,
-subroutine and mcdc (bare and C<pair:N>), so excused entries show in every
+subroutine, pod and mcdc (bare and C<pair:N>), including stale markers on
+covered code, so excused and covered-but-marked entries show in every
 reporter
 
 =item B<Trivial> - single sub, no branches or conditions

--- a/test_output/cover/uncoverable.5.020000
+++ b/test_output/cover/uncoverable.5.020000
@@ -42,7 +42,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 16                                             # uncoverable condition when:0X
 17                                             # uncoverable condition when:11
 18                                             
-19             1   - 50   - 33   -  0          if ($x && !$y) {
+19             1   -100   -100   -100          if ($x && !$y) {
 20            -0                                   $x++;  # uncoverable statement
 21                                                 # uncoverable statement
 22            -0                                   z();
@@ -56,7 +56,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 30                                             # an ordinary comment between the markers
 31                                               # and the code
 32                                             
-33             1   - 50   - 33   -  0          if (!$x && $y) {
+33             1   -100   -100   -100          if (!$x && $y) {
 34                                                 # uncoverable statement count:1
 35                                                 # uncoverable statement count:2
 36            -0                                   b(); b();
@@ -97,13 +97,13 @@ line  err   stmt   bran   cond   mcdc    sub   code
 55                                             # uncoverable branch false count:2
 56                                             # uncoverable condition when:0X
 57                                             # uncoverable condition when:10
-58             1   - 50   - 33   -  0          if ($x > 0 && $y > 0) {
-                   -  0                        
+58             1   -100   -100   -100          if ($x > 0 && $y > 0) {
+                   -100                        
 59             1                                   $y++;
 60                                               # uncoverable condition when:0X
 61                                               # uncoverable condition when:10
 62                                               # uncoverable condition when:11
-63                        -  0   -  0          } elsif ($x < 2 && $y < 0) {
+63                        -100   -100          } elsif ($x < 2 && $y < 0) {
 64            -0                                   $y++; # uncoverable statement
 65                                             } else {
 66            -0                                   $y++; # uncoverable statement
@@ -118,10 +118,10 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-19          - 50     -0      1   if ($x and not $y)
-33          - 50     -0      1   if (not $x and $y)
-58          - 50      1     -0   if ($x > 0 and $y > 0) { }
-            -  0     -0     -0   elsif ($x < 2 and $y < 0) { }
+19          -100     -0      1   if ($x and not $y)
+33          -100     -0      1   if (not $x and $y)
+58          -100      1     -0   if ($x > 0 and $y > 0) { }
+            -100     -0     -0   elsif ($x < 2 and $y < 0) { }
 
 
 Conditions
@@ -131,10 +131,10 @@ and 3 conditions
 
 line  err      %     !l  l&&!r   l&&r   expr
 ----- --- ------ ------ ------ ------   ----
-19          - 33     -0      1     -0   $x and not $y
-33          - 33      1     -0     -0   not $x and $y
-58          - 33     -0     -0      1   $x > 0 and $y > 0
-63          -  0     -0     -0     -0   $x < 2 and $y < 0
+19          -100     -0      1     -0   $x and not $y
+33          -100      1     -0     -0   not $x and $y
+58          -100     -0     -0      1   $x > 0 and $y > 0
+63          -100     -0     -0     -0   $x < 2 and $y < 0
 
 
 MC/DC
@@ -142,14 +142,14 @@ MC/DC
 
 line  err      %  cov  tot   missing                expr
 ----- --- ------ ---- ----   --------------------   ----
-19          -  0    0    2                          $x and not $y
-33          -  0    0    2                          not $x and $y
-58          -  0    0    2                          $x > 0 and $y > 0
-63          -  0    0    2                          $x < 2 and $y < 0
+19          -100    0    2                          $x and not $y
+33          -100    0    2                          not $x and $y
+58          -100    0    2                          $x > 0 and $y > 0
+63          -100    0    2                          $x < 2 and $y < 0
 
 
-Uncovered Subroutines
----------------------
+Uncoverable Subroutines
+-----------------------
 
 Subroutine Count  CC  SCAR Location            
 ---------- ----- --- ----- --------------------

--- a/test_output/cover/uncoverable_count.5.020000
+++ b/test_output/cover/uncoverable_count.5.020000
@@ -53,9 +53,9 @@ line  err   stmt   bran   cond   code
 24                               # uncoverable branch false count:2
 25                               # uncoverable branch true count:3
 26                               # uncoverable branch false count:3
-27             1   - 50          if ($N == 0) {
-                   -  0          
-                   -  0          
+27             1   -100          if ($N == 0) {
+                   -100          
+                   -100          
 28             1                   $R = "zero";
 29                               } elsif ($N == 1) {
 30            -0                   $R = "one";  # uncoverable statement
@@ -75,20 +75,20 @@ line  err   stmt   bran   cond   code
 44                               # uncoverable branch false count:3
 45                               # uncoverable condition when:0X
 46                               # uncoverable condition when:11
-47             1   - 50   - 33   if ($From < $Start && $Until < $End) {
-                   - 50          
-                   - 50          
+47             1   -100   -100   if ($From < $Start && $Until < $End) {
+                   -100          
+                   -100          
 48            -0                   $R = "a";  # uncoverable statement
 49                                            # uncoverable condition when:10 count:1
 50                                            # uncoverable condition when:11 count:1
 51                                            # uncoverable condition when:10 count:2
 52                                            # uncoverable condition when:11 count:2
-53                        - 33   } elsif ($From >= $Start && $From < $End && $Until >= $End) {
-                          - 33   
+53                        -100   } elsif ($From >= $Start && $From < $End && $Until >= $End) {
+                          -100   
 54            -0                   $R = "b";  # uncoverable statement
 55                                            # uncoverable condition when:0X
 56                                            # uncoverable condition when:10
-57                        - 33   } elsif ($From < $Start && $Until >= $End) {
+57                        -100   } elsif ($From < $Start && $Until >= $End) {
 58             1                   $R = "c";
 59                               }
 60                               
@@ -102,15 +102,15 @@ line  err   stmt   bran   cond   code
 68                               # uncoverable branch false count:1
 69                               # uncoverable branch true count:2
 70                               # uncoverable statement count:4
-71             1   - 50          if ($A) { $X = 1 } if ($B) { $Y = 1 }
-               1   - 50          
+71             1   -100          if ($A) { $X = 1 } if ($B) { $Y = 1 }
+               1   -100          
                1                 
               -0                 
 72                               
 73                               # uncoverable branch false count:1
 74                               # uncoverable branch true count:2
-75             1   - 50          $X++ if $A; $Y++ if $B;
-               1   - 50          
+75             1   -100          $X++ if $A; $Y++ if $B;
+               1   -100          
 76                               #>>>
 
 
@@ -119,16 +119,16 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-27          - 50      1     -0   if ($N == 0) { }
-            -  0     -0     -0   elsif ($N == 1) { }
-            -  0     -0     -0   elsif ($N == 2) { }
-47          - 50     -0      1   if ($From < $Start and $Until < $End) { }
-            - 50     -0      1   elsif ($From >= $Start and $From < $End and $Until >= $End) { }
-            - 50      1     -0   elsif ($From < $Start and $Until >= $End) { }
-71          - 50      1     -0   if ($A)
-            - 50     -0      1   if ($B)
-75          - 50      1     -0   if $A
-            - 50     -0      1   if $B
+27          -100      1     -0   if ($N == 0) { }
+            -100     -0     -0   elsif ($N == 1) { }
+            -100     -0     -0   elsif ($N == 2) { }
+47          -100     -0      1   if ($From < $Start and $Until < $End) { }
+            -100     -0      1   elsif ($From >= $Start and $From < $End and $Until >= $End) { }
+            -100      1     -0   elsif ($From < $Start and $Until >= $End) { }
+71          -100      1     -0   if ($A)
+            -100     -0      1   if ($B)
+75          -100      1     -0   if $A
+            -100     -0      1   if $B
 
 
 Conditions
@@ -138,9 +138,9 @@ and 3 conditions
 
 line  err      %     !l  l&&!r   l&&r   expr
 ----- --- ------ ------ ------ ------   ----
-47          - 33     -0      1     -0   $From < $Start and $Until < $End
-53          - 33      1     -0     -0   $From >= $Start and $From < $End and $Until >= $End
-            - 33      1     -0     -0   $From >= $Start and $From < $End
-57          - 33     -0     -0      1   $From < $Start and $Until >= $End
+47          -100     -0      1     -0   $From < $Start and $Until < $End
+53          -100      1     -0     -0   $From >= $Start and $From < $End and $Until >= $End
+            -100      1     -0     -0   $From >= $Start and $From < $End
+57          -100     -0     -0      1   $From < $Start and $Until >= $End
 
 

--- a/test_output/cover/uncoverable_error.5.020000
+++ b/test_output/cover/uncoverable_error.5.020000
@@ -49,7 +49,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 17             1                           1       my $x = 1;
 18                                                 # uncoverable branch false class:ignore_covered_err
 19                                                 # uncoverable branch true
-20             1   - 50                            if ($x > 1) {
+20             1   -100                            if ($x > 1) {
 21    ***     *0                                       $x = 0;
 22                                                     # uncoverable statement class:ignore_covered_err
 23            -0                                       $x = 2;
@@ -63,7 +63,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 31                                                 # uncoverable condition when:0X
 32                                                 # uncoverable condition when:10 class:ignore_covered_err
 33                                                 # uncoverable condition when:11
-34             1   - 50   - 33   -  0              if ($x > 0 && $y > 0) {
+34             1   -100   -100   -100              if ($x > 0 && $y > 0) {
 35                                                     # uncoverable statement
 36            -0                                       $y = 1;
 37                                                 }
@@ -72,7 +72,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 40                                                     # uncoverable branch false
 41                                                     # uncoverable condition when:0X
 42                                                     # uncoverable condition when:10
-43    ***      2  *-100  *- 66   - 50                  if ($x > 0 && $y > 0) {
+43    ***      2  *- 50  *- 66   -100                  if ($x > 0 && $y > 0) {
 44             1                                           $y = 4;
 45                                                     } else {
 46             1                                           $y++;
@@ -92,11 +92,11 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-20          - 50     -0     -1   if ($x > 1)
+20          -100     -0     -1   if ($x > 1)
 24    ***      0      0      0   if ($x > 3)
-34          - 50     -0      1   if ($x > 0 and $y > 0)
+34          -100     -0      1   if ($x > 0 and $y > 0)
 39           100      2      1   if ($y < 4)
-43    ***   -100      1     -1   if ($x > 0 and $y > 0) { }
+43    ***   - 50      1     -1   if ($x > 0 and $y > 0) { }
 
 
 Conditions
@@ -106,7 +106,7 @@ and 3 conditions
 
 line  err      %     !l  l&&!r   l&&r   expr
 ----- --- ------ ------ ------ ------   ----
-34          - 33     -0     -1     -0   $x > 0 and $y > 0
+34          -100     -0     -1     -0   $x > 0 and $y > 0
 43    ***   - 66     -0     -1      1   $x > 0 and $y > 0
 
 
@@ -115,8 +115,8 @@ MC/DC
 
 line  err      %  cov  tot   missing                expr
 ----- --- ------ ---- ----   --------------------   ----
-34          -  0    0    2                          $x > 0 and $y > 0
-43          - 50    1    2                          $x > 0 and $y > 0
+34          -100    0    2                          $x > 0 and $y > 0
+43          -100    1    2                          $x > 0 and $y > 0
 
 
 Covered Subroutines

--- a/test_output/cover/uncoverable_error_ignore.5.020000
+++ b/test_output/cover/uncoverable_error_ignore.5.020000
@@ -51,7 +51,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 19             1                           1       my $x = 1;
 20                                                 # uncoverable branch false
 21                                                 # uncoverable branch true
-22             1   - 50                            if ($x > 1) {
+22             1   -100                            if ($x > 1) {
 23    ***     *0                                       $x = 0;
 24                                                     # uncoverable statement
 25            -0                                       $x = 2;
@@ -63,7 +63,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 31             1                                   my $y = 0;
 32                                                 # uncoverable branch true
 33                                                 # uncoverable condition when:10
-34    ***      1   - 50  *- 33   *  0              if ($x > 0 && $y > 0) {
+34    ***      1   -100  *- 33   *  0              if ($x > 0 && $y > 0) {
 35                                                     # uncoverable statement
 36            -0                                       $y = 1;
 37                                                 }
@@ -72,7 +72,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 40                                                     # uncoverable branch false
 41                                                     # uncoverable condition when:0X
 42                                                     # uncoverable condition when:10
-43             2   -100   - 66   - 50                  if ($x > 0 && $y > 0) {
+43             2   -100   -100   -100                  if ($x > 0 && $y > 0) {
 44             1                                           $y = 4;
 45                                                     } else {
 46             1                                           $y++;
@@ -92,9 +92,9 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-22          - 50     -0     -1   if ($x > 1)
+22          -100     -0     -1   if ($x > 1)
 26    ***      0      0      0   if ($x > 3)
-34          - 50     -0      1   if ($x > 0 and $y > 0)
+34          -100     -0      1   if ($x > 0 and $y > 0)
 39           100      2      1   if ($y < 4)
 43          -100      1     -1   if ($x > 0 and $y > 0) { }
 
@@ -107,7 +107,7 @@ and 3 conditions
 line  err      %     !l  l&&!r   l&&r   expr
 ----- --- ------ ------ ------ ------   ----
 34    ***   - 33      0     -1      0   $x > 0 and $y > 0
-43          - 66     -0     -1      1   $x > 0 and $y > 0
+43          -100     -0     -1      1   $x > 0 and $y > 0
 
 
 MC/DC
@@ -116,7 +116,7 @@ MC/DC
 line  err      %  cov  tot   missing                expr
 ----- --- ------ ---- ----   --------------------   ----
 34    ***      0    0    2   $x > 0, $y > 0         $x > 0 and $y > 0
-43          - 50    1    2                          $x > 0 and $y > 0
+43          -100    1    2                          $x > 0 and $y > 0
 
 
 Covered Subroutines

--- a/test_output/cover/uncoverable_flow.5.020000
+++ b/test_output/cover/uncoverable_flow.5.020000
@@ -49,41 +49,41 @@ line  err   stmt   bran   cond   code
 20             1                 my $r;
 21                               
 22                               # uncoverable branch true
-23             1   - 50          unless ($t) {
+23             1   -100          unless ($t) {
 24            -0                   $r = "u1";  # uncoverable statement
 25                               }
 26                               
 27                               # uncoverable branch false
-28             1   - 50          unless ($f) {
+28             1   -100          unless ($f) {
 29             1                   $r = "u2";
 30                               }
 31                               
 32                               # uncoverable branch true
 33                               # uncoverable condition when:01,00
-34             1   - 50   - 33   unless ($t || $f) {
+34             1   -100   -100   unless ($t || $f) {
 35            -0                   $r = "u3";  # uncoverable statement
 36                               }
 37                               
 38                               # uncoverable branch true
-39             1   - 50          while ($f) {
+39             1   -100          while ($f) {
 40            -0                   $r = "w1";  # uncoverable statement
 41                               }
 42                               
 43                               # uncoverable branch true
-44             1   - 50          until ($t) {
+44             1   -100          until ($t) {
 45            -0                   $r = "t1";  # uncoverable statement
 46                               }
 47                               
 48                               # uncoverable branch true
-49             1   - 50          for (my $i = 5; $i < 3; $i++) {
+49             1   -100          for (my $i = 5; $i < 3; $i++) {
 50            -0                   $r = "f1";  # uncoverable statement
 51                               }
 52                               
 53                               # uncoverable branch true
-54             1   - 50          $r = "m1" unless $t;
+54             1   -100          $r = "m1" unless $t;
 55                               
 56                               # uncoverable branch false
-57             1   - 50          $r = "m2" if $t;
+57             1   -100          $r = "m2" if $t;
 
 
 Branches
@@ -91,14 +91,14 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-23          - 50     -0      1   unless ($t)
-28          - 50      1     -0   unless ($f)
-34          - 50     -0      1   unless ($t or $f)
-39          - 50     -0      1   if ($f)
-44          - 50     -0      1   unless ($t)
-49          - 50     -0      1   if ($i < 3)
-54          - 50     -0      1   unless $t
-57          - 50      1     -0   if $t
+23          -100     -0      1   unless ($t)
+28          -100      1     -0   unless ($f)
+34          -100     -0      1   unless ($t or $f)
+39          -100     -0      1   if ($f)
+44          -100     -0      1   unless ($t)
+49          -100     -0      1   if ($i < 3)
+54          -100     -0      1   unless $t
+57          -100      1     -0   if $t
 
 
 Conditions
@@ -108,6 +108,6 @@ or 3 conditions
 
 line  err      %      l  !l&&r !l&&!r   expr
 ----- --- ------ ------ ------ ------   ----
-34          - 33      1     -0     -0   $t or $f
+34          -100      1     -0     -0   $t or $f
 
 

--- a/test_output/cover/uncoverable_guards.5.020000
+++ b/test_output/cover/uncoverable_guards.5.020000
@@ -53,21 +53,21 @@ line  err   stmt   bran   code
 15                        sub require_value {
 16             1            my ($v) = @_;
 17                          # uncoverable branch false
-18    ***      1  *- 50     my $ok = $v or die "no value";
+18    ***      1  *-  0     my $ok = $v or die "no value";
 19             1            return $ok;
 20                        }
 21                        
 22                        sub require_value_unless {
 23             1            my ($v) = @_;
 24                          # uncoverable branch true
-25             1   - 50     die "no value" unless $v;
+25             1   -100     die "no value" unless $v;
 26             1            return $v;
 27                        }
 28                        
 29                        sub require_value_if {
 30             1            my ($v) = @_;
 31                          # uncoverable branch true
-32             1   - 50     if (!$v) {
+32             1   -100     if (!$v) {
 33                            # uncoverable statement
 34            -0              die "no value";
 35                          }
@@ -77,7 +77,7 @@ line  err   stmt   bran   code
 39                        sub require_value_unless_block {
 40             1            my ($v) = @_;
 41                          # uncoverable branch true
-42             1   - 50     unless ($v) {
+42             1   -100     unless ($v) {
 43                            # uncoverable statement
 44            -0              die "no value";
 45                          }
@@ -95,9 +95,9 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-18    ***   - 50      0     -1   unless my $ok = $v
-25          - 50     -0      1   unless $v
-32          - 50     -0      1   unless ($v)
-42          - 50     -0      1   unless ($v)
+18    ***   -  0      0     -1   unless my $ok = $v
+25          -100     -0      1   unless $v
+32          -100     -0      1   unless ($v)
+42          -100     -0      1   unless ($v)
 
 

--- a/test_output/cover/uncoverable_guards.5.044000
+++ b/test_output/cover/uncoverable_guards.5.044000
@@ -53,21 +53,21 @@ line  err   stmt   bran   code
 15                        sub require_value {
 16             1            my ($v) = @_;
 17                          # uncoverable branch false
-18             1   - 50     my $ok = $v or die "no value";
+18             1   -100     my $ok = $v or die "no value";
 19             1            return $ok;
 20                        }
 21                        
 22                        sub require_value_unless {
 23             1            my ($v) = @_;
 24                          # uncoverable branch true
-25             1   - 50     die "no value" unless $v;
+25             1   -100     die "no value" unless $v;
 26             1            return $v;
 27                        }
 28                        
 29                        sub require_value_if {
 30             1            my ($v) = @_;
 31                          # uncoverable branch true
-32             1   - 50     if (!$v) {
+32             1   -100     if (!$v) {
 33                            # uncoverable statement
 34            -0              die "no value";
 35                          }
@@ -77,7 +77,7 @@ line  err   stmt   bran   code
 39                        sub require_value_unless_block {
 40             1            my ($v) = @_;
 41                          # uncoverable branch true
-42             1   - 50     unless ($v) {
+42             1   -100     unless ($v) {
 43                            # uncoverable statement
 44            -0              die "no value";
 45                          }
@@ -95,9 +95,9 @@ Branches
 
 line  err      %   true  false   branch
 ----- --- ------ ------ ------   ------
-18          - 50      1     -0   my $ok = $v or die "no value"
-25          - 50     -0      1   unless $v
-32          - 50     -0      1   unless ($v)
-42          - 50     -0      1   unless ($v)
+18          -100      1     -0   my $ok = $v or die "no value"
+25          -100     -0      1   unless $v
+32          -100     -0      1   unless ($v)
+42          -100     -0      1   unless ($v)
 
 

--- a/test_output/cover/uncoverable_mcdc.5.020000
+++ b/test_output/cover/uncoverable_mcdc.5.020000
@@ -54,7 +54,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 16                                             sub dor_default {
 17             2                           2     my ($h, $k, $val) = @_;
 18                                               # uncoverable mcdc all
-19    ***      2          * 66   -  0            return $h->{$k} //= $val;
+19    ***      2          * 66   -100            return $h->{$k} //= $val;
 20                                             }
 21                                             
 22                                             # $a && $b where the left operand is always true: its pair can never be formed,
@@ -63,7 +63,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 25             2                           2     my ($b) = @_;
 26             2                                 my $always = 1;
 27                                               # uncoverable mcdc pair:1
-28    ***      2          * 66   - 50            return $always && $b;
+28    ***      2          * 66   -100            return $always && $b;
 29                                             }
 30                                             
 31                                             # $a && $b && $c is a compound decision, parsed ($a && $b) && $c.  $b is held
@@ -75,8 +75,8 @@ line  err   stmt   bran   cond   mcdc    sub   code
 37             3                           3     my ($a, $c) = @_;
 38             3                                 my $b = 1;
 39                                               # uncoverable condition when:10 count:2
-40             3           100   - 66            return $a && $b && $c;
-                          - 66                 
+40             3           100   -100            return $a && $b && $c;
+                          -100                 
 41                                             }
 42                                             
 43                                             sub main {
@@ -104,7 +104,7 @@ line  err      %     !l  l&&!r   l&&r   expr
 ----- --- ------ ------ ------ ------   ----
 28    ***     66      0      1      1   $always && $b
 40           100      1      1      1   $a && $b && $c
-            - 66      1     -0      2   $a and $b
+            -100      1     -0      2   $a and $b
 
 or 3 conditions
 
@@ -118,9 +118,9 @@ MC/DC
 
 line  err      %  cov  tot   missing                expr
 ----- --- ------ ---- ----   --------------------   ----
-19          -  0    0    2                          $$h{$k} //= $val
-28          - 50    1    2                          $always && $b
-40          - 66    2    3                          $a && $b && $c
+19          -100    0    2                          $$h{$k} //= $val
+28          -100    1    2                          $always && $b
+40          -100    2    3                          $a && $b && $c
 
 
 Covered Subroutines

--- a/test_output/cover/uncoverable_mcdc.5.022000
+++ b/test_output/cover/uncoverable_mcdc.5.022000
@@ -54,7 +54,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 16                                             sub dor_default {
 17             2                           2     my ($h, $k, $val) = @_;
 18                                               # uncoverable mcdc all
-19    ***      2          * 66   -  0            return $h->{$k} //= $val;
+19    ***      2          * 66   -100            return $h->{$k} //= $val;
 20                                             }
 21                                             
 22                                             # $a && $b where the left operand is always true: its pair can never be formed,
@@ -63,7 +63,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 25             2                           2     my ($b) = @_;
 26             2                                 my $always = 1;
 27                                               # uncoverable mcdc pair:1
-28    ***      2          * 66   - 50            return $always && $b;
+28    ***      2          * 66   -100            return $always && $b;
 29                                             }
 30                                             
 31                                             # $a && $b && $c is a compound decision, parsed ($a && $b) && $c.  $b is held
@@ -75,8 +75,8 @@ line  err   stmt   bran   cond   mcdc    sub   code
 37             3                           3     my ($a, $c) = @_;
 38             3                                 my $b = 1;
 39                                               # uncoverable condition when:10 count:2
-40             3           100   - 66            return $a && $b && $c;
-                          - 66                 
+40             3           100   -100            return $a && $b && $c;
+                          -100                 
 41                                             }
 42                                             
 43                                             sub main {
@@ -104,7 +104,7 @@ line  err      %     !l  l&&!r   l&&r   expr
 ----- --- ------ ------ ------ ------   ----
 28    ***     66      0      1      1   $always && $b
 40           100      1      1      1   $a && $b && $c
-            - 66      1     -0      2   $a and $b
+            -100      1     -0      2   $a and $b
 
 or 3 conditions
 
@@ -118,9 +118,9 @@ MC/DC
 
 line  err      %  cov  tot   missing                expr
 ----- --- ------ ---- ----   --------------------   ----
-19          -  0    0    2                          $h->{$k} //= $val
-28          - 50    1    2                          $always && $b
-40          - 66    2    3                          $a && $b && $c
+19          -100    0    2                          $h->{$k} //= $val
+28          -100    1    2                          $always && $b
+40          -100    2    3                          $a && $b && $c
 
 
 Covered Subroutines

--- a/test_output/cover/uncoverable_pod.5.020000
+++ b/test_output/cover/uncoverable_pod.5.020000
@@ -1,0 +1,141 @@
+cover: Reading database from ...
+
+Common prefix: tests/
+
+------------------ ------ ------ ------ ------ ------
+File                 stmt    sub    pod  total   scar
+------------------ ------ ------ ------ ------ ------
+Uncoverable_pod.pm  100.0  100.0   75.0   92.3    0.0
+uncoverable_pod     100.0  100.0    n/a  100.0    0.0
+Total               100.0  100.0   75.0   96.8    0.0
+------------------ ------ ------ ------ ------ ------
+
+
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+
+Module Summary
+--------------
+
+Files CC   Cov CRAP SCAR
+----- -- ----- ---- ----
+    2  1 100.0  1.0  0.0
+
+
+Uncoverable_pod.pm
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+ 1 100.0  1.0  0.0
+
+line  err   stmt    sub    pod   code
+1                                # Copyright 2026, Paul Johnson (paul@pjcj.net)
+2                                
+3                                # This software is free.  It is licensed under the same terms as Perl itself.
+4                                
+5                                # The latest version of this software should be available from my homepage:
+6                                # https://pjcj.net
+7                                
+8                                package Uncoverable_pod;
+9                                
+10             1      1      1   sub documented { "documented" }
+11                               
+12                               sub excused_pod {
+13                                 # uncoverable pod
+14             1      1     -0     "excused";
+15                               }
+16                               
+17                               sub stale_pod {
+18                                 # uncoverable pod
+19    ***      1      1    *-1     "stale";
+20                               }
+21                               
+22                               sub never_called {
+23                                 # uncoverable subroutine
+24                                 # uncoverable statement
+25                                 # uncoverable pod
+26            -0     -0     -0     die "never called";
+27                               }
+28                               
+29             1                 1
+30                               
+31                               __END__
+
+
+Covered Subroutines
+-------------------
+
+Subroutine   Count Pod  CC  SCAR Location             
+------------ ----- --- --- ----- ---------------------
+documented       1   1   1   0.0 Uncoverable_pod.pm:10
+excused_pod      1  -0   1   0.0 Uncoverable_pod.pm:14
+stale_pod        1 *-1   1   0.0 Uncoverable_pod.pm:19
+
+Uncoverable Subroutines
+-----------------------
+
+Subroutine   Count Pod  CC  SCAR Location             
+------------ ----- --- --- ----- ---------------------
+never_called    -0  -0   1   0.0 Uncoverable_pod.pm:26
+
+
+uncoverable_pod
+
+File Summary
+------------
+
+CC   Cov CRAP SCAR
+-- ----- ---- ----
+ 1 100.0  1.0  0.0
+
+line  err   stmt    sub    pod   code
+1                                #!/usr/bin/perl
+2                                
+3                                # Copyright 2026, Paul Johnson (paul@pjcj.net)
+4                                
+5                                # This software is free.  It is licensed under the same terms as Perl itself.
+6                                
+7                                # The latest version of this software should be available from my homepage:
+8                                # https://pjcj.net
+9                                
+10                               # __COVER__ criteria statement subroutine pod
+11                               # __COVER__ skip_test eval "use Pod::Coverage"; $@
+12                               # __COVER__ skip_reason Pod::Coverage unavailable
+13                               
+14             1      1          use strict;
+               1                 
+               1                 
+15             1      1          use warnings;
+               1                 
+               1                 
+16                               
+17             1      1          use lib "tests";
+               1                 
+               1                 
+18                               
+19             1      1          use Uncoverable_pod;
+               1                 
+               1                 
+20                               
+21             1                 Uncoverable_pod::documented();
+22             1                 Uncoverable_pod::excused_pod();
+23             1                 Uncoverable_pod::stale_pod();
+
+
+Covered Subroutines
+-------------------
+
+Subroutine Count  CC  SCAR Location          
+---------- ----- --- ----- ------------------
+BEGIN          1   1   0.0 uncoverable_pod:14
+BEGIN          1   1   0.0 uncoverable_pod:15
+BEGIN          1   1   0.0 uncoverable_pod:17
+BEGIN          1   1   0.0 uncoverable_pod:19
+
+

--- a/tests/Uncoverable_pod.pm
+++ b/tests/Uncoverable_pod.pm
@@ -1,0 +1,43 @@
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+package Uncoverable_pod;
+
+sub documented { "documented" }
+
+sub excused_pod {
+  # uncoverable pod
+  "excused";
+}
+
+sub stale_pod {
+  # uncoverable pod
+  "stale";
+}
+
+sub never_called {
+  # uncoverable subroutine
+  # uncoverable statement
+  # uncoverable pod
+  die "never called";
+}
+
+1
+
+__END__
+
+=head2 documented
+
+A documented subroutine.
+
+=cut
+
+=head2 stale_pod
+
+A documented subroutine whose pod marker is stale.
+
+=cut

--- a/tests/uncoverable_pod
+++ b/tests/uncoverable_pod
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# __COVER__ criteria statement subroutine pod
+# __COVER__ skip_test eval "use Pod::Coverage"; $@
+# __COVER__ skip_reason Pod::Coverage unavailable
+
+use strict;
+use warnings;
+
+use lib "tests";
+
+use Uncoverable_pod;
+
+Uncoverable_pod::documented();
+Uncoverable_pod::excused_pod();
+Uncoverable_pod::stale_pod();


### PR DESCRIPTION
## Summary

Every criterion and report rendered uncoverable constructs differently - excused code could read as failure (red statement cells, quickfix lines, missing editor signs) or as plain success, and a marker on code which ran often went unreported. This branch settles one presentation and applies it across the criteria and reports. A construct marked uncoverable reads as acknowledged, and a marker which no longer tells the truth reads as an error.

## Changes

- Base each construct's displayed percentage on errors, matching the summary definition, so excused constructs no longer drag the numbers down (BREAKING).
- Rework the Text subroutine tables, listing excused subs under an Uncoverable Subroutines heading and flagging covered subs whose marker is stale.
- Base the Compilation report on error state, adding "marked uncoverable but covered" messages and dropping the excused false positives.
- Show markers in the crisp and basic HTML reports as a diagonal stripe over the outcome colour - excused striped green, stale markers striped red - with tooltips, and a help legend in crisp.
- Fix the basic report's branch and condition detail cells passing raw counts where percentages were expected.
- Add a grey third sign state to the Vim and Nvim reports for excused lines.
- Rebuild the JSON report's condition truth tables from observed vectors, with an uncoverable flag per row, and record the error rule in a top-level `ignore_covered_err` key (BREAKING).
- Document the four states and each report's vocabulary in the POD, add showcase demos and regenerate the affected golden results.

## Implications

- Text2, Html_minimal and Html_subtle are deliberately unchanged - GH-706 deprecates them, which also clears the road to deleting Truth_Table.

## Ticket

Closes #703