### PR TITLE
GH-353 Close filehandles perl leaves open

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Read MYMETA.json without CPAN::Meta->load_file, which leaks the
+  filehandle it opens (GH-353)
 - Release the lock on a coverage database file when the read or write
   finishes - a program which had closed STDIN previously held it until exit
   (GH-353)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Label warning and error output with Warning or Error so it stands out
+  from routine messages (GH-353)
 - Report input problems with dcwarn rather than dcinfo, dropping the
   Warning prefix from their text (GH-353)
 - Read MYMETA.json without CPAN::Meta->load_file, which leaks the

--- a/Changes
+++ b/Changes
@@ -3,7 +3,7 @@ Devel::Cover history
 {{$NEXT}}
 - Close each source file after taking its MD5 digest, so a program that closes
   and reopens STDIN can still read from it with <> (Josh Soref) (GH-353)
-- BREAKING: Stop installing the cpancover command (Gabor Szabó) (GH-273)
+- BREAKING: Stop installing the cpancover command (Gábor Szabó) (GH-273)
 - BREAKING: Base each construct's displayed percentage on errors, matching
   the summary definition, so excused constructs read -100 instead of
   dragging the number down (GH-703)
@@ -340,7 +340,7 @@ Devel::Cover history
  - Fix spelling mistakes (Gregor Herrmann) (GH-171)
  - Fix condition coverage for complex conditions (Heinz Knutzen) (GH-165)
  - Use JSON::MaybeXS for sppen and flexibility (Olivier Mengué) (GH-139)
- - Add CONTRIBUTING file (Gabor Szabó) (GH-100)
+ - Add CONTRIBUTING file (Gábor Szabó) (GH-100)
 
 1.24 - 18 April 2017
  - Work with 5.25.x (op_sibling) (Dan Collins, Matthew Horsfall) (GH-162)
@@ -1014,10 +1014,10 @@ Devel::Cover history
  - Clean up time routines in XS code
 
 0.28 - 1st December 2003
- - Remove leading whitespace from HTML templates (Gabor Szabó)
+ - Remove leading whitespace from HTML templates (Gábor Szabó)
  - Remove obsolete indent option
  - Add MD5 checksums (Michael Carman)
- - Add Html_minimal.pm (Michael Carman) (Obsoleting Gabor's patch before it was
+ - Add Html_minimal.pm (Michael Carman) (Obsoleting Gábor's patch before it was
    released)
  - Pass unknown cover options to the formatter and remove -option
  - Specify the output directory for HTML

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Close each source file after taking its MD5 digest, so a program that closes
+  and reopens STDIN can still read from it with <> (Josh Soref) (GH-353)
 - BREAKING: Stop installing the cpancover command (Gabor Szabó) (GH-273)
 - BREAKING: Base each construct's displayed percentage on errors, matching
   the summary definition, so excused constructs read -100 instead of

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Report input problems with dcwarn rather than dcinfo, dropping the
+  Warning prefix from their text (GH-353)
 - Read MYMETA.json without CPAN::Meta->load_file, which leaks the
   filehandle it opens (GH-353)
 - Release the lock on a coverage database file when the read or write

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Release the lock on a coverage database file when the read or write
+  finishes - a program which had closed STDIN previously held it until exit
+  (GH-353)
 - Close each source file after taking its MD5 digest, so a program that closes
   and reopens STDIN can still read from it with <> (Josh Soref) (GH-353)
 - BREAKING: Stop installing the cpancover command (Gábor Szabó) (GH-273)

--- a/bin/gcov2perl
+++ b/bin/gcov2perl
@@ -16,7 +16,7 @@ no warnings qw( experimental::signatures experimental::postderef );
 # VERSION
 
 use Devel::Cover::DB  ();
-use Devel::Cover::Log qw( dcerror dcinfo );
+use Devel::Cover::Log qw( dcerror dcinfo dcwarn );
 
 use Config       qw( %Config );
 use File::Path   qw( mkpath );
@@ -138,7 +138,7 @@ sub add_cover ($file) {
         $structure->add_branch($f, [$line, { text => $text }]);
         push $run{count}{$f}{branch}->@*, \@branches;
       } else {
-        dcinfo "Warning: ignoring branch with "
+        dcwarn "Ignoring branch with "
           . scalar @branches
           . " targets at $f:$line $text";
       }

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -354,7 +354,11 @@ sub populate_run {
   if (-e $mymeta) {
     eval {
       require CPAN::Meta;
-      my $json = CPAN::Meta->load_file($mymeta)->as_struct;
+      open my $fh, "<:encoding(UTF-8)", $mymeta
+        or die "Can't open $mymeta: $!\n";
+      my $meta = do { local $/; <$fh> };
+      close $fh or die "Can't close $mymeta: $!\n";
+      my $json = CPAN::Meta->load_json_string($meta)->as_struct;
       $Run{$_} = $json->{$_} for qw( name version abstract );
     }
   } elsif ($Dir =~ m|.*/([^/]+)$|) {

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -1325,7 +1325,7 @@ sub _cover_file (
     my $fc  = $f->{$criterion};
     my $get = "get_$criterion";
     my $sc  = $st->$get($digest) or do {
-      dcinfo "Warning: can't locate structure for $criterion in $file"
+      dcwarn "Can't locate structure for $criterion in $file"
         unless $warned->{$file}{$criterion}++;
       next;
     };

--- a/lib/Devel/Cover/DB/IO/Base.pm
+++ b/lib/Devel/Cover/DB/IO/Base.pm
@@ -29,7 +29,9 @@ sub _lock ($self, $file, $type) {
 
 sub _read ($self, $file, $reader) {
   my $lock_fh = $self->_lock($file, LOCK_SH);
-  $reader->()
+  my $data    = $reader->();
+  close $lock_fh or die "Can't close $file.lock: $!\n";
+  $data
 }
 
 sub _write ($self, $file, $writer) {
@@ -40,6 +42,7 @@ sub _write ($self, $file, $writer) {
     unlink $tmp;
     die "Can't rename $tmp to $file: $!\n";
   };
+  close $lock_fh or die "Can't close $file.lock: $!\n";
   $self
 }
 

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -172,6 +172,7 @@ sub digest ($self, $file) {
   if (open my $fh, "<", $file) {
     binmode $fh;
     $digest = Digest::MD5->new->addfile($fh)->hexdigest;
+    close $fh or dcwarn "Can't close $file after MD5 digest: $!";
   } else {
     dcinfo "Warning: can't open $file for MD5 digest: $!"
       unless lc $file eq "-e" or $file =~ $Devel::Cover::DB::Ignore_filenames;

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -174,7 +174,7 @@ sub digest ($self, $file) {
     $digest = Digest::MD5->new->addfile($fh)->hexdigest;
     close $fh or dcwarn "Can't close $file after MD5 digest: $!";
   } else {
-    dcinfo "Warning: can't open $file for MD5 digest: $!"
+    dcwarn "Can't open $file for MD5 digest: $!"
       unless lc $file eq "-e" or $file =~ $Devel::Cover::DB::Ignore_filenames;
   }
   $digest

--- a/lib/Devel/Cover/Log.pm
+++ b/lib/Devel/Cover/Log.pm
@@ -28,12 +28,12 @@ sub dcinfo ($msg) {
 }
 
 sub dcerror ($msg) {
-  print STDERR "$Prefix: $msg\n";
+  print STDERR "$Prefix: Error: $msg\n";
 }
 
 sub dcwarn ($msg) {
   return if $Devel::Cover::Silent;
-  print STDERR "$Prefix: $msg\n";
+  print STDERR "$Prefix: Warning: $msg\n";
 }
 
 sub dcprogress ($msg) {
@@ -67,9 +67,10 @@ Devel::Cover::Log - Centralised diagnostic output for Devel::Cover
 =head1 DESCRIPTION
 
 All diagnostic output goes to STDERR with a consistent C<"$Prefix: "> prefix
-(default C<cover>).  STDOUT is reserved for requested output such as the
-summary table, the C<--dump_db> dump, and report content for text-based
-reporters.
+(default C<cover>).  Warnings and errors carry a further C<Warning> or
+C<Error> label so they stand out from routine output.  STDOUT is reserved
+for requested output such as the summary table, the C<--dump_db> dump, and
+report content for text-based reporters.
 
 Functions are exported on request; import only those you need.
 
@@ -84,12 +85,14 @@ C<$Devel::Cover::Silent> is true.
 
 =item dcerror($msg)
 
-Error message.  Never silenced: errors are always reported.
+Error message, labelled C<Error>.  Never silenced, so errors are always
+reported.
 
 =item dcwarn($msg)
 
-Warning about a problem in the input or configuration; the requested output
-is still produced.  Silenced when C<$Devel::Cover::Silent> is true.
+Warning about a problem in the input or configuration, labelled C<Warning>.
+The requested output is still produced.  Silenced when
+C<$Devel::Cover::Silent> is true.
 
 =item dcprogress($msg)
 

--- a/t/internal/db_io_lock.t
+++ b/t/internal/db_io_lock.t
@@ -1,0 +1,75 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing like plan )];
+
+BEGIN {
+  plan skip_all => "flock is emulated on Windows" if $^O eq "MSWin32";
+}
+
+sub setup ($tmpdir) {
+  my $script = File::Spec->catfile($tmpdir, "lock.pl");
+  open my $fh, ">", $script or die "write $script: $!";
+  print $fh <<'PERL';
+use Fcntl qw( LOCK_EX LOCK_NB );
+use Devel::Cover::DB::IO::Base ();
+
+my ($mode, $file) = @ARGV;
+open my $fh, ">", $file or die "write $file: $!";
+print $fh "data";
+close $fh or die "close $file: $!";
+
+close STDIN;
+
+my $io = Devel::Cover::DB::IO::Base->new;
+if ($mode eq "read") {
+  $io->read_fh($file, sub { my $in = shift; local $/; <$in> });
+} else {
+  $io->write_fh($file, sub { my $out = shift; print $out "more" });
+}
+
+open my $lock, "+>>", "$file.lock" or die "open lock: $!";
+my $state = flock($lock, LOCK_EX | LOCK_NB) ? "released" : "held";
+print "$mode lock $state\n";
+PERL
+  close $fh or die "close $script: $!";
+  $script
+}
+
+sub test_lock_released ($mode) {
+  my $tmpdir = tempdir(CLEANUP => 1);
+  my $script = setup($tmpdir);
+
+  my $file   = File::Spec->catfile($tmpdir, "data");
+  my $cmd    = join " ", map qq("$_"), $^X, "-Mblib", $script, $mode, $file;
+  my $output = `$cmd 2>&1`;
+
+  like $output, qr/\Q$mode lock released\E/,
+    "$mode releases the lock when STDIN is closed"
+    or diag $output;
+}
+
+sub main () {
+  test_lock_released("read");
+  test_lock_released("write");
+  done_testing;
+}
+
+main;

--- a/t/internal/log.t
+++ b/t/internal/log.t
@@ -58,22 +58,22 @@ sub test_dcinfo_silenced () {
 sub test_dcerror_writes_to_stderr () {
   local $Devel::Cover::Silent = 0;
   my ($out, $err) = capture { dcerror "oops" };
-  is $out, "",              "dcerror: nothing on STDOUT";
-  is $err, "cover: oops\n", "dcerror: prefixed message on STDERR";
+  is $out, "",                     "dcerror: nothing on STDOUT";
+  is $err, "cover: Error: oops\n", "dcerror: labelled message on STDERR";
 }
 
 sub test_dcerror_not_silenced () {
   local $Devel::Cover::Silent = 1;
   my ($out, $err) = capture { dcerror "oops" };
-  is $out, "",              "dcerror silent: nothing on STDOUT";
-  is $err, "cover: oops\n", "dcerror silent: still emitted - not guarded";
+  is $out, "",                     "dcerror silent: nothing on STDOUT";
+  is $err, "cover: Error: oops\n", "dcerror silent: still emitted";
 }
 
 sub test_dcwarn_writes_to_stderr () {
   local $Devel::Cover::Silent = 0;
   my ($out, $err) = capture { dcwarn "beware" };
-  is $out, "",                "dcwarn: nothing on STDOUT";
-  is $err, "cover: beware\n", "dcwarn: prefixed message on STDERR";
+  is $out, "",                         "dcwarn: nothing on STDOUT";
+  is $err, "cover: Warning: beware\n", "dcwarn: labelled message on STDERR";
 }
 
 sub test_dcwarn_silenced () {
@@ -109,7 +109,8 @@ sub test_prefix_override_error () {
   local $Devel::Cover::Silent      = 0;
   local $Devel::Cover::Log::Prefix = "gcov2perl";
   my ($out, $err) = capture { dcerror "bad" };
-  is $err, "gcov2perl: bad\n", "prefix override: dcerror uses custom prefix";
+  is $err, "gcov2perl: Error: bad\n",
+    "prefix override: dcerror uses custom prefix";
 }
 
 sub test_multiline_message () {

--- a/t/internal/mymeta_stdin.t
+++ b/t/internal/mymeta_stdin.t
@@ -1,0 +1,82 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing like plan )];
+
+BEGIN {
+  plan skip_all => "CPAN::Meta required for this test"
+    unless eval "require CPAN::Meta; 1";
+}
+
+sub write_file ($file, $contents) {
+  open my $fh, ">", $file or die "write $file: $!";
+  print $fh $contents;
+  close $fh or die "close $file: $!";
+}
+
+sub setup ($tmpdir) {
+  write_file(File::Spec->catfile($tmpdir, "MYMETA.json"), <<'JSON');
+{
+   "abstract" : "test distribution",
+   "author" : [ "nobody" ],
+   "dynamic_config" : 0,
+   "generated_by" : "Devel::Cover tests",
+   "license" : [ "perl_5" ],
+   "meta-spec" : {
+      "url" : "https://metacpan.org/pod/CPAN::Meta::Spec",
+      "version" : 2
+   },
+   "name" : "Test-Dist",
+   "release_status" : "stable",
+   "version" : "0.01"
+}
+JSON
+
+  my $script = File::Spec->catfile($tmpdir, "stdin.pl");
+  write_file($script, <<'PERL');
+BEGIN { close STDIN }
+my $data = "-world-";
+open STDIN, "<", \$data or die "open STDIN: $!";
+my $line = <>;
+print "got(", defined $line ? $line : "UNDEF", ")\n";
+PERL
+  $script
+}
+
+sub test_readline_with_mymeta () {
+  my $tmpdir = tempdir(CLEANUP => 1);
+  my $script = setup($tmpdir);
+
+  my $db  = File::Spec->catdir($tmpdir, "cover_db");
+  my $cmd = join " ", map qq("$_"), $^X, "-Mblib",
+    "-MDevel::Cover=-silent,1,-db,$db,-dir,$tmpdir", $script;
+  my $output = `$cmd 2>&1`;
+
+  like $output, qr/\Qgot(-world-)\E/,
+    "reading the distribution metadata leaves STDIN alone"
+    or diag $output;
+}
+
+sub main () {
+  test_readline_with_mymeta;
+  done_testing;
+}
+
+main;

--- a/t/internal/stdin_reopen.t
+++ b/t/internal/stdin_reopen.t
@@ -1,0 +1,64 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing like )];
+
+sub write_file ($file, $contents) {
+  open my $fh, ">", $file or die "write $file: $!";
+  print $fh $contents;
+  close $fh or die "close $file: $!";
+}
+
+sub test_readline_after_reopening_stdin () {
+  my $tmpdir = tempdir(CLEANUP => 1);
+
+  # Loading our own file means exactly one new file is digested
+  my $trigger = File::Spec->catfile($tmpdir, "trigger.pl");
+  write_file($trigger, "my \$loaded = 1;\n1;\n");
+  $trigger =~ s|\\|/|g;
+
+  my $source = <<'PERL';
+close STDIN;
+require "TRIGGER";
+my $data = "-world-";
+open STDIN, "<", \$data or die "open STDIN: $!";
+my $line = <>;
+print "got(", defined $line ? $line : "UNDEF", ")\n";
+PERL
+  $source =~ s|TRIGGER|$trigger|;
+
+  my $script = File::Spec->catfile($tmpdir, "stdin.pl");
+  write_file($script, $source);
+
+  my $db  = File::Spec->catdir($tmpdir, "cover_db");
+  my $cmd = join " ", map qq("$_"), $^X, "-Mblib",
+    "-MDevel::Cover=-silent,1,-db,$db", $script;
+  my $output = `$cmd 2>&1`;
+
+  like $output, qr/\Qgot(-world-)\E/, "<> reads a reopened STDIN under coverage"
+    or diag $output;
+}
+
+sub main () {
+  test_readline_after_reopening_stdin;
+  done_testing;
+}
+
+main;

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -84,7 +84,7 @@ sub test_digest_missing () {
     my $d = $st->digest($bogus);
     ok !defined $d, "digest missing: returns undef"
   };
-  like $stderr, qr/can't open/, "digest missing: warns on STDERR";
+  like $stderr, qr/Can't open/, "digest missing: warns on STDERR";
 }
 
 sub test_digest_missing_silent () {

--- a/test_output/cover/mcdc_wide.5.020000
+++ b/test_output/cover/mcdc_wide.5.020000
@@ -1,6 +1,6 @@
 cover: Reading database from ...
-cover: MC/DC decision at tests/mcdc_wide:23 has 18 conditions, exceeding the analysis limit of 16
-cover: MC/DC decision at tests/mcdc_wide:41 has 17 conditions, exceeding the analysis limit of 16
+cover: Warning: MC/DC decision at tests/mcdc_wide:23 has 18 conditions, exceeding the analysis limit of 16
+cover: Warning: MC/DC decision at tests/mcdc_wide:41 has 17 conditions, exceeding the analysis limit of 16
 --------------- ------ ------ ------ ------ ------ ------ ------
 File              stmt   bran   cond   mcdc    sub  total   scar
 --------------- ------ ------ ------ ------ ------ ------ ------

--- a/test_output/cover/uncoverable.5.020000
+++ b/test_output/cover/uncoverable.5.020000
@@ -1,5 +1,5 @@
 cover: Reading database from ...
-cover: 2 unmatched uncoverable comments not found at end of tests/uncoverable
+cover: Warning: 2 unmatched uncoverable comments not found at end of tests/uncoverable
 ----------------- ------ ------ ------ ------ ------ ------ ------
 File                stmt   bran   cond   mcdc    sub  total   scar
 ----------------- ------ ------ ------ ------ ------ ------ ------


### PR DESCRIPTION
## Summary

Under coverage, `<>` returned nothing after a program reopened `STDIN`. With an empty `@ARGV`, `<>` reads a fixed slot in perl's PerlIO table rather than the `STDIN` glob, and `Perl_sv_clear` will not close a handle sitting in that slot. So a file Devel::Cover opened and left to scope exit kept the slot, and the program's own `STDIN` went elsewhere.

Close the three filehandles that relied on scope exit - the MD5 digest of each source file, the lock on a database file, and the one `CPAN::Meta->load_file` opens for `MYMETA.json`. That last leak is in `Parse::CPAN::Meta::_slurp` rather than ours, so read the file here instead.

Label the output of `dcwarn` and `dcerror`, which printed exactly what `dcinfo` did, so nothing marked a problem.

## Ticket

Closes #353