### PR TITLE
GH-710 Keep working files out of the distribution

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -30,8 +30,8 @@ lib/Devel/Cover/Inc.pm$
 \.git/
 \.tar.bz2$
 MYMETA\.
-tags
-.perl-version
+^tags
+^\.perl-version$
 \.db
 ^\.build\b
 CLAUDE\.md$

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -12,6 +12,7 @@ pm_to_blib$
 \.c$
 \.o$
 \.bs$
+\.def$
 cover_db/
 core$
 \.out$

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -22,6 +22,11 @@ lib/Devel/Cover/Inc.pm$
 \.debug$
 ^tmp/
 ^bugs/
+^llm/
+^dc_cover[^/]*/
+^local/
+^\.claude/
+^\.test_info\.
 \.git/
 \.tar.bz2$
 MYMETA\.

--- a/dist.ini
+++ b/dist.ini
@@ -36,6 +36,7 @@ x_IRC             = irc://irc.perl.org/#perl-qa
 directory = tests
 directory = t
 directory = utils
+directory = llm
 
 [MetaProvides::Package]
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -43,6 +43,11 @@
 
     - `dc install_dzil`
 
-11. Make the release
+11. Check what the distribution will contain
+
+    - `prove -l t/internal/manifest_skip.t`
+    - `dzil build && find Devel-Cover-* -type f | sort | less`
+
+12. Make the release
 
     - `dzil release`

--- a/t/internal/manifest_skip.t
+++ b/t/internal/manifest_skip.t
@@ -34,8 +34,20 @@ sub test_working_paths_are_skipped () {
     local/lib/perl5/Foo.pm
     .claude/settings.local.json
     .test_info.123.json
+    tags
+    tags.tmp
+    .perl-version
   );
   ok $Skip->($_), "$_ is skipped" for @paths;
+}
+
+sub test_shipped_paths_are_kept () {
+  my @paths = qw(
+    docs/perl-version-update.md
+    docs/montags.md
+    utils/tags
+  );
+  ok !$Skip->($_), "$_ is kept" for @paths;
 }
 
 sub test_only_expected_entries_survive () {
@@ -63,6 +75,7 @@ sub test_only_expected_entries_survive () {
 
 sub main () {
   test_working_paths_are_skipped;
+  test_shipped_paths_are_kept;
   test_only_expected_entries_survive;
   done_testing;
 }

--- a/t/internal/manifest_skip.t
+++ b/t/internal/manifest_skip.t
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# Dist::Zilla gathers every file in the working tree, dotfiles included, and
+# MANIFEST.SKIP is the only filter, so working files must be skipped and
+# nothing unexpected may reach the CPAN tarball.
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use ExtUtils::Manifest qw( maniskip );
+use File::Find         qw( find );
+
+use Test::More import => [qw( diag done_testing is ok plan )];
+
+plan skip_all => "must run from the root of a git checkout"
+  unless -d ".git" && -e "dist.ini" && -e "MANIFEST.SKIP";
+
+my $Skip = maniskip;
+
+sub test_working_paths_are_skipped () {
+  my @paths = qw(
+    llm/todo.md
+    llm/plans/GH-1/status.md
+    dc_cover_lib_db/runs/x
+    local/lib/perl5/Foo.pm
+    .claude/settings.local.json
+    .test_info.123.json
+  );
+  ok $Skip->($_), "$_ is skipped" for @paths;
+}
+
+sub test_only_expected_entries_survive () {
+  my %expected = map { $_ => 1 } qw(
+    .codespell .dprint.json .editorconfig .gitattributes .github .gitignore
+    .hadolint.yaml .jscpd.json .markdownlint.yaml .mdformat.toml .perlcriticrc
+    .perlimports.toml .perltidyrc .pre-commit-config.yaml .shellcheckrc
+    .typos.toml .yamllint Changes Contributors Cover.xs MANIFEST.SKIP
+    Makefile.PL README.md SECURITY.md bin dist.ini docker docs lib t
+    test_output tests utils xt
+  );
+  my %stray;
+  find sub {
+    if (-d && $_ eq ".git") { $File::Find::prune = 1; return }
+    return unless -f;
+    my $name = $File::Find::name =~ s|^\./||r;
+    return if $Skip->($name);
+    my ($top) = $name =~ m|^([^/]+)|;
+    $stray{$top}++ unless $expected{$top};
+  }, ".";
+  is join(" ", sort keys %stray), "", "no stray files survive MANIFEST.SKIP"
+    or diag "add working files to MANIFEST.SKIP"
+    . " or distribution files to the expected list";
+}
+
+sub main () {
+  test_working_paths_are_skipped;
+  test_only_expected_entries_survive;
+  done_testing;
+}
+
+main;

--- a/t/internal/manifest_skip.t
+++ b/t/internal/manifest_skip.t
@@ -34,6 +34,7 @@ sub test_working_paths_are_skipped () {
     local/lib/perl5/Foo.pm
     .claude/settings.local.json
     .test_info.123.json
+    Cover.def
     tags
     tags.tmp
     .perl-version


### PR DESCRIPTION
## Summary

Dist::Zilla gathers every file in the working tree and reads only `MANIFEST.SKIP`, never `.gitignore`. Add skip patterns for the `llm/`, `dc_cover*/`, `local/` and `.claude/` working directories and for yath's transient `.test_info` file, stop MetaCPAN indexing `llm`, and add a test that checks the working paths are skipped and nothing unexpected survives the filter. The test runs only from the root of a git checkout, so user installs from the tarball skip it.

Also anchor the `tags` and `.perl-version` skip patterns, which matched anywhere in a path and silently dropped shipped files such as `docs/perl-version-update.md` from the tarball.

Also add a release step to look at the gathered file list before upload, since nothing between `dzil build` and the upload did.

## Ticket

Closes #710