### PR TITLE
GH-714 Fix cover -test space and comma handling

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -313,13 +313,14 @@ sub harness_options () {
 sub do_test ($dbname) {
   return 0                  unless $Options->{test};
   delete_db($dbname, @ARGV) unless defined $Options->{delete};
-  my $extra = "-db,$dbname";
-  $extra .= ",-coverage,$_" for $Options->{coverage}->@*;
+  my $esc   = sub ($v) { $v =~ s/,/\\,/gr };
+  my $extra = "-db," . $esc->($dbname);
+  $extra .= ",-coverage,$_" for map $esc->($_), $Options->{coverage}->@*;
   $extra .= ",-ignore,$_"
-    for $Options->{ignore_re}->@*, map quotemeta, map glob,
+    for map $esc->($_), $Options->{ignore_re}->@*, map quotemeta, map glob,
     $Options->{ignore}->@*;
   $extra .= ",-select,$_"
-    for $Options->{select_re}->@*, map quotemeta, map glob,
+    for map $esc->($_), $Options->{select_re}->@*, map quotemeta, map glob,
     $Options->{select}->@*;
 
   $Options->{$_} = [] for qw( ignore ignore_re select select_re );

--- a/bin/cover
+++ b/bin/cover
@@ -313,10 +313,7 @@ sub harness_options () {
 sub do_test ($dbname) {
   return 0                  unless $Options->{test};
   delete_db($dbname, @ARGV) unless defined $Options->{delete};
-  my $env_db_name = $dbname;
-  $env_db_name =~ s/\\/\\\\/g if $^O eq "MSWin32";
-  $env_db_name =~ s/ /\\ /g;
-  my $extra = "";
+  my $extra = "-db,$dbname";
   $extra .= ",-coverage,$_" for $Options->{coverage}->@*;
   $extra .= ",-ignore,$_"
     for $Options->{ignore_re}->@*, map quotemeta, map glob,
@@ -328,8 +325,9 @@ sub do_test ($dbname) {
   $Options->{$_} = [] for qw( ignore ignore_re select select_re );
   $Options->{report} = ["html"] unless $Options->{report}->@*;
 
-  my $opts = join " ", grep $_, $ENV{DEVEL_COVER_TEST_OPTS},
-    "-MDevel::Cover=-db,$env_db_name$extra";
+  my $opts = join " ", grep $_, $ENV{DEVEL_COVER_TEST_OPTS}, "-MDevel::Cover";
+  local $ENV{DEVEL_COVER_OPTIONS} = join ",", $extra, grep defined && length,
+    $ENV{DEVEL_COVER_OPTIONS};
   local $ENV{HARNESS_PERL_SWITCHES} = $opts;
   local $ENV{PERL5OPT}              = $opts;
   local $ENV{HARNESS_OPTIONS}       = harness_options();

--- a/bin/cover
+++ b/bin/cover
@@ -170,6 +170,36 @@ sub get_options () {
   }
 }
 
+sub valid_report ($report) {
+  if ($report !~ /^\w+$/) {
+    dcerror "$report is not a recognised output format\n";
+    return;
+  }
+  my $format = "Devel::Cover::Report::\u$report";
+  eval "use $format";
+  if ($@) {
+    dcerror "$report is not a recognised output format\n$@";
+    return;
+  }
+  1
+}
+
+sub get_annotation ($ann) {
+  if ($ann !~ /^\w+$/) {
+    dcerror "$ann is not a recognised annotation\n";
+    exit 1;
+  }
+  my $annotation = "Devel::Cover::Annotation::\u$ann";
+  eval "use $annotation";
+  if ($@) {
+    dcerror "$ann is not a recognised annotation\n$@";
+    exit 1;
+  }
+  my $ann_obj = $annotation->new;
+  $ann_obj->get_options($Options) if $ann_obj->can("get_options");
+  $ann_obj
+}
+
 sub check_options () {
   get_options;
   my @argv = @ARGV;  # store args after local processing for report processing
@@ -177,46 +207,15 @@ sub check_options () {
   $Devel::Cover::Silent             = 1 if $Options->{silent};
   $Devel::Cover::Ignore_covered_err = 1 if $Options->{ignore_covered_err};
 
-  $Options->{report} = [
-    grep {
-      my $report = $_;
-      if ($report !~ /^\w+$/) {
-        dcerror "$report is not a recognised output format\n";
-        ()
-      } else {
-        my $format = "Devel::Cover::Report::\u$report";
-        eval "use $format";
-        if ($@) {
-          dcerror "$report is not a recognised output format\n$@";
-          ()
-        } else {
-          $report
-        }
-      }
-    } $Options->{report}->@*
-  ];
+  $Options->{report} = [grep valid_report($_), $Options->{report}->@*];
 
   exit 1
     if !$Options->{report}->@*
     && !$Options->{delete}
     && !exists $Options->{write};
 
-  $Options->{annotations} = [];
-  for my $ann ($Options->{annotation}->@*) {
-    if ($ann !~ /^\w+$/) {
-      dcerror "$ann is not a recognised annotation\n";
-      exit 1;
-    }
-    my $annotation = "Devel::Cover::Annotation::\u$ann";
-    eval "use $annotation";
-    if ($@) {
-      dcerror "$ann is not a recognised annotation\n$@";
-      exit 1;
-    }
-    my $ann_obj = $annotation->new;
-    $ann_obj->get_options($Options) if $ann_obj->can("get_options");
-    push $Options->{annotations}->@*, $ann_obj;
-  }
+  $Options->{annotations}
+    = [map get_annotation($_), $Options->{annotation}->@*];
 
   say "$0 version $VERSION$Devel::Cover::Inc::Dev" and exit 0
     if $Options->{version};

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -311,7 +311,7 @@ sub import ($class, @o) {
 
   # Untaint - users of this module can do worse things than mess with tainting
   my $options = ($ENV{DEVEL_COVER_OPTIONS} || "") =~ /(.*)/ ? $1 : "";
-  @o = (@o, split /,/, $options);
+  @o = (@o, map s|\\,|,|gr, split /(?<!\\),/, $options);
   defined or $_ = "" for @o;
 
   my $blib = -d "blib";

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -608,7 +608,11 @@ C<ignore_covered_err> key.
 The -silent option is turned on when Devel::Cover is invoked via
 $HARNESS_PERL_SWITCHES or $PERL5OPT.  Devel::Cover tries to do the right thing
 when $MOD_PERL is set.  $DEVEL_COVER_OPTIONS is appended to any options passed
-into Devel::Cover.
+into Devel::Cover.  Devel::Cover splits the value on commas.  Escape a comma
+inside an option value, such as a database path or a regular expression, as
+C<\,>.  No such escape exists for the C<-MDevel::Cover=...> switch itself,
+since perl performs that split, so values containing commas must go in
+$DEVEL_COVER_OPTIONS.
 
 Note that when Devel::Cover is invoked via an environment variable, any modules
 specified on the command line, such as via the -Mmodule option, will not be

--- a/t/internal/cover_test_filter_commas.t
+++ b/t/internal/cover_test_filter_commas.t
@@ -1,0 +1,101 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Config     qw( %Config );
+use Cwd        qw( getcwd );
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use Test::More import => [qw( done_testing is like note plan unlike )];
+
+if ($^O eq "MSWin32") {
+  plan skip_all => "test drives make with a stub Makefile";
+  exit;
+}
+
+my $Project   = getcwd;
+my $Cover     = File::Spec->catfile($Project, "bin", "cover");
+my $Blib_lib  = File::Spec->catdir($Project, "blib", "lib");
+my $Blib_arch = File::Spec->catdir($Project, "blib", "arch");
+my $Make      = $Config{make};
+
+unless (-f $Cover && -d $Blib_lib && -d $Blib_arch) {
+  plan skip_all => "build artefacts missing - run after `make`";
+  exit;
+}
+
+if (system "command -v $Make >/dev/null 2>&1") {
+  plan skip_all => "$Make not available";
+  exit;
+}
+
+sub write_file ($path, $contents) {
+  open my $fh, ">", $path or die "open $path: $!";
+  print $fh $contents;
+  close $fh or die "close $path: $!";
+}
+
+sub write_dist ($dir) {
+  write_file(
+    File::Spec->catfile($dir, "Module.pm"),
+    "package Module;\nsub answer { 42 }\n1;\n",
+  );
+  write_file(
+    File::Spec->catfile($dir, "script.pl"),
+    "use Module;\nModule::answer();\n",
+  );
+  write_file(
+    File::Spec->catfile($dir, "Makefile"),
+    "test:\n\t\@'$^X' -I. script.pl\n",
+  );
+}
+
+sub run_cover_test ($dir, @args) {
+  my $args = join " ", @args;
+  my $out = `cd '$dir' && '$^X' '$Cover' -test -nogcov -report text $args 2>&1`;
+  note $out;
+  ($? >> 8, $out)
+}
+
+sub test_comma_regex_is_ignored () {
+  my $dir = tempdir(CLEANUP => 1);
+  write_dist($dir);
+
+  my ($rc, $out) = run_cover_test($dir, "-ignore_re", "'Mod{1,1}ule'");
+  is $rc, 0, "cover -test exits successfully";
+  unlike $out, qr/Unescaped left brace/, "pattern arrives uncorrupted";
+  unlike $out, qr/^Module\.pm\b/m,       "pattern with comma ignores the file";
+}
+
+sub test_comma_db_path () {
+  my $dir = File::Spec->catdir(tempdir(CLEANUP => 1), "with,comma");
+  mkdir $dir or die "mkdir $dir: $!";
+  write_dist($dir);
+
+  my ($rc, $out) = run_cover_test($dir);
+  is $rc, 0, "cover -test exits successfully";
+  unlike $out, qr/Unknown option|Can't stat/, "db path arrives uncorrupted";
+  like $out,   qr/^Module\.pm\b/m, "coverage collected in the comma path";
+}
+
+sub main () {
+  local $ENV{PERL5LIB} = join $Config{path_sep}, $Blib_lib, $Blib_arch,
+    ($ENV{PERL5LIB} // ());
+
+  test_comma_regex_is_ignored;
+  test_comma_db_path;
+  done_testing;
+}
+
+main;

--- a/t/internal/cover_test_space_path.t
+++ b/t/internal/cover_test_space_path.t
@@ -1,0 +1,76 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Config     qw( %Config );
+use Cwd        qw( getcwd );
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use Test::More import => [qw( done_testing is like note plan unlike )];
+
+if ($^O eq "MSWin32") {
+  plan skip_all => "test drives make with a stub Makefile";
+  exit;
+}
+
+my $Project   = getcwd;
+my $Cover     = File::Spec->catfile($Project, "bin", "cover");
+my $Blib_lib  = File::Spec->catdir($Project, "blib", "lib");
+my $Blib_arch = File::Spec->catdir($Project, "blib", "arch");
+my $Make      = $Config{make};
+
+unless (-f $Cover && -d $Blib_lib && -d $Blib_arch) {
+  plan skip_all => "build artefacts missing - run after `make`";
+  exit;
+}
+
+if (system "command -v $Make >/dev/null 2>&1") {
+  plan skip_all => "$Make not available";
+  exit;
+}
+
+sub write_makefile ($dir) {
+  my $makefile = File::Spec->catfile($dir, "Makefile");
+  open my $fh, ">", $makefile or die "open $makefile: $!";
+  print $fh "test:\n\t\@'$^X' -e 'my \$\$x = 1'\n";
+  close $fh or die "close $makefile: $!";
+}
+
+sub run_cover_test ($dir) {
+  my $out = `cd '$dir' && '$^X' '$Cover' -test -nogcov -report text 2>&1`;
+  note $out;
+  ($? >> 8, $out)
+}
+
+sub test_space_path () {
+  my $dir = File::Spec->catdir(tempdir(CLEANUP => 1), "with space");
+  mkdir $dir or die "mkdir $dir: $!";
+  write_makefile($dir);
+
+  my ($rc, $out) = run_cover_test($dir);
+  is $rc, 0, "cover -test exits successfully";
+  unlike $out, qr/Illegal switch in PERL5OPT/, "no PERL5OPT switch error";
+  unlike $out, qr/Can't stat/,                 "database was written and read";
+  like $out,   qr/^Run: +-e$/m,                "run recorded in the database";
+}
+
+sub main () {
+  local $ENV{PERL5LIB} = join $Config{path_sep}, $Blib_lib, $Blib_arch,
+    ($ENV{PERL5LIB} // ());
+
+  test_space_path;
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

- `cover -test` run from a directory whose path contains a space collected nothing. perl splits `$PERL5OPT` on whitespace with no unescaping, so each perl process the test run started exited with `Illegal switch in PERL5OPT` before running any tests.
- Move the options into `$DEVEL_COVER_OPTIONS`, whose split Devel::Cover controls, so the switch variables hold just `-MDevel::Cover`.
- Escape commas in the values cover inserts and split `$DEVEL_COVER_OPTIONS` on unescaped commas only, so filter patterns such as `a{1,3}` and database paths containing commas survive. Document the `\,` escape in the POD.
- Extract two validation helpers from `check_options` to reduce its complexity.

## Ticket

Closes #714