### PR TITLE
GH-718 Write make diff output via the harness

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Make the make diff developer target compare cleanly against golden
+  files, so a matching test produces an empty diff and a zero exit
+  (GH-718)
 - BREAKING: Remove the .uncoverable file interface and the four cover
   options managing it - the file was never read when producing a report,
   so the options had no effect (GH-716)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -446,8 +446,8 @@ basic : _run
 subtle : _run
 \t \$(PERL) -Mblib bin/cover `\$(COVER_PARAMETERS)` -report html_subtle
 
-out : _run
-\t \$(PERL) -Mblib bin/cover `\$(COVER_PARAMETERS)` -report text > \$(TEST).out
+out : pure_all
+\t \$(PERL) utils/create_gold --test-output \$(TEST)
 
 text : out
 \t \$(PAGER) \$(TEST).out
@@ -488,14 +488,10 @@ GOLD_FILE = \$(PERL) -Mblib -MDevel::Cover::Test \\
 \t -e '\$\$t = Devel::Cover::Test->new(qq(\$(TEST))); \\
 \t print join qq(.), \$\$t->cover_gold'
 
-_diff : out
-\t \$(PERL) utils/makeh strip_criterion 'time' \$(TEST).out
-\t \$(PERL) utils/makeh strip_criterion ' pod' \$(TEST).out
-
-diff : _diff
+diff : out
 \t gold="`\$(GOLD_FILE)`" && diff -u "\$\$gold" \$(TEST).out
 
-ediff : _diff
+ediff : out
 \t gold="`\$(GOLD_FILE)`" && \$(EDITOR) -d "\$\$gold" \$(TEST).out
 
 gold : pure_all

--- a/lib/Devel/Cover/Test.pm
+++ b/lib/Devel/Cover/Test.pm
@@ -329,6 +329,23 @@ sub _prune_redundant_gold ($self, $td, $test, $new_gold, $ng) {
   }
 }
 
+sub create_out ($self, $file) {
+  if ($self->{skip}) {
+    print STDERR "Skipping: $self->{skip}\n";
+    return;
+  }
+
+  $self->{run_test}
+    ? $self->{run_test}->($self)
+    : $self->run_command($self->test_command);
+
+  $self->_capture_cover_output($self->cover_command, $file);
+
+  $self->{end}->() if $self->{end};
+
+  1
+}
+
 sub create_gold ($self) {
   # Pod::Coverage not available on all versions, but it must be
   # there on 5.20.0
@@ -492,6 +509,11 @@ Runs the cover command and compares output against golden results.
 
 Runs the full test cycle: executes the test file under coverage, then runs cover
 and compares against golden results.
+
+=head2 create_out ($self, $file)
+
+Runs the test and writes the cover output to C<$file>, normalised the same
+way golden results are, so it can be compared against them byte for byte.
 
 =head2 create_gold ($self)
 

--- a/t/internal/create_out.t
+++ b/t/internal/create_out.t
@@ -1,0 +1,81 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# create_out writes the cover output for a test to a file, normalised the
+# same way create_gold normalises golden results, so make diff can compare
+# the two byte for byte.
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use lib qw( ./lib ./blib/lib ./blib/arch ./t );
+
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is ok )];
+
+use Devel::Cover::Test ();
+
+my $Dir = tempdir(CLEANUP => 1);
+
+sub write_fake_cover () {
+  my $path = "$Dir/fake_cover";
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh <<'PERL';
+print "cover: merging 1 and 2\n";
+print "cover: Reading database from /tmp/cover_db\n";
+print "Run: tests/foo\n";
+print "Perl version: 5.44.0\n";
+print "OS: darwin\n";
+print "Start: Tue Aug 18 15:00:00 2026\n";
+print "Finish: Tue Aug 18 15:00:01 2026\n";
+print "Total 100.0\n";
+PERL
+  close $fh or die "Cannot close $path: $!";
+  $path
+}
+
+sub read_file ($file) {
+  open my $fh, "<", $file or die "Cannot open $file: $!";
+  local $/;
+  <$fh>
+}
+
+sub main () {
+  my $fake = write_fake_cover;
+  my $test
+    = Devel::Cover::Test->new("create_out_selftest", run_test => sub { });
+
+  ok $test->can("create_out"), "create_out exists";
+
+  my $out = "$Dir/selftest.out";
+  {
+    no warnings "redefine";
+    local *Devel::Cover::Test::cover_command = sub ($self) {
+      qq($^X "$fake")
+    };
+    $test->create_out($out);
+  }
+
+  is read_file($out), <<'TEXT', "output is normalised like a golden file";
+cover: Reading database from ...
+Run: ...
+Perl version: ...
+OS: ...
+Start: ...
+Finish: ...
+Total 100.0
+TEXT
+
+  rmdir "./t/e2e/cover_db_create_out_selftest";
+}
+
+main;
+done_testing;

--- a/t/internal/makeh.t
+++ b/t/internal/makeh.t
@@ -29,12 +29,6 @@ sub write_test ($content) {
   $path
 }
 
-sub read_file ($file) {
-  open my $fh, "<", $file or die "Cannot open $file: $!";
-  local $/;
-  <$fh>
-}
-
 sub makeh (@args) {
   qx($^X utils/makeh @args 2>&1)
 }
@@ -69,26 +63,6 @@ is makeh(test_options => $Both), "-subs_only,1,-coverage,statement,branch",
   "combined directives, test_options";
 is makeh(cover_parameters => $Both), "-ignore_covered_err",
   "combined directives, cover_parameters";
-
-my $Out
-  = "before\n"
-  . "line  err   stmt   time   code\n"
-  . "1           4    0.01  print 1;\n"
-  . "--------\n"
-  . "after\n";
-my $Report = write_test($Out);
-is makeh(strip_criterion => "time", $Report), "", "strip_criterion is silent";
-is read_file($Report),
-    "before\n"
-  . "line  err   stmt   code\n"
-  . "1           4   print 1;\n"
-  . "--------\n"
-  . "after\n", "time column stripped between header and separator only";
-is read_file("$Report.bak"), $Out, "original kept in .bak";
-
-my $Absent = write_test($Out);
-is makeh(strip_criterion => "pod", $Absent), "", "absent criterion is silent";
-is read_file($Absent), $Out, "absent criterion leaves file unchanged";
 
 like makeh(test_options => "$Dir/missing"), qr/^Cannot open /,
   "unreadable file is reported";

--- a/utils/create_gold
+++ b/utils/create_gold
@@ -34,7 +34,7 @@ sub get_tests_from_dir {
 
 sub run_test_in_child ($test) {
   my $e    = "t/e2e";
-  my $file = (grep -e, "$e/$test", "$e/a$test.t")[0] // $test;
+  my $file = (grep -e, "$e/$test", "$e/$test.t", "$e/a$test.t")[0] // $test;
   say "creating golden results for $test: ";
   my $pid = fork // die "Can't fork";
   if ($pid) {

--- a/utils/create_gold
+++ b/utils/create_gold
@@ -7,6 +7,13 @@
 # The latest version of this software should be available from my homepage:
 # https://pjcj.net
 
+# Usage: create_gold [--test-output] [test ...]
+#
+# Creates golden results in test_output/cover/ for the given tests, or for
+# every test in tests/ when none are named. With --test-output, writes each
+# test's normalised cover output to <test>.out in the current directory
+# instead, which make diff compares against the golden results.
+
 use 5.20.0;
 use warnings;
 
@@ -32,10 +39,12 @@ sub get_tests_from_dir {
   @tests
 }
 
-sub run_test_in_child ($test) {
+sub run_test_in_child ($test, $test_output) {
   my $e    = "t/e2e";
   my $file = (grep -e, "$e/$test", "$e/$test.t", "$e/a$test.t")[0] // $test;
-  say "creating golden results for $test: ";
+  say $test_output
+    ? "writing $test.out: "
+    : "creating golden results for $test: ";
   my $pid = fork // die "Can't fork";
   if ($pid) {
     waitpid $pid, 0;
@@ -43,23 +52,27 @@ sub run_test_in_child ($test) {
     no warnings "redefine";
     local *Devel::Cover::Test::run_test = sub { };
     my $t = require "./$file" or die "Can't require $file: $!";
-    $t->create_gold and say "";
+    ($test_output ? $t->create_out("$test.out") : $t->create_gold) and say "";
     exit;
   }
 }
 
 sub main {
-  if ($Config{useithreads}) {
+  my $test_output = grep $_ eq "--test-output", @ARGV;
+  my @tests       = grep $_ ne "--test-output", @ARGV;
+
+  if (!$test_output && $Config{useithreads}) {
     say "useithreads true, exiting";
     return;
   }
 
-  mkdir "test_output"       unless -d "test_output";
-  mkdir "test_output/cover" unless -d "test_output/cover";
+  unless ($test_output) {
+    mkdir "test_output"       unless -d "test_output";
+    mkdir "test_output/cover" unless -d "test_output/cover";
+  }
 
-  my @tests = @ARGV;
   @tests = get_tests_from_dir unless @tests;
-  run_test_in_child($_) for @tests;
+  run_test_in_child($_, $test_output) for @tests;
 }
 
 main

--- a/utils/makeh
+++ b/utils/makeh
@@ -30,18 +30,6 @@ my $Command = {
     my $p = $l =~ /__COVER__\s+cover_parameters\s+(.*)/ ? $1 : "";
     print $p;
   },
-  strip_criterion => sub ($command, $criterion, $file) {
-    my $t;
-    local ($^I, @ARGV) = (".bak", $file);
-    while (my $line = <>) {
-      $t = index($line, "$criterion   code") - 3 if !defined $t || $t < 0;
-      substr $line, $t, 7, ""
-        if $line =~ /^line  err   stmt/ .. $line =~ /^--------/
-        and $t > -1
-        and length($line) > $t;
-      print $line;
-    }
-  },
 };
 
 sub main () {


### PR DESCRIPTION
## Summary

`make diff TEST=<test>` always failed, even when the coverage output matched the golden file, because the `out` target wrote raw `cover` output while golden files are captured through the test harness, which takes stderr and normalises volatile lines such as the database path and run metadata. The raw run also collected all criteria where the harness collects the fixture's list, and the `strip_criterion` step only papered over part of that.

Add `create_out` to `Devel::Cover::Test`, which runs a test and writes its cover output through the same capture and normalisation as `create_gold`, drive it from `utils/create_gold --test-output`, and point the `out` target at it. A matching test now produces an empty diff and a zero exit, `strip_criterion` and its tests go away, and looking up e2e tests generated without the `a` prefix (from `tests/*.t`) now works, which also fixes `make gold TEST=<test>` for those tests.

## Ticket

Closes #718