### PR TITLE
Document the -test switch replacement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,9 @@ make dist
 ### Testing Requirements
 
 - Tests must use Test::More system (not Test2 as it is not core)
+  - Exception: author tests in `xt/` may use Test2, and are encouraged to - they
+    ship in the distribution but never run during install, and already run under
+    `yath`, which is Test2-Harness
 - All new code requires tests in the `t/` directory
 - Tests should be run with `yath` test runner
 - Coverage verification using Devel::Cover with JSON reports

--- a/bin/cover
+++ b/bin/cover
@@ -753,6 +753,10 @@ L<https://metacpan.org/module/ExtUtils::MakeMaker> or for Module::Build at
 L<https://metacpan.org/module/Module::Build> both of which come as standard
 in recent Perl distributions.
 
+C<cover -test> replaces any C<PERL5OPT> and C<HARNESS_PERL_SWITCHES> in the
+environment with its own switches for the spawned test run.  To pass extra
+perl switches to the test run, set C<DEVEL_COVER_TEST_OPTS>.
+
 The C<-jobs> option (also spelt C<-j>) asks the test harness to run that many
 test processes in parallel by setting C<HARNESS_OPTIONS=jN> for the spawned
 C<make test> or C<./Build test>.  Devel::Cover stores per-process runs


### PR DESCRIPTION
Fixes #720

## Summary
- Document in `bin/cover`'s POD that `cover -test` replaces `PERL5OPT` and `HARNESS_PERL_SWITCHES` for the spawned test run, and that `DEVEL_COVER_TEST_OPTS` is the way to add extra perl switches.
- Also record in `CLAUDE.md` that author tests in `xt/` may use Test2.