### PR TITLE
GH-722 Estimate mcdc for untested select_dir files

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Estimate mcdc for untested files found via --select_dir, so the mcdc
+  Total no longer covers tested files only (GH-722)
 - Make the make diff developer target compare cleanly against golden
   files, so a matching test produces an empty diff and a zero exit
   (GH-718)

--- a/bin/cover
+++ b/bin/cover
@@ -722,9 +722,11 @@ globs; C<-select_re> and C<-ignore_re> are interpreted as regular expressions.
 The C<-select_dir> option scans the given directory for C<.pm> and C<.pl>
 files and ensures they appear in the coverage report even if no tests
 exercised them.  This is useful for identifying completely untested code.
-Files under C<blib> directories below the scan root are excluded, but a
-C<blib> directory may itself be given as the scan root.  The option may be
-specified multiple times.
+Per-criterion totals for these files are estimated by static analysis
+(requiring L<PPI>), so they are close to, but may not exactly match, the
+counts a test run would produce.  Files under C<blib> directories below the
+scan root are excluded, but a C<blib> directory may itself be given as the
+scan root.  The option may be specified multiple times.
 
 Specify C<-coverage> options to report on specific criteria.  By default all
 available information on all criteria in all files will be reported. Available

--- a/lib/Devel/Cover/Static.pm
+++ b/lib/Devel/Cover/Static.pm
@@ -12,6 +12,8 @@ use warnings;
 use feature qw( postderef signatures );
 no warnings qw( experimental::postderef experimental::signatures );
 
+use Scalar::Util qw( refaddr );
+
 my $Have_ppi;
 
 BEGIN { $Have_ppi = eval { require PPI; 1 } }
@@ -129,15 +131,17 @@ sub _has_const_rhs ($op) {
   0
 }
 
+sub _logical_ops ($doc) {
+  $doc->find(sub {
+    $_[1]->isa("PPI::Token::Operator")
+      && $_[1]->content =~ m!^(?:&&|\|\||//|&&=|\|\|=|//=|and|or|xor)$!
+  }) || []
+}
+
 sub _count_conditions ($doc) {
   my $total = 0;
 
-  my $ops = $doc->find(sub {
-    $_[1]->isa("PPI::Token::Operator")
-      && $_[1]->content =~ m!^(?:&&|\|\||//|&&=|\|\|=|//=|and|or|xor)$!
-  }) || [];
-
-  for my $op (@$ops) {
+  for my $op (_logical_ops($doc)->@*) {
     my $name = $op->content;
     if ($name eq "xor") {
       $total += 4;
@@ -148,6 +152,20 @@ sub _count_conditions ($doc) {
     }
   }
 
+  $total
+}
+
+sub _count_mcdc ($doc) {
+  my %decisions;
+  for my $op (_logical_ops($doc)->@*) {
+    my $s = $op->statement or next;
+    my $d = $decisions{ refaddr $s } //= { ops => 0, const => 0 };
+    $d->{ops}++;
+    $d->{const}++ if $op->content ne "xor" && _has_const_rhs($op);
+  }
+
+  my $total = 0;
+  $total += $_->{ops} + 1 - $_->{const} for values %decisions;
   $total
 }
 
@@ -177,6 +195,7 @@ sub count_criteria ($file) {
     statement  => _count_statements($doc, $includes, $compounds),
     branch     => _count_branches($doc),
     condition  => _count_conditions($doc),
+    mcdc       => _count_mcdc($doc),
     subroutine => _count_subroutines($doc, $includes),
     pod        => _count_pod($doc),
   }
@@ -226,13 +245,14 @@ Devel::Cover::Static - PPI-based static analysis for uncovered files
   use Devel::Cover::Static;
 
   my $counts = Devel::Cover::Static::count_criteria("lib/Foo.pm");
-  # { statement => 12, branch => 4, condition => 2, subroutine => 3, pod => 3 }
+  # { statement => 12, branch => 4, condition => 2, mcdc => 2,
+  #   subroutine => 3, pod => 3 }
 
 =head1 DESCRIPTION
 
 This module provides static analysis of Perl source files using PPI. It
 estimates the number of coverable constructs (statements, branches, conditions,
-subroutines, and pod) without executing the code.
+mcdc atomics, subroutines, and pod) without executing the code.
 
 It is used by L<Devel::Cover::DB> to populate coverage data for files discovered
 via C<--select_dir> that were never exercised by any test. The counts allow
@@ -252,6 +272,7 @@ Parses C<$file> with PPI and returns a hashref of estimated coverable counts:
     statement  => $n,
     branch     => $n,
     condition  => $n,
+    mcdc       => $n,
     subroutine => $n,
     pod        => $n,
   }
@@ -269,6 +290,14 @@ currently omitted to avoid overcounting.
 B<Conditions> count outcomes per logical operator: 4 for C<xor>, 2 when the
 right-hand side is a constant or flow-control keyword (matching Devel::Cover's
 C<$Const_right> heuristic), and 3 otherwise.
+
+B<Mcdc> counts atomic conditions per decision, treating each statement that
+holds logical operators as one decision: operators plus one, less one for each
+short-circuit operator whose right-hand side is a constant or flow-control
+keyword (its truth table carries no atomic for that operand). The estimate is
+rough in both directions - a decision evaluated in boolean context builds a
+narrower table than the source suggests, and a statement holding two separate
+decisions is counted as one.
 
 B<Subroutines> count named subs plus one BEGIN per C<use>/C<require>.
 
@@ -324,15 +353,25 @@ Used by both C<_count_branches> and C<per_sub_complexity>.
 Counts branch outcomes by delegating to C<_count_decisions> and doubling. Each
 decision contributes two outcomes.
 
+=item _logical_ops($doc)
+
+Finds every logical operator token (C<&&>, C<||>, C<//>, C<and>, C<or>, C<xor>
+and their assignment forms). Used by C<_count_conditions> and C<_count_mcdc>.
+
 =item _count_conditions($doc)
 
-Counts condition outcomes from logical operators (C<&&>, C<||>, C<//>, C<and>,
-C<or>, C<xor> and their assignment forms).
+Counts condition outcomes from logical operators.
 
 =item _has_const_rhs($op)
 
 Returns true if the right-hand side of a logical operator is a constant or
 flow-control keyword, reducing the condition from 3 outcomes to 2.
+
+=item _count_mcdc($doc)
+
+Counts mcdc atomic conditions by grouping logical operators into their
+enclosing statements, each group contributing its operator count plus one,
+less one per const-RHS short-circuit operator.
 
 =item _count_subroutines($doc, $includes)
 

--- a/t/internal/select_dir.t
+++ b/t/internal/select_dir.t
@@ -78,7 +78,7 @@ sub test_scan () {
   if (have_ppi) {
     my %collected = map { $_ => 1 } $db->collected;
     ok $collected{$_}, "$_ collected via estimates on a runless db"
-      for qw( statement branch condition subroutine pod );
+      for qw( statement branch condition mcdc subroutine pod );
   }
 }
 

--- a/t/internal/static.t
+++ b/t/internal/static.t
@@ -60,6 +60,7 @@ EOPERL
   is $counts->{condition},  0, "minimal: 0 condition outcomes";
   is $counts->{subroutine}, 3, "minimal: 3 subs (1 user + 2 BEGIN)";
   is $counts->{pod},        1, "minimal: 1 pod-coverable sub";
+  is $counts->{mcdc},       0, "minimal: 0 mcdc atomics";
 }
 
 # Branches: if/elsif/else, unless, ternary.
@@ -253,6 +254,43 @@ EOPERL
   # xor_op: xor -> 4
   # total: 9 + 10 + 6 + 4 = 29
   is $counts->{condition}, 29, "conditions: 29 condition outcomes";
+
+  # mcdc atomics per statement: ops + 1, minus one per short-circuit op
+  # with a constant RHS (its table has no atomic for that operand).
+  # normal_and/or/dor: 2 each = 6
+  # flow_control: 5 statements, each 1 const op -> 1 each = 5
+  # const_rhs: 3 statements, each 1 const op -> 1 each = 3
+  # xor_op: xor keeps both atomics -> 2
+  # total: 6 + 5 + 3 + 2 = 16
+  is $counts->{mcdc}, 16, "conditions: 16 mcdc atomics";
+}
+
+# MC/DC estimate: each statement holding logical operators is one decision
+# whose atomics are ops + 1, less one per const-RHS short-circuit op.
+sub test_mcdc_estimate () {
+  my $file = write_file("Logical.pm", <<'EOPERL');
+package Logical;
+
+sub pick {
+  my ($a, $b, $c) = @_;
+  my $r = $a && $b;
+  my $s = $a || $b || $c;
+  return $r || $s;
+}
+
+sub guard {
+  my ($x, $y) = @_;
+  $x && $y or die "no";
+  return $x;
+}
+
+1
+EOPERL
+
+  my $counts = Devel::Cover::Static::count_criteria($file);
+
+  # pick: 2 + 3 + 2 = 7; guard: 2 ops, one const RHS -> 2
+  is $counts->{mcdc}, 9, "mcdc: atomics are ops plus decisions";
 }
 
 # Nonexistent file returns undef.
@@ -418,6 +456,7 @@ sub main () {
   test_branches;
   test_loops;
   test_conditions;
+  test_mcdc_estimate;
   test_pod;
   test_missing_file;
   test_per_sub_complexity;


### PR DESCRIPTION
## Summary

The static analysis behind `--select_dir` estimated five criteria but not mcdc, so an untested file showed n/a in its mcdc column while every other column showed 0.0, and the mcdc Total covered tested files only. Add an mcdc estimate treating each statement holding logical operators as one decision whose atomics are operators plus one, less one for each short-circuit operator with a constant right-hand side, matching the truth tables a dynamic run builds. Note in the `cover` POD that per-criterion totals for these files are estimates.

## Ticket

Closes #722