### PR TITLE
GH-724 Fix cover -test exit and -write handling

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -335,8 +335,13 @@ sub do_test ($dbname) {
   }
   # print STDERR "$_: $ENV{$_}\n" for qw(PERL5OPT HARNESS_PERL_SWITCHES);
   dcinfo "running $test";
-  my $test_result = system $test;
-  $test_result >>= 8;
+  my $status = system $test;
+  if ($status == -1) {
+    dcerror "Can't run $test: $!";
+    return 255;
+  }
+  my $signal = $status & 127;
+  $signal ? 128 + $signal : $status >> 8
 }
 
 sub run_gcov ($name, $dir, $gc, $seen) {

--- a/bin/cover
+++ b/bin/cover
@@ -316,7 +316,6 @@ sub do_test ($dbname) {
     $Options->{select}->@*;
 
   $Options->{$_} = [] for qw( ignore ignore_re select select_re );
-  $Options->{report} = ["html"] unless $Options->{report}->@*;
 
   my $opts = join " ", grep $_, $ENV{DEVEL_COVER_TEST_OPTS}, "-MDevel::Cover";
   local $ENV{DEVEL_COVER_OPTIONS} = join ",", $extra, grep defined && length,

--- a/t/internal/cover_test_signal_exit.t
+++ b/t/internal/cover_test_signal_exit.t
@@ -1,0 +1,83 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Config     qw( %Config );
+use Cwd        qw( getcwd );
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use Test::More import => [qw( done_testing is like note plan )];
+
+if ($^O eq "MSWin32") {
+  plan skip_all => "test drives a stub Build shell script with signals";
+  exit;
+}
+
+my $Project   = getcwd;
+my $Cover     = File::Spec->catfile($Project, "bin", "cover");
+my $Blib_lib  = File::Spec->catdir($Project, "blib", "lib");
+my $Blib_arch = File::Spec->catdir($Project, "blib", "arch");
+
+unless (-f $Cover && -d $Blib_lib && -d $Blib_arch) {
+  plan skip_all => "build artefacts missing - run after `make`";
+  exit;
+}
+
+sub write_build ($dir, $body) {
+  my $build = File::Spec->catfile($dir, "Build");
+  open my $fh, ">", $build or die "open $build: $!";
+  print $fh "#!/bin/sh\n$body\n";
+  close $fh or die "close $build: $!";
+  chmod 0755, $build or die "chmod $build: $!";
+}
+
+sub run_cover ($dir, @args) {
+  my $args = join " ", map "'$_'", @args;
+  my $out = `cd '$dir' && '$^X' '$Cover' -test -nogcov -report text $args 2>&1`;
+  note $out;
+  ($? >> 8, $out)
+}
+
+sub test_signal_death () {
+  my $dir = tempdir(CLEANUP => 1);
+  write_build($dir, 'kill -KILL $$');
+  my ($rc, $out) = run_cover($dir);
+  is $rc, 137, "signal-killed test run exits 128 plus the signal";
+}
+
+sub test_plain_failure () {
+  my $dir = tempdir(CLEANUP => 1);
+  write_build($dir, "exit 3");
+  my ($rc, $out) = run_cover($dir);
+  is $rc, 3, "failing test run passes its exit status through";
+}
+
+sub test_unrunnable_command () {
+  my $dir = tempdir(CLEANUP => 1);
+  my ($rc, $out) = run_cover($dir, "-make", "/no/such/prog");
+  is $rc, 255, "unrunnable test command exits 255";
+  like $out, qr/Can't run/, "unrunnable test command reports the error";
+}
+
+sub main () {
+  local $ENV{PERL5LIB} = join $Config{path_sep}, $Blib_lib, $Blib_arch,
+    ($ENV{PERL5LIB} // ());
+
+  test_signal_death;
+  test_plain_failure;
+  test_unrunnable_command;
+  done_testing;
+}
+
+main;

--- a/t/internal/cover_test_write.t
+++ b/t/internal/cover_test_write.t
@@ -1,0 +1,95 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Config     qw( %Config );
+use Cwd        qw( getcwd );
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use Test::More import => [qw( done_testing is like note ok plan unlike )];
+
+if ($^O eq "MSWin32") {
+  plan skip_all => "test drives make with a stub Makefile";
+  exit;
+}
+
+my $Project   = getcwd;
+my $Cover     = File::Spec->catfile($Project, "bin", "cover");
+my $Blib_lib  = File::Spec->catdir($Project, "blib", "lib");
+my $Blib_arch = File::Spec->catdir($Project, "blib", "arch");
+my $Make      = $Config{make};
+
+unless (-f $Cover && -d $Blib_lib && -d $Blib_arch) {
+  plan skip_all => "build artefacts missing - run after `make`";
+  exit;
+}
+
+if (system "command -v $Make >/dev/null 2>&1") {
+  plan skip_all => "$Make not available";
+  exit;
+}
+
+sub write_makefile ($dir) {
+  my $makefile = File::Spec->catfile($dir, "Makefile");
+  open my $fh, ">", $makefile or die "open $makefile: $!";
+  print $fh "test:\n\t\@'$^X' -e 'my \$\$x = 1'\n";
+  close $fh or die "close $makefile: $!";
+}
+
+sub run_cover ($dir, @args) {
+  my $args = join " ", map "'$_'", @args;
+  my $out  = `cd '$dir' && '$^X' '$Cover' -test -nogcov $args 2>&1`;
+  note $out;
+  ($? >> 8, $out)
+}
+
+sub test_write_generates_no_report () {
+  my $dir = tempdir(CLEANUP => 1);
+  write_makefile($dir);
+  my ($rc, $out) = run_cover($dir, "-write", "mydb");
+  is $rc, 0, "cover -test -write exits with the test status";
+  unlike $out, qr/Can't locate object method/, "no unloaded report crash";
+  ok -e File::Spec->catfile($dir, "mydb", "cover.15"), "database written";
+  my @html = glob File::Spec->catfile($dir, "cover_db", "*.html");
+  is @html, 0, "no report generated";
+}
+
+sub test_write_with_explicit_report () {
+  my $dir = tempdir(CLEANUP => 1);
+  write_makefile($dir);
+  my ($rc, $out) = run_cover($dir, "-write", "mydb", "-report", "text");
+  is $rc, 0, "cover -test -write -report text exits with the test status";
+  like $out, qr/^Run: +-e$/m, "explicit report still generated";
+}
+
+sub test_write_with_invalid_report () {
+  my $dir = tempdir(CLEANUP => 1);
+  write_makefile($dir);
+  my ($rc, $out) = run_cover($dir, "-write", "mydb", "-report", "bogus");
+  is $rc, 0, "cover -test -write -report bogus exits with the test status";
+  like $out,   qr/not a recognised output format/, "invalid report reported";
+  unlike $out, qr/Can't locate object method/,     "no unloaded report crash";
+}
+
+sub main () {
+  local $ENV{PERL5LIB} = join $Config{path_sep}, $Blib_lib, $Blib_arch,
+    ($ENV{PERL5LIB} // ());
+
+  test_write_generates_no_report;
+  test_write_with_explicit_report;
+  test_write_with_invalid_report;
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

- Fix `cover -test` exiting 0 when the test command dies from a signal, so a run killed by a CI timeout or the OOM killer no longer passes for a success. A signal death now exits 128 plus the signal number, and a test command that cannot be started reports the error and exits 255.
- Delete `do_test`'s report re-default, which injected an html report `check_options` had never loaded, so every `cover -test -write` run died calling a method on an unloaded package. `-write` now suppresses the default report as the POD promises, and an unrecognised `-report` format alongside `-write` degrades to an error message rather than the same crash.

## Ticket

Closes #724