### PR TITLE
GH-726 Restrict report totals to selected files

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -536,8 +536,16 @@ sub set_files ($db) {
   $Options->{file}->@* = sort grep $keep->($_), keys %f;
 }
 
+sub restrict_summary ($db) {
+  $db->calculate_summary(
+    (map { $_ => 1 } $Options->{coverage}->@*),
+    files => $Options->{file},
+    force => 1,
+  );
+}
+
 sub print_summary ($db) {
-  $db->print_summary($Options->{file}, $Options->{coverage}, { force => 1 })
+  $db->print_summary($Options->{file}, $Options->{coverage})
     if $Options->{summary};
 }
 
@@ -570,6 +578,7 @@ sub main () {
   do_gcov($dbname);
   my $db = manage_dbs($dbname, $test_result);
   set_files($db);
+  restrict_summary($db);
   print_summary($db);
   run_reports($db, $argv);
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -604,6 +604,16 @@ sub calculate_summary ($self, %options) {
   $self->summarise_complexity($s, \@files);
 }
 
+sub file_summary ($self, $files, %options) {
+  my $existed = exists $self->{summary};
+  my $saved   = $self->{summary};
+  $self->calculate_summary(%options, files => $files, force => 1);
+  my $summary = $self->{summary};
+  if ($existed) { $self->{summary} = $saved }
+  else          { delete $self->{summary} }
+  $summary
+}
+
 sub trimmed_file ($f, $len) {
   substr $f, 0, 3 - $len, "..." if length $f > $len;
   $f
@@ -1623,6 +1633,14 @@ combined coverage.
 Calculate coverage summaries for all files, filtered by the criteria given as
 true-valued keys. Populates C<< $db->{summary} >> and triggers
 L</summarise_complexity>.
+
+=head2 file_summary
+
+  my $summary = $db->file_summary(\@files, statement => 1, branch => 1);
+
+Calculate and return a coverage summary restricted to C<@files>, leaving any
+cached C<< $db->{summary} >> as it was found. The file list is required.
+C<< $db->{dir_summary} >> is still recalculated over the restricted files.
 
 =head2 trimmed_file
 

--- a/lib/Devel/Cover/Report/Json.pm
+++ b/lib/Devel/Cover/Report/Json.pm
@@ -205,11 +205,11 @@ sub get_options ($self, $opt) {
 }
 
 sub report ($pkg, $db, $options) {
-  my %sum_options = map { $_ => 1 } "force", grep {
+  my %sum_options = map { $_ => 1 } grep {
     $_ eq "total"
       || Devel::Cover::Criterion->criterion_class($_)->measures_coverage
   } $db->all_criteria;
-  $db->calculate_summary(%sum_options);
+  my $summary = $db->file_summary($options->{file}, %sum_options);
 
   my %files;
   for my $file ($options->{file}->@*) {
@@ -234,7 +234,7 @@ sub report ($pkg, $db, $options) {
     devel_cover_version => $Devel::Cover::Inc::VERSION,
     ignore_covered_err  => $Devel::Cover::Ignore_covered_err ? 1 : 0,
     runs                => _runs($db),
-    summary             => $db->{summary},
+    summary             => $summary,
     files               => \%files,
   };
 

--- a/lib/Devel/Cover/Report/Json_summary.pm
+++ b/lib/Devel/Cover/Report/Json_summary.pm
@@ -29,16 +29,17 @@ sub add_runs ($db) {
 }
 
 sub report ($pkg, $db, $options) {
-  my %options = map { $_ => 1 } "force", grep {
+  my %options = map { $_ => 1 } grep {
     $_ eq "total"
       || Devel::Cover::Criterion->criterion_class($_)->measures_coverage
   } $db->all_criteria;
-  $db->calculate_summary(%options);
+  my $summary = $db->file_summary($options->{file}, %options);
 
-  my $json = { runs => add_runs($db), summary => $db->{summary} };
+  my $json = { runs => add_runs($db), summary => $summary };
 
   my $path = "$options->{outputdir}/cover.json";
   my $io   = Devel::Cover::DB::IO::JSON->new(options => "pretty");
+
   $io->write($json, $path);
 
   dcinfo "JSON output written to $path";

--- a/t/internal/cover_select_summary.t
+++ b/t/internal/cover_select_summary.t
@@ -1,0 +1,83 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use List::Util qw( sum );
+use Test::More import => [qw( diag done_testing is ok )];
+use Devel::Cover::Test::Showcase qw(
+  create_cover_db
+  run_cover
+  setup_lib_dir
+);
+
+sub text_report ($libdir, $cover_db, @extra) {
+  my ($out, $exit) = run_cover(
+    "--select", "$libdir/Covered/Trivial.pm",
+    "--select", "$libdir/Covered/Utils.pm",
+    "--report", "text",
+    "--silent", @extra,
+    $cover_db,
+  );
+  is $exit, 0, "cover --report text exits 0 (@extra)" or diag $out;
+  $out
+}
+
+sub module_summary ($out) {
+  my ($table) = $out =~ /(Module Summary\n-+\n\n.*?\n\n)/s;
+  $table
+}
+
+sub module_cc ($table) {
+  my ($cc) = $table =~ /^\s*\d+\s+(\d+)\s/m;
+  $cc
+}
+
+sub file_ccs ($out) {
+  $out =~ /File Summary\n-+\n\nCC[^\n]*\n[- ]+\n\s*(\d+)\s/g
+}
+
+# The Module Summary must cover only the selected files, with or without
+# -summary.  CC aggregates as sum - count + 1, so the module CC must equal
+# the file CC sum minus one per extra file.
+sub test_select_summary () {
+  my ($tmpdir, $libdir) = setup_lib_dir;
+  my $cover_db = create_cover_db($tmpdir, $libdir);
+
+  my $plain     = text_report($libdir, $cover_db);
+  my $nosummary = text_report($libdir, $cover_db, "--nosummary");
+
+  my $table = module_summary($plain);
+
+  ok $table, "text report has a Module Summary table";
+  is module_summary($nosummary), $table,
+    "-nosummary leaves the Module Summary unchanged";
+
+  for my $run ([summary => $plain], [nosummary => $nosummary]) {
+    my ($name, $out) = @$run;
+    my @file_cc = file_ccs($out);
+    is @file_cc, 2, "$name run has two File Summary tables";
+    is module_cc(module_summary($out)), sum(@file_cc) - (@file_cc - 1),
+      "$name module CC derives from the file CC values";
+  }
+}
+
+sub main () {
+  test_select_summary;
+  done_testing;
+}
+
+main;

--- a/t/internal/cover_select_summary.t
+++ b/t/internal/cover_select_summary.t
@@ -24,12 +24,12 @@ use Devel::Cover::Test::Showcase qw(
   setup_lib_dir
 );
 
-sub text_report ($libdir, $cover_db, @extra) {
+sub text_report ($cover_db, @extra) {
   my ($out, $exit) = run_cover(
-    "--select", "$libdir/Covered/Trivial.pm",
-    "--select", "$libdir/Covered/Utils.pm",
-    "--report", "text",
-    "--silent", @extra,
+    "--select_re", '/Covered.Trivial.pm$',
+    "--select_re", '/Covered.Utils.pm$',
+    "--report",    "text",
+    "--silent",    @extra,
     $cover_db,
   );
   is $exit, 0, "cover --report text exits 0 (@extra)" or diag $out;
@@ -57,8 +57,8 @@ sub test_select_summary () {
   my ($tmpdir, $libdir) = setup_lib_dir;
   my $cover_db = create_cover_db($tmpdir, $libdir);
 
-  my $plain     = text_report($libdir, $cover_db);
-  my $nosummary = text_report($libdir, $cover_db, "--nosummary");
+  my $plain     = text_report($cover_db);
+  my $nosummary = text_report($cover_db, "--nosummary");
 
   my $table = module_summary($plain);
 

--- a/t/internal/json.t
+++ b/t/internal/json.t
@@ -18,7 +18,8 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 
 use File::Spec ();
 use List::Util qw( first );
-use Test::More import => [qw( diag done_testing is isa_ok like ok plan )];
+use Test::More import =>
+  [qw( diag done_testing is is_deeply isa_ok like ok plan )];
 use Devel::Cover::Test::Showcase qw(
   create_cover_db
   run_cover
@@ -214,6 +215,43 @@ sub test_summary_and_detailed_distinct ($tmpdir, $libdir, $cover_db) {
     "json_summary lacks devel_cover_version";
 }
 
+# The summary must cover only the selected files, not the whole database
+sub test_summary_restricted ($tmpdir, $libdir, $cover_db) {
+  my $outdir = File::Spec->catdir($tmpdir, "json_select");
+  my ($out, $exit) = run_cover(
+    "--select",    "$libdir/Covered/Trivial.pm",
+    "--report",    "json",
+    "--outputdir", $outdir,
+    "--silent",    $cover_db,
+  );
+  is $exit, 0, "cover --select --report json exits 0" or diag $out;
+  my $json = JSON::MaybeXS->new(utf8 => 1)
+    ->decode(slurp(File::Spec->catfile($outdir, "cover.json")));
+  is_deeply [sort keys $json->{summary}->%*],
+    [sort "Total", keys $json->{files}->%*],
+    "summary keys are the files keys plus Total";
+}
+
+# A report after json in the same run must keep the restricted summary
+sub test_summary_isolated ($tmpdir, $libdir, $cover_db) {
+  my @select = (
+    "--select", "$libdir/Covered/Trivial.pm",
+    "--select", "$libdir/Covered/Utils.pm",
+  );
+  my $outdir = File::Spec->catdir($tmpdir, "json_text");
+  my ($text_only)
+    = run_cover(@select, "--report", "text", "--silent", $cover_db);
+  my ($combined) = run_cover(
+    @select, "--report",    "json",  "--report",
+    "text",  "--outputdir", $outdir, "--silent",
+    $cover_db,
+  );
+  my $banner = sub ($out) { ($out =~ /(Module Summary\n-+\n\n.*?\n\n)/s)[0] };
+
+  is $banner->($combined), $banner->($text_only),
+    "text Module Summary unchanged after a json report";
+}
+
 sub main () {
   my ($tmpdir, $libdir) = setup_lib_dir;
   my $cover_db = create_cover_db($tmpdir, $libdir);
@@ -229,6 +267,8 @@ sub main () {
   test_error_rule_recorded($json, $json_ignore, $libdir);
   test_summary_pod_uncoverable($json);
   test_summary_and_detailed_distinct($tmpdir, $libdir, $cover_db);
+  test_summary_restricted($tmpdir, $libdir, $cover_db);
+  test_summary_isolated($tmpdir, $libdir, $cover_db);
   done_testing;
 }
 

--- a/t/internal/json.t
+++ b/t/internal/json.t
@@ -219,14 +219,15 @@ sub test_summary_and_detailed_distinct ($tmpdir, $libdir, $cover_db) {
 sub test_summary_restricted ($tmpdir, $libdir, $cover_db) {
   my $outdir = File::Spec->catdir($tmpdir, "json_select");
   my ($out, $exit) = run_cover(
-    "--select",    "$libdir/Covered/Trivial.pm",
+    "--select_re", '/Covered.Trivial.pm$',
     "--report",    "json",
     "--outputdir", $outdir,
     "--silent",    $cover_db,
   );
-  is $exit, 0, "cover --select --report json exits 0" or diag $out;
+  is $exit, 0, "cover --select_re --report json exits 0" or diag $out;
   my $json = JSON::MaybeXS->new(utf8 => 1)
     ->decode(slurp(File::Spec->catfile($outdir, "cover.json")));
+  is keys $json->{files}->%*, 1, "one file selected";
   is_deeply [sort keys $json->{summary}->%*],
     [sort "Total", keys $json->{files}->%*],
     "summary keys are the files keys plus Total";
@@ -235,8 +236,8 @@ sub test_summary_restricted ($tmpdir, $libdir, $cover_db) {
 # A report after json in the same run must keep the restricted summary
 sub test_summary_isolated ($tmpdir, $libdir, $cover_db) {
   my @select = (
-    "--select", "$libdir/Covered/Trivial.pm",
-    "--select", "$libdir/Covered/Utils.pm",
+    "--select_re", '/Covered.Trivial.pm$',
+    "--select_re", '/Covered.Utils.pm$',
   );
   my $outdir = File::Spec->catdir($tmpdir, "json_text");
   my ($text_only)
@@ -248,6 +249,7 @@ sub test_summary_isolated ($tmpdir, $libdir, $cover_db) {
   );
   my $banner = sub ($out) { ($out =~ /(Module Summary\n-+\n\n.*?\n\n)/s)[0] };
 
+  ok defined $banner->($text_only), "text-only run prints a Module Summary";
   is $banner->($combined), $banner->($text_only),
     "text Module Summary unchanged after a json report";
 }

--- a/t/internal/json_summary.t
+++ b/t/internal/json_summary.t
@@ -17,7 +17,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
 use File::Spec ();
-use Test::More import => [qw( diag done_testing is isa_ok ok plan )];
+use Test::More import => [qw( diag done_testing is isa_ok like ok plan )];
 use Devel::Cover::Test::Showcase qw(
   create_cover_db
   run_cover
@@ -32,10 +32,8 @@ eval "require JSON::MaybeXS; 1" or do {
 
 # json_summary is the per-file/total summary feed used by cpancover (and by
 # anyone wanting badge-style numbers).  It must NOT include per-line detail.
-sub test_json_summary_report () {
-  my ($tmpdir, $libdir) = setup_lib_dir;
-  my $cover_db = create_cover_db($tmpdir, $libdir);
-  my $outdir   = File::Spec->catdir($tmpdir, "json");
+sub test_json_summary_report ($tmpdir, $libdir, $cover_db) {
+  my $outdir = File::Spec->catdir($tmpdir, "json");
 
   my ($out, $exit) = run_cover(
     "--select_dir", $libdir, "--report", "json_summary",
@@ -61,8 +59,30 @@ sub test_json_summary_report () {
     "summary->Total->statement->percentage is defined";
 }
 
+# The summary must cover only the selected files, not the whole database
+sub test_summary_restricted ($tmpdir, $libdir, $cover_db) {
+  my $outdir = File::Spec->catdir($tmpdir, "json_select");
+  my ($out, $exit) = run_cover(
+    "--select",    "$libdir/Covered/Trivial.pm",
+    "--report",    "json_summary",
+    "--outputdir", $outdir,
+    "--silent",    $cover_db,
+  );
+  is $exit, 0, "cover --select --report json_summary exits 0" or diag $out;
+  my $json = JSON::MaybeXS->new(utf8 => 1)
+    ->decode(slurp(File::Spec->catfile($outdir, "cover.json")));
+  my @keys = sort keys $json->{summary}->%*;
+  is @keys, 2, "summary holds the selected file plus Total";
+  like $keys[0], qr/Covered\W+Trivial\.pm$/, "the selected file is summarised";
+  is $keys[1], "Total", "the Total is summarised";
+}
+
 sub main () {
-  test_json_summary_report;
+  my ($tmpdir, $libdir) = setup_lib_dir;
+  my $cover_db = create_cover_db($tmpdir, $libdir);
+
+  test_json_summary_report($tmpdir, $libdir, $cover_db);
+  test_summary_restricted($tmpdir, $libdir, $cover_db);
   done_testing;
 }
 

--- a/t/internal/json_summary.t
+++ b/t/internal/json_summary.t
@@ -63,12 +63,12 @@ sub test_json_summary_report ($tmpdir, $libdir, $cover_db) {
 sub test_summary_restricted ($tmpdir, $libdir, $cover_db) {
   my $outdir = File::Spec->catdir($tmpdir, "json_select");
   my ($out, $exit) = run_cover(
-    "--select",    "$libdir/Covered/Trivial.pm",
+    "--select_re", '/Covered.Trivial.pm$',
     "--report",    "json_summary",
     "--outputdir", $outdir,
     "--silent",    $cover_db,
   );
-  is $exit, 0, "cover --select --report json_summary exits 0" or diag $out;
+  is $exit, 0, "cover --select_re --report json_summary exits 0" or diag $out;
   my $json = JSON::MaybeXS->new(utf8 => 1)
     ->decode(slurp(File::Spec->catfile($outdir, "cover.json")));
   my @keys = sort keys $json->{summary}->%*;


### PR DESCRIPTION
## Summary

- Recompute the summary over the selected files once `set_files` has run, so every report sees totals for the selection whether or not the summary is printed. Previously only printing the summary put it right, leaving `-nosummary` runs with Module Summary and Total rows covering files excluded with `-select` or `-ignore`.
- Add `file_summary` to `Devel::Cover::DB` and use it in the json and json_summary reports, so their summary block matches their file list and reports running after them in the same command keep the restricted numbers.

## Ticket

Closes #726