### PR TITLE
GH-728 Fix Text, Compilation and Sort reports

### DIFF
--- a/lib/Devel/Cover/Report/Compilation.pm
+++ b/lib/Devel/Cover/Report/Compilation.pm
@@ -58,9 +58,8 @@ sub print_conditions ($db, $file, $) {
 
   my %r;
   for my $location (sort { $a <=> $b } $conditions->items) {
-    my %seen;
     for my $c ($conditions->location($location)->@*) {
-      push $r{ $c->type }->@*, [$c, $seen{ $c->type }++ ? "" : $location];
+      push $r{ $c->type }->@*, [$c, $location];
     }
   }
 

--- a/lib/Devel/Cover/Report/Sort.pm
+++ b/lib/Devel/Cover/Report/Sort.pm
@@ -38,7 +38,7 @@ sub print_sort ($db, $options) {
       for my $criterion (@collected) {
         my ($v, $sz) = $vec->{$file}{$criterion}->@{ "vec", "size" };
         $sz |= 0;
-        printf "$file:%10s %5d: ", $criterion, $sz;
+        printf "%s:%10s %5d: ", $file, $criterion, $sz;
         unless ($sz) {
           say "";
           next;

--- a/lib/Devel/Cover/Report/Sort.pm
+++ b/lib/Devel/Cover/Report/Sort.pm
@@ -28,7 +28,7 @@ sub print_sort ($db, $options) {
     say "Start:        ", scalar gmtime $r->start;
     say "Finish:       ", scalar gmtime $r->finish;
 
-    $runs{ $r->run }->@{ "vec", "size" } = ("", 0);
+    $runs{ $r->run }->@{ "vec", "size", "count" } = ("", 0, 0);
     my $run = $runs{ $r->run };
     my $vec = $r->vec;
     for my $file (

--- a/lib/Devel/Cover/Report/Sort.pm
+++ b/lib/Devel/Cover/Report/Sort.pm
@@ -25,8 +25,8 @@ sub print_sort ($db, $options) {
     say "Run:          ", $r->run;
     say "Perl version: ", $r->perl;
     say "OS:           ", $r->OS;
-    say "Start:        ", scalar gmtime $r->start / 1e6;
-    say "Finish:       ", scalar gmtime $r->finish / 1e6;
+    say "Start:        ", scalar gmtime $r->start;
+    say "Finish:       ", scalar gmtime $r->finish;
 
     $runs{ $r->run }->@{ "vec", "size" } = ("", 0);
     my $run = $runs{ $r->run };

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -109,7 +109,7 @@ sub print_dir_block ($db, $files, $prefix) {
 
   my @rows;
   for my $dir (@dirs) {
-    my $scar = $db->dir_summary($dir, "scar") or return;
+    my $scar = $db->dir_summary($dir, "scar") or next;
     my $display
       = $prefix && $dir =~ /^\Q$prefix\E(.*)/ ? ($1 || ".") : ($dir || ".");
     push @rows, {
@@ -121,6 +121,7 @@ sub print_dir_block ($db, $files, $prefix) {
         sort_key => $scar->{file_scar},
       };
   }
+  return unless @rows > 1;
 
   @rows = sort { $b->{sort_key} <=> $a->{sort_key} } @rows;
 

--- a/t/internal/compilation.t
+++ b/t/internal/compilation.t
@@ -75,7 +75,11 @@ sub test_compilation_report () {
 
   package Mock::Criterion;
   sub new ($class, @locations) { bless { locations => \@locations }, $class }
-  sub items ($self) { map $_->[0], $self->{locations}->@* }
+
+  sub items ($self) {
+    my %seen;
+    grep !$seen{$_}++, map $_->[0], $self->{locations}->@*
+  }
 
   sub location ($self, $loc) {
     [map $_->[1], grep { $_->[0] == $loc } $self->{locations}->@*]
@@ -268,6 +272,22 @@ sub test_condition_states () {
     "condition names only genuinely missed outcomes and reports stale ones";
 }
 
+# Two conditions of the same type on one line each need the line number,
+# since every message here is meant to be machine-navigable.
+sub test_condition_repeated_location () {
+  my $crit = Mock::Criterion->new(
+    [2, cond_obj('$p', "1", [1, 0])],
+    [2, cond_obj('$p', "2", [1, 0])],
+  );
+  is capture_output(\&Devel::Cover::Report::Compilation::print_conditions,
+    $crit),
+    lines(
+      'Uncovered condition (l) at Mock.pm line 2: $p && 1',
+      'Uncovered condition (l) at Mock.pm line 2: $p && 2',
+    ),
+    "every condition on a line carries the line number";
+}
+
 sub test_mcdc_states () {
   my $crit = Mock::Criterion->new(
     [1, mcdc_obj('$a || $b', [1, 1])],
@@ -296,6 +316,7 @@ sub main () {
   test_pod_states;
   test_branch_states;
   test_condition_states;
+  test_condition_repeated_location;
   test_mcdc_states;
   done_testing;
 }

--- a/t/internal/complexity.t
+++ b/t/internal/complexity.t
@@ -687,6 +687,39 @@ sub test_text_dir_block_suppressed () {
     "dir: suppressed when only one directory in report";
 }
 
+{
+
+  package Mock::Dir_db;
+  sub new         ($class, %scar)           { bless { scar => \%scar }, $class }
+  sub dir_summary ($self, $dir, $criterion) { $self->{scar}{$dir} }
+}
+
+# A directory whose files hold no named subs has no scar entry. That must
+# skip the directory, not abandon the whole table.
+sub test_text_dir_block_partial_scar () {
+  my $db = Mock::Dir_db->new(
+    a => { file_cc => 3, file_cov => 100, file_crap => 3, file_scar => 0 },
+    c => { file_cc => 5, file_cov => 50,  file_crap => 9, file_scar => 4 },
+  );
+
+  my $output;
+  {
+    open my $fh, ">", \$output or die $!;
+    local *STDOUT = $fh;
+    Devel::Cover::Report::Text::print_dir_block(
+      $db, ["a/A.pm", "b/B.pm", "c/C.pm"], ""
+    );
+    close $fh or die $!;
+  }
+  $output //= "";
+
+  like $output, qr/^Directory Summary\b/m,
+    "dir: a directory without complexity data does not suppress the table";
+  like $output,   qr/^a\s/m, "dir: first directory with data listed";
+  like $output,   qr/^c\s/m, "dir: second directory with data listed";
+  unlike $output, qr/^b\s/m, "dir: directory without data omitted";
+}
+
 # print_summary SCAR column tests.
 # Verifies that DB::print_summary emits a scar column after the criteria
 # columns, with the same file_scar aggregate for files and Total.
@@ -745,6 +778,7 @@ sub main () {
   test_text_module_block;
   test_text_dir_block;
   test_text_dir_block_suppressed;
+  test_text_dir_block_partial_scar;
 }
 
 main;

--- a/t/internal/sort_report.t
+++ b/t/internal/sort_report.t
@@ -19,7 +19,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 use File::Spec ();
 use File::Temp qw( tempdir );
 
-use Test::More import => [qw( done_testing is like ok )];
+use Test::More import => [qw( diag done_testing is like ok )];
 
 use Devel::Cover::DB           ();
 use Devel::Cover::Report::Sort ();
@@ -45,10 +45,11 @@ sub covered_db ($label, $name = "run.pl") {
   $db
 }
 
-sub sort_output ($db_path) {
-  my $db      = Devel::Cover::DB->new(db => $db_path)->merge_runs;
-  my @files   = $db->cover->items;
-  my $options = { coverage => ["statement"], file => \@files };
+sub sort_output ($db_path, %opts) {
+  my $db    = Devel::Cover::DB->new(db => $db_path)->merge_runs;
+  my @files = $db->cover->items;
+  my $options
+    = { coverage => $opts{coverage} // ["statement"], file => \@files };
 
   my $output;
   {
@@ -92,9 +93,19 @@ sub test_filename_with_percent () {
   is "@warnings", "", "no printf warnings while writing the report";
 }
 
+sub test_count_line_with_nothing_collected () {
+  my @warnings;
+  local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+  my ($output) = sort_output(covered_db("empty"), coverage => ["time"]);
+  is @warnings, 0, "no warnings when nothing is collected"
+    or diag join "", @warnings;
+  like $output, qr|^Count:\s+0 / 0$|m, "count printed as zero";
+}
+
 sub main () {
   test_run_times_are_epoch_seconds;
   test_filename_with_percent;
+  test_count_line_with_nothing_collected;
   done_testing;
 }
 

--- a/t/internal/sort_report.t
+++ b/t/internal/sort_report.t
@@ -1,0 +1,82 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use Test::More import => [qw( done_testing like ok )];
+
+use Devel::Cover::DB           ();
+use Devel::Cover::Report::Sort ();
+
+my $Tmpdir = File::Spec->rel2abs(tempdir(CLEANUP => 1));
+
+sub covered_db ($label) {
+  my $dir = File::Spec->catdir($Tmpdir, $label);
+  mkdir $dir or die "Cannot create $dir: $!";
+  my $script = File::Spec->catfile($dir, "run.pl");
+  open my $fh, ">", $script or die "Cannot write $script: $!";
+  print $fh "my \$x = 0;\n\$x++ for 1 .. 3;\n";
+  close $fh or die "Cannot close $script: $!";
+
+  my $db = File::Spec->catdir($dir, "cover_db");
+  local $ENV{DEVEL_COVER_SELF};
+  local $ENV{DEVEL_COVER_OPTIONS};
+  delete @ENV{qw( DEVEL_COVER_SELF DEVEL_COVER_OPTIONS )};
+  system(
+    $^X, "-Iblib/lib", "-Iblib/arch",
+    "-MDevel::Cover=-db,$db,-silent,1,-merge,0", $script,
+  ) == 0 or die "Failed to run $label under Devel::Cover: $?";
+  $db
+}
+
+sub sort_output ($db_path) {
+  my $db      = Devel::Cover::DB->new(db => $db_path)->merge_runs;
+  my @files   = $db->cover->items;
+  my $options = { coverage => ["statement"], file => \@files };
+
+  my $output;
+  {
+    open my $fh, ">", \$output or die "Cannot open scalar ref: $!";
+    local *STDOUT = $fh;
+    Devel::Cover::Report::Sort->report($db, $options);
+    close $fh or die "Cannot close scalar ref: $!";
+  }
+  ($output // "", $db)
+}
+
+sub test_run_times_are_epoch_seconds () {
+  my ($output, $db) = sort_output(covered_db("times"));
+  my @runs = $db->runs;
+  ok @runs, "database contains at least one run";
+  for my $r (@runs) {
+    my $start  = scalar gmtime $r->start;
+    my $finish = scalar gmtime $r->finish;
+    like $output, qr/^Start:\s+\Q$start\E$/m,
+      "start printed as epoch seconds ($start)";
+    like $output, qr/^Finish:\s+\Q$finish\E$/m,
+      "finish printed as epoch seconds ($finish)";
+  }
+}
+
+sub main () {
+  test_run_times_are_epoch_seconds;
+  done_testing;
+}
+
+main;

--- a/t/internal/sort_report.t
+++ b/t/internal/sort_report.t
@@ -19,17 +19,17 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 use File::Spec ();
 use File::Temp qw( tempdir );
 
-use Test::More import => [qw( done_testing like ok )];
+use Test::More import => [qw( done_testing is like ok )];
 
 use Devel::Cover::DB           ();
 use Devel::Cover::Report::Sort ();
 
 my $Tmpdir = File::Spec->rel2abs(tempdir(CLEANUP => 1));
 
-sub covered_db ($label) {
+sub covered_db ($label, $name = "run.pl") {
   my $dir = File::Spec->catdir($Tmpdir, $label);
   mkdir $dir or die "Cannot create $dir: $!";
-  my $script = File::Spec->catfile($dir, "run.pl");
+  my $script = File::Spec->catfile($dir, $name);
   open my $fh, ">", $script or die "Cannot write $script: $!";
   print $fh "my \$x = 0;\n\$x++ for 1 .. 3;\n";
   close $fh or die "Cannot close $script: $!";
@@ -74,8 +74,27 @@ sub test_run_times_are_epoch_seconds () {
   }
 }
 
+# The covered file name is data, not a printf format.
+sub test_filename_with_percent () {
+  my $db_path = covered_db("percent", "pc%dt.pl");
+
+  my @warnings;
+  my ($output, $db);
+  {
+    local $SIG{__WARN__} = sub { push @warnings, @_ };
+    ($output, $db) = sort_output($db_path);
+  }
+
+  my ($file) = grep /pc%dt\.pl$/, $db->cover->items;
+  ok $file, "the covered file is recorded under its own name";
+  like $output, qr/^\Q$file\E:\s+statement\s+\d+: [01]+$/m,
+    "the file name and the criterion both reach the report intact";
+  is "@warnings", "", "no printf warnings while writing the report";
+}
+
 sub main () {
   test_run_times_are_epoch_seconds;
+  test_filename_with_percent;
   done_testing;
 }
 


### PR DESCRIPTION
## Summary

Five small output fixes across three report backends.

- Skip a directory without subroutine data in the text report's Directory Summary rather than abandoning the whole table.
- Print the line number on every condition message in the compilation report, so repeated conditions on one line stay navigable in quickfix-style tools.
- Print run start and finish times correctly in the sort report, which divided the stored seconds by 1e6 a second time and showed every run as 1 January 1970.
- Pass the covered file name to the sort report's printf as data, so a percent in the name no longer garbles the row.
- Initialise the sort report's per-run count, so a run collecting nothing prints a zero count instead of warning.

## Ticket

Closes #728