### PR TITLE
GH-732 Fix the crisp "Hide 100% covered" filter

### DIFF
--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -139,7 +139,7 @@ sub cov_bar ($pc, $uncompiled) {
   qq(<span class="$bar">\n$fill</span>\n)
 }
 
-sub cov_cell ($s, $uncompiled, $data_value = undef, $link = undef) {
+sub cov_cell ($s, $uncompiled, $data_value = undef, $link = undef, $attr = "") {
   my $dv      = $data_value // (is_na($s->{pc}) ? -1 : $s->{pc});
   my $no_data = $uncompiled && !$R{have_ppi};
   my $no_tip  = $no_data || ($s->{total} // 0) == 0;
@@ -148,8 +148,9 @@ sub cov_cell ($s, $uncompiled, $data_value = undef, $link = undef) {
   my $bar     = cov_bar($s->{pc}, $uncompiled);
   my $inner   = "$s->{pc} $bar";
 
+  $attr  = " $attr"                                         if $attr;
   $inner = qq(<a class="cell-link" href="$link">$inner</a>) if $link;
-  qq(<td class="$cls" data-value="$dv">$inner $tip</td>)
+  qq(<td class="$cls"$attr data-value="$dv">$inner $tip</td>)
 }
 
 sub file_row ($f, $dir) {
@@ -171,7 +172,10 @@ HTML
     $o .= cov_cell($f->{criteria}{$c}, $f->{uncompiled}, undef, $link);
   }
   my $total_link = $linkable ? "$f->{link}#filter=total" : undef;
-  $o .= cov_cell($f->{total}, $f->{uncompiled}, $f->{total_sort}, $total_link);
+  $o .= cov_cell(
+    $f->{total}, $f->{uncompiled}, $f->{total_sort},
+    $total_link, 'data-col="total"',
+  );
   $o .= cc_cell($f);
   $o .= scar_cell($f, $linkable ? $f->{link} : undef);
   $o .= "</tr>\n";
@@ -2516,8 +2520,9 @@ $Assets{js} = $Crisp_theme_js . <<'JS';
         function(row) {
           var name = row.children[0]
             .getAttribute("data-value") || "";
-          var cells = row.children;
-          var tv = cells[cells.length - 2];
+          var tv = row.querySelector(
+            'td[data-col="total"]');
+          if (!tv) return;
           var total = parseFloat(
             tv.getAttribute("data-value"));
           var show = (!re || re.test(name))

--- a/t/internal/html_crisp_render.t
+++ b/t/internal/html_crisp_render.t
@@ -593,6 +593,44 @@ sub test_index_filter_links () {
     "index: SCAR cell links to file without #filter";
 }
 
+sub test_file_row_total_marker () {
+  no warnings "once";
+  local %Devel::Cover::Report::Html_crisp::R
+    = (criteria => ["statement"], have_ppi => 1);
+
+  my $f = {
+    basename   => "Calc.pm",
+    short      => "Covered/Calc.pm",
+    link       => "lib-Covered-Calc-pm.html",
+    exists     => 1,
+    uncompiled => 0,
+    criteria   => {
+      statement => { pc => "50.0", class => "c1", covered => 1, total => 2 },
+    },
+    total      => { pc => "75.0", class => "c2", covered => 3, total => 4 },
+    total_sort => "75.0",
+    file_cc    => 5,
+    file_scar  => "33.4",
+    file_crap  => "12.5",
+    file_cov   => 80,
+    worst_subs => [],
+  };
+
+  my $row    = Devel::Cover::Report::Html_crisp::file_row($f, "Covered");
+  my @marked = $row =~ /(<td[^>]*data-col="total"[^>]*>)/g;
+  is @marked, 1, "file row marks exactly one cell as the total";
+  like $marked[0] // "", qr/data-value="75\.0"/,
+    "marked cell carries the total percentage";
+}
+
+sub test_index_filter_total_cell () {
+  my $app_js = slurp(File::Spec->catfile($Outdir, "assets", "app.js"));
+  like $app_js, qr/td\[data-col="total"\]/,
+    "index filter selects the total cell by attribute";
+  unlike $app_js, qr/cells\.length - 2/,
+    "index filter no longer counts columns from the end";
+}
+
 sub test_dir_header_no_links () {
   my $got = $Golden{"coverage.html"};
   my ($dir_block) = $got =~ m{(<tr class="dir-header".*?</tr>)}s;
@@ -1146,6 +1184,8 @@ sub main () {
   test_render_worst_files_untested_colour;
   test_stat_badge_no_tip_when_empty;
   test_index_filter_links;
+  test_file_row_total_marker;
+  test_index_filter_total_cell;
   test_dir_header_no_links;
   test_build_dir_groups;
   test_app_js_hash_filter;


### PR DESCRIPTION
## Summary

The "Hide 100% covered" checkbox on the crisp index page read the second cell from the end of each row, which the CC and SCAR columns had made the complexity cell, so it compared complexity against 100 and hid nothing. Mark the total cell with `data-col="total"` and select it by that mark, so a future column move cannot silently break the filter again.

## Ticket

Closes #732