### PR TITLE
GH-734 Fix correctness problems in HTML reports

### DIFF
--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -101,8 +101,11 @@ sub _build_annotations ($n) {
   for my $ann ($R{options}{annotations}->@*) {
     for my $i (0 .. $ann->count - 1) {
       my $text = $ann->text($R{file}, $n, $i);
-      $text = "&nbsp;" unless $text && length $text;
-      push @entries, { text => $text, class => $ann->class($R{file}, $n, $i) };
+      $text = $text && length $text ? escape_html($text) : "&nbsp;";
+      push @entries, {
+          text  => $text,
+          class => escape_html($ann->class($R{file}, $n, $i) // ""),
+        };
     }
   }
   \@entries
@@ -424,8 +427,10 @@ sub report ($pkg, $db, $options) {
         (0 .. $db->criteria - 1)
     ],
     annotations => [
-      map { my $ann = $_; map $ann->header($_), 0 .. $ann->count - 1 }
-        $options->{annotations}->@*
+      map {
+        my $ann = $_;
+        map escape_html($ann->header($_) // ""), 0 .. $ann->count - 1
+      } $options->{annotations}->@*
     ],
     filenames  => unique_filenames($options->{file}->@*),
     exists     => { map { $_ => -e } $options->{file}->@* },

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -558,7 +558,7 @@ $Templates{summary} = <<'HTML';
   </tr>
   <tr>
     <td class="sh" align="right">Database:</td>
-    <td class="sv" align="left" colspan="4">[% R.db.db %]</td>
+    <td class="sv" align="left" colspan="4">[% R.db.db | html %]</td>
   </tr>
   <tr>
     <td class="sh" align="right">Report date:</td>

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -395,10 +395,11 @@ filter active. Click a SCAR cell to open the file at the top.</dd>
 HTML
 
   if ($R{common_prefix}) {
+    my $prefix = escape_html($R{common_prefix});
     $o .= <<HTML;
 <div class="common-prefix">
 <span class="common-prefix-label">Prefix:</span>
-<span class="common-prefix-path">$R{common_prefix}</span>
+<span class="common-prefix-path">$prefix</span>
 </div>
 HTML
   }

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -51,6 +51,7 @@ sub render_layout (%args) {
   my $asset_prefix = $args{asset_prefix} // "";
   my $title        = escape_html($args{title} || "Coverage Report");
   my $content      = $args{content} // "";
+  my $report_id    = escape_html($R{report_id});
   <<HTML
 <!DOCTYPE html>
 <html lang="en">
@@ -71,7 +72,7 @@ https://pjcj.net
 </svg>">
 <title>$title - Devel::Cover</title>
 </head>
-<body data-report-id="$R{report_id}" data-file-count="$R{file_count}">
+<body data-report-id="$report_id" data-file-count="$R{file_count}">
 $content
 <div class="footer">
 Coverage information from

--- a/lib/Devel/Cover/Report/Html_minimal.pm
+++ b/lib/Devel/Cover/Report/Html_minimal.pm
@@ -632,15 +632,17 @@ sub print_summary_report ($db, $options) {
   };
   my $perl_v = $^V;
   my $os     = $^O;
+  my $title  = escape_html($options->{option}{summarytitle});
+  my $dbname = escape_html($db->{db});
 
   print_html_header($fh, $options->{option}{summarytitle});
   # TODO - >= 100% doesn't look nice.  See also Html_basic.
   print $fh <<"END_HTML";
 <body>
-<h1>$options->{option}{summarytitle}</h1>
+<h1>$title</h1>
 <table>
   <tr><td class="h" align="right">Database:</td>
-  <td align="left" colspan="4">$db->{db}</td></tr>
+  <td align="left" colspan="4">$dbname</td></tr>
   <tr><td class="h" align="right">Report Date:</td>
   <td align="left" colspan="4">$date</td></tr>
   <tr><td class="h" align="right">Perl Version:</td>

--- a/lib/Devel/Cover/Report/Html_minimal.pm
+++ b/lib/Devel/Cover/Report/Html_minimal.pm
@@ -293,16 +293,15 @@ sub get_link ($file, $type = undef, $line = undef) {
 sub escape_HTML ($text) {  ## no critic (NamingConventions::Capitalization)
   chomp $text;
 
-  $text = escape_html($text);
-
   # Do not allow FF in text
   $text =~ tr/\x0c//d;
 
   # IE doesn't honour "white-space: pre" CSS
   my @text = split m/\n/ => $text;
   for (@text) {
-    # Expand all tabs to spaces
+    # Expand all tabs to spaces, measuring the source, not the markup
     1 while s/\t+/' ' x (length($&) * 8 - length($`) % 8)/e;
+    $_ = escape_html($_);
     # make multiple spaces be multiple spaces
     s/(  +)/'&nbsp;' x length $1/ge;
   }

--- a/lib/Devel/Cover/Report/Html_subtle.pm
+++ b/lib/Devel/Cover/Report/Html_subtle.pm
@@ -27,7 +27,7 @@ use Template 2.00 ();
 my $Template;
 my %Filenames;
 my %File_exists;
-my $Perlver    = join ".", map { ord } split //, $^V;
+my $Perlver    = "$^V";
 my $Threshold  = default_thresholds;
 my %Class_name = (
   na => "uncovered",

--- a/lib/Devel/Cover/Report/Html_subtle.pm
+++ b/lib/Devel/Cover/Report/Html_subtle.pm
@@ -499,7 +499,7 @@ $Templates{summary} = <<'HTML';
 <table>
   <tr>
     <td class="header" align="right">Database:</td>
-    <td>[% dbname %]</td>
+    <td>[% dbname | html %]</td>
   </tr>
 </table>
 <div><br></br></div>

--- a/t/internal/html_escape.t
+++ b/t/internal/html_escape.t
@@ -248,6 +248,74 @@ sub test_common_prefix_escaped ($tmpdir, $cover_db) {
     "html_crisp: raw prefix does not reach the page";
 }
 
+# The database path, the summary title and the crisp report id are printed on
+# the summary page of each HTML report, so markup characters in them must be
+# escaped there too.  run_cover joins its arguments through the shell, so the
+# marked paths are quoted on the way in.
+sub _sq ($s) { "'" . ($s =~ s/'/'\\''/gr) . "'" }
+
+sub _setup_marked_db () {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+  my $dbdir  = File::Spec->catdir($tmpdir, "a<MARK>&d");
+  make_path($dbdir);
+
+  my $script = File::Spec->catfile($tmpdir, "run.pl");
+  open my $fh, ">", $script or die "Cannot write $script: $!";
+  print $fh "my \$x = 0;\n\$x++ for 1 .. 3;\n";
+  close $fh or die "Cannot close $script: $!";
+
+  my $cover_db = File::Spec->catdir($dbdir, "cover_db");
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my @cmd = (
+    $^X, "-Iblib/lib", "-Iblib/arch",
+    "-MDevel::Cover=-db,$cover_db,-silent,1,-merge,0", $script,
+  );
+  system(@cmd) == 0 or die "Failed to create cover_db (status $?)";
+
+  ($tmpdir, $cover_db)
+}
+
+sub test_summary_db_path_escaped ($report, $tmpdir, $cover_db) {
+  my $outdir = File::Spec->catdir($tmpdir, $report);
+  my ($out, $exit) = run_cover(
+    "--report", $report, "--outputdir", $outdir,
+    "--silent", _sq($cover_db),
+  );
+  is $exit, 0, "cover --report $report exits 0" or diag $out;
+  my $html = slurp(File::Spec->catfile($outdir, "coverage.html"));
+  unlike $html, qr|<MARK>|, "$report: raw db path is not on the summary page";
+  like $html,   qr|&lt;MARK&gt;|, "$report: db path is escaped";
+}
+
+sub test_summary_title_escaped ($tmpdir, $cover_db) {
+  my $outdir = File::Spec->catdir($tmpdir, "title");
+  my ($out, $exit) = run_cover(
+    "--report",       "html_minimal",   "--outputdir", $outdir,
+    "--summarytitle", _sq("T<MARK>&t"), "--silent",    _sq($cover_db),
+  );
+  is $exit, 0, "cover --summarytitle exits 0" or diag $out;
+  my $html = slurp(File::Spec->catfile($outdir, "coverage.html"));
+  unlike $html, qr|<h1>T<MARK>&t</h1>|,
+    "html_minimal: raw summary title is not in the heading";
+  like $html, qr|<h1>T&lt;MARK&gt;&amp;t</h1>|,
+    "html_minimal: summary title is escaped in the heading";
+}
+
+sub test_crisp_report_id_escaped ($tmpdir, $cover_db) {
+  my $outdir = File::Spec->catdir($tmpdir, "out<MARK>&d");
+  my ($out, $exit) = run_cover(
+    "--report", "html_crisp", "--outputdir", _sq($outdir),
+    "--silent", _sq($cover_db),
+  );
+  is $exit, 0, "cover --report html_crisp exits 0" or diag $out;
+  my $html = slurp(File::Spec->catfile($outdir, "coverage.html"));
+  unlike $html, qr/data-report-id="[^"]*<MARK>/,
+    "html_crisp: raw output directory is not in the attribute";
+  like $html, qr/data-report-id="[^"]*&lt;MARK&gt;/,
+    "html_crisp: output directory is escaped in the attribute";
+}
+
 # The module name and version reach the coverage summary page from the covered
 # distribution's MYMETA.json (or its directory name), so they may contain
 # markup characters and must be escaped on the summary page too.
@@ -454,6 +522,15 @@ sub main () {
 
     my ($td, $cdb) = _setup_marked_dir;
     test_common_prefix_escaped($td, $cdb);
+
+    my ($mt, $mdb) = _setup_marked_db;
+    test_summary_db_path_escaped("html_minimal", $mt, $mdb);
+    if ($Have_template) {
+      test_summary_db_path_escaped("html_basic",  $mt, $mdb);
+      test_summary_db_path_escaped("html_subtle", $mt, $mdb);
+    }
+    test_summary_title_escaped($mt, $mdb);
+    test_crisp_report_id_escaped($mt, $mdb);
   }
 
   done_testing;

--- a/t/internal/html_escape.t
+++ b/t/internal/html_escape.t
@@ -211,6 +211,43 @@ sub test_filename_escaped ($report, $tmpdir, $cover_db) {
   like $html, qr|&lt;MARK&gt;|, "$report: file name metacharacters are escaped";
 }
 
+# The common prefix of the covered file paths is printed on the crisp index
+# page, so a directory name holding markup characters must be escaped there.
+# It takes two covered files to produce a non-empty prefix.
+sub _setup_marked_dir () {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+  my $libdir = File::Spec->catdir($tmpdir, "a&b<c");
+  make_path($libdir);
+
+  for my $mod (qw( AAA BBB )) {
+    my $path = File::Spec->catfile($libdir, "$mod.pm");
+    open my $fh, ">", $path or die "Cannot write $path: $!";
+    print $fh "package $mod;\nsub go { 1 }\n1;\n";
+    close $fh or die "Cannot close $path: $!";
+  }
+
+  my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my @cmd = (
+    $^X, "-Iblib/lib", "-Iblib/arch", "-I$libdir",
+    "-MDevel::Cover=-db,$cover_db,-silent,1,-merge,0",
+    "-e", "use AAA; use BBB; AAA::go; BBB::go",
+  );
+  system(@cmd) == 0 or die "Failed to create cover_db (status $?)";
+
+  ($tmpdir, $cover_db)
+}
+
+sub test_common_prefix_escaped ($tmpdir, $cover_db) {
+  my $outdir = _report($tmpdir, $cover_db, "html_crisp");
+  my $html   = slurp(File::Spec->catfile($outdir, "coverage.html"));
+  like $html, qr|common-prefix-path">[^<]*a&amp;b&lt;c|,
+    "html_crisp: common prefix is escaped on the index page";
+  unlike $html, qr|common-prefix-path">[^<]*a&b|,
+    "html_crisp: raw prefix does not reach the page";
+}
+
 # The module name and version reach the coverage summary page from the covered
 # distribution's MYMETA.json (or its directory name), so they may contain
 # markup characters and must be escaped on the summary page too.
@@ -414,6 +451,9 @@ sub main () {
     test_filename_escaped("html_minimal", $t, $db);
     test_filename_escaped("html_basic",   $t, $db) if $Have_template;
     test_filename_escaped("html_subtle",  $t, $db) if $Have_template;
+
+    my ($td, $cdb) = _setup_marked_dir;
+    test_common_prefix_escaped($td, $cdb);
   }
 
   done_testing;

--- a/t/internal/html_escape.t
+++ b/t/internal/html_escape.t
@@ -113,6 +113,62 @@ sub test_html_crisp ($tmpdir, $cover_db) {
     "html_crisp: file page contains escaped source";
 }
 
+# Annotation text, headers and classes come from a plugin, so they may
+# contain markup and must be escaped like every other value on the page.
+my $Ann_text   = "Smith & Sons<script>alert(1)</script>";
+my $Ann_header = "H<script>hdr</script>";
+my $Ann_class  = 'x"><script>cls</script>';
+
+sub _write_annotation ($tmpdir) {
+  my $dir = File::Spec->catdir($tmpdir, "annlib", qw( Devel Cover Annotation ));
+  make_path($dir);
+  my $path = File::Spec->catfile($dir, "Evil.pm");
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh <<"PERL";
+package Devel::Cover::Annotation::Evil;
+use strict;
+use warnings;
+sub new    { bless {}, shift }
+sub count  { 1 }
+sub header { '$Ann_header' }
+sub width  { 40 }
+sub text   { '$Ann_text' }
+sub error  { 0 }
+sub class  { '$Ann_class' }
+1;
+PERL
+  close $fh or die "Cannot close $path: $!";
+  File::Spec->catdir($tmpdir, "annlib")
+}
+
+sub test_annotation_escaped ($tmpdir, $cover_db) {
+  my $annlib = _write_annotation($tmpdir);
+  local $ENV{PERL5LIB} = $annlib;
+  my $outdir = _report(
+    $tmpdir,        $cover_db, "html_basic", @No_highlight,
+    "--annotation", "evil",
+  );
+
+  my ($file_page) = grep !m|/coverage\.html$| && !/--\w+\.html$/,
+    glob "$outdir/*.html";
+  my $html = slurp($file_page);
+
+  unlike $html, qr|<script>alert\(1\)</script>|,
+    "html_basic: annotation text is not written as raw markup";
+  like $html, qr|&lt;script&gt;alert\(1\)&lt;/script&gt;|,
+    "html_basic: annotation text is escaped";
+  like $html, qr|Smith &amp; Sons|,
+    "html_basic: an ampersand in annotation text is escaped";
+  unlike $html, qr|<th> H<script>hdr</script> </th>|,
+    "html_basic: annotation header is not written as raw markup";
+  like $html, qr|H&lt;script&gt;hdr&lt;/script&gt;|,
+    "html_basic: annotation header is escaped";
+  unlike $html, qr|class="x"><script>cls</script>"|,
+    "html_basic: annotation class is not written as raw markup";
+  like $html, qr|x&quot;&gt;&lt;script&gt;cls&lt;/script&gt;|,
+    "html_basic: annotation class is escaped";
+}
+
 # The covered file name reaches the report title, headings and links, and may
 # contain markup characters, so it must be escaped there too and not only in
 # the source body.  Windows file names cannot contain < > " so this is
@@ -318,6 +374,7 @@ sub main () {
   my ($tmpdir, $cover_db) = _setup;
   test_html_basic($tmpdir, $cover_db) if $Have_template;
   test_html_crisp($tmpdir, $cover_db);
+  test_annotation_escaped($tmpdir, $cover_db) if $Have_template;
 
   if ($Have_template && $Have_cpan_meta) {
     my ($t, $db) = _setup_meta;

--- a/t/internal/html_minimal.t
+++ b/t/internal/html_minimal.t
@@ -88,9 +88,22 @@ sub test_void_compound_renders_uncovered () {
     "unproven compound rows render uncovered without observed vectors";
 }
 
+# Tab stops must be measured on the source text, not on the escaped markup,
+# or the entities lengthen the line and shift the expansion.
+sub test_tab_stops_measure_source_columns () {
+  my $e = \&Devel::Cover::Report::Html_minimal::escape_HTML;
+  is $e->("abcd\tX"), "abcd&nbsp;&nbsp;&nbsp;&nbsp;X",
+    "tab after plain text reaches column 8";
+  is $e->("a<b\tX"), "a&lt;b&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;X",
+    "tab after an escaped character reaches column 8";
+  is $e->("a<b\tX\nc&d"), "a&lt;b&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;X\nc&amp;d",
+    "per-line escaping matches whole-text escaping";
+}
+
 sub main () {
   test_truth_table_honours_observed_vectors;
   test_void_compound_renders_uncovered;
+  test_tab_stops_measure_source_columns;
   done_testing;
 }
 

--- a/t/internal/html_subtle_perl_version.t
+++ b/t/internal/html_subtle_perl_version.t
@@ -1,0 +1,76 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( realpath );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is like plan unlike )];
+use Devel::Cover::Test::Showcase qw( run_cover slurp );
+
+eval "require HTML::Entities; 1" or do {
+  plan skip_all => "HTML::Entities not available";
+  exit;
+};
+eval "require Template; 1" or do {
+  plan skip_all => "Template not available";
+  exit;
+};
+
+sub _setup () {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+  my $script = File::Spec->catfile($tmpdir, "run.pl");
+  open my $fh, ">", $script or die "Cannot write $script: $!";
+  print $fh "my \$x = 0;\n\$x++ for 1 .. 3;\n";
+  close $fh or die "Cannot close $script: $!";
+
+  my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my @cmd = (
+    $^X, "-Iblib/lib", "-Iblib/arch",
+    "-MDevel::Cover=-db,$cover_db,-silent,1,-merge,0", $script,
+  );
+  system(@cmd) == 0 or die "Failed to create cover_db (status $?)";
+
+  ($tmpdir, $cover_db)
+}
+
+# The report once read $^V as a v-string, taking the ord of each character.
+# $^V has been a version object since 5.10, so that spelt v5.44.0 as
+# 118.53.46.52.52.46.48.
+sub test_perl_version_is_printed_as_a_version ($tmpdir, $cover_db) {
+  my $outdir = File::Spec->catdir($tmpdir, "out");
+  my ($out, $exit) = run_cover(
+    "--report", "html_subtle", "--outputdir", $outdir,
+    "--silent", $cover_db,
+  );
+  is $exit, 0, "cover --report html_subtle exits 0" or diag $out;
+  my $html = join "\n", map slurp($_), glob "$outdir/*.html";
+  my $v    = "$^V";
+  like $html,   qr/Perl version/, "a page shows the perl version row";
+  like $html,   qr/\Q$v\E/,       "pages name the running perl version";
+  unlike $html, qr/\b118\.53\./,  "pages do not print character codes";
+}
+
+sub main () {
+  my ($tmpdir, $cover_db) = _setup;
+  test_perl_version_is_printed_as_a_version($tmpdir, $cover_db);
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

- Escape annotation text, headers and classes in Html_basic.
- Escape the common path prefix on the crisp index page.
- Escape the database path, summary title and report id slots on the summary pages of the four HTML reports.
- Expand tabs before escaping in Html_minimal, which measured tab stops on the escaped markup and misaligned the source.
- Fix the perl version in the html_subtle report, printed as character codes since `$^V` became a version object in 5.10.

## Ticket

Closes #734