### PR TITLE
GH-738 Collection process, lock and version fixes

### DIFF
--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -328,9 +328,15 @@ class Devel::Cover::Collection {
     say "Wrote json output to $f";
   }
 
+  method _parse_version ($v) {
+    no warnings "misc";  # some malformed versions warn rather than die
+    my $p = eval { version->parse($v) };
+    $p
+  }
+
   method _newer ($va, $vb) {
-    my ($pa, $pb) = map { eval { version->parse($_) } } $va, $vb;
-    return $pa > $pb if $pa && $pb;
+    my ($pa, $pb) = map $self->_parse_version($_), $va, $vb;
+    return $pa > $pb if defined $pa && defined $pb;
     ($va // "") gt($vb // "")
   }
 

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -29,6 +29,7 @@ use feature "class";
 no warnings "experimental::class";
 
 my $Dist_ext_re = qr/\.(?:zip|tgz|tar\.(?:gz|bz2|xz))/;
+my $Log_re      = qr/^\w-\w\w-(\w+)-(.+?)${Dist_ext_re}--/;
 
 class Devel::Cover::Collection {
   # ro attributes
@@ -432,8 +433,9 @@ class Devel::Cover::Collection {
       for my $mod (@$mods) {
         my $m   = $mod->{module};
         my $log = $vars->{vals}{$m}{log};
-        if (defined $log && $log =~ /^\w-\w\w-(\w+)-\Q$m\E${Dist_ext_re}--/) {
-          $mod->{metacpan} = "https://metacpan.org/release/$1/$m";
+        my ($author, $name) = defined $log ? $log =~ $Log_re : ();
+        if (defined $name && $name eq $m) {
+          $mod->{metacpan} = "https://metacpan.org/release/$author/$m";
         } elsif (defined $mod->{name}) {
           $mod->{metacpan} = "https://metacpan.org/dist/$mod->{name}";
         }
@@ -466,6 +468,58 @@ class Devel::Cover::Collection {
         };
     }
     $vars->{overview} = { count => $count, segments => $segments };
+  }
+
+  # returns $mod and $m in one structure so workers keep their shared ref
+  method _module_data ($d, $module, $criteria) {
+    my $cover = "$d/$module/cover.json";
+    return undef unless -e $cover;
+    say "Adding $module" if $verbose;
+
+    my $json = Devel::Cover::DB::IO::JSON->new->read($cover);
+
+    my $mod = {
+      module => $module,
+      map { $_ => $json->{runs}[0]{$_} } qw( name version dir ),
+    };
+    unless (defined $mod->{name} && defined $mod->{version}) {
+      my ($name, $version) = ($mod->{module} // $module) =~ /(.+)-(\d+\.\d+)$/;
+      $mod->{name}    //= $name;
+      $mod->{version} //= $version;
+    }
+
+    my $m = { module => $mod };
+    $m->{link} = "$module/index.html"
+      if $json->{summary}{Total}{total}{total} && -e "$d/$module/index.html";
+
+    for my $criterion (@$criteria) {
+      my $summary = $json->{summary}{Total}{$criterion};
+      # print "summary:", Dumper $summary;
+      my $pc = $summary->{percentage};
+      $pc                     = defined $pc ? sprintf "%.2f", $pc : "n/a";
+      $m->{$criterion}{pc}    = $pc;
+      $m->{$criterion}{class} = $self->coverage_class($pc);
+      $m->{$criterion}{details}
+        = ($summary->{covered} || 0) . " / " . ($summary->{total} || 0);
+    }
+
+    my $s      = $json->{summary}{Total}{scar};
+    my @fields = qw( file_scar file_cc file_cov file_crap );
+    if ($s && @fields == grep defined, @$s{@fields}) {
+      $m->{cc}   = { val => $s->{file_cc}, class => "cc-val" };
+      $m->{scar} = {
+        val   => sprintf("%.1f", $s->{file_scar}),
+        class => "scar-val scar-" . scar_class($s->{file_scar}),
+        tip   => sprintf(
+          "CC %d &middot; cov %.0f%% &middot; CRAP %.1f",
+          $s->{file_cc}, $s->{file_cov}, $s->{file_crap},
+        ),
+      };
+    } else {
+      $m->{$_} = { val => "n/a", class => "na" } for qw( cc scar );
+    }
+
+    { module => $module, mod => $mod, m => $m }
   }
 
   method generate_html {
@@ -502,60 +556,22 @@ class Devel::Cover::Collection {
     my @mods = sort grep !/^\./, readdir $dh;
     closedir $dh or die "Can't closedir $d: $!";
 
+    my @data = eval { require Parallel::Iterator; 1 }
+      ? _iterate(
+        { workers => $workers },
+        sub {
+          my (undef, $module) = @_;
+          $self->_module_data($d, $module, $vars->{criteria})
+        },
+        \@mods,
+      )
+      : map $self->_module_data($d, $_, $vars->{criteria}), @mods;
+
     my $n = 0;
-    for my $module (@mods) {
-      my $cover = "$d/$module/cover.json";
-      next unless -e $cover;
-      say "Adding $module" if $verbose;
-
-      my $io   = Devel::Cover::DB::IO::JSON->new;
-      my $json = $io->read($cover);
-
-      my $mod = {
-        module => $module,
-        map { $_ => $json->{runs}[0]{$_} } qw( name version dir ),
-      };
-      unless (defined $mod->{name} && defined $mod->{version}) {
-        my ($name, $version)
-          = ($mod->{module} // $module) =~ /(.+)-(\d+\.\d+)$/;
-        $mod->{name}    //= $name;
-        $mod->{version} //= $version;
-      }
-      my $start = uc substr $module, 0, 1;
-      push $vars->{modules}{$start}->@*, $mod;
-
-      my $m = $vars->{vals}{$module} = {};
-      $m->{module} = $mod;
-      $m->{link}   = "$module/index.html"
-        if $json->{summary}{Total}{total}{total} && -e "$d/$module/index.html";
-
-      for my $criterion ($vars->{criteria}->@*) {
-        my $summary = $json->{summary}{Total}{$criterion};
-        # print "summary:", Dumper $summary;
-        my $pc = $summary->{percentage};
-        $pc                     = defined $pc ? sprintf "%.2f", $pc : "n/a";
-        $m->{$criterion}{pc}    = $pc;
-        $m->{$criterion}{class} = $self->coverage_class($pc);
-        $m->{$criterion}{details}
-          = ($summary->{covered} || 0) . " / " . ($summary->{total} || 0);
-      }
-
-      my $s      = $json->{summary}{Total}{scar};
-      my @fields = qw( file_scar file_cc file_cov file_crap );
-      if ($s && @fields == grep defined, @$s{@fields}) {
-        $m->{cc}   = { val => $s->{file_cc}, class => "cc-val" };
-        $m->{scar} = {
-          val   => sprintf("%.1f", $s->{file_scar}),
-          class => "scar-val scar-" . scar_class($s->{file_scar}),
-          tip   => sprintf(
-            "CC %d &middot; cov %.0f%% &middot; CRAP %.1f",
-            $s->{file_cc}, $s->{file_cov}, $s->{file_crap},
-          ),
-        };
-      } else {
-        $m->{$_} = { val => "n/a", class => "na" } for qw( cc scar );
-      }
-
+    for my $data (grep defined, @data) {
+      my $start = uc substr $data->{module}, 0, 1;
+      push $vars->{modules}{$start}->@*, $data->{mod};
+      $vars->{vals}{ $data->{module} } = $data->{m};
       print "." if !($n++ % 1000) && !$verbose;
     }
 

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -19,7 +19,7 @@ use Devel::Cover::Inc          ();
 use Devel::Cover::Web          qw( write_file );
 
 use JSON::MaybeXS ();
-use POSIX         qw( setsid );
+use POSIX         qw( _exit setsid );
 use Template      ();
 use Time::HiRes   qw( alarm time );
 use version       ();
@@ -137,9 +137,14 @@ class Devel::Cover::Collection {
             . ($signal ? ", signal $signal" : "") . ")\n";
         }
       } else {
-        setsid() != -1 or die "Can't start a new session: $!";
-        open STDERR, ">&", STDOUT or die "Can't dup stdout: $!";
-        exec @command or die "Can't exec @command: $!";
+        # a failure here must never return to the caller's code
+        eval {
+          setsid() != -1 or die "Can't start a new session: $!\n";
+          open STDERR, ">&", STDOUT or die "Can't dup stdout: $!\n";
+          exec @command or die "Can't exec @command: $!\n";
+        };
+        syswrite STDOUT, $@ if $@;
+        _exit 127;
       }
     };
     if ($@) {

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -276,6 +276,7 @@ class Devel::Cover::Collection {
         # TODO - option to merge DB with existing one
         # TODO - portability
         $output .= $self->fsys("rm", "-rf", $rdir);
+        # structure lock files are all named <digest>.lock, so glob sees them
         $output .= $self->fsys("rm", "-f",  glob "$db/structure/*.lock");
         $output .= $self->fsys("mv", $db,   $rdir);
         $output .= $self->fsys("rm", "-rf", $db);

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -32,22 +32,21 @@ my $Dist_ext_re = qr/\.(?:zip|tgz|tar\.(?:gz|bz2|xz))/;
 
 class Devel::Cover::Collection {
   # ro attributes
-  field $bin_dir       :param :reader = undef;
-  field $cpancover_dir :param :reader = undef;
-  field $cpan_dir      :param :reader = undef;
-  field $results_dir   :param :reader = undef;
-  field $dryrun        :param :reader = undef;
-  field $env           :param :reader = undef;
-  field $force         :param :reader = undef;
-  field $output_file   :param :reader = undef;
-  field $report        :param :reader = undef;
-  field $timeout       :param :reader = undef;
-  field $verbose       :param :reader = undef;
-  field $workers       :param :reader = undef;
-  field $docker        :param :reader = undef;
-  field $local         :param :reader = undef;
+  field $bin_dir     :param :reader = undef;
+  field $cpan_dir    :param :reader = undef;
+  field $results_dir :param :reader = undef;
+  field $dryrun      :param :reader = undef;
+  field $env         :param :reader = undef;
+  field $force       :param :reader = undef;
+  field $output_file :param :reader = undef;
+  field $report      :param :reader = undef;
+  field $timeout     :param :reader = undef;
+  field $verbose     :param :reader = undef;
+  field $workers     :param :reader = undef;
+  field $docker      :param :reader = undef;
+  field $local       :param :reader = undef;
 
-  # rwp attributes (reader + private setter)
+  # attributes set internally after construction
   field $build_dirs  :param :reader = undef;
   field $modules     :param :reader = undef;
   field $module_file :param :reader = undef;
@@ -56,7 +55,7 @@ class Devel::Cover::Collection {
   field $rebuild_batch :param :reader = undef;
   field $mark_rebuilt  :param :reader = undef;
 
-  # rw attributes (custom accessors for Moo compatibility)
+  # rw attributes
   field $dir  :param = undef;
   field $file :param = undef;
 
@@ -84,12 +83,7 @@ class Devel::Cover::Collection {
     $ENV{CPANCOVER_TIMEOUT} = $timeout;
   }
 
-  # rwp private setters
-  method _set_build_dirs  ($val) { $build_dirs  = $val }
-  method _set_modules     ($val) { $modules     = $val }
-  method _set_module_file ($val) { $module_file = $val }
-
-  # rw accessors (Moo-compatible: reader acts as writer when called with arg)
+  # rw accessors (the reader acts as a writer when called with an arg)
   method dir  ($new = undef) { $dir  = $new if defined $new; $dir }
   method file ($new = undef) { $file = $new if defined $new; $file }
 
@@ -162,10 +156,9 @@ class Devel::Cover::Collection {
     $ok ? $output : undef
   }
 
-  method sys   (@a) { $self->_sys(4e4, @a) // "" }
-  method bsys  (@a) { $self->_sys(0,   @a) // "" }
-  method fsys  (@a) { $self->_sys(4e4, @a) // die "Can't run @a" }
-  method fbsys (@a) { $self->_sys(0,   @a) // die "Can't run @a" }
+  method sys  (@a) { $self->_sys(4e4, @a) // "" }
+  method bsys (@a) { $self->_sys(0,   @a) // "" }
+  method fsys (@a) { $self->_sys(4e4, @a) // die "Can't run @a" }
 
   # Only the parallel paths need Parallel::Iterator, so load it on demand
   # and leave report generation working without it
@@ -175,8 +168,8 @@ class Devel::Cover::Collection {
   }
 
   method add_modules     (@o) { push @$modules, @o }
-  method set_modules     (@o) { @$modules = @o }
-  method set_module_file ($f) { $self->_set_module_file($f) }
+  method set_modules     (@o) { @$modules    = @o }
+  method set_module_file ($f) { $module_file = $f }
 
   method process_module_file {
     my $f = $module_file;
@@ -1212,10 +1205,6 @@ These attributes can only be set via the constructor.
 
 Directory containing the C<cover> binary. Used when running coverage commands.
 
-=head3 cpancover_dir
-
-Directory for CPANCover-specific files and configuration.
-
 =head3 cpan_dir
 
 An arrayref of CPAN directories to search for build directories. Defaults to
@@ -1287,10 +1276,10 @@ each module it builds, without the rebuild-mode selection or distdir
 replacement that C<rebuild> implies. Used by the rebuild loop's latest
 pass so fresh builds are not rebuilt again by the batch pass. Default: 0.
 
-=head2 Read-Write-Private Attributes
+=head2 Internally Managed Attributes
 
-These attributes have public readers but private setters. Use the provided
-methods to modify them.
+These attributes have public readers. Use the provided methods to modify
+them.
 
 =head3 build_dirs
 
@@ -1692,12 +1681,6 @@ Like C<sys>, but buffers all output (no immediate display).
   my $output = $collection->fsys(@command);
 
 Like C<sys>, but dies on failure.
-
-=head3 fbsys
-
-  my $output = $collection->fbsys(@command);
-
-Like C<bsys>, but dies on failure.
 
 =head1 EMBEDDED CLASSES
 

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -193,8 +193,6 @@ sub set_file ($self, $file) {
 
 sub delete_file ($self, $file) { delete $self->{f}{$file} }
 
-# TODO - concurrent runs updating structure?
-
 sub write ($self, $dir) {
   $dir .= "/structure";
   unless (mkdir $dir) {
@@ -211,21 +209,8 @@ sub write ($self, $dir) {
         || ($Devel::Cover::Self_cover && $file =~ "/Devel/Cover[./]");
       next;
     }
-    my $df_final = "$dir/$digest";
-    my $df_temp  = "$dir/.$digest.$$";
     # TODO - determine if Structure has changed to save writing it
-    my $io = Devel::Cover::DB::IO->new;
-    $io->write($self->{f}{$file}, $df_temp);               # unless -e $df;
-    unless (rename $df_temp, $df_final) {
-      if (-e $df_final) {
-        dcinfo "Can't rename $df_temp to $df_final (which exists): $!";
-      } else {
-        dcinfo "Can't rename $df_temp to $df_final: $!";
-      }
-      unless (unlink $df_temp) {
-        dcinfo "Can't remove $df_temp after failed rename: $!";
-      }
-    }
+    Devel::Cover::DB::IO->new->write($self->{f}{$file}, "$dir/$digest");
   }
 }
 

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -291,4 +291,16 @@ for my $f (qw( index.html dist/F.html about.html )) {
 my @Tmp = map glob, "$Dir/*.tmp.*", "$Dir/dist/*.tmp.*";
 is @Tmp, 0, "no tmp files remain";
 
+my $Parallel
+  = Devel::Cover::Collection->new(results_dir => "$Dir", workers => 2);
+{
+  local $SIG{__WARN__} = sub { push @Warnings, @_ };
+  $Parallel->generate_html;
+}
+chdir $Cwd or die "Can't chdir $Cwd: $!";
+is slurp("$Dir/index.html"), $Page{index},
+  "a parallel run writes the same index page";
+is slurp("$Dir/dist/F.html"), $Page{dist},
+  "a parallel run writes the same dist page";
+
 done_testing;

--- a/t/internal/collection_html.t
+++ b/t/internal/collection_html.t
@@ -127,180 +127,230 @@ sub setup_results_dir {
   $dir
 }
 
-my $Cwd = getcwd;
-my $Dir = setup_results_dir;
+my ($Cwd, $Dir, $Collection, @Warnings, %Page, $Css);
 
-my $Collection = Devel::Cover::Collection->new(results_dir => "$Dir");
-my @Warnings;
-{
-  local $SIG{__WARN__} = sub { push @Warnings, @_ };
-  $Collection->generate_html;
-}
-chdir $Cwd or die "Can't chdir $Cwd: $!";
+sub generate () {
+  $Cwd        = getcwd;
+  $Dir        = setup_results_dir;
+  $Collection = Devel::Cover::Collection->new(results_dir => "$Dir");
+  {
+    local $SIG{__WARN__} = sub { push @Warnings, @_ };
+    $Collection->generate_html;
+  }
+  chdir $Cwd or die "Can't chdir $Cwd: $!";
 
-is grep(/uninitialized/, @Warnings), 0,
-  "generate_html emits no uninitialized warnings";
-
-my %Page = (
-  index  => slurp("$Dir/index.html"),
-  dist   => slurp("$Dir/dist/F.html"),
-  dist_b => slurp("$Dir/dist/B.html"),
-  dist_d => slurp("$Dir/dist/D.html"),
-  dist_n => slurp("$Dir/dist/N.html"),
-  about  => slurp("$Dir/about.html"),
-);
-
-for my $name (sort keys %Page) {
-  unlike $Page{$name}, qr{/latest/},        "$name page has no /latest/ links";
-  unlike $Page{$name}, qr{(?:href|src)="/}, "$name page has no absolute links";
+  %Page = (
+    index  => slurp("$Dir/index.html"),
+    dist   => slurp("$Dir/dist/F.html"),
+    dist_b => slurp("$Dir/dist/B.html"),
+    dist_d => slurp("$Dir/dist/D.html"),
+    dist_n => slurp("$Dir/dist/N.html"),
+    about  => slurp("$Dir/about.html"),
+  );
+  $Css = slurp("$Dir/collection.css");
 }
 
-for my $name (qw( index about )) {
-  like $Page{$name}, qr{href="collection\.css"},
-    "$name page links stylesheet relatively";
-  like $Page{$name}, qr{src="collection\.js"},
-    "$name page links script relatively";
-  like $Page{$name}, qr{href="about\.html"},
-    "$name page links about page relatively";
-  like $Page{$name}, qr{<h1><a href="index\.html">CPANCover</a></h1>},
-    "$name page header links home";
+sub test_no_warnings () {
+  is grep(/uninitialized/, @Warnings), 0,
+    "generate_html emits no uninitialized warnings";
 }
 
-like $Page{index}, qr{href="dist/F\.html"}, "index links dist page";
+sub test_page_links () {
+  for my $name (sort keys %Page) {
+    unlike $Page{$name}, qr{/latest/}, "$name page has no /latest/ links";
+    unlike $Page{$name}, qr{(?:href|src)="/},
+      "$name page has no absolute links";
+  }
 
-like $Page{dist}, qr{href="\.\./collection\.css"}, "dist page links stylesheet";
-like $Page{dist}, qr{src="\.\./collection\.js"},   "dist page links script";
-like $Page{dist}, qr{href="\.\./about\.html"},     "dist page links about page";
-like $Page{dist}, qr{<h1><a href="\.\./index\.html">CPANCover</a></h1>},
-  "dist page header links home";
-like $Page{dist}, qr{href="\.\./\Q$Dist\E/index\.html"},
-  "dist page links module report";
-like $Page{dist_n}, qr{No-Page}, "dist without a report page is listed";
-unlike $Page{dist_n}, qr{href="\.\./\Q$Dist5\E/index\.html"},
-  "dist without a report page is not linked";
-like $Page{dist}, qr{href="\.\./\Q$Log_new\E"},
-  "dist page links the log named in .log_ref";
-unlike $Page{dist}, qr{href="\.\./\Q$Log\E"},
-  "dist page does not link the older log";
-like $Page{dist_b}, qr{href="\.\./\Q$Log2\E"},
-  "dist page links uncompressed build log";
-like $Page{dist_d}, qr{href="\.\./\Q$Log3\E"},
-  "dangling .log_ref falls back to the name-matched log";
-unlike $Page{dist_d}, qr{href="\.\./\Q$Ref3\E"},
-  "dangling .log_ref target is not linked";
-like $Page{dist_d}, qr{href="\.\./\Q$Log_new\E"},
-  "dependency dist links its target's log via .log_ref";
+  for my $name (qw( index about )) {
+    like $Page{$name}, qr{href="collection\.css"},
+      "$name page links stylesheet relatively";
+    like $Page{$name}, qr{src="collection\.js"},
+      "$name page links script relatively";
+    like $Page{$name}, qr{href="about\.html"},
+      "$name page links about page relatively";
+    like $Page{$name}, qr{<h1><a href="index\.html">CPANCover</a></h1>},
+      "$name page header links home";
+  }
 
-like $Page{dist}, qr{href="https://metacpan\.org/release/PJCJ/\Q$Dist\E"},
-  "version links the metacpan release parsed from the log";
-like $Page{dist_b}, qr{href="https://metacpan\.org/release/PJCJ/\Q$Dist2\E"},
-  "version links the metacpan release for an uncompressed log";
-like $Page{dist_d}, qr{href="https://metacpan\.org/release/PJCJ/\Q$Dist3\E"},
-  "version links the metacpan release via the name-matched log";
-like $Page{dist_d}, qr{href="https://metacpan\.org/dist/Dep-Only"},
-  "dependency dist falls back to the metacpan dist link";
-unlike $Page{dist_d}, qr{href="https://metacpan\.org/release/\w+/\Q$Dist4\E"},
-  "dependency dist gets no release link from its target's log";
+  like $Page{index}, qr{href="dist/F\.html"}, "index links dist page";
 
-like $Page{dist}, qr{<th>CC</th>},                "dist page has a CC header";
-like $Page{dist}, qr{<th>SCAR</th>},              "dist page has a SCAR header";
-like $Page{dist}, qr{<td class="cc-val">12</td>}, "dist page shows CC";
-my $Tip = quotemeta
-  '<span class="glass-tip">CC 12 &middot; cov 90% &middot; CRAP 14.3</span>';
-like $Page{dist},
-  qr{<td class="scar-val scar-c2 tip-hover">26\.6\s*$Tip\s*</td>},
-  "dist page shows SCAR with class and tip";
-my @Na_cells = $Page{dist_b} =~ m{(<td class="na">n/a</td>)}g;
-is @Na_cells, 2, "dist with incomplete scar data shows n/a for CC and SCAR";
-my @Na_cells_n = $Page{dist_n} =~ m{(<td class="na">n/a</td>)}g;
-is @Na_cells_n, 2, "dist without scar data shows n/a for CC and SCAR";
+  like $Page{dist}, qr{href="\.\./collection\.css"},
+    "dist page links stylesheet";
+  like $Page{dist}, qr{src="\.\./collection\.js"}, "dist page links script";
+  like $Page{dist}, qr{href="\.\./about\.html"},   "dist page links about page";
+  like $Page{dist}, qr{<h1><a href="\.\./index\.html">CPANCover</a></h1>},
+    "dist page header links home";
+  like $Page{dist}, qr{href="\.\./\Q$Dist\E/index\.html"},
+    "dist page links module report";
+  like $Page{dist_n}, qr{No-Page}, "dist without a report page is listed";
+  unlike $Page{dist_n}, qr{href="\.\./\Q$Dist5\E/index\.html"},
+    "dist without a report page is not linked";
+}
 
-my $Css = slurp("$Dir/collection.css");
-like $Css, qr{td\.na[^{}]*\{[^{}]*text-align:\s*center}s,
-  "n/a cells are centred";
-like $Css, qr{th[^{}]*\{[^{}]*position:\s*sticky}s, "table headers are sticky";
-like $Css, qr{th[^{}]*\{[^{}]*top:\s*calc\(var\(--header-height}s,
-  "table headers stick below the page header";
-like slurp("$Dir/collection.js"), qr{--header-height},
-  "collection.js measures the page header height";
+sub test_log_links () {
+  like $Page{dist}, qr{href="\.\./\Q$Log_new\E"},
+    "dist page links the log named in .log_ref";
+  unlike $Page{dist}, qr{href="\.\./\Q$Log\E"},
+    "dist page does not link the older log";
+  like $Page{dist_b}, qr{href="\.\./\Q$Log2\E"},
+    "dist page links uncompressed build log";
+  like $Page{dist_d}, qr{href="\.\./\Q$Log3\E"},
+    "dangling .log_ref falls back to the name-matched log";
+  unlike $Page{dist_d}, qr{href="\.\./\Q$Ref3\E"},
+    "dangling .log_ref target is not linked";
+  like $Page{dist_d}, qr{href="\.\./\Q$Log_new\E"},
+    "dependency dist links its target's log via .log_ref";
+}
 
-like $Page{index}, qr{<p class="dist-count">6 distributions</p>},
-  "index page counts distributions once per name";
-like $Page{index},
-  qr{<div class="dist-bar-seg c1" style="width: 83\.33%">\s*5\s*</div>},
-  "index page bar has a c1 segment counting latest versions only";
-like $Page{index},
-  qr{<div class="dist-bar-seg na" style="width: 16\.67%">\s*1\s*</div>},
-  "index page bar has an n/a segment";
-like $Page{index}, qr{dist-bar-seg c1.*dist-bar-seg na}s,
-  "bar segments run from best to worst";
-unlike $Page{index}, qr{dist-bar-seg c[023]}, "empty bands are omitted";
-like $Page{index},   qr{dist-bar.*az-nav}s,   "bar appears above the A-Z nav";
-like $Css, qr{\.dist-bar\b[^{}]*\{[^{}]*display:\s*flex}s,
-  "bar segments lay out in a row";
-like $Css,
-  qr{\.dist-bar-seg\.c1[^{}]*\{[^{}]*background:\s*var\(--cov-low-bg\)}s,
-  "bar segments use the shared coverage colours";
+sub test_metacpan_links () {
+  like $Page{dist}, qr{href="https://metacpan\.org/release/PJCJ/\Q$Dist\E"},
+    "version links the metacpan release parsed from the log";
+  like $Page{dist_b}, qr{href="https://metacpan\.org/release/PJCJ/\Q$Dist2\E"},
+    "version links the metacpan release for an uncompressed log";
+  like $Page{dist_d}, qr{href="https://metacpan\.org/release/PJCJ/\Q$Dist3\E"},
+    "version links the metacpan release via the name-matched log";
+  like $Page{dist_d}, qr{href="https://metacpan\.org/dist/Dep-Only"},
+    "dependency dist falls back to the metacpan dist link";
+  unlike $Page{dist_d}, qr{href="https://metacpan\.org/release/\w+/\Q$Dist4\E"},
+    "dependency dist gets no release link from its target's log";
+}
 
-my $Overview_vars = {
-  vals => {
-    (
-      map { ("Dist$_-1.00" => {
-        module => { name => "Dist$_", version => "1.00" },
-        total  => { pc   => "100.00" },
-      }) } 1 .. 30
-    ),
-    "Low-1.00" => {
-      module => { name => "Low", version => "1.00" },
-      total  => { pc   => "50.00" },
+sub test_cc_scar () {
+  like $Page{dist}, qr{<th>CC</th>},   "dist page has a CC header";
+  like $Page{dist}, qr{<th>SCAR</th>}, "dist page has a SCAR header";
+  like $Page{dist}, qr{<td class="cc-val">12</td>}, "dist page shows CC";
+  my $tip = quotemeta
+    '<span class="glass-tip">CC 12 &middot; cov 90% &middot; CRAP 14.3</span>';
+  like $Page{dist},
+    qr{<td class="scar-val scar-c2 tip-hover">26\.6\s*$tip\s*</td>},
+    "dist page shows SCAR with class and tip";
+  my @na_cells = $Page{dist_b} =~ m{(<td class="na">n/a</td>)}g;
+  is @na_cells, 2, "dist with incomplete scar data shows n/a for CC and SCAR";
+  my @na_cells_n = $Page{dist_n} =~ m{(<td class="na">n/a</td>)}g;
+  is @na_cells_n, 2, "dist without scar data shows n/a for CC and SCAR";
+}
+
+sub test_css () {
+  like $Css, qr{td\.na[^{}]*\{[^{}]*text-align:\s*center}s,
+    "n/a cells are centred";
+  like $Css, qr{th[^{}]*\{[^{}]*position:\s*sticky}s,
+    "table headers are sticky";
+  like $Css, qr{th[^{}]*\{[^{}]*top:\s*calc\(var\(--header-height}s,
+    "table headers stick below the page header";
+  like slurp("$Dir/collection.js"), qr{--header-height},
+    "collection.js measures the page header height";
+}
+
+sub test_overview_bar () {
+  like $Page{index}, qr{<p class="dist-count">6 distributions</p>},
+    "index page counts distributions once per name";
+  like $Page{index},
+    qr{<div class="dist-bar-seg c1" style="width: 83\.33%">\s*5\s*</div>},
+    "index page bar has a c1 segment counting latest versions only";
+  like $Page{index},
+    qr{<div class="dist-bar-seg na" style="width: 16\.67%">\s*1\s*</div>},
+    "index page bar has an n/a segment";
+  like $Page{index}, qr{dist-bar-seg c1.*dist-bar-seg na}s,
+    "bar segments run from best to worst";
+  unlike $Page{index}, qr{dist-bar-seg c[023]}, "empty bands are omitted";
+  like $Page{index},   qr{dist-bar.*az-nav}s,   "bar appears above the A-Z nav";
+  like $Css, qr{\.dist-bar\b[^{}]*\{[^{}]*display:\s*flex}s,
+    "bar segments lay out in a row";
+  like $Css,
+    qr{\.dist-bar-seg\.c1[^{}]*\{[^{}]*background:\s*var\(--cov-low-bg\)}s,
+    "bar segments use the shared coverage colours";
+}
+
+sub test_overview_segments () {
+  my $vars = {
+    vals => {
+      (
+        map { ("Dist$_-1.00" => {
+          module => { name => "Dist$_", version => "1.00" },
+          total  => { pc   => "100.00" },
+        }) } 1 .. 30
+      ),
+      "Low-1.00" => {
+        module => { name => "Low", version => "1.00" },
+        total  => { pc   => "50.00" },
+      },
     },
-  },
-};
-$Collection->add_overview($Overview_vars);
-my $Segments = $Overview_vars->{overview}{segments};
-is $Segments->[-1]{label}, "",
-  "segments too narrow for their count drop the label";
-
-my $Search = JSON::PP->new->decode(slurp("$Dir/search.json"));
-is join(",", @$Search),
-  "Baz-Qux-2.00,Dangle-Ref-3.00,Dep-Only-4.00,Foo-Bar-1.00,Foo-Bar-0.50",
-  "search.json lists newest versions first, report pages only";
-like $Page{index}, qr{<input[^>]*id="module-search"[^>]*data-root=""},
-  "index page has the search input";
-like $Page{index}, qr{<input[^>]*placeholder="Search distributions"},
-  "search placeholder says distributions";
-like $Page{dist}, qr{<input[^>]*id="module-search"[^>]*data-root="\.\./"},
-  "dist page search input carries the root prefix";
-like slurp("$Dir/collection.js"), qr{module-search},
-  "collection.js wires up the search";
-
-my $Cpancover = JSON::PP->new->decode(slurp("$Dir/cpancover.json"));
-my $Coverage  = $Cpancover->{"Foo-Bar"}{"1.00"}{coverage}{total};
-is join(",", sort keys %$Coverage), "statement,total",
-  "cpancover.json has no cc or scar keys";
-
-my $Version = $Devel::Cover::Inc::VERSION . $Devel::Cover::Inc::Dev;
-for my $name (sort keys %Page) {
-  like $Page{$name}, qr{Devel::Cover</a>\s+\Q$Version\E\s+by},
-    "$name page footer shows the Devel::Cover version";
+  };
+  $Collection->add_overview($vars);
+  my $segments = $vars->{overview}{segments};
+  is $segments->[-1]{label}, "",
+    "segments too narrow for their count drop the label";
 }
 
-for my $f (qw( index.html dist/F.html about.html )) {
-  is slurp("$Dir/$f.seeded"), "old", "$f is written atomically";
+sub test_search () {
+  my $search = JSON::PP->new->decode(slurp("$Dir/search.json"));
+  is join(",", @$search),
+    "Baz-Qux-2.00,Dangle-Ref-3.00,Dep-Only-4.00,Foo-Bar-1.00,Foo-Bar-0.50",
+    "search.json lists newest versions first, report pages only";
+  like $Page{index}, qr{<input[^>]*id="module-search"[^>]*data-root=""},
+    "index page has the search input";
+  like $Page{index}, qr{<input[^>]*placeholder="Search distributions"},
+    "search placeholder says distributions";
+  like $Page{dist}, qr{<input[^>]*id="module-search"[^>]*data-root="\.\./"},
+    "dist page search input carries the root prefix";
+  like slurp("$Dir/collection.js"), qr{module-search},
+    "collection.js wires up the search";
 }
-my @Tmp = map glob, "$Dir/*.tmp.*", "$Dir/dist/*.tmp.*";
-is @Tmp, 0, "no tmp files remain";
 
-my $Parallel
-  = Devel::Cover::Collection->new(results_dir => "$Dir", workers => 2);
-{
-  local $SIG{__WARN__} = sub { push @Warnings, @_ };
-  $Parallel->generate_html;
+sub test_cpancover_json () {
+  my $cpancover = JSON::PP->new->decode(slurp("$Dir/cpancover.json"));
+  my $coverage  = $cpancover->{"Foo-Bar"}{"1.00"}{coverage}{total};
+  is join(",", sort keys %$coverage), "statement,total",
+    "cpancover.json has no cc or scar keys";
 }
-chdir $Cwd or die "Can't chdir $Cwd: $!";
-is slurp("$Dir/index.html"), $Page{index},
-  "a parallel run writes the same index page";
-is slurp("$Dir/dist/F.html"), $Page{dist},
-  "a parallel run writes the same dist page";
 
+sub test_version_footer () {
+  my $version = $Devel::Cover::Inc::VERSION . $Devel::Cover::Inc::Dev;
+  for my $name (sort keys %Page) {
+    like $Page{$name}, qr{Devel::Cover</a>\s+\Q$version\E\s+by},
+      "$name page footer shows the Devel::Cover version";
+  }
+}
+
+sub test_atomic_writes () {
+  for my $f (qw( index.html dist/F.html about.html )) {
+    is slurp("$Dir/$f.seeded"), "old", "$f is written atomically";
+  }
+  my @tmp = map glob, "$Dir/*.tmp.*", "$Dir/dist/*.tmp.*";
+  is @tmp, 0, "no tmp files remain";
+}
+
+sub test_parallel_run () {
+  my $parallel
+    = Devel::Cover::Collection->new(results_dir => "$Dir", workers => 2);
+  {
+    local $SIG{__WARN__} = sub { push @Warnings, @_ };
+    $parallel->generate_html;
+  }
+  chdir $Cwd or die "Can't chdir $Cwd: $!";
+  is slurp("$Dir/index.html"), $Page{index},
+    "a parallel run writes the same index page";
+  is slurp("$Dir/dist/F.html"), $Page{dist},
+    "a parallel run writes the same dist page";
+}
+
+sub main () {
+  generate;
+  test_no_warnings;
+  test_page_links;
+  test_log_links;
+  test_metacpan_links;
+  test_cc_scar;
+  test_css;
+  test_overview_bar;
+  test_overview_segments;
+  test_search;
+  test_cpancover_json;
+  test_version_footer;
+  test_atomic_writes;
+  test_parallel_run;
+}
+
+main;
 done_testing;

--- a/t/internal/collection_newer.t
+++ b/t/internal/collection_newer.t
@@ -1,0 +1,69 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();  ## no perlimports
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is ok plan )];
+
+BEGIN {
+  plan skip_all => "Devel::Cover::Collection requires Perl 5.42" if $] < 5.042;
+  plan skip_all => "Devel::Cover::Collection is not portable to Windows"
+    if $^O eq "MSWin32";
+  for my $module (qw( Template Parallel::Iterator JSON::MaybeXS )) {
+    plan skip_all => "$module required for this test"
+      unless eval "require $module; 1";
+  }
+}
+
+use Devel::Cover::Collection ();
+
+my $C = Devel::Cover::Collection->new;
+
+sub test_zero_versions () {
+  ok !$C->_newer("0.0", "0"),   "equal zero versions are not newer";
+  ok !$C->_newer("0",   "0.0"), "equal zero versions are not newer reversed";
+  ok $C->_newer("1.2",  "0"),   "a real version is newer than zero";
+  ok !$C->_newer("0",   "1.2"), "zero is not newer than a real version";
+}
+
+sub test_parse_version () {
+  my @parsed = $C->_parse_version("not a version!!");
+  is @parsed, 1, "a failed parse still yields one result";
+  ok !defined $parsed[0], "a failed parse yields undef";
+}
+
+sub test_numeric_compare () {
+  ok $C->_newer("v1.10.0", "v1.9.0"), "versions compare numerically";
+}
+
+sub test_undef_versions () {
+  my @warnings;
+  {
+    local $SIG{__WARN__} = sub { push @warnings, @_ };
+    ok !$C->_newer(undef, undef), "undef versions are not newer";
+  }
+  is "@warnings", "", "undef versions compare without warning";
+}
+
+sub main () {
+  test_zero_versions;
+  test_parse_version;
+  test_numeric_compare;
+  test_undef_versions;
+}
+
+main;
+done_testing;

--- a/t/internal/collection_sys.t
+++ b/t/internal/collection_sys.t
@@ -16,6 +16,8 @@ use FindBin ();  ## no perlimports
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
+use File::Temp ();
+
 use Test::More import => [qw( done_testing is like plan )];
 
 BEGIN {
@@ -63,5 +65,32 @@ is $Output, "", "timeout returns empty string";
 like $Warned, qr/Timed out/,   "timeout is warned";
 like $Warned, qr/BEFORE HANG/, "timeout warning includes the command's output";
 like $Warned, qr/killed [1-9]\d* process/, "timeout kills the hung command";
+
+my $Tmp    = File::Temp->newdir;
+my $Marks  = "$Tmp/marks";
+my $Script = "$Tmp/escape.pl";
+open my $Sfh, ">", $Script or die "Can't open $Script: $!";
+print $Sfh <<'PERL';
+use Devel::Cover::Collection ();
+my ($marks) = @ARGV;
+my $c = Devel::Cover::Collection->new;
+$SIG{__WARN__} = sub { };
+for (1, 2) { eval { $c->fsys("/no/such/command", "x") } }
+open my $fh, ">>", $marks or die "Can't open $marks: $!";
+print $fh "$$\n";
+close $fh or die "Can't close $marks: $!";
+PERL
+close $Sfh or die "Can't close $Script: $!";
+system $^X, "-I$FindBin::Bin/../../lib", $Script, $Marks;
+open my $Mfh, "<", $Marks or die "Can't open $Marks: $!";
+my @Pids = <$Mfh>;
+close $Mfh or die "Can't close $Marks: $!";
+is @Pids, 1, "a failed exec never escapes the child";
+
+{
+  local $SIG{__WARN__} = sub { };
+  eval { $Collection->fsys("/no/such/command", "x") };
+}
+like $@, qr/^Can't run/, "fsys dies in the parent on a failed exec";
 
 done_testing;

--- a/t/internal/collection_sys.t
+++ b/t/internal/collection_sys.t
@@ -39,38 +39,49 @@ sub bsys_warnings ($collection, @command) {
   ($output, join "", @warnings)
 }
 
-my $Collection = Devel::Cover::Collection->new;
+sub test_success () {
+  my ($output, $warned) = bsys_warnings(
+    Devel::Cover::Collection->new,
+    $^X, "-e", 'print "stdout line\n"; warn "stderr line\n"',
+  );
+  like $output, qr/stdout line/, "success returns stdout";
+  like $output, qr/stderr line/, "success returns merged stderr";
+  is $warned, "", "success warns nothing";
+}
 
-my ($Output, $Warned) = bsys_warnings(
-  $Collection, $^X, "-e", 'print "stdout line\n"; warn "stderr line\n"'
-);
-like $Output, qr/stdout line/, "success returns stdout";
-like $Output, qr/stderr line/, "success returns merged stderr";
-is $Warned, "", "success warns nothing";
+sub test_failure () {
+  # uc keeps the expected text out of the command echoed by the warning
+  my ($output, $warned) = bsys_warnings(
+    Devel::Cover::Collection->new,
+    $^X,
+    "-e",
+    'print uc("stdout detail"), "\n"; warn uc("stderr detail"), "\n"; exit(3)',
+  );
+  is $output, "", "failure returns empty string";
+  like $warned, qr/Error running/, "failure is warned";
+  like $warned, qr/exit 3/,        "warning reports the exit status";
+  like $warned, qr/STDOUT DETAIL/, "warning includes the command's stdout";
+  like $warned, qr/STDERR DETAIL/, "warning includes the command's stderr";
+}
 
-# uc keeps the expected text out of the command echoed by the warning
-($Output, $Warned) = bsys_warnings($Collection, $^X, "-e",
-  'print uc("stdout detail"), "\n"; warn uc("stderr detail"), "\n"; exit(3)');
-is $Output, "", "failure returns empty string";
-like $Warned, qr/Error running/, "failure is warned";
-like $Warned, qr/exit 3/,        "warning reports the exit status";
-like $Warned, qr/STDOUT DETAIL/, "warning includes the command's stdout";
-like $Warned, qr/STDERR DETAIL/, "warning includes the command's stderr";
+sub test_timeout () {
+  my ($output, $warned) = bsys_warnings(
+    Devel::Cover::Collection->new(timeout => 1),
+    $^X, "-e", '$| = 1; print uc("before hang"), "\n"; sleep 30',
+  );
+  is $output, "", "timeout returns empty string";
+  like $warned, qr/Timed out/, "timeout is warned";
+  like $warned, qr/BEFORE HANG/,
+    "timeout warning includes the command's output";
+  like $warned, qr/killed [1-9]\d* process/, "timeout kills the hung command";
+}
 
-my $Quick = Devel::Cover::Collection->new(timeout => 1);
-($Output, $Warned) = bsys_warnings(
-  $Quick, $^X, "-e", '$| = 1; print uc("before hang"), "\n"; sleep 30'
-);
-is $Output, "", "timeout returns empty string";
-like $Warned, qr/Timed out/,   "timeout is warned";
-like $Warned, qr/BEFORE HANG/, "timeout warning includes the command's output";
-like $Warned, qr/killed [1-9]\d* process/, "timeout kills the hung command";
-
-my $Tmp    = File::Temp->newdir;
-my $Marks  = "$Tmp/marks";
-my $Script = "$Tmp/escape.pl";
-open my $Sfh, ">", $Script or die "Can't open $Script: $!";
-print $Sfh <<'PERL';
+sub test_escaped_child () {
+  my $tmp    = File::Temp->newdir;
+  my $marks  = "$tmp/marks";
+  my $script = "$tmp/escape.pl";
+  open my $sfh, ">", $script or die "Can't open $script: $!";
+  print $sfh <<'PERL';
 use Devel::Cover::Collection ();
 my ($marks) = @ARGV;
 my $c = Devel::Cover::Collection->new;
@@ -80,17 +91,30 @@ open my $fh, ">>", $marks or die "Can't open $marks: $!";
 print $fh "$$\n";
 close $fh or die "Can't close $marks: $!";
 PERL
-close $Sfh or die "Can't close $Script: $!";
-system $^X, "-I$FindBin::Bin/../../lib", $Script, $Marks;
-open my $Mfh, "<", $Marks or die "Can't open $Marks: $!";
-my @Pids = <$Mfh>;
-close $Mfh or die "Can't close $Marks: $!";
-is @Pids, 1, "a failed exec never escapes the child";
-
-{
-  local $SIG{__WARN__} = sub { };
-  eval { $Collection->fsys("/no/such/command", "x") };
+  close $sfh or die "Can't close $script: $!";
+  system $^X, "-I$FindBin::Bin/../../lib", $script, $marks;
+  open my $mfh, "<", $marks or die "Can't open $marks: $!";
+  my @pids = <$mfh>;
+  close $mfh or die "Can't close $marks: $!";
+  is @pids, 1, "a failed exec never escapes the child";
 }
-like $@, qr/^Can't run/, "fsys dies in the parent on a failed exec";
 
+sub test_fsys_dies () {
+  my $c = Devel::Cover::Collection->new;
+  {
+    local $SIG{__WARN__} = sub { };
+    eval { $c->fsys("/no/such/command", "x") };
+  }
+  like $@, qr/^Can't run/, "fsys dies in the parent on a failed exec";
+}
+
+sub main () {
+  test_success;
+  test_failure;
+  test_timeout;
+  test_escaped_child;
+  test_fsys_dies;
+}
+
+main;
 done_testing;

--- a/t/internal/structure.t
+++ b/t/internal/structure.t
@@ -396,29 +396,16 @@ sub test_write_rename_failure () {
   mkdir "$base/structure/$digest"
     or die "Cannot mkdir $base/structure/$digest: $!";
 
-  my $stderr = capture_stderr { $st->write($base) };
+  my $ok = eval { $st->write($base); 1 };
   rmdir "$base/structure/$digest";
 
-  like $stderr, qr/Can't rename/, "write rename fail: warns on STDERR";
-}
+  ok !$ok, "write rename fail: dies";
+  like $@, qr/Can't rename/, "write rename fail: error names the rename";
 
-sub test_write_rename_failure_silent () {
-  local $Devel::Cover::Silent = 1;
-  my $base   = fresh_base("rename_fail_s");
-  my $file   = write_source("renamefails.pm", "package RenameFailS;\n1\n");
-  my $digest = md5_file($file);
-
-  my $st = Devel::Cover::DB::Structure->new(base => $base);
-
-  $st->set_file($file);
-
-  mkdir "$base/structure/$digest"
-    or die "Cannot mkdir $base/structure/$digest: $!";
-
-  my $stderr = capture_stderr { $st->write($base) };
-  rmdir "$base/structure/$digest";
-
-  is $stderr, "", "write rename fail silent: no warning";
+  opendir my $dh, "$base/structure" or die "Cannot opendir: $!";
+  my @stray = grep /tmp/, readdir $dh;
+  closedir $dh;
+  is @stray, 0, "write rename fail: no temporary file left behind";
 }
 
 sub test_autoload_get_time () {
@@ -843,7 +830,6 @@ sub main () {
   test_write_no_digest_silent;
   test_write_creates_structure_dir;
   test_write_rename_failure;
-  test_write_rename_failure_silent;
   test_autoload_get_time;
   test_set_file_missing;
   test_add_count_no_file;

--- a/t/internal/structure_write_lock.t
+++ b/t/internal/structure_write_lock.t
@@ -1,0 +1,121 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Fcntl      qw( LOCK_EX );
+use File::Path qw( make_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use POSIX      qw( WNOHANG _exit );
+use Test::More import => [qw( done_testing is is_deeply plan )];
+
+BEGIN {
+  plan skip_all => "flock is emulated on Windows" if $^O eq "MSWin32";
+}
+
+use Devel::Cover::DB::Structure ();
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+
+sub write_source ($name, $content) {
+  my $path = File::Spec->catfile($Tmpdir, $name);
+  open my $fh, ">", $path or die "Can't write $path: $!";
+  print $fh $content;
+  close $fh or die "Can't close $path: $!";
+  $path
+}
+
+sub structure_entries ($base) {
+  opendir my $dh, "$base/structure" or die "Can't opendir $base/structure: $!";
+  my @entries = sort grep !/^\.\.?$/, readdir $dh;
+  closedir $dh;
+  @entries
+}
+
+sub built_structure ($label) {
+  my $file = write_source("$label.pm", "package Lock;\n1\n");
+  my $base = File::Spec->catdir($Tmpdir, $label);
+  make_path("$base/structure");
+  my $st = Devel::Cover::DB::Structure->new(base => $base);
+  $st->add_criteria("statement");
+  $st->set_file($file);
+  $st->{f}{$file}{statement} = [[$file, 1]];
+  ($base, $st, $file)
+}
+
+sub test_write_lock_names () {
+  my ($base, $st, $file) = built_structure("names");
+  $st->write($base);
+  my $digest = $st->{f}{$file}{digest};
+  is_deeply [structure_entries($base)], [sort $digest, "$digest.lock"],
+    "write leaves only the structure file and its lock";
+
+  my @locks = grep /\.lock$/, structure_entries($base);
+  is_deeply [sort map "$base/structure/$_", @locks],
+    [sort glob "$base/structure/*.lock"],
+    "every lock file is visible to the cleanup glob";
+}
+
+sub test_second_write () {
+  my ($base, $st) = built_structure("rewrite");
+  $st->write($base);
+  my @before = structure_entries($base);
+  $st->write($base);
+  is_deeply [structure_entries($base)], \@before,
+    "a second write adds no files";
+}
+
+sub test_read_back () {
+  my ($base, $st, $file) = built_structure("read");
+  $st->write($base);
+  my $st2 = Devel::Cover::DB::Structure->new(base => $base);
+  $st2->read_all;
+  is_deeply $st2->{f}{$file}{statement}, [[$file, 1]],
+    "the structure file reads back";
+}
+
+sub test_writer_waits () {
+  my ($base, $st, $file) = built_structure("waits");
+  $st->write($base);
+  my $digest = $st->{f}{$file}{digest};
+  my $lock   = "$base/structure/$digest.lock";
+  open my $lfh, "+>>", $lock or die "Can't open $lock: $!";
+  flock $lfh, LOCK_EX or die "Can't lock $lock: $!";
+
+  my $pid = fork // die "Can't fork: $!";
+  unless ($pid) {
+    # drop the inherited lock handle so only the parent holds the lock
+    close $lfh or _exit 1;
+    my (undef, $child_st) = built_structure("waits");
+    eval { $child_st->write($base) };
+    _exit 0;
+  }
+  sleep 1;
+  is waitpid($pid, WNOHANG), 0, "a writer waits for the lock holder";
+  close $lfh or die "Can't close $lock: $!";
+  is waitpid($pid, 0), $pid, "the writer finishes once the lock is free";
+}
+
+sub main () {
+  test_write_lock_names;
+  test_second_write;
+  test_read_back;
+  test_writer_waits;
+}
+
+main;
+done_testing;

--- a/utils/dc
+++ b/utils/dc
@@ -1496,6 +1496,7 @@ cpan_collection_module() {
 
   # Move results to collection results_dir
   if [[ -d cover_db ]]; then
+    # structure lock files are all named <digest>.lock, so the glob sees them
     rm -f cover_db/structure/*.lock
     mkdir -p "$results_dir"
     rm -rf "${results_dir:?}/$distdir"

--- a/xt/collection.t
+++ b/xt/collection.t
@@ -97,24 +97,18 @@ sub rw_accessors () {
   is $c->file, "/tmp/test.html", "rw accessor file writable";
 }
 
-sub rwp_accessors () {
-  my $c = Devel::Cover::Collection->new;
-  is $c->build_dirs, [], "rwp accessor build_dirs readable";
-  ok $c->can("_set_build_dirs"), "rwp accessor build_dirs has _set_build_dirs";
-  $c->_set_build_dirs(["/dir1", "/dir2"]);
-  is $c->build_dirs, ["/dir1", "/dir2"],
-    "rwp accessor build_dirs settable via _set_build_dirs";
-  is $c->modules, [], "rwp accessor modules readable";
-  ok $c->can("_set_modules"), "rwp accessor modules has _set_modules";
-  $c->_set_modules(["Foo::Bar"]);
-  is $c->modules, ["Foo::Bar"],
-    "rwp accessor modules settable via _set_modules";
-  is $c->module_file, undef, "rwp accessor module_file readable";
-  ok $c->can("_set_module_file"),
-    "rwp accessor module_file has _set_module_file";
-  $c->_set_module_file("/tmp/modules.txt");
-  is $c->module_file, "/tmp/modules.txt",
-    "rwp accessor module_file settable via _set_module_file";
+sub internal_accessors () {
+  my $c = Devel::Cover::Collection->new(
+    build_dirs  => ["/dir1", "/dir2"],
+    modules     => ["Foo::Bar"],
+    module_file => "/tmp/modules.txt",
+  );
+  is $c->build_dirs,  ["/dir1", "/dir2"], "build_dirs set via constructor";
+  is $c->modules,     ["Foo::Bar"],       "modules set via constructor";
+  is $c->module_file, "/tmp/modules.txt", "module_file set via constructor";
+  ok !$c->can("_set_build_dirs"),  "build_dirs has no private setter";
+  ok !$c->can("_set_modules"),     "modules has no private setter";
+  ok !$c->can("_set_module_file"), "module_file has no private setter";
 }
 
 sub add_modules () {
@@ -324,27 +318,6 @@ sub fsys_failed_command () {
   like $warning, qr/Error running false/, "fsys warns on failed command";
 }
 
-sub fbsys_successful_command () {
-  skip_all "alarm not available on Windows" if $Is_win32;
-  my $c      = Devel::Cover::Collection->new(verbose => 0, timeout => 10);
-  my $output = $c->fbsys("echo", "fatal buffered");
-  like $output, qr/fatal buffered/, "fbsys captures output";
-}
-
-sub fbsys_failed_command () {
-  skip_all "alarm not available on Windows" if $Is_win32;
-  my $c       = Devel::Cover::Collection->new(verbose => 0, timeout => 10);
-  my $warning = "";
-  local $SIG{__WARN__} = sub { $warning .= shift };
-  my $died = 0;
-  eval {
-    $c->fbsys("false");
-    1;
-  } or $died = 1;
-  ok $died, "fbsys dies on failed command";
-  like $warning, qr/Error running false/, "fbsys warns on failed command";
-}
-
 sub sys_timeout () {
   skip_all "alarm not available on Windows" if $Is_win32;
   my $c       = Devel::Cover::Collection->new(verbose => 0, timeout => 1);
@@ -496,16 +469,18 @@ sub compress_old_versions () {
 }
 
 sub filter_build_dirs_to_targets () {
-  my $c = Devel::Cover::Collection->new(modules => [
-    "P/PJ/PJCJ/Perl-Critic-PJCJ-v0.2.4.tar.gz",
-    "A/AU/AUTHOR/My-Module-1.23.tar.gz",
-  ]);
-  $c->_set_build_dirs([
-    "/home/x/.cpan/build/Perl-Critic-PJCJ-v0.2.4-0",
-    "/home/x/.cpan/build/My-Module-1.23-3",
-    "/home/x/.cpan/build/PPI-1.280-0",
-    "/home/x/.cpan/build/Test-Deep-1.204-1",
-  ]);
+  my $c = Devel::Cover::Collection->new(
+    modules => [
+      "P/PJ/PJCJ/Perl-Critic-PJCJ-v0.2.4.tar.gz",
+      "A/AU/AUTHOR/My-Module-1.23.tar.gz",
+    ],
+    build_dirs => [
+      "/home/x/.cpan/build/Perl-Critic-PJCJ-v0.2.4-0",
+      "/home/x/.cpan/build/My-Module-1.23-3",
+      "/home/x/.cpan/build/PPI-1.280-0",
+      "/home/x/.cpan/build/Test-Deep-1.204-1",
+    ],
+  );
   $c->filter_build_dirs_to_targets;
   is $c->build_dirs, [
       "/home/x/.cpan/build/Perl-Critic-PJCJ-v0.2.4-0",
@@ -513,12 +488,13 @@ sub filter_build_dirs_to_targets () {
     ],
     "filter keeps only build dirs that match a target distdir";
 
-  my $c2
-    = Devel::Cover::Collection->new(modules => ["T/TA/TAR/Target-1.0.tar.gz"]);
-  $c2->_set_build_dirs([
-    "/cpan/build/Target-1.0-0", "/cpan/build/Target-1.0-1",
-    "/cpan/build/Target-1.0-2",
-  ]);
+  my $c2 = Devel::Cover::Collection->new(
+    modules    => ["T/TA/TAR/Target-1.0.tar.gz"],
+    build_dirs => [
+      "/cpan/build/Target-1.0-0", "/cpan/build/Target-1.0-1",
+      "/cpan/build/Target-1.0-2",
+    ],
+  );
   $c2->filter_build_dirs_to_targets;
   is $c2->build_dirs, [
       "/cpan/build/Target-1.0-0", "/cpan/build/Target-1.0-1",
@@ -526,14 +502,15 @@ sub filter_build_dirs_to_targets () {
     ],
     "filter keeps all reinstall attempts of the same target";
 
-  my $c3 = Devel::Cover::Collection->new;
-  $c3->_set_build_dirs(["/cpan/build/Random-1.0-0"]);
+  my $c3
+    = Devel::Cover::Collection->new(build_dirs => ["/cpan/build/Random-1.0-0"]);
   $c3->filter_build_dirs_to_targets;
   is $c3->build_dirs, [], "filter empties build_dirs when modules is empty";
 
-  my $c4
-    = Devel::Cover::Collection->new(modules => ["A/AU/AUTHOR/Foo-1.0.tar.gz"]);
-  $c4->_set_build_dirs([]);
+  my $c4 = Devel::Cover::Collection->new(
+    modules    => ["A/AU/AUTHOR/Foo-1.0.tar.gz"],
+    build_dirs => [],
+  );
   $c4->filter_build_dirs_to_targets;
   is $c4->build_dirs, [], "filter is a no-op on empty build_dirs";
 }
@@ -1007,7 +984,7 @@ sub main () {
     constructor_with_args
     ro_accessors
     rw_accessors
-    rwp_accessors
+    internal_accessors
     add_modules
     set_modules
     set_module_file
@@ -1021,8 +998,6 @@ sub main () {
     bsys_failed_command
     fsys_successful_command
     fsys_failed_command
-    fbsys_successful_command
-    fbsys_failed_command
     sys_timeout
     sys_verbose_output
     bsys_multiline_output


### PR DESCRIPTION
## Summary

- Exit a forked child whose exec failed via `_exit`, so it can no longer escape into the caller's code and run alongside the parent.
- Write structure files under the shared `<digest>.lock` rather than a per-process temporary name, so concurrent writers exclude each other and the cleanup globs see every lock file.
- Compare versions numerically even when one side is zero, and keep a failed parse from shifting the other side's result.
- Remove the Moo leftovers - an unused field, private setters and `fbsys` - and rewrite the author tests against the public interface.
- Read each distribution's `cover.json` through the worker pool and precompile the metacpan log pattern.

## Ticket

Closes #738