### PR TITLE
GH-740 Fix outputfile and run metadata handling

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -222,6 +222,9 @@ sub check_options () {
     $format->get_options(dclone($Options)) if $format->can("get_options");
   }
 
+  # reports without get_options accept -outputfile too, see run_reports
+  GetOptions(\my %ignored, "outputfile=s");
+
   # Anything left starting with "-" is unknown to every consumer.
   if (my @unknown = grep /^-/, @ARGV) {
     dcerror "Unknown option: $_" for @unknown;
@@ -549,13 +552,37 @@ sub print_summary ($db) {
     if $Options->{summary};
 }
 
+# run a report which prints to stdout, redirecting to -outputfile if given
+sub run_report ($format, $db, $options, $outputfile) {
+  return $format->report($db, $options) unless defined $outputfile;
+  my $out
+    = File::Spec->file_name_is_absolute($outputfile)
+    ? $outputfile
+    : File::Spec->catfile($options->{outputdir}, $outputfile);
+  open my $fh, ">", $out or die "Can't open $out: $!\n";
+  my $err;
+  {
+    local *STDOUT = $fh;
+    eval { $format->report($db, $options) };
+    $err = $@;
+  }
+  $err ||= "Can't close $out: $!\n" unless close $fh;
+  die $err if $err;
+  dcinfo "Report written to $out";
+}
+
 sub run_reports ($db, $argv) {
   for my $report ($Options->{report}->@*) {
     local @ARGV = @$argv;  # restore locally processed args for each report
     my $options = dclone($Options);
     my $format  = "Devel::Cover::Report::\u$report";
-    $format->get_options($options) if $format->can("get_options");
-    $format->report($db, $options);
+    if ($format->can("get_options")) {
+      $format->get_options($options);
+      $format->report($db, $options);
+    } else {
+      GetOptions(\my %opt, "outputfile=s");
+      run_report($format, $db, $options, $opt{outputfile});
+    }
 
     if ($options->{launch}) {
       if ($format->can("launch")) {
@@ -631,6 +658,7 @@ The following command line options are supported:
  -summary              - give summary report                (default on)
  -report report_format - report format                      (default html)
  -outputdir dir        - directory for output               (default given db)
+ -outputfile file      - file for output         (default report dependent)
  -launch               - launch report in viewer (if avail) (default off)
 
  -select filename      - only report on the file            (default all)
@@ -659,6 +687,9 @@ The following command line options are supported:
 
 The C<-report>, C<-select>, C<-select_dir>, C<-ignore>, C<-select_re>,
 C<-ignore_re>, and C<-coverage> options may be specified multiple times.
+
+The C<-outputfile> option applies to every report.  Reports which normally
+print to standard output write to the named file instead.
 
 =head1 REPORT FORMATS
 

--- a/dist.ini
+++ b/dist.ini
@@ -53,6 +53,7 @@ Storable                      = 0
 
 [Prereqs / Recommends]
 Browser::Open                 = 0
+CPAN::DistnameInfo            = 0
 CPAN::Releases::Latest        = 0
 Capture::Tiny                 = 0
 Class::XSAccessor             = 0

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -359,7 +359,9 @@ sub populate_run {
       my $meta = do { local $/; <$fh> };
       close $fh or die "Can't close $mymeta: $!\n";
       my $json = CPAN::Meta->load_json_string($meta)->as_struct;
-      $Run{$_} = $json->{$_} for qw( name version abstract );
+      for my $field (qw( name version abstract )) {
+        $Run{$field} = $json->{$field} if defined $json->{$field};
+      }
     }
   } elsif ($Dir =~ m|.*/([^/]+)$|) {
     my $filename = $1;

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -366,8 +366,11 @@ sub populate_run {
     eval {
       require CPAN::DistnameInfo;
       my $dinfo = CPAN::DistnameInfo->new($filename);
-      $Run{name}    = $dinfo->dist;
-      $Run{version} = $dinfo->version;
+      my $dist  = $dinfo->dist;
+      if (defined $dist) {
+        $Run{name}    = $dist;
+        $Run{version} = $dinfo->version // "unknown";
+      }
     }
   }
 

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -294,15 +294,31 @@ class Devel::Cover::Collection {
     );
   }
 
+  method _module_name_version ($mod, $module) {
+    my ($name, $version) = ($mod->{name}, $mod->{version});
+    # a name containing a slash is a run directory path, not a dist name
+    ($name, $version) = (undef, undef) if ($name // "") =~ m|/|;
+    unless (defined $name && defined $version) {
+      # the suffix turns a distdir into the archive name DistnameInfo parses
+      my ($n, $v) = eval {
+        require CPAN::DistnameInfo;
+        my $d
+          = CPAN::DistnameInfo->new(($mod->{module} // $module) . ".tar.gz");
+        ($d->dist, $d->version)
+      };
+      $name    //= $n;
+      $version //= $v;
+    }
+    ($name, $version)
+  }
+
   method write_json ($vars) {
     # print Dumper $vars;
     my $results = {};
     for my $module (keys $vars->{vals}->%*) {
       my $m   = $vars->{vals}{$module};
       my $mod = $m->{module};
-      my ($name, $version) = ($mod->{module} // $module) =~ /(.+)-(\d+\.\d+)$/;
-      $name    = $mod->{name}    if defined $mod->{name};
-      $version = $mod->{version} if defined $mod->{version};
+      my ($name, $version) = $self->_module_name_version($mod, $module);
       if (defined $name && defined $version) {
         $results->{$name}{$version}{coverage}{total} = {
           map { $_ => $m->{$_}{pc} } grep $m->{$_}{pc} ne "n/a",
@@ -482,11 +498,7 @@ class Devel::Cover::Collection {
       module => $module,
       map { $_ => $json->{runs}[0]{$_} } qw( name version dir ),
     };
-    unless (defined $mod->{name} && defined $mod->{version}) {
-      my ($name, $version) = ($mod->{module} // $module) =~ /(.+)-(\d+\.\d+)$/;
-      $mod->{name}    //= $name;
-      $mod->{version} //= $version;
-    }
+    $mod->@{qw( name version )} = $self->_module_name_version($mod, $module);
 
     my $m = { module => $mod };
     $m->{link} = "$module/index.html"

--- a/lib/Devel/Cover/Collection.pm
+++ b/lib/Devel/Cover/Collection.pm
@@ -606,12 +606,9 @@ class Devel::Cover::Collection {
       my $f    = "$entry/cover.json";
       my $json = JSON::MaybeXS->new(utf8 => 1, allow_blessed => 1);
       open my $fh, "<", $f or next;
-      # say "file: $f";
-      my $data
-        = do { local $/; eval { $json->decode(<$fh>) } }
-        or next;
-      next if $@;
-      close $fh or next;
+      my $data = do { local $/; eval { $json->decode(<$fh>) } };
+      close $fh or warn "Can't close $f: $!";
+      next unless $data;
       my ($name) = $entry =~ /.+\/(.+)/;
       $name =~ s/-[^-]+$//;
       my @runs = grep { ($_->{name} // "") eq $name } $data->{runs}->@*;

--- a/lib/Devel/Cover/Report/Json_summary.pm
+++ b/lib/Devel/Cover/Report/Json_summary.pm
@@ -17,6 +17,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 use Devel::Cover::Criterion    ();
 use Devel::Cover::DB::IO::JSON ();
 use Devel::Cover::Log          qw( dcinfo );
+use Getopt::Long               qw( GetOptions );
 
 sub add_runs ($db) {
   my @runs;
@@ -28,6 +29,12 @@ sub add_runs ($db) {
   \@runs
 }
 
+sub get_options ($self, $opt) {
+  $opt->{option}{outputfile} = "cover.json";
+  die "Invalid command line options"
+    unless GetOptions($opt->{option}, qw( outputfile=s ));
+}
+
 sub report ($pkg, $db, $options) {
   my %options = map { $_ => 1 } grep {
     $_ eq "total"
@@ -37,8 +44,9 @@ sub report ($pkg, $db, $options) {
 
   my $json = { runs => add_runs($db), summary => $summary };
 
-  my $path = "$options->{outputdir}/cover.json";
-  my $io   = Devel::Cover::DB::IO::JSON->new(options => "pretty");
+  my $path = $options->{option}{outputfile} // "cover.json";
+  $path = "$options->{outputdir}/$path" unless $path =~ m{^/};
+  my $io = Devel::Cover::DB::IO::JSON->new(options => "pretty");
 
   $io->write($json, $path);
 

--- a/t/internal/html_escape.t
+++ b/t/internal/html_escape.t
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# HARNESS-DURATION-LONG
 
 # Copyright 2026, Paul Johnson (paul@pjcj.net)
 

--- a/t/internal/report_outputfile.t
+++ b/t/internal/report_outputfile.t
@@ -1,0 +1,95 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use JSON::PP   ();
+use Test::More import => [qw( diag done_testing is like ok unlike )];
+use Devel::Cover::Test::Showcase qw(
+  create_cover_db
+  run_cover
+  setup_lib_dir
+  slurp
+);
+
+my ($Tmpdir, $Libdir) = setup_lib_dir;
+my $Cover_db = create_cover_db($Tmpdir, $Libdir);
+
+sub outdir ($name) { File::Spec->catdir($Tmpdir, $name) }
+
+sub report_to_file ($name, $report, $file, @extra) {
+  my $dir = outdir($name);
+  my ($out, $exit) = run_cover(
+    "--report",    $report, "--outputfile", $file,
+    "--outputdir", $dir,    "--nosummary",  "--silent",
+    @extra,        $Cover_db,
+  );
+  is $exit, 0, "cover --report $report --outputfile exits 0" or diag $out;
+  my $path = File::Spec->catfile($dir, $file);
+  ok -s $path, "$report report written to $file" or return ($out, $dir, "");
+  ($out, $dir, slurp($path))
+}
+
+sub test_text_report () {
+  my ($out, $dir, $content) = report_to_file("text", "text", "out.txt");
+  like $content, qr/Module Summary/, "text report content is in the file";
+  unlike $out,   qr/Module Summary/, "text report is not printed to stdout";
+}
+
+sub test_compilation_report () {
+  report_to_file("compilation", "compilation", "out.cmp");
+}
+
+sub test_json_summary_report () {
+  my ($out, $dir, $content)
+    = report_to_file("json_summary", "json_summary", "out.json");
+  my $json = eval { JSON::PP::decode_json($content) } // {};
+  ok $json->{summary}, "json_summary file parses as JSON" or diag $@;
+  ok !-e File::Spec->catfile($dir, "cover.json"),
+    "json_summary writes no cover.json beside the named file";
+}
+
+sub test_mixed_reports () {
+  my $dir = outdir("mixed");
+  my ($out, $exit) = run_cover(
+    "--report",     "json",     "--report",    "text",
+    "--outputfile", "out.mix",  "--outputdir", $dir,
+    "--nosummary",  "--silent", $Cover_db,
+  );
+  is $exit, 0, "cover with mixed reports exits 0" or diag $out;
+  like slurp(File::Spec->catfile($dir, "out.mix")), qr/Module Summary/,
+    "the last report given owns the named file";
+}
+
+sub test_unknown_option () {
+  my ($out, $exit) = run_cover(
+    "--report", "text", "--outputfyle", "x.txt", "--silent", $Cover_db,
+  );
+  is $exit, 1, "a genuine typo still exits 1";
+  like $out, qr/Unknown option/, "a genuine typo is still reported";
+}
+
+sub main () {
+  test_text_report;
+  test_compilation_report;
+  test_json_summary_report;
+  test_mixed_reports;
+  test_unknown_option;
+  done_testing;
+}
+
+main;

--- a/t/internal/run_name.t
+++ b/t/internal/run_name.t
@@ -37,7 +37,7 @@ sub write_file ($path, $contents) {
   close $fh or die "Cannot close $path: $!";
 }
 
-sub run_in ($name, $meta = undef) {
+sub run_in ($name, $meta = undef, $inc = undef) {
   my $dir = File::Spec->catdir($Tmpdir, $name);
   make_path($dir);
   write_file(File::Spec->catfile($dir, "MYMETA.json"), $meta) if $meta;
@@ -50,7 +50,8 @@ sub run_in ($name, $meta = undef) {
   local $ENV{DEVEL_COVER_DB_FORMAT} = "JSON";
   delete @ENV{qw( DEVEL_COVER_SELF DEVEL_COVER_OPTIONS )};
   system(
-    $^X, "-Iblib/lib", "-Iblib/arch",
+    $^X, ($inc ? "-I$inc" : ()),
+    "-Iblib/lib",                                          "-Iblib/arch",
     "-MDevel::Cover=-db,$db,-dir,$dir,-silent,1,-merge,0", $script,
   ) == 0 or die "Failed to run under Devel::Cover: $?";
 
@@ -87,9 +88,46 @@ JSON
   is $run->{version}, "0.01",      "run version comes from MYMETA.json";
 }
 
+sub test_meta_with_undef_version () {
+  my $stub_lib = File::Spec->catdir($Tmpdir, "stublib");
+  make_path(File::Spec->catdir($stub_lib, "CPAN"));
+  write_file(File::Spec->catfile($stub_lib, "CPAN", "Meta.pm"), <<'PERL');
+package CPAN::Meta;
+
+sub load_json_string { bless {}, shift }
+sub as_struct { +{ name => "Stub-Dist", version => undef } }
+
+1;
+PERL
+  my ($run) = run_in("stubapp", "{}", $stub_lib);
+  is $run->{name}, "Stub-Dist", "run name comes from the parsed metadata";
+  is $run->{version}, "unknown",
+    "an undef version in the metadata keeps the default";
+}
+
+sub test_mymeta_missing_version () {
+  my ($run, $dir) = run_in("sparsemeta", <<'JSON');
+{
+   "abstract" : "test distribution",
+   "author" : [ "nobody" ],
+   "dynamic_config" : 0,
+   "generated_by" : "Devel::Cover tests",
+   "license" : [ "perl_5" ],
+   "meta-spec" : { "version" : 2 },
+   "name" : "Test-Dist",
+   "release_status" : "stable"
+}
+JSON
+  is $run->{name}, $dir, "a rejected MYMETA.json keeps the name default";
+  is $run->{version}, "unknown",
+    "a rejected MYMETA.json keeps the version default";
+}
+
 sub main () {
   test_directory_without_mymeta;
   test_directory_with_mymeta;
+  test_meta_with_undef_version;
+  test_mymeta_missing_version;
   done_testing;
 }
 

--- a/t/internal/run_name.t
+++ b/t/internal/run_name.t
@@ -1,0 +1,96 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Path qw( make_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use Test::More import => [qw( done_testing is plan )];
+
+BEGIN {
+  plan skip_all => "JSON::MaybeXS required for this test"
+    unless eval "require JSON::MaybeXS; 1";
+  plan skip_all => "CPAN::Meta required for this test"
+    unless eval "require CPAN::Meta; 1";
+}
+
+my $Tmpdir = File::Spec->rel2abs(tempdir(CLEANUP => 1));
+
+sub write_file ($path, $contents) {
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $contents;
+  close $fh or die "Cannot close $path: $!";
+}
+
+sub run_in ($name, $meta = undef) {
+  my $dir = File::Spec->catdir($Tmpdir, $name);
+  make_path($dir);
+  write_file(File::Spec->catfile($dir, "MYMETA.json"), $meta) if $meta;
+  my $script = File::Spec->catfile($dir, "run.pl");
+  write_file($script, "my \$x = 0;\n\$x++ for 1 .. 3;\n");
+
+  my $db = File::Spec->catdir($dir, "cover_db");
+  local $ENV{DEVEL_COVER_SELF};
+  local $ENV{DEVEL_COVER_OPTIONS};
+  local $ENV{DEVEL_COVER_DB_FORMAT} = "JSON";
+  delete @ENV{qw( DEVEL_COVER_SELF DEVEL_COVER_OPTIONS )};
+  system(
+    $^X, "-Iblib/lib", "-Iblib/arch",
+    "-MDevel::Cover=-db,$db,-dir,$dir,-silent,1,-merge,0", $script,
+  ) == 0 or die "Failed to run under Devel::Cover: $?";
+
+  my ($file) = grep !/\.lock$/,
+    glob File::Spec->catfile($db, "runs", "*", "cover.*");
+  open my $fh, "<", $file or die "Cannot read $file: $!";
+  my $json = do { local $/; <$fh> };
+  close $fh or die "Cannot close $file: $!";
+  my ($run) = values JSON::MaybeXS::decode_json($json)->{runs}->%*;
+  ($run, $dir)
+}
+
+sub test_directory_without_mymeta () {
+  my ($run, $dir) = run_in("myapp");
+  is $run->{name},    $dir,      "run name defaults to the run directory";
+  is $run->{version}, "unknown", "run version defaults to unknown";
+}
+
+sub test_directory_with_mymeta () {
+  my ($run) = run_in("metaapp", <<'JSON');
+{
+   "abstract" : "test distribution",
+   "author" : [ "nobody" ],
+   "dynamic_config" : 0,
+   "generated_by" : "Devel::Cover tests",
+   "license" : [ "perl_5" ],
+   "meta-spec" : { "version" : 2 },
+   "name" : "Test-Dist",
+   "release_status" : "stable",
+   "version" : "0.01"
+}
+JSON
+  is $run->{name},    "Test-Dist", "run name comes from MYMETA.json";
+  is $run->{version}, "0.01",      "run version comes from MYMETA.json";
+}
+
+sub main () {
+  test_directory_without_mymeta;
+  test_directory_with_mymeta;
+  done_testing;
+}
+
+main;

--- a/xt/collection.t
+++ b/xt/collection.t
@@ -379,6 +379,38 @@ sub coverage_class_method () {
   is $c->coverage_class(100),   "c3", "coverage_class(100) -> 'c3'";
 }
 
+sub module_name_version () {
+  my $c = Devel::Cover::Collection->new;
+
+  my %parsed = (
+    "Foo-1.2"            => ["Foo",       "1.2"],
+    "Foo-1.2.3"          => ["Foo",       "1.2.3"],
+    "Foo-v1.2.3"         => ["Foo",       "v1.2.3"],
+    "Foo-Bar-0.10.6"     => ["Foo-Bar",   "0.10.6"],
+    "Foo-1.2_01"         => ["Foo",       "1.2_01"],
+    "Perl-Tidy-20240903" => ["Perl-Tidy", "20240903"],
+  );
+  for my $module (sort keys %parsed) {
+    is [$c->_module_name_version({}, $module)], $parsed{$module},
+      "$module parses to name and version";
+  }
+
+  is [$c->_module_name_version({}, "Foo")], ["Foo", undef],
+    "a distdir with no version yields an undef version";
+  is [
+    $c->_module_name_version(
+      { name => "Real-Name", version => "9.9" }, "Foo-1.2",
+    ),
+    ],
+    ["Real-Name", "9.9"], "recorded metadata wins";
+  is [
+    $c->_module_name_version(
+      { name => "/build/Foo-1.2.3", version => "unknown" }, "Foo-1.2.3",
+    ),
+    ],
+    ["Foo", "1.2.3"], "a run directory path as name is discarded";
+}
+
 sub write_json () {
   skip_all "alarm not available on Windows" if $Is_win32;
   my $dir = tempdir(CLEANUP => 1);
@@ -396,6 +428,10 @@ sub write_json () {
         total      => { pc => "82.50" },
         link       => "/Foo-Bar/index.html",
         log        => "build.log",
+      },
+      "Foo-Baz-v1.2.3" => {
+        module => { module => "Foo-Baz-v1.2.3" },
+        total  => { pc     => "50.00" },
       },
     },
   };
@@ -416,6 +452,9 @@ sub write_json () {
   unlike $content, qr/"condition"/, "JSON excludes n/a criteria";
   unlike $content, qr/"link"/,      "JSON excludes link field";
   unlike $content, qr/"log"/,       "JSON excludes log field";
+  like $content,   qr/"Foo-Baz"/, "JSON contains name parsed from the distdir";
+  like $content, qr/"v1\.2\.3"/,
+    "JSON contains a three-part version parsed from the distdir";
 }
 
 sub compress_old_versions () {
@@ -1004,6 +1043,7 @@ sub main () {
     bsys_stderr_capture
     dc_file
     coverage_class_method
+    module_name_version
     write_json
     compress_old_versions
     filter_build_dirs_to_targets

--- a/xt/collection.t
+++ b/xt/collection.t
@@ -483,6 +483,14 @@ sub compress_old_versions () {
     close $fh or die "Can't close: $!";
   }
 
+  # entries the scan must skip: invalid JSON and a missing cover.json
+  my $broken = "$dir/Net-RDAP-0.6";
+  mkdir $broken or die "Can't mkdir $broken: $!";
+  open my $bfh, ">", "$broken/cover.json" or die "Can't write: $!";
+  print $bfh "not json";
+  close $bfh                or die "Can't close: $!";
+  mkdir "$dir/Net-RDAP-0.3" or die "Can't mkdir: $!";
+
   my $c = Devel::Cover::Collection->new(results_dir => $dir, dryrun => 1);
 
   my $outfile = "$dir/compress_output.txt";
@@ -505,6 +513,10 @@ sub compress_old_versions () {
     "recent version 0.9 is kept";
   unlike $output, qr/^compressing Net-RDAP-0\.8$/m,
     "recent version 0.8 is kept";
+  unlike $output, qr/^compressing Net-RDAP-0\.6$/m,
+    "a distdir with invalid JSON is skipped";
+  unlike $output, qr/^compressing Net-RDAP-0\.3$/m,
+    "a distdir without cover.json is skipped";
 }
 
 sub filter_build_dirs_to_targets () {


### PR DESCRIPTION
## Summary

- Honour `-outputfile` in every report. The stdout reports rejected it as an unknown option, which broke any non-default report through cpancover, and a consuming report masked the error for the others.
- Keep the run name and version defaults when `CPAN::DistnameInfo` cannot parse the run directory. Every run made without a `MYMETA.json` had recorded null for both since release 1.26.
- Guard the `MYMETA.json` metadata copy with defined checks, matching the fixed branch beside it.
- Parse every version format in the collection's distdir fallback via `CPAN::DistnameInfo`, so three-part, v-prefixed, single-part, date and underscore versions are no longer dropped from `cpancover.json` or shown as raw distdirs. `CPAN::DistnameInfo` is now a recommended prerequisite.
- Fix the error handling in `compress_old_versions` - remove a dead check and keep a parsed version whose file fails to close, warning instead of silently never compressing it.
- Mark `html_escape.t` as long-running so yath stops dispatching it last.

## Ticket

Closes #740