### PR TITLE
GH-742 Parse dist name from release-named dirs

### DIFF
--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -363,7 +363,7 @@ sub populate_run {
         $Run{$field} = $json->{$field} if defined $json->{$field};
       }
     }
-  } elsif ($Dir =~ m|.*/([^/]+)$|) {
+  } elsif ($Dir =~ m|.*[/\\]([^/\\]+)$|) {
     my $filename = $1;
     eval {
       require CPAN::DistnameInfo;

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -367,11 +367,12 @@ sub populate_run {
     my $filename = $1;
     eval {
       require CPAN::DistnameInfo;
-      my $dinfo = CPAN::DistnameInfo->new($filename);
-      my $dist  = $dinfo->dist;
-      if (defined $dist) {
+      my $dinfo   = CPAN::DistnameInfo->new("$filename.tar.gz");
+      my $dist    = $dinfo->dist;
+      my $version = $dinfo->version;
+      if (defined $dist && defined $version) {
         $Run{name}    = $dist;
-        $Run{version} = $dinfo->version // "unknown";
+        $Run{version} = $version;
       }
     }
   }

--- a/t/internal/run_name.t
+++ b/t/internal/run_name.t
@@ -20,7 +20,7 @@ use File::Path qw( make_path );
 use File::Spec ();
 use File::Temp qw( tempdir );
 
-use Test::More import => [qw( done_testing is plan )];
+use Test::More import => [qw( done_testing is plan skip )];
 
 BEGIN {
   plan skip_all => "JSON::MaybeXS required for this test"
@@ -68,6 +68,29 @@ sub test_directory_without_mymeta () {
   my ($run, $dir) = run_in("myapp");
   is $run->{name},    $dir,      "run name defaults to the run directory";
   is $run->{version}, "unknown", "run version defaults to unknown";
+}
+
+sub test_release_named_directory () {
+  SKIP: {
+    skip "CPAN::DistnameInfo required for this test", 2
+      unless eval "require CPAN::DistnameInfo; 1";
+    my ($run) = run_in("Test-Dist-1.42");
+    is $run->{name},    "Test-Dist", "run name comes from the directory";
+    is $run->{version}, "1.42",      "run version comes from the directory";
+  }
+}
+
+sub test_release_named_directory_without_module () {
+  my $stub_lib = File::Spec->catdir($Tmpdir, "distnamestub");
+  make_path(File::Spec->catdir($stub_lib, "CPAN"));
+  write_file(
+    File::Spec->catfile($stub_lib, "CPAN", "DistnameInfo.pm"), <<'PERL');
+die "CPAN::DistnameInfo is not installed\n";
+PERL
+  my ($run, $dir) = run_in("Stub-Dist-1.42", undef, $stub_lib);
+  is $run->{name}, $dir, "a missing CPAN::DistnameInfo keeps the name default";
+  is $run->{version}, "unknown",
+    "a missing CPAN::DistnameInfo keeps the version default";
 }
 
 sub test_directory_with_mymeta () {
@@ -125,6 +148,8 @@ JSON
 
 sub main () {
   test_directory_without_mymeta;
+  test_release_named_directory;
+  test_release_named_directory_without_module;
   test_directory_with_mymeta;
   test_meta_with_undef_version;
   test_mymeta_missing_version;


### PR DESCRIPTION
## Summary

A coverage run in a directory without a `MYMETA.json` falls back to parsing the directory name with `CPAN::DistnameInfo`, but that parse never succeeded because the module only parses archive filenames with an extension. Append `.tar.gz` before parsing so a release-named checkout records its real distribution name and version, which lets cpancover match such a run by name. Require a defined version so a plain directory name still keeps the run directory default.

## Ticket

Closes #742