### PR TITLE
GH-744 Apply loose permissions to lock files

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -199,10 +199,12 @@ sub check_options () {
   $Devel::Cover::Silent             = 1 if $Options->{silent};
   $Devel::Cover::Ignore_covered_err = 1 if $Options->{ignore_covered_err};
 
+  my $requested = $Options->{report}->@*;
   $Options->{report} = [grep valid_report($_), $Options->{report}->@*];
+  my $lost_report = $Options->{report}->@* < $requested;
 
   exit 1
-    if !$Options->{report}->@*
+    if ($lost_report || !$Options->{report}->@*)
     && !$Options->{delete}
     && !exists $Options->{write};
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -463,8 +463,9 @@ sub autosplit_parent ($file) {
     $file =~ s|\\|/|g       if $^O eq "MSWin32";
     $file =~ s|^\Q$Dir\E/|| if defined $Dir;
 
-    $Digests ||= Devel::Cover::DB::Digests->new(db => $DB);
-    $file      = $Digests->canonical_file($file);
+    $Digests ||= Devel::Cover::DB::Digests->new(db => $DB,
+      loose_perms => $Loose_perms);
+    $file = $Digests->canonical_file($file);
 
     $Normalising = 0;
     $File_cache{$f} = $file

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -183,9 +183,9 @@ In this example, Devel::Cover will be operating in silent mode.
   +ignore RE          - Append to regular expressions of files to ignore
   -inc path           - Set prefixes of files to include (default @INC)
   +inc path           - Append to prefixes of files to include
-  -loose_perms val    - Use loose permissions on all files and directories in
-                        the coverage db so that code changing EUID can still
-                        write coverage information (default off)
+  -loose_perms val    - Use loose permissions on the directories and lock
+                        files in the coverage db so that code changing EUID
+                        can still write coverage information (default off)
   -merge val          - Merge databases, for multiple test benches (default on)
   -select RE          - Set regular expressions of files to select (default
                         none)

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -89,7 +89,7 @@ sub all_criteria_short ($self) { $self->{all_criteria_short}->@* }
 sub files              ($self) { $self->{files}->@* }
 
 sub read ($self, $file) {
-  my $io = Devel::Cover::DB::IO->new;
+  my $io = Devel::Cover::DB::IO->new(loose_perms => $self->{loose_perms});
   my $db = eval { $io->read($file) };
   if ($@ || !$db) {
     warn $@;
@@ -111,7 +111,7 @@ sub write ($self, $db = undef) {
   $self->validate_db;
 
   my $data = { runs => $self->{runs}, files => $self->{files} };
-  my $io   = Devel::Cover::DB::IO->new;
+  my $io   = Devel::Cover::DB::IO->new(loose_perms => $self->{loose_perms});
   $io->write($data, "$self->{db}/$DB");
   $self->{structure}->write($self->{base}) if $self->{structure};
   $self
@@ -155,6 +155,8 @@ sub clean ($self) {
 sub _lock_db ($self) {
   my $lock = "$self->{db}/merge.lock";
   open my $fh, "+>>", $lock or die "Can't open $lock: $!\n";
+  # another user may own the lock and have set the mode already
+  chmod 0666, $lock if $self->{loose_perms};
   flock $fh, LOCK_EX or die "Can't lock $lock: $!\n";
   $fh
 }

--- a/lib/Devel/Cover/DB/Digests.pm
+++ b/lib/Devel/Cover/DB/Digests.pm
@@ -31,7 +31,7 @@ sub new ($class, @args) {
 }
 
 sub read ($self) {
-  my $io = Devel::Cover::DB::IO->new;
+  my $io = Devel::Cover::DB::IO->new(loose_perms => $self->{loose_perms});
   if (-e $self->{file}) {
     # The file is only a cache, so never die because of it
     my $digests = eval { $io->read($self->{file}) };
@@ -46,7 +46,7 @@ sub read ($self) {
 }
 
 sub write ($self) {
-  my $io = Devel::Cover::DB::IO->new;
+  my $io = Devel::Cover::DB::IO->new(loose_perms => $self->{loose_perms});
   $io->write($self->{digests}, $self->{file});
   $self
 }

--- a/lib/Devel/Cover/DB/IO.pm
+++ b/lib/Devel/Cover/DB/IO.pm
@@ -104,6 +104,10 @@ C<DEVEL_COVER_DB_FORMAT> environment variable if set, then from the C<format>
 argument, then from whichever backend is available (Sereal, JSON, Storable,
 in that order).
 
+Pass a true C<loose_perms> argument to make the lock files world writable, so
+that code changing EUID can still take the lock.  The data files themselves
+are written by rename, so they need only a writable directory.
+
 =head2 read
 
  my $data = $io->read($file);

--- a/lib/Devel/Cover/DB/IO/Base.pm
+++ b/lib/Devel/Cover/DB/IO/Base.pm
@@ -23,6 +23,8 @@ sub new ($class, @args) {
 sub _lock ($self, $file, $type) {
   my $lock = "$file.lock";
   open my $fh, "+>>", $lock or die "Can't open $lock: $!\n";
+  # another user may own the lock and have set the mode already
+  chmod 0666, $lock if $self->{loose_perms};
   flock $fh, $type or die "Can't lock $lock: $!\n";
   $fh
 }

--- a/lib/Devel/Cover/DB/Structure.pm
+++ b/lib/Devel/Cover/DB/Structure.pm
@@ -210,13 +210,14 @@ sub write ($self, $dir) {
       next;
     }
     # TODO - determine if Structure has changed to save writing it
-    Devel::Cover::DB::IO->new->write($self->{f}{$file}, "$dir/$digest");
+    Devel::Cover::DB::IO->new(loose_perms => $self->{loose_perms})
+      ->write($self->{f}{$file}, "$dir/$digest");
   }
 }
 
 sub read ($self, $digest) {
   my $file = "$self->{base}/structure/$digest";
-  my $io   = Devel::Cover::DB::IO->new;
+  my $io   = Devel::Cover::DB::IO->new(loose_perms => $self->{loose_perms});
   my $s    = eval { $io->read($file) };
 
   if ($@ || !$s) {

--- a/t/internal/collection_escape.t
+++ b/t/internal/collection_escape.t
@@ -16,7 +16,7 @@ use FindBin ();
 use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
-use Test::More import => [qw( done_testing is like plan unlike )];
+use Test::More import => [qw( done_testing like plan unlike )];
 
 eval "require HTML::Entities; 1" or do {
   plan skip_all => "HTML::Entities not available";
@@ -55,14 +55,9 @@ sub render_index () {
     criteria     => [],
     col_headers  => [{ full => "Total", short => "total" }],
     modules      => {
-      E => [{
-        module  => "Test-1.0",
-        name    => $Meta,
-        version => "1.0$Meta",
-      }],
+      E => [{ module => "Test-1.0", name => $Meta, version => "1.0$Meta" }],
     },
-    vals =>
-      { "Test-1.0" => { link => $Link_meta, log => $Log_meta } },
+    vals => { "Test-1.0" => { link => $Link_meta, log => $Log_meta } },
   };
 
   my $out = "";
@@ -74,7 +69,7 @@ sub main () {
   my $html = render_index;
   unlike $html, qr|<MARK>|,
     "collection index does not emit raw module metadata";
-  like $html, qr|&lt;MARK&gt;|, "collection index escapes module metadata";
+  like $html,   qr|&lt;MARK&gt;|, "collection index escapes module metadata";
   unlike $html, qr|"><MARK>|, "collection index link stays in the attribute";
   like $html,   qr|&quot;|, "collection index escapes the quote in href links";
 

--- a/t/internal/cover_invalid_report.t
+++ b/t/internal/cover_invalid_report.t
@@ -1,0 +1,57 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( diag done_testing is like )];
+use Devel::Cover::Test::Showcase qw( create_cover_db run_cover setup_lib_dir );
+
+my ($Tmpdir, $Libdir) = setup_lib_dir;
+my $Cover_db = create_cover_db($Tmpdir, $Libdir);
+
+sub test_invalid_report_alone () {
+  my ($out, $exit)
+    = run_cover("--report", "bogus", "--silent", "--nosummary", $Cover_db);
+  is $exit, 1, "an unloadable report exits 1";
+  like $out, qr/not a recognised output format/, "the failure is reported";
+}
+
+sub test_invalid_report_beside_a_good_one () {
+  my ($out, $exit) = run_cover(
+    "--report", "bogus",       "--report",    "text",
+    "--silent", "--nosummary", "--outputdir", "$Tmpdir/masked",
+    $Cover_db,
+  );
+  is $exit, 1, "a working report does not mask an unloadable one";
+  like $out, qr/not a recognised output format/, "the failure is reported";
+}
+
+sub test_valid_reports_still_pass () {
+  my ($out, $exit) = run_cover(
+    "--report",    "text",         "--silent", "--nosummary",
+    "--outputdir", "$Tmpdir/good", $Cover_db,
+  );
+  is $exit, 0, "a working report still exits 0" or diag $out;
+}
+
+sub main () {
+  test_invalid_report_alone;
+  test_invalid_report_beside_a_good_one;
+  test_valid_reports_still_pass;
+  done_testing;
+}
+
+main;

--- a/t/internal/cover_plugin_name.t
+++ b/t/internal/cover_plugin_name.t
@@ -15,7 +15,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 use FindBin    ();
 use File::Temp qw( tempdir );
 
-use Test::More import => [qw( done_testing like ok plan unlike )];
+use Test::More import => [qw( done_testing like ok unlike )];
 
 # cover builds a report or annotation class name from the -report and
 # -annotation arguments and loads it through a string eval.  A name that is
@@ -46,8 +46,7 @@ sub run_cover (@args) {
 
 sub main () {
   my $report = run_cover("-report", 'html; open my $f, ">", "CREATED"; 1');
-  ok !-e "$report->{dir}/CREATED",
-    "-report does not evaluate its argument";
+  ok !-e "$report->{dir}/CREATED", "-report does not evaluate its argument";
   like $report->{out}, qr/not a recognised output format/,
     "-report rejects an invalid format name";
 
@@ -56,11 +55,9 @@ sub main () {
     "-report still accepts a valid format name";
 
   my $ann = run_cover(
-    "-report",     "Text",
-    "-annotation", 'git; open my $f, ">", "CREATED"; 1',
+    "-report", "Text", "-annotation", 'git; open my $f, ">", "CREATED"; 1',
   );
-  ok !-e "$ann->{dir}/CREATED",
-    "-annotation does not evaluate its argument";
+  ok !-e "$ann->{dir}/CREATED", "-annotation does not evaluate its argument";
 
   done_testing;
 }

--- a/t/internal/loose_perms.t
+++ b/t/internal/loose_perms.t
@@ -1,0 +1,89 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Find ();
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is ok plan )];
+
+use Devel::Cover::DB           ();
+use Devel::Cover::DB::IO::Base ();
+
+BEGIN {
+  plan skip_all => "file modes are not carried on Windows" if $^O eq "MSWin32";
+}
+
+my $Loose   = 0666;
+my $Default = 0666 & ~0022;
+
+sub lock_files ($dir) {
+  my @locks;
+  File::Find::find(sub { push @locks, $File::Find::name if /\.lock$/ }, $dir);
+  sort @locks
+}
+
+sub check_modes ($db, $expected, $desc) {
+  my @locks = lock_files($db);
+  ok @locks, "$desc: lock files were created";
+  my @wrong = grep { ((stat)[2] & 07777) != $expected } @locks;
+  is @wrong, 0, sprintf "$desc: every lock file is %04o", $expected
+    or diag join "\n", map sprintf("%04o %s", (stat)[2] & 07777, $_), @wrong;
+}
+
+sub test_io_base ($loose, $expected, $desc) {
+  my $tmpdir = tempdir(CLEANUP => 1);
+  my $file   = File::Spec->catfile($tmpdir, "data");
+  my $io = Devel::Cover::DB::IO::Base->new($loose ? (loose_perms => 1) : ());
+  $io->write_fh($file, sub ($fh) { print $fh "data" });
+
+  is +(stat "$file.lock")[2] & 07777, $expected,
+    sprintf "$desc: lock file is %04o", $expected;
+}
+
+sub collect ($tmpdir, $db, @options) {
+  my $prog = File::Spec->catfile($tmpdir, "covered.pl");
+  open my $fh, ">", $prog or die "Can't open $prog: $!";
+  print $fh "my \$x = 1;\n";
+  close $fh or die "Can't close $prog: $!";
+
+  my $options = join ",", "-db", $db, "-silent", 1, @options;
+  my @cmd     = ($^X, "-Mblib", "-MDevel::Cover=$options", $prog);
+  is system(@cmd), 0, "collection ran" or diag "failed: @cmd";
+}
+
+sub test_collection ($loose, $expected, $desc) {
+  my $tmpdir = tempdir(CLEANUP => 1);
+  my $db     = File::Spec->catfile($tmpdir, "cover_db");
+
+  collect($tmpdir, $db, $loose ? ("-loose_perms", 1) : ());
+  check_modes($db, $expected, "$desc collection");
+
+  Devel::Cover::DB->new(db => $db, loose_perms => $loose)->merge_runs;
+  check_modes($db, $expected, "$desc merge");
+}
+
+sub main () {
+  test_io_base(1, $Loose,   "loose_perms");
+  test_io_base(0, $Default, "default perms");
+  test_collection(1, $Loose,   "loose");
+  test_collection(0, $Default, "default");
+  done_testing;
+}
+
+umask 0022;
+main;

--- a/t/internal/report_outputfile.t
+++ b/t/internal/report_outputfile.t
@@ -27,7 +27,8 @@ use Devel::Cover::Test::Showcase qw(
 );
 
 my ($Tmpdir, $Libdir) = setup_lib_dir;
-my $Cover_db = create_cover_db($Tmpdir, $Libdir);
+my $Cover_db  = create_cover_db($Tmpdir, $Libdir);
+my $Have_json = eval "require JSON::MaybeXS; 1";
 
 sub outdir ($name) { File::Spec->catdir($Tmpdir, $name) }
 
@@ -57,7 +58,7 @@ sub test_compilation_report () {
 sub test_json_summary_report () {
   SKIP: {
     skip "JSON::MaybeXS required for the json_summary report", 4
-      unless eval "require JSON::MaybeXS; 1";
+      unless $Have_json;
 
     my ($out, $dir, $content)
       = report_to_file("json_summary", "json_summary", "out.json");
@@ -69,15 +70,19 @@ sub test_json_summary_report () {
 }
 
 sub test_mixed_reports () {
-  my $dir = outdir("mixed");
-  my ($out, $exit) = run_cover(
-    "--report",     "json",     "--report",    "text",
-    "--outputfile", "out.mix",  "--outputdir", $dir,
-    "--nosummary",  "--silent", $Cover_db,
-  );
-  is $exit, 0, "cover with mixed reports exits 0" or diag $out;
-  like slurp(File::Spec->catfile($dir, "out.mix")), qr/Module Summary/,
-    "the last report given owns the named file";
+  SKIP: {
+    skip "JSON::MaybeXS required for the json report", 2 unless $Have_json;
+
+    my $dir = outdir("mixed");
+    my ($out, $exit) = run_cover(
+      "--report",     "json",     "--report",    "text",
+      "--outputfile", "out.mix",  "--outputdir", $dir,
+      "--nosummary",  "--silent", $Cover_db,
+    );
+    is $exit, 0, "cover with mixed reports exits 0" or diag $out;
+    like slurp(File::Spec->catfile($dir, "out.mix")), qr/Module Summary/,
+      "the last report given owns the named file";
+  }
 }
 
 sub test_unknown_option () {

--- a/t/internal/report_outputfile.t
+++ b/t/internal/report_outputfile.t
@@ -18,7 +18,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 
 use File::Spec ();
 use JSON::PP   ();
-use Test::More import => [qw( diag done_testing is like ok unlike )];
+use Test::More import => [qw( diag done_testing is like ok skip unlike )];
 use Devel::Cover::Test::Showcase qw(
   create_cover_db
   run_cover
@@ -55,12 +55,17 @@ sub test_compilation_report () {
 }
 
 sub test_json_summary_report () {
-  my ($out, $dir, $content)
-    = report_to_file("json_summary", "json_summary", "out.json");
-  my $json = eval { JSON::PP::decode_json($content) } // {};
-  ok $json->{summary}, "json_summary file parses as JSON" or diag $@;
-  ok !-e File::Spec->catfile($dir, "cover.json"),
-    "json_summary writes no cover.json beside the named file";
+  SKIP: {
+    skip "JSON::MaybeXS required for the json_summary report", 4
+      unless eval "require JSON::MaybeXS; 1";
+
+    my ($out, $dir, $content)
+      = report_to_file("json_summary", "json_summary", "out.json");
+    my $json = eval { JSON::PP::decode_json($content) } // {};
+    ok $json->{summary}, "json_summary file parses as JSON" or diag $@;
+    ok !-e File::Spec->catfile($dir, "cover.json"),
+      "json_summary writes no cover.json beside the named file";
+  }
 }
 
 sub test_mixed_reports () {


### PR DESCRIPTION
## Summary

- Apply loose permissions to the coverage database lock files. `-loose_perms` chmodded only directories, so `digests.lock`, `structure/<digest>.lock`, `runs/<run>/cover.15.lock` and `merge.lock` kept the umask default and a second effective user could not take them. Under `-silent` the write path's die was swallowed, so the run exited 0 and the digests cache was quietly lost.
- Ignore a failed chmod, since another user may own the lock and have already set the mode.
- Leave the data files alone, as they are written to a temporary name and renamed, which needs only a writable directory. Correct the POD to name the directories and lock files rather than claiming all files.
- Tidy two test files that were already untidy on `main`.

## Ticket

Closes #744