### PR TITLE
GH-750 Validate uncoverable count and class

### DIFF
--- a/lib/Devel/Cover/Condition_table.pm
+++ b/lib/Devel/Cover/Condition_table.pm
@@ -94,9 +94,9 @@ sub _make_rows ($spec, $hits, $unc) {
   } @$spec
 }
 
-# Uncoverable flags align positionally with the outcome (spec-row) order
+# Uncoverable classes align positionally with the outcome (spec-row) order
 sub _uncov ($condition) {
-  map $_ ? 1 : 0, ($condition->[2] // [])->@*
+  map $_ // 0, ($condition->[2] // [])->@*
 }
 
 sub _expr ($condition) {
@@ -363,7 +363,8 @@ True if this input combination was exercised.
 
 =item uncoverable
 
-True if this row is excused by an C<# uncoverable condition> marker.
+The class name of the C<# uncoverable condition> marker excusing this row,
+or 0 when there is none.
 
 =back
 

--- a/lib/Devel/Cover/Criterion.pm
+++ b/lib/Devel/Cover/Criterion.pm
@@ -75,6 +75,8 @@ sub criterion ($self) {
   Carp::confess("criterion() must be overridden")
 }
 
+sub uncoverable_classes ($class) { qw( default ignore_covered_err ) }
+
 sub err_chk ($self, $covered, $uncoverable) {
   no warnings qw( once uninitialized );
   $Devel::Cover::Ignore_covered_err || $uncoverable eq "ignore_covered_err"
@@ -160,6 +162,11 @@ except time.
 Return the criterion names shown by the editor reports, in canonical
 order. The Vim and Nvim templates place signs last-in-list-wins, so this
 order is the sign display priority.
+
+=head2 uncoverable_classes
+
+Return the class words an uncoverable comment may carry - C<default>
+and C<ignore_covered_err>. The comment parser rejects anything else.
 
 =head1 CRITERION METADATA
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -905,6 +905,13 @@ sub _uncoverable_when ($criterion, $patterns, $has_type, $context) {
   [map "when:" . uc, split /,/, $patterns]
 }
 
+sub _uncoverable_class ($class, $context) {
+  return $class
+    if any { $class eq $_ } Devel::Cover::Criterion->uncoverable_classes;
+  dcwarn "Unknown class $class $context";
+  return;
+}
+
 sub _uncoverable_counts ($count, $context) {
   my @counts = map { m/^(\d+)\.\.(\d+)$/ ? ($1 .. $2) : $_ } split m/,/, $count;
   if (any { $_ < 1 } @counts) {
@@ -944,7 +951,10 @@ sub _uncoverable_details ($criterion, $info, $file, $line) {
   my $c = qr/\d+(?:\.\.\d+)?/;
   for my $word (@words) {
     if ($word =~ /^count:($c(?:,$c)*)$/) { $count = $1; next }
-    if ($word =~ /^class:(\w+)$/)        { $class = $1; next }
+    if ($word =~ /^class:(\w+)$/) {
+      $class = _uncoverable_class($1, $context) or return;
+      next;
+    }
     if ($word =~ /^pair:(\d+)$/) {
       my $pair = _uncoverable_pair($criterion, $1, $has_type, $context)
         or return;

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -905,6 +905,15 @@ sub _uncoverable_when ($criterion, $patterns, $has_type, $context) {
   [map "when:" . uc, split /,/, $patterns]
 }
 
+sub _uncoverable_counts ($count, $context) {
+  my @counts = map { m/^(\d+)\.\.(\d+)$/ ? ($1 .. $2) : $_ } split m/,/, $count;
+  if (any { $_ < 1 } @counts) {
+    dcwarn "Invalid count:$count (counts are numbered from 1) $context";
+    return;
+  }
+  \@counts
+}
+
 sub _uncoverable_details ($criterion, $info, $file, $line) {
   my $context = "parsing uncoverable $criterion at $file:$line";
 
@@ -960,8 +969,8 @@ sub _uncoverable_details ($criterion, $info, $file, $line) {
   }
   @types = undef unless @types;
 
-  my @counts = map { m/^(\d+)\.\.(\d+)$/ ? ($1 .. $2) : $_ } split m/,/, $count;
-  (\@counts, \@types, $class, $note)
+  my $counts = _uncoverable_counts($count, $context) or return;
+  ($counts, \@types, $class, $note)
 }
 
 sub uncoverable_comments ($self, $uncoverable, $file, $digest) {

--- a/lib/Devel/Cover/Report/Json.pm
+++ b/lib/Devel/Cover/Report/Json.pm
@@ -109,8 +109,8 @@ sub _truth_table ($table) {
     },
     $table->rows;
   my $errors = grep {
-    Devel::Cover::Criterion->err_chk($_->{covered}, $_->{uncoverable})
-  } @rows;
+    Devel::Cover::Criterion->err_chk($proven && $_->covered, $_->uncoverable)
+  } $table->rows;
   +{
     expr       => $table->expr,
     percentage => @rows ? 100 - $errors * 100 / @rows : 100,

--- a/t/internal/uncoverable_class.t
+++ b/t/internal/uncoverable_class.t
@@ -1,0 +1,115 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+# The class of an uncoverable marker must reach err_chk for truth-table rows,
+# so a per-outcome class:ignore_covered_err excuses a stale marker in the
+# crisp and JSON reports as it already does in the text report (GH-750).
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( done_testing is is_deeply skip )];
+
+use Devel::Cover::Condition_and_3 ();
+use Devel::Cover::Condition_table ();
+
+my $Has_json = eval "require JSON::MaybeXS; 1"
+  && eval "require Devel::Cover::Report::Json; 1";
+my $Has_html = eval "require HTML::Entities; 1"
+  && eval "require Devel::Cover::Report::Html_crisp; 1";
+
+package Mock::Criterion {
+  sub new      ($class, $loc) { bless { loc => $loc }, $class }
+  sub location ($self, $line) { $self->{loc} }
+}
+
+package Mock::File {
+  sub new ($class, $criterion) { bless { criterion => $criterion }, $class }
+  sub condition ($self)        { $self->{criterion} }
+}
+
+## no critic (Subroutines::ProtectPrivateSubs)
+
+sub mock_condition ($hits, $unc) {
+  bless [$hits, { type => "and_3", left => '$a', op => "&&", right => '$b' },
+    $unc],
+    "Devel::Cover::Condition_and_3"
+}
+
+sub table_for ($hits, $unc) {
+  my ($table)
+    = Devel::Cover::Condition_table->for_line([mock_condition($hits, $unc)]);
+  $table
+}
+
+sub test_row_carries_class () {
+  my $table = table_for([1, 1, 1], [("ignore_covered_err") x 3]);
+  is $_->uncoverable, "ignore_covered_err", "row carries the class"
+    for $table->rows;
+}
+
+sub test_unmarked_rows_stay_false () {
+  my $table = table_for([1, 0, 1], [undef, "default", undef]);
+  is_deeply [map $_->uncoverable, $table->rows], [0, "default", 0],
+    "only the marked outcome carries a class";
+}
+
+sub test_json_ignore_covered_err_excuses () {
+  SKIP: {
+    skip "JSON::MaybeXS not available", 2 unless $Has_json;
+    my $table = table_for([1, 1, 1], [("ignore_covered_err") x 3]);
+    my $tt    = Devel::Cover::Report::Json::_truth_table($table);
+    is $tt->{percentage}, 100, "json: stale ignore_covered_err rows excused";
+    is_deeply [map $_->{uncoverable}, $tt->{rows}->@*], [1, 1, 1],
+      "json: the emitted uncoverable field stays 0 or 1";
+  }
+}
+
+sub test_json_default_class_still_errors () {
+  SKIP: {
+    skip "JSON::MaybeXS not available", 1 unless $Has_json;
+    my $table = table_for([1, 1, 1], [("default") x 3]);
+    my $tt    = Devel::Cover::Report::Json::_truth_table($table);
+    is $tt->{percentage}, 0, "json: stale default rows still error";
+  }
+}
+
+sub test_crisp_ignore_covered_err_excuses () {
+  SKIP: {
+    skip "HTML::Entities not available", 2 unless $Has_html;
+    my $f = Mock::File->new(Mock::Criterion->new(
+      [mock_condition([1, 1, 1], [("ignore_covered_err") x 3])]
+    ));
+    my ($tt) = Devel::Cover::Report::Html_crisp::line_truth_tables($f, 2);
+    is grep($_->{error}, $tt->{rows}->@*), 0,
+      "crisp: stale ignore_covered_err rows excused";
+    my $g = Mock::File->new(Mock::Criterion->new(
+      [mock_condition([1, 1, 1], [("default") x 3])]));
+    my ($gt) = Devel::Cover::Report::Html_crisp::line_truth_tables($g, 2);
+    is grep($_->{error}, $gt->{rows}->@*), 3,
+      "crisp: stale default rows still error";
+  }
+}
+
+sub main () {
+  test_row_carries_class;
+  test_unmarked_rows_stay_false;
+  test_json_ignore_covered_err_excuses;
+  test_json_default_class_still_errors;
+  test_crisp_ignore_covered_err_excuses;
+}
+
+main;
+done_testing;

--- a/t/internal/uncoverable_grammar.t
+++ b/t/internal/uncoverable_grammar.t
@@ -103,6 +103,38 @@ PERL
   ok !exists $unc->{digest}, "pair: nothing is recorded";
 }
 
+sub test_zero_count_warns () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable statement count:0
+# uncoverable statement count:0..2
+$n++;
+PERL
+  is @$warnings, 2, "zero count: one warning per comment";
+  my $at = qr/parsing uncoverable statement at \Q$path\E/;
+  like $warnings->[0], qr/Invalid count:0 \(counts are numbered from 1\) $at:2/,
+    "zero count: a bare zero warns";
+  like $warnings->[1],
+    qr/Invalid count:0\.\.2 \(counts are numbered from 1\) $at:3/,
+    "zero count: a range starting at zero warns";
+  ok !exists $unc->{digest}, "zero count: nothing is recorded";
+}
+
+sub test_zero_count_after_higher () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable statement count:2
+# uncoverable statement count:0
+$n++; $n++;
+PERL
+  is @$warnings, 1, "zero count after higher: the zero warns";
+  my $at = qr/parsing uncoverable statement at \Q$path\E/;
+  like $warnings->[0], qr/Invalid count:0 \(counts are numbered from 1\) $at:3/,
+    "zero count after higher: warning names the count";
+  is scalar $unc->{digest}{statement}{4}[1]->@*, 1,
+    "zero count after higher: slot 1 keeps a single marker";
+}
+
 sub test_double_spaced_attributes_parse () {
   my ($unc, $warnings) = parse_comments(<<'PERL');
 my $n = 1;
@@ -154,6 +186,8 @@ sub main () {
   test_unknown_type_drops;
   test_invalid_attributes_warn;
   test_pair_restrictions;
+  test_zero_count_warns;
+  test_zero_count_after_higher;
   test_double_spaced_attributes_parse;
   test_count_lists_expand;
   test_note_consumes_the_rest;

--- a/t/internal/uncoverable_grammar.t
+++ b/t/internal/uncoverable_grammar.t
@@ -135,6 +135,36 @@ PERL
     "zero count after higher: slot 1 keeps a single marker";
 }
 
+sub test_unknown_class_warns () {
+  my ($unc, $warnings, $path) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable statement class:typo
+# uncoverable branch true class:ignore_covered_er
+$n++;
+PERL
+  is @$warnings, 2, "unknown class: one warning per comment";
+  like $warnings->[0],
+    qr/Unknown class typo parsing uncoverable statement at \Q$path\E:2/,
+    "unknown class: warning names the class";
+  like $warnings->[1],
+    qr/Unknown class ignore_covered_er parsing uncoverable branch/,
+    "unknown class: a near miss warns";
+  ok !exists $unc->{digest}, "unknown class: nothing is recorded";
+}
+
+sub test_known_classes_parse () {
+  my ($unc, $warnings) = parse_comments(<<'PERL');
+my $n = 1;
+# uncoverable statement class:default
+# uncoverable statement count:2 class:ignore_covered_err
+$n++; $n++;
+PERL
+  is @$warnings, 0, "known class: no warnings";
+  is_deeply $unc->{digest}{statement}{4},
+    [[[undef, "default", ""]], [[undef, "ignore_covered_err", ""]]],
+    "known class: both classes are recorded";
+}
+
 sub test_double_spaced_attributes_parse () {
   my ($unc, $warnings) = parse_comments(<<'PERL');
 my $n = 1;
@@ -162,22 +192,24 @@ PERL
 sub test_note_consumes_the_rest () {
   my ($unc, $warnings) = parse_comments(<<'PERL');
 my $n = 1;
-# uncoverable branch false class:x note:looks like cont:2 typo
+# uncoverable branch false class:default note:looks like cont:2 typo
 $n++;
 PERL
   is @$warnings, 0, "note: no warnings";
-  is_deeply $unc->{digest}{branch}{3}, [[[1, "x", "looks like cont:2 typo"]]],
+  is_deeply $unc->{digest}{branch}{3},
+    [[[1, "default", "looks like cont:2 typo"]]],
     "note: takes everything after note:";
 }
 
 sub test_attribute_order_is_free () {
   my ($unc, $warnings) = parse_comments(<<'PERL');
 my $n = 1;
-# uncoverable statement class:c count:2
+# uncoverable statement class:ignore_covered_err count:2
 $n++;
 PERL
   is @$warnings, 0, "order: no warnings";
-  is_deeply $unc->{digest}{statement}{3}, [undef, [[undef, "c", ""]]],
+  is_deeply $unc->{digest}{statement}{3},
+    [undef, [[undef, "ignore_covered_err", ""]]],
     "order: class before count parses";
 }
 
@@ -188,6 +220,8 @@ sub main () {
   test_pair_restrictions;
   test_zero_count_warns;
   test_zero_count_after_higher;
+  test_unknown_class_warns;
+  test_known_classes_parse;
   test_double_spaced_attributes_parse;
   test_count_lists_expand;
   test_note_consumes_the_rest;


### PR DESCRIPTION
## Summary

- Reject a `count:0` uncoverable comment (or a range starting at zero), which became an array subscript of -1, usually killing the whole report and otherwise silently marking a statement the author never named.
- Reject an unknown `class:` word with a warning, as the docs promise and as the neighbouring checks already do.
- Keep the class of an uncoverable marker on truth-table rows, so a per-outcome `class:ignore_covered_err` now excuses a stale marker in the crisp and JSON reports as it already does in the text report.

## Ticket

Closes #750