### PR TITLE
GH-752 Quieten warning leak in db_is_valid.t

### DIFF
--- a/t/internal/db_is_valid.t
+++ b/t/internal/db_is_valid.t
@@ -49,7 +49,7 @@ sub db_with (@entries) {
 sub is_valid ($path) {
   my $db = Devel::Cover::DB->new;
   $db->{db} = $path;
-  local $SIG{__WARN__} = sub { };
+  local $Devel::Cover::Silent = 1;
   $db->is_valid
 }
 


### PR DESCRIPTION
## Summary

Replace the test's `$SIG{__WARN__}` handler with `$Devel::Cover::Silent`. The `is_valid` method warns through `dcwarn`, which prints straight to STDERR, so the handler caught nothing and five warnings broke up the `make prove` output.

## Ticket

Closes #752