### PR TITLE
GH-756 Report pod coverage without Pod::Coverage

### DIFF
--- a/lib/Devel/Cover/Pod.pm
+++ b/lib/Devel/Cover/Pod.pm
@@ -29,11 +29,6 @@ sub display_mode     ($class) { "count" }
 sub detail_criterion ($class) { "subroutine" }
 sub sign_letter      ($class) { "P" }
 
-sub calculate_summary ($self, $db, $file) {
-  return unless $INC{"Pod/Coverage.pm"};
-  $self->SUPER::calculate_summary($db, $file)
-}
-
 1
 
 __END__

--- a/t/internal/criterion_percentage.t
+++ b/t/internal/criterion_percentage.t
@@ -92,7 +92,6 @@ sub test_ignore_covered_err () {
 }
 
 sub test_pod_summary_aggregates_uncoverable () {
-  local $INC{"Pod/Coverage.pm"} = $INC{"Pod/Coverage.pm"} // "mocked";
   my $db = { summary => {} };
   pod(0, 1)->calculate_summary($db, "file.pl");
   my $counts = { total => 1, uncoverable => 1 };
@@ -104,7 +103,6 @@ sub test_pod_summary_aggregates_uncoverable () {
 }
 
 sub test_pod_summary_covered_but_marked () {
-  local $INC{"Pod/Coverage.pm"} = $INC{"Pod/Coverage.pm"} // "mocked";
   my $db = { summary => {} };
   pod(1, 1)->calculate_summary($db, "file.pl");
   my $counts = { total => 1, uncoverable => 1, covered => 1, error => 1 };
@@ -115,12 +113,26 @@ sub test_pod_summary_covered_but_marked () {
     "pod summary flags a covered but marked subroutine as an error";
 }
 
+sub test_pod_summary_without_pod_coverage () {
+  local %INC = %INC;
+  delete $INC{"Pod/Coverage.pm"};
+  my $db = { summary => {} };
+  pod(1, 0)->calculate_summary($db, "file.pl");
+  my $counts = { total => 1, covered => 1 };
+  is_deeply $db->{summary}, {
+      "file.pl" => { pod => $counts, total => $counts },
+      Total     => { pod => $counts, total => $counts },
+    },
+    "pod summary aggregates without Pod::Coverage loaded";
+}
+
 sub main () {
   test_single_construct_states;
   test_vector_states;
   test_ignore_covered_err;
   test_pod_summary_aggregates_uncoverable;
   test_pod_summary_covered_but_marked;
+  test_pod_summary_without_pod_coverage;
   done_testing;
 }
 


### PR DESCRIPTION
## Summary

If Pod::Coverage was not installed on the machine running `cover`, every pod figure silently vanished from the report and each affected file's total rose to fill the gap, so a half-documented file read as fully covered. The pod verdict for each sub is decided during collection and stored in the database, so remove the `%INC` probe that suppressed the stored data at report time. The probe dates from when collection and reporting shared one process.

## Ticket

Closes #756