### PR TITLE
GH-758 Fix git annotation author and date

### DIFF
--- a/lib/Devel/Cover/Annotation/Git.pm
+++ b/lib/Devel/Cover/Annotation/Git.pm
@@ -48,6 +48,8 @@ sub get_annotations ($self, $file) {
   # print "Running [$command]\n";
   open my $c, "-|", $command or warn("cover: Can't run $command: $!\n"), return;
   my @annotation;
+  my %commits;
+  my $sha   = "";
   my $start = 1;
   while (my $line = <$c>) {
     # print "[$_]\n";
@@ -58,11 +60,19 @@ sub get_annotations ($self, $file) {
     }
 
     if ($start == 1) {
-      $annotation[0] = substr $1, 0, 8 if $line =~ /^(\w+)/;
+      if ($line =~ /^(\w+)/) {
+        $sha = $1;
+        $annotation[0] = substr $sha, 0, 8;
+        # Headers only follow a commit's first group, so cache them by sha
+        my $cached = $commits{$sha} ||= [];
+        @annotation[1, 2] = @$cached;
+      }
       $start = 0;
     } else {
-      $annotation[1] = $1 if $line =~ /^author (.*)/;
-      if ($line =~ /^author-time (.*)/) { $annotation[2] = localtime $1 }
+      $annotation[1] = $commits{$sha}[0] = $1 if $line =~ /^author (.*)/;
+      if ($line =~ /^author-time (.*)/) {
+        $annotation[2] = $commits{$sha}[1] = localtime $1;
+      }
     }
   }
   close $c or warn "cover: Failed running $command: $!\n"

--- a/t/internal/annotation_git.t
+++ b/t/internal/annotation_git.t
@@ -86,8 +86,42 @@ sub test_path_with_metacharacters () {
   ok !-e $probe, "no shell command injected via the file name";
 }
 
+sub write_repeat_helper () {
+  my $helper = "$Dir/repeat.pl";
+  open my $fh, ">", $helper or die "Can't open $helper: $!";
+  print $fh <<'PERL';
+my $a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+my $b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+print "$a 1 1 1\n";
+print "author Ann Author\n";
+print "author-time 1000000000\n";
+print "\tline one\n";
+print "$b 2 2 1\n";
+print "author Bob Blame\n";
+print "author-time 1100000000\n";
+print "\tline two\n";
+print "$a 3 3 1\n";
+print "\tline three\n";
+PERL
+  close $fh or die "Can't close $helper: $!";
+  $helper
+}
+
+sub test_repeated_commit () {
+  my $git  = annotator_for(write_repeat_helper);
+  my $file = "lib/Foo.pm";
+  $git->get_annotations($file);
+
+  is $git->text($file, 3, 0), "aaaaaaaa", "repeated commit keeps its sha";
+  is $git->text($file, 3, 1), "Ann Author",
+    "repeated commit keeps its own author";
+  is $git->text($file, 3, 2), $git->text($file, 1, 2),
+    "repeated commit keeps its own date";
+}
+
 test_version_column;
 test_path_with_spaces;
 test_path_with_metacharacters;
+test_repeated_commit;
 
 done_testing;


### PR DESCRIPTION
## Summary

`cover -annotation git` showed the wrong author and date for every block after a commit's first, because `git blame --porcelain` prints a commit's header lines only once and the parser never cleared the previous values. Cache the headers by sha and read them back when the commit comes round again, which also keeps a user-supplied `--line-porcelain` command working.

## Ticket

Closes #758