### PR TITLE
GH-760 Fix tests to pass without Pod::Coverage

### DIFF
--- a/t/internal/html_crisp.t
+++ b/t/internal/html_crisp.t
@@ -42,8 +42,13 @@ sub test_dir_header_rows ($content) {
 
   my ($covered) = grep m{data-dir="Covered"}, @rows;
   ok $covered, "Covered dir-header row present";
-  unlike $covered, qr/class="na"/,
-    "Covered dir row has aggregates for all criteria";
+  if (eval { require Pod::Coverage; 1 }) {
+    unlike $covered, qr/class="na"/,
+      "Covered dir row has aggregates for all criteria";
+  } else {
+    my @na = $covered =~ /class="na"/g;
+    is @na, 1, "Covered dir row has n/a only for pod";
+  }
   like $covered, qr{<dt>CC</dt><dd>[1-9]},
     "Covered dir row SCAR tooltip has non-zero CC";
   unlike $covered, qr/data-value="0" class="scar-val/,

--- a/t/internal/json.t
+++ b/t/internal/json.t
@@ -19,7 +19,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 use File::Spec ();
 use List::Util qw( first );
 use Test::More import =>
-  [qw( diag done_testing is is_deeply isa_ok like ok plan )];
+  [qw( diag done_testing is is_deeply isa_ok like ok plan skip )];
 use Devel::Cover::Test::Showcase qw(
   create_cover_db
   run_cover
@@ -192,8 +192,12 @@ sub test_error_rule_recorded ($json, $json_ignore, $libdir) {
 
 # Phase 0 made pod aggregate uncoverable like every other criterion
 sub test_summary_pod_uncoverable ($json) {
-  ok exists $json->{summary}{Total}{pod}{uncoverable},
-    "summary Total pod has an uncoverable count";
+  SKIP: {
+    skip "Pod::Coverage not available", 1
+      unless eval { require Pod::Coverage; 1 };
+    ok exists $json->{summary}{Total}{pod}{uncoverable},
+      "summary Total pod has an uncoverable count";
+  }
 }
 
 # json_summary should NOT have a files key - this protects against accidental


### PR DESCRIPTION
## Summary

Without the optional Pod::Coverage, two internal tests failed because they assumed pod coverage data was always present. Check that the pod column is the only `n/a` cell in the `html_crisp` dir row when it is missing, and skip the `json` pod check, as the pod-specific tests already do.

## Ticket

Closes #760