### PR TITLE
GH-762 Run gcov on XS files in subdirectories

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -348,8 +348,22 @@ sub do_test ($dbname) {
   $signal ? 128 + $signal : $status >> 8
 }
 
+# a .gcov whose source is unreadable from $cwd is a stub without line data
+sub gcov_source_found ($path, $cwd) {
+  open my $fh, "<", $path or return 0;
+  while (my $line = <$fh>) {
+    next unless $line =~ /^\s*-:\s*0:Source:(.*)$/;
+    my $src = $1;
+    $src = File::Spec->catfile($cwd, $src)
+      unless File::Spec->file_name_is_absolute($src);
+    return -f $src;
+  }
+  0
+}
+
 sub run_gcov ($name, $dir, $gc, $seen) {
-  my $gcov_flags = "-abc";
+  # -p keeps the path in .gcov names so same-named sources don't collide
+  my $gcov_flags = "-abcp";
   $gcov_flags .= "r" if $Options->{relative_only};
   my @args = $Options->{gcov_chdir} ? () : ("-o", $dir);
   my @c    = ("gcov", $gcov_flags, @args, $name);
@@ -362,11 +376,20 @@ sub run_gcov ($name, $dir, $gc, $seen) {
   while (my $line = <$fh>) {
     print $line;
     next unless $line =~ /^Creating '([^']+)'\s*$/;
-    my $path = $cwd eq "." ? $1 : "$cwd/$1";
-    $path =~ s{^\./}{};
+    my $path = ($cwd eq "." ? $1 : "$cwd/$1") =~ s|^\./||r;
+    unless (gcov_source_found($path, $cwd)) {
+      dcinfo "discarding $path - source not found from $cwd";
+      unlink $path;
+      next;
+    }
     push $gc->@*, $path unless $seen->{$path}++;
   }
   close $fh or dcinfo "gcov exited non-zero (exit $?)";
+}
+
+sub is_build_root ($dir) {
+  grep -e File::Spec->catfile($dir, $_),
+    qw( Makefile.PL Build.PL Makefile Build )
 }
 
 sub do_gcov ($dbname) {
@@ -374,26 +397,27 @@ sub do_gcov ($dbname) {
   my @gc;
   my %seen;
   my $gc = sub () {
+    # skip separate builds - their sources are recorded relative to them
+    if (!$Options->{gcov_chdir} && -d && $_ ne "." && is_build_root($_)) {
+      $File::Find::prune = 1;
+      return;
+    }
     return unless /\.(xs|cc?|hh?)$/;
-    # Without gcov_chdir, gcov runs from our cwd and can only read sources
-    # there.  Skip anything in a subdirectory: trying to gcov it produces a
-    # noisy error and a useless stub .gcov that contaminates this run.
-    return if !$Options->{gcov_chdir} && $File::Find::dir ne ".";
     for my $re ($Options->{ignore_re}->@*) {
       return if /$re/;
     }
-    my ($name) = /([^\/]+$)/;
+    my $name = s|^\./||r;
 
     # Don't bother running gcov if there's no index files.
     # Otherwise it's noisy.
-    my $graph_file = $_;
-    $graph_file =~ s{\.\w+$}{.gcno};
+    my $graph_file = s/\.\w+$/.gcno/r;
     return unless -e $graph_file;
 
     # Capture gcov stdout to learn exactly which .gcov files this run
     # produced; walking the tree afterwards picks up stale artefacts from
     # unrelated builds (e.g. tmp/runs/<dist>/) that we don't own.
-    run_gcov($name, $File::Find::dir, \@gc, \%seen);
+    my $dir = $File::Find::dir =~ s|^\./||r;
+    run_gcov($name, $dir, \@gc, \%seen);
   };
   File::Find::find({ wanted => $gc, no_chdir => !$Options->{gcov_chdir} }, ".");
 
@@ -824,9 +848,12 @@ it.
 
 The C<-gcov> option will try to run gcov on any XS code.  This requires that
 you are using gcc of course.  If you are using the C<-test> option will be
-turned on by default. If you have XS code in subdirectories, you will
-probably need to add the C<-gcov_chdir> option since gcov seems to work
-better with that.
+turned on by default.  XS code in subdirectories is covered too.  gcov's
+C<-p> flag keeps the path in the output names so same-named sources in
+different directories do not collide.  A subdirectory holding its own
+F<Makefile.PL>, F<Build.PL>, F<Makefile> or F<Build> is a separate build
+whose object files record sources relative to that directory, so it is
+skipped.  Run C<cover> in that directory instead, or use C<-gcov_chdir>.
 
 By default the C<-relative_only> option is enabled, which passes C<-r> to gcov
 so that source files reached via absolute paths (typically Perl's own CORE

--- a/t/internal/cover_gcov_subdir.t
+++ b/t/internal/cover_gcov_subdir.t
@@ -82,7 +82,8 @@ sub write_fake_gcov ($dir) {
 #!/usr/bin/env bash
 
 set -eEuo pipefail
-shopt -s inherit_errexit
+# inherit_errexit needs bash 4.4, newer than the macOS system bash
+shopt -s inherit_errexit 2>/dev/null || true
 
 echo "$@" >>gcov.args
 obj_dir=.

--- a/t/internal/cover_gcov_subdir.t
+++ b/t/internal/cover_gcov_subdir.t
@@ -1,0 +1,172 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Config     qw( %Config );
+use Cwd        qw( getcwd );
+use File::Path qw( mkpath );
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use Test::More import => [qw( done_testing is like note ok plan unlike )];
+
+if ($^O eq "MSWin32") {
+  plan skip_all => "test drives make with a stub Makefile";
+  exit;
+}
+
+my $Project   = getcwd;
+my $Cover     = File::Spec->catfile($Project, "bin", "cover");
+my $Blib_lib  = File::Spec->catdir($Project, "blib", "lib");
+my $Blib_arch = File::Spec->catdir($Project, "blib", "arch");
+my $Make      = $Config{make};
+
+unless (-f $Cover && -d $Blib_lib && -d $Blib_arch) {
+  plan skip_all => "build artefacts missing - run after `make`";
+  exit;
+}
+
+if (system "command -v $Make >/dev/null 2>&1") {
+  plan skip_all => "$Make not available";
+  exit;
+}
+
+sub write_file ($path, $contents) {
+  open my $fh, ">", $path or die "open $path: $!";
+  print $fh $contents;
+  close $fh or die "close $path: $!";
+}
+
+sub setup_dist ($dir) {
+  write_file(
+    File::Spec->catfile($dir, "Makefile"),
+    "test:\n\t\@'$^X' -e 'my \$\$x = 1'\n",
+  );
+  write_file(File::Spec->catfile($dir, "Top.xs"),   "int top_line;\n");
+  write_file(File::Spec->catfile($dir, "Top.gcno"), "Top.xs\n");
+  my $deep = File::Spec->catdir($dir, "lib", "Deep");
+  mkpath $deep;
+  write_file(File::Spec->catfile($deep, "Thing.xs"),   "int deep_line;\n");
+  write_file(File::Spec->catfile($deep, "Thing.gcno"), "lib/Deep/Thing.xs\n");
+
+  # a distribution built in its own directory, as under tmp/runs
+  my $foreign = File::Spec->catdir($dir, "foreign");
+  mkpath $foreign;
+  write_file(File::Spec->catfile($foreign, "Alien.xs"),   "int alien_line;\n");
+  write_file(File::Spec->catfile($foreign, "Alien.gcno"), "Alien.xs\n");
+
+  # the same, but recognisable as a separate build from its build files
+  my $bundled = File::Spec->catdir($dir, "bundled");
+  mkpath $bundled;
+  write_file(File::Spec->catfile($bundled, "Makefile"),   "test:\n");
+  write_file(File::Spec->catfile($bundled, "Inner.xs"),   "int inner_line;\n");
+  write_file(File::Spec->catfile($bundled, "Inner.gcno"), "Inner.xs\n");
+}
+
+# each .gcno fixture holds the compiler-recorded source name gcov works from
+sub write_fake_gcov ($dir) {
+  my $fakebin = File::Spec->catdir($dir, "fakebin");
+  mkpath $fakebin;
+  my $gcov = File::Spec->catfile($fakebin, "gcov");
+  write_file($gcov, <<'BASH');
+#!/usr/bin/env bash
+
+set -eEuo pipefail
+shopt -s inherit_errexit
+
+echo "$@" >>gcov.args
+obj_dir=.
+mangle=false
+prev=
+src=
+for arg; do
+  if [[ $prev == -o ]]; then obj_dir=$arg; fi
+  if [[ $arg == -[!-]*p* ]]; then mangle=true; fi
+  prev=$arg
+  src=$arg
+done
+base=$(basename "$src")
+gcno=$obj_dir/${base%.*}.gcno
+recorded=$(cat "$gcno")
+if [[ $mangle == true ]]; then
+  out=${recorded//\//#}.gcov
+else
+  out=$(basename "$recorded").gcov
+fi
+headers() {
+  printf '        -:    0:Source:%s\n' "$recorded"
+  printf '        -:    0:Graph:%s\n' "$gcno"
+  printf '        -:    0:Data:%s\n' "${gcno%.gcno}.gcda"
+  printf '        -:    0:Runs:1\n'
+}
+if [[ -r $recorded ]]; then
+  {
+    headers
+    printf '        1:    1:%s\n' "$(cat "$recorded")"
+  } >"$out"
+else
+  headers >"$out"
+fi
+echo "Creating '$out'"
+BASH
+  chmod 0755, $gcov;
+  $fakebin
+}
+
+sub run_cover ($dir, $fakebin) {
+  my $cmd = qq(cd '$dir' && PATH='$fakebin':"\$PATH" )
+    . "'$^X' '$Cover' -test -gcov -report text 2>&1";
+  my $out = `$cmd`;
+  note $out;
+  ($? >> 8, $out)
+}
+
+sub gcov_args ($dir) {
+  my $path = File::Spec->catfile($dir, "gcov.args");
+  return "" unless -e $path;
+  open my $fh, "<", $path or die "open $path: $!";
+  local $/;
+  my $args = <$fh>;
+  close $fh or die "close $path: $!";
+  $args
+}
+
+sub main () {
+  local $ENV{PERL5LIB} = join $Config{path_sep}, $Blib_lib, $Blib_arch,
+    ($ENV{PERL5LIB} // ());
+
+  my $dir = tempdir(CLEANUP => 1);
+  setup_dist($dir);
+  my $fakebin = write_fake_gcov($dir);
+  my ($rc, $out) = run_cover($dir, $fakebin);
+
+  is $rc, 0, "cover -test -gcov exits successfully";
+
+  my $args = gcov_args($dir);
+  like $args, qr|^-\S*p\S* -o lib/Deep lib/Deep/Thing\.xs$|m,
+    "gcov runs for the subdirectory XS with its path and -p";
+  like $args, qr/^-\S*p\S* -o \. Top\.xs$/m, "gcov runs for the top-level XS";
+
+  like $out, qr|lib/Deep/Thing\.xs\s+100\.0|,
+    "subdirectory XS has statement coverage in the report";
+  like $out, qr/Top\.xs\s+100\.0/, "top-level XS has statement coverage";
+
+  ok !-e File::Spec->catfile($dir, "Alien.xs.gcov"),
+    "stub .gcov from a foreign build is removed";
+  unlike $out,  qr/Alien\.xs\s+\d/, "foreign build does not reach the report";
+  unlike $args, qr/Inner/,          "no gcov run inside a bundled build";
+
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

- Run gcov on XS and C sources below the top level rather than skipping them silently, so distributions keeping their XS under `lib` get XS coverage at all.
- Pass the path-qualified source name to gcov and add `-p` so output names keep the path and same-named sources cannot clobber each other.
- Prune subdirectories holding their own build files and discard stub `.gcov` files whose source does not resolve, so bundled builds such as those under `tmp/runs` stay out of the run.
- Verified against `Net-IDN-Encode`, whose `lib/Net/IDN/Punycode.xs` now reports coverage matching a hand-run gcov.

## Ticket

Closes #762