### PR TITLE
GH-764 Fix gcov source path resolution

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -348,20 +348,27 @@ sub do_test ($dbname) {
   $signal ? 128 + $signal : $status >> 8
 }
 
-# a .gcov whose source is unreadable from $cwd is a stub without line data
-sub gcov_source_found ($path, $cwd) {
+# a usable .gcov names a findable source and holds line records
+sub gcov_usable ($path, $root) {
   open my $fh, "<", $path or return 0;
+  my $source_found;
   while (my $line = <$fh>) {
-    next unless $line =~ /^\s*-:\s*0:Source:(.*)$/;
-    my $src = $1;
-    $src = File::Spec->catfile($cwd, $src)
-      unless File::Spec->file_name_is_absolute($src);
-    return -f $src;
+    if ($line =~ /^\s*-:\s*0:Source:(.*)$/) {
+      my $src = $1;
+      # relative sources may be recorded against gcov's cwd or the build root
+      $source_found
+        = -f $src
+        || (!File::Spec->file_name_is_absolute($src)
+          && -f File::Spec->catfile($root, $src));
+      return 0 unless $source_found;
+    } elsif ($line =~ /^[^:]+:\s*(\d+):/ && $1 > 0) {
+      return 1 if $source_found;
+    }
   }
   0
 }
 
-sub run_gcov ($name, $dir, $gc, $seen) {
+sub run_gcov ($name, $dir, $root, $gc, $seen) {
   # -p keeps the path in .gcov names so same-named sources don't collide
   my $gcov_flags = "-abcp";
   $gcov_flags .= "r" if $Options->{relative_only};
@@ -376,10 +383,12 @@ sub run_gcov ($name, $dir, $gc, $seen) {
   while (my $line = <$fh>) {
     print $line;
     next unless $line =~ /^Creating '([^']+)'\s*$/;
-    my $path = ($cwd eq "." ? $1 : "$cwd/$1") =~ s|^\./||r;
-    unless (gcov_source_found($path, $cwd)) {
-      dcinfo "discarding $path - source not found from $cwd";
-      unlink $path;
+    # $local names the file from gcov's cwd, $path from the build root
+    my $local = $1;
+    my $path  = ($cwd eq "." ? $local : "$cwd/$local") =~ s|^\./||r;
+    unless (gcov_usable($local, $root)) {
+      dcinfo "discarding $path - source not found or no line records";
+      unlink $local;
       next;
     }
     push $gc->@*, $path unless $seen->{$path}++;
@@ -394,6 +403,8 @@ sub is_build_root ($dir) {
 
 sub do_gcov ($dbname) {
   return unless $Options->{gcov};
+  require Cwd;
+  my $root = Cwd::getcwd;
   my @gc;
   my %seen;
   my $gc = sub () {
@@ -417,7 +428,7 @@ sub do_gcov ($dbname) {
     # produced; walking the tree afterwards picks up stale artefacts from
     # unrelated builds (e.g. tmp/runs/<dist>/) that we don't own.
     my $dir = $File::Find::dir =~ s|^\./||r;
-    run_gcov($name, $dir, \@gc, \%seen);
+    run_gcov($name, $dir, $root, \@gc, \%seen);
   };
   File::Find::find({ wanted => $gc, no_chdir => !$Options->{gcov_chdir} }, ".");
 
@@ -430,8 +441,6 @@ sub do_gcov ($dbname) {
 
   if (@gc) {
     # Find the right gcov2perl based on this current script
-    require Cwd;
-
     my $path = Cwd::abs_path($0);
     my ($vol, $dir, $cover) = File::Spec->splitpath($path);
     my $gcov2perl = File::Spec->catpath($vol, $dir, "gcov2perl");

--- a/bin/gcov2perl
+++ b/bin/gcov2perl
@@ -60,10 +60,11 @@ sub is_core_path ($path) {
 }
 
 sub resolve_source ($source, $dir) {
-  my $f = $source;
-  $f = File::Spec->abs2rel(File::Spec->catfile($dir, $f))
-    unless File::Spec->file_name_is_absolute($f);
-  $f;
+  return $source if File::Spec->file_name_is_absolute($source);
+  my $f = File::Spec->abs2rel(File::Spec->catfile($dir, $source));
+  # the source may be recorded against the compilation directory, the cwd
+  return $source if !-f $f && -f $source;
+  $f
 }
 
 sub add_cover ($file) {

--- a/t/internal/cover_gcov_subdir.t
+++ b/t/internal/cover_gcov_subdir.t
@@ -110,13 +110,17 @@ headers() {
   printf '        -:    0:Data:%s\n' "${gcno%.gcno}.gcda"
   printf '        -:    0:Runs:1\n'
 }
+# FAKE_GCOV_STUBS gives Apple-style header-only stubs for unreadable sources
 if [[ -r $recorded ]]; then
-  {
-    headers
-    printf '        1:    1:%s\n' "$(cat "$recorded")"
-  } >"$out"
+  text=$(cat "$recorded")
+elif [[ ${FAKE_GCOV_STUBS:-} ]]; then
+  text=
 else
-  headers >"$out"
+  text='/*EOF*/'
+fi
+headers >"$out"
+if [[ $text ]]; then
+  printf '        1:    1:%s\n' "$text" >>"$out"
 fi
 echo "Creating '$out'"
 BASH
@@ -124,9 +128,10 @@ BASH
   $fakebin
 }
 
-sub run_cover ($dir, $fakebin) {
-  my $cmd = qq(cd '$dir' && PATH='$fakebin':"\$PATH" )
-    . "'$^X' '$Cover' -test -gcov -report text 2>&1";
+sub run_cover ($dir, $fakebin, @extra) {
+  my $opts = join " ", "-test", "-gcov", @extra, "-report", "text";
+  my $cmd
+    = qq(cd '$dir' && PATH='$fakebin':"\$PATH" ) . "'$^X' '$Cover' $opts 2>&1";
   my $out = `$cmd`;
   note $out;
   ($? >> 8, $out)
@@ -142,10 +147,7 @@ sub gcov_args ($dir) {
   $args
 }
 
-sub main () {
-  local $ENV{PERL5LIB} = join $Config{path_sep}, $Blib_lib, $Blib_arch,
-    ($ENV{PERL5LIB} // ());
-
+sub test_default_mode () {
   my $dir = tempdir(CLEANUP => 1);
   setup_dist($dir);
   my $fakebin = write_fake_gcov($dir);
@@ -166,6 +168,50 @@ sub main () {
     "stub .gcov from a foreign build is removed";
   unlike $out,  qr/Alien\.xs\s+\d/, "foreign build does not reach the report";
   unlike $args, qr/Inner/,          "no gcov run inside a bundled build";
+}
+
+# under -gcov_chdir the recorded source stays relative to the build root
+sub test_gcov_chdir () {
+  my $dir = tempdir(CLEANUP => 1);
+  setup_dist($dir);
+  my $fakebin = write_fake_gcov($dir);
+  my ($rc, $out) = run_cover($dir, $fakebin, "-gcov_chdir");
+
+  is $rc, 0, "cover -test -gcov -gcov_chdir exits successfully";
+
+  like gcov_args(File::Spec->catdir($dir, "lib", "Deep")),
+    qr/^-\S*p\S* Thing\.xs$/m, "gcov runs inside the subdirectory without -o";
+
+  like $out, qr|lib/Deep/Thing\.xs\s+100\.0|,
+    "subdirectory XS has statement coverage in the report";
+  like $out, qr/Top\.xs\s+100\.0/, "top-level XS has statement coverage";
+  like $out, qr|foreign/Alien\.xs\s+100\.0|,
+    "separate build is covered under -gcov_chdir";
+}
+
+# a root-compiled subdirectory XS gives a header-only stub under -gcov_chdir
+sub test_gcov_chdir_stub () {
+  my $dir = tempdir(CLEANUP => 1);
+  setup_dist($dir);
+  my $fakebin = write_fake_gcov($dir);
+  local $ENV{FAKE_GCOV_STUBS} = 1;
+  my ($rc, $out) = run_cover($dir, $fakebin, "-gcov_chdir");
+
+  is $rc, 0, "cover exits successfully when stubs are discarded";
+  unlike $out, qr|lib/Deep/Thing\.xs\s+\d|,
+    "header-only stub does not reach the report";
+  like $out, qr/discarding/, "stub discard is reported";
+  ok !-e File::Spec->catfile($dir, "lib", "Deep", "lib#Deep#Thing.xs.gcov"),
+    "stub .gcov is removed";
+}
+
+sub main () {
+  local $ENV{PERL5LIB} = join $Config{path_sep}, $Blib_lib, $Blib_arch,
+    ($ENV{PERL5LIB} // ());
+
+  test_default_mode;
+  test_gcov_chdir;
+  test_gcov_chdir_stub;
 
   done_testing;
 }

--- a/t/internal/gcov2perl.t
+++ b/t/internal/gcov2perl.t
@@ -10,6 +10,7 @@ use Test::More import => [qw( diag done_testing is like ok unlike )];
 use Config         qw( %Config );
 use File::Basename qw( dirname );
 use File::Copy     qw( copy );
+use File::Path     qw( mkpath );
 use File::Spec     ();
 use File::Temp     qw( tempdir );
 
@@ -19,6 +20,8 @@ my $Test_dir = dirname(__FILE__);
 my $Root     = File::Spec->catdir($Test_dir, "..", "..");
 my $Bin      = File::Spec->catfile($Root, "bin", "gcov2perl");
 my $Fixtures = File::Spec->catdir($Root, "t", "fixtures", "gcov2perl");
+my $Abs_bin  = File::Spec->rel2abs($Bin);
+my $Abs_blib = File::Spec->rel2abs(File::Spec->catdir("blib", "lib"));
 
 sub setup ($stem) {
   my $tmpdir = tempdir(CLEANUP => 1);
@@ -139,11 +142,67 @@ sub test_branch_collected ($tmpdir) {
     "branch is advertised in collected criteria";
 }
 
+sub write_file ($path, $contents) {
+  open my $fh, ">", $path or die "Cannot create $path: $!";
+  print $fh $contents;
+  close $fh or die "Cannot close $path: $!";
+}
+
+sub subdir_gcov ($tmpdir, $source) {
+  my $deep = File::Spec->catdir($tmpdir, "lib", "Deep");
+  mkpath $deep;
+  write_file(File::Spec->catfile($deep, "Thing.xs"),      "int thing;\n");
+  write_file(File::Spec->catfile($deep, "Thing.xs.gcov"), <<GCOV);
+        -:    0:Source:$source
+        -:    0:Graph:Thing.gcno
+        -:    0:Data:Thing.gcda
+        -:    0:Runs:1
+        1:    1:int thing;
+GCOV
+}
+
+sub run_gcov2perl_in ($dir, $db_dir, $gcov_path) {
+  my $cmd = "cd '$dir' && $^X '-I$Abs_blib' '$Abs_bin' "
+    . "-db '$db_dir' '$gcov_path' 2>&1";
+  my $output    = `$cmd`;
+  my $exit_code = $? >> 8;
+  ($exit_code, $output);
+}
+
+# the Source: path may be relative to the build root, not the .gcov dir
+sub test_source_relative_to_root () {
+  my $tmpdir = tempdir(CLEANUP => 1);
+  subdir_gcov($tmpdir, "lib/Deep/Thing.xs");
+  my $db_dir = File::Spec->catdir($tmpdir, "cover_db");
+  my ($exit_code, $output)
+    = run_gcov2perl_in($tmpdir, $db_dir, "lib/Deep/Thing.xs.gcov");
+
+  is $exit_code, 0, "gcov2perl exits successfully on root-relative source";
+  unlike $output, qr/no source/,
+    "no doubled-path error for root-relative source";
+  like $output, qr/Writing coverage database/,
+    "gcov2perl writes database for root-relative source";
+}
+
+sub test_source_relative_to_gcov_dir () {
+  my $tmpdir = tempdir(CLEANUP => 1);
+  subdir_gcov($tmpdir, "Thing.xs");
+  my $db_dir = File::Spec->catdir($tmpdir, "cover_db");
+  my ($exit_code, $output)
+    = run_gcov2perl_in($tmpdir, $db_dir, "lib/Deep/Thing.xs.gcov");
+
+  is $exit_code, 0, "gcov2perl exits successfully on gcov-dir source";
+  like $output, qr/Writing coverage database/,
+    "gcov2perl writes database for gcov-dir-relative source";
+}
+
 sub main () {
   my $tmpdir = setup("simple");
   test_gcov2perl($tmpdir);
   test_skip_core($tmpdir);
   test_branch_collected(setup("branch"));
+  test_source_relative_to_root;
+  test_source_relative_to_gcov_dir;
   done_testing;
 }
 

--- a/t/internal/gcov2perl.t
+++ b/t/internal/gcov2perl.t
@@ -8,6 +8,7 @@ no warnings qw( experimental::postderef experimental::signatures );
 use Test::More import => [qw( diag done_testing is like ok unlike )];
 
 use Config         qw( %Config );
+use Cwd            qw( getcwd );
 use File::Basename qw( dirname );
 use File::Copy     qw( copy );
 use File::Path     qw( mkpath );
@@ -162,10 +163,12 @@ GCOV
 }
 
 sub run_gcov2perl_in ($dir, $db_dir, $gcov_path) {
-  my $cmd = "cd '$dir' && $^X '-I$Abs_blib' '$Abs_bin' "
-    . "-db '$db_dir' '$gcov_path' 2>&1";
+  my $cwd = getcwd;
+  chdir $dir or die "Cannot chdir $dir: $!";
+  my $cmd = qq("$^X" "-I$Abs_blib" "$Abs_bin" -db "$db_dir" "$gcov_path" 2>&1);
   my $output    = `$cmd`;
   my $exit_code = $? >> 8;
+  chdir $cwd or die "Cannot chdir $cwd: $!";
   ($exit_code, $output);
 }
 


### PR DESCRIPTION
## Summary

- Fall back to the compilation directory when resolving the `Source:` path in a `.gcov` file. `gcov2perl` joined it only to the directory holding the `.gcov` file, so a root-relative source in a subdirectory doubled the path and the conversion failed.
- Fix the same wrong-directory assumption in `cover` under `-gcov_chdir`, whose stub check opened the `.gcov` by the wrong path and resolved the source against the wrong directory, discarding every subdirectory `.gcov`.
- Discard a `.gcov` holding no line records, the header-only stub Apple's gcov writes when it cannot read the source.

## Ticket

Closes #764