### PR TITLE
GH-768 Fix run sorting with missing run data

### DIFF
--- a/lib/Devel/Cover/Base/Editor.pm
+++ b/lib/Devel/Cover/Base/Editor.pm
@@ -37,7 +37,7 @@ sub report ($pkg, $db, $options) {
           start  => scalar gmtime $_->start,
           finish => scalar gmtime $_->finish,
       },
-      sort { $a->start <=> $b->start } $db->runs,
+      reverse($db->runs),
     ],
     cov_time => do {
       my $time = 0;

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -1435,8 +1435,7 @@ sub cover ($self) {
 
 sub run_keys ($self) {
   $self->cover unless $self->{cover_valid};
-  sort { $self->{runs}{$b}{start} <=> $self->{runs}{$a}{start} }
-    keys $self->{runs}->%*
+  $self->_sorted_run_keys
 }
 
 sub runs ($self) {
@@ -1822,13 +1821,16 @@ C<< $file->x >>.
 
   my @keys = $db->run_keys;
 
-Return run identifiers sorted by start time (most recent first).
+Return run identifiers sorted by start time (most recent first).  A run can
+lack its start time, probably when the code under test forks.  Such runs sort
+last, and runs sharing a start time are ordered by their identifiers, so the
+order is stable across invocations.
 
 =head2 runs
 
   my @runs = $db->runs;
 
-Return L<Devel::Cover::DB::Run> objects sorted by start time (most recent
+Return L<Devel::Cover::DB::Run> objects in L</run_keys> order (most recent
 first).
 
 =head2 set_structure

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -1365,6 +1365,13 @@ sub _warn_unmatched_uncoverable ($self, $cover, $uncoverable, $digests) {
   }
 }
 
+sub _sorted_run_keys ($self) {
+  my $runs = $self->{runs};
+  my %start
+    = map { $_ => ref $runs->{$_} ? $runs->{$_}{start} : undef } keys %$runs;
+  sort { ($start{$b} || 0) <=> ($start{$a} || 0) || $b cmp $a } keys %start
+}
+
 sub cover ($self) {
   return $self->{cover} if $self->{cover_valid};
 
@@ -1377,13 +1384,7 @@ sub cover ($self) {
     Devel::Cover::DB::Structure->new(base => $self->{base})->read_all;
   };
 
-  # Sometimes the start value is undefined.  It's not yet clear why, but it
-  # probably has something to do with the code under test forking.  We'll
-  # just try to cope with that here.
-  my @runs = sort {
-    ($self->{runs}{$b}{start} || 0) <=> ($self->{runs}{$a}{start} || 0)
-      || $b cmp $a
-  } keys $self->{runs}->%*;
+  my @runs = $self->_sorted_run_keys;
 
   $self->_choose_canonical_files(\@runs, \%digests, $uncoverable);
 

--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -818,9 +818,6 @@ sub add_subroutine ($self, $cc, $sc, $fc, $uc) {
 #       observed_vectors() below.
 sub observed_vectors ($entry) { $entry->[3] }
 
-# A "when:<inputs>" mark resolves to the row whose operand values match, a
-# deprecated word to its fixed row; marks naming no row are dropped here
-# and warned about at report time
 sub _resolve_condition_uncoverable ($marks, $type) {
   return $marks unless $marks && any { defined $_->[0] } @$marks;
   require Devel::Cover::Condition_table;
@@ -1169,8 +1166,6 @@ sub _derive_mcdc ($self, $cover, $uncoverable = {}) {
   }
 }
 
-# Per-column uncoverable vector for one mcdc decision, or undef if unmarked. A
-# marker with a column marks that condition; one without marks every column.
 sub _mcdc_uncoverable ($unc, $file, $line, $n, $total) {
   my $marks = $unc && $unc->{$line}[$n] or return undef;
   my @uncov;
@@ -1207,11 +1202,6 @@ sub _lib_preferred ($self, $file) {
   -e $ff ? $ff : $file
 }
 
-# The same content can be recorded under more than one name - a copy or a
-# symlink run from a directory deleted before the report is built.  When
-# names compete for a digest, prefer a path that still exists, outside the
-# temp directory and relative to the project tree, so a vanished alias
-# cannot become the reported name and hide the real file.
 sub _choose_canonical_files ($self, $runs, $digests, $uncoverable) {
   my %candidates;
   for my $run (@$runs) {
@@ -1839,6 +1829,195 @@ first).
 
 Attach a L<Devel::Cover::DB::Structure> object for use by
 L</summarise_complexity>.
+
+=head1 PRIVATE SUBROUTINES
+
+=head2 _lock_db ($self)
+
+Take an exclusive lock on the database's F<merge.lock> file, creating it if
+necessary, and return the open handle. The lock is released when the handle
+goes out of scope.
+
+=head2 _merge_hash ($into, $from, $noadd = 0)
+
+Recursively merge the hash C<$from> into C<$into>. Arrays already present in
+C<$into> merge through C<_merge_array>, nested hashes recurse, and anything
+else is copied across.
+
+=head2 _merge_array ($into, $from, $noadd = 0)
+
+Merge the array C<$from> into C<$into> element by element, recursing into
+nested structures and summing numeric counts. With C<$noadd> set, or for
+values that are not plain numbers, differing values warn and the value from
+C<$from> wins. Extra elements in C<$from> are appended.
+
+=head2 _sub_coverage ($file_obj, $start, $end)
+
+Return the percentage of statement, branch and condition points covered
+between lines C<$start> and C<$end> of C<$file_obj>, or 100 if there are
+none.
+
+=head2 _crap ($cc, $cov_pct)
+
+Return the CRAP score for a subroutine with cyclomatic complexity C<$cc> and
+coverage percentage C<$cov_pct>.
+
+=head2 _scar ($crap)
+
+Return the SCAR value for a CRAP score - ten times its natural logarithm, or
+zero for scores of one or less.
+
+=head2 _file_coverage ($s_file)
+
+Return the combined statement, branch and condition coverage percentage from
+the summary entry C<$s_file>, or 100 if nothing was counted.
+
+=head2 _file_dir ($file)
+
+Return the directory part of C<$file>, or the empty string for a file at the
+top level.
+
+=head2 _file_cc_data ($file_obj, $cc_hash, $end_hash)
+
+Build per-subroutine complexity data for a compiled file from the structure's
+complexity and end-line hashes. Return the maximum, sum and count of the
+cyclomatic complexities along with a CRAP and SCAR entry for each subroutine,
+or nothing when the file has no subroutines.
+
+=head2 _summarise_dir_complexity ($self, $s, $dir_files, $dir_stats)
+
+Build the per-directory summary. Each directory aggregates the criterion
+totals of its files, and for directories with complexity data it also
+records a SCAR entry computed from the complexity-weighted mean of their
+subroutines' CRAP scores.
+
+=head2 _uncompiled_cc_data ($sub_data)
+
+Build the same per-subroutine complexity data as C<_file_cc_data> for an
+uncompiled file, using the statically estimated subroutine data and treating
+every subroutine as uncovered.
+
+=head2 _compiled_cc_data ($self, $st, $file_obj)
+
+Fetch the complexity and end-line hashes for C<$file_obj> from the structure
+C<$st> and pass them to C<_file_cc_data>. Return nothing when the file has no
+digest or no complexity data.
+
+=head2 _record_file_complexity ($s, $file, $d, $dir_stats, $totals)
+
+Store the complexity and SCAR summary entries for C<$file> from the data in
+C<$d>, and accumulate the figures into the per-directory statistics and the
+running totals.
+
+=head2 _record_total_complexity ($s, $totals)
+
+Store the Total complexity and SCAR summary entries from the accumulated
+totals.
+
+=head2 _format_summary_pct ($options, $part, $criterion)
+
+Format one percentage cell for the summary table, or C<n/a> when the
+criterion was not collected for that row.
+
+=head2 _format_summary_scar ($self, $file, $part, $have_ppi)
+
+Format the scar cell for a summary row. Files with no SCAR data show C<n/a>,
+except uncompiled files without PPI, which show C<->.
+
+=head2 _flag_uncoverable ($entry, $uncoverable, $counts)
+
+Apply parsed uncoverable marks to a coverage entry. A mark with an element
+index flags that element and a mark without one, from an C<all> comment,
+flags them all.
+
+=head2 _resolve_condition_uncoverable ($marks, $type)
+
+Resolve condition uncoverable marks to truth-table row indexes for the
+condition type C<$type>. A C<< when:<inputs> >> mark resolves to the row
+whose operand values match and a deprecated type word to its fixed row.
+Marks naming no row are dropped here and warned about at report time.
+
+=head2 _uncoverable_pair ($criterion, $pair, $has_type, $context)
+
+Validate a C<pair:> attribute, which applies only to mcdc, and return an
+arrayref holding the zero-based index of the condition it names.
+
+=head2 _uncoverable_when ($criterion, $patterns, $has_type, $context)
+
+Validate a C<when:> attribute, which applies only to conditions, and return
+its comma-separated patterns as C<when:> marks for later resolution.
+
+=head2 _uncoverable_class ($class, $context)
+
+Return C<$class> if it is a known uncoverable class, otherwise warn and
+return nothing.
+
+=head2 _uncoverable_counts ($count, $context)
+
+Parse a C<count:> attribute, expanding ranges, and return the counts as an
+arrayref. Counts below one warn and invalidate the comment.
+
+=head2 _uncoverable_details ($criterion, $info, $file, $line)
+
+Parse the attributes of one uncoverable comment and return its counts,
+types, class and note. Invalid attributes warn, giving the file and line,
+and invalidate the comment.
+
+=head2 _derive_mcdc ($self, $cover, $uncoverable = {})
+
+Derive mcdc coverage for every file from its condition truth tables. The
+condition pairs for each decision come from the analyser, decisions too wide
+to analyse are flagged and warned about, and explicit uncoverable mcdc
+markers are merged with conditions the analyser excused.
+
+=head2 _mcdc_uncoverable ($unc, $file, $line, $n, $total)
+
+Return the per-column uncoverable vector for one mcdc decision, or undef
+when it carries no markers. A marker with a column marks that condition and
+one without marks every column.
+
+=head2 _file_digest ($r, $file)
+
+Return the digest recorded for C<$file> in run C<$r>, or undef, logging the
+miss unless the file is one expected to have no digest.
+
+=head2 _lib_preferred ($self, $file)
+
+Under C<prefer_lib>, return the F<lib> path for a F<blib> file when it
+exists, otherwise return C<$file> unchanged.
+
+=head2 _choose_canonical_files ($self, $runs, $digests, $uncoverable)
+
+Pick a canonical name for content recorded under more than one name - a copy
+or a symlink run from a directory deleted before the report is built. When
+names compete for a digest, prefer a path that still exists, outside the
+temp directory and relative to the project tree, so a vanished alias cannot
+become the reported name and hide the real file.
+
+=head2 _cover_file
+
+Merge one file's coverage data from one run into the cover structure, keyed
+by the canonical name for the file's digest. Parse the file's uncoverable
+comments the first time its digest is seen and dispatch each criterion to
+its C<add_*> method.
+
+=head2 _uncoverable_mark_warnings ($criterion, $slot, $entry, $file, $line, $n)
+
+Return warnings for uncoverable marks that name no row of their entry, such
+as C<condition false> on C<//> or an unmatched C<when:>, including
+deprecation warnings for condition type words.
+
+=head2 _warn_unmatched_uncoverable ($self, $cover, $uncoverable, $digests)
+
+Warn, in a stable order, about uncoverable comments that matched no coverage
+and about marks that do not apply to the construct they annotate.
+
+=head2 _sorted_run_keys ($self)
+
+Return the run keys sorted as L</run_keys> describes. The start times are
+pulled out without dereferencing the runs, since a run can be undef (as
+self-coverage runs produce) and autovivifying it would stop
+L</objectify_cover> deleting it.
 
 =head1 SEE ALSO
 

--- a/lib/Devel/Cover/Report/Json.pm
+++ b/lib/Devel/Cover/Report/Json.pm
@@ -24,7 +24,7 @@ use Getopt::Long                  qw( GetOptions );
 
 sub _runs ($db) {
   my @runs;
-  for my $r (sort { $a->{start} <=> $b->{start} } $db->runs) {
+  for my $r (reverse $db->runs) {
     push @runs,
       { map { $_ => $r->$_ }
         qw( run perl OS dir name version abstract start finish ) };

--- a/lib/Devel/Cover/Report/Json_summary.pm
+++ b/lib/Devel/Cover/Report/Json_summary.pm
@@ -21,7 +21,7 @@ use Getopt::Long               qw( GetOptions );
 
 sub add_runs ($db) {
   my @runs;
-  for my $r (sort { $a->{start} <=> $b->{start} } $db->runs) {
+  for my $r (reverse $db->runs) {
     push @runs,
       { map { $_ => $r->$_ }
         qw( run perl OS dir name version abstract start finish ) };

--- a/lib/Devel/Cover/Report/Sort.pm
+++ b/lib/Devel/Cover/Report/Sort.pm
@@ -21,7 +21,7 @@ sub print_sort ($db, $options) {
   my @collected
     = grep Devel::Cover::Criterion->criterion_class($_)->measures_coverage,
     $options->{coverage}->@*;
-  for my $r (sort { $a->{start} <=> $b->{start} } $db->runs) {
+  for my $r (reverse $db->runs) {
     say "Run:          ", $r->run;
     say "Perl version: ", $r->perl;
     say "OS:           ", $r->OS;

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -242,7 +242,7 @@ sub print_file_banner ($db, $file, $short) {
 }
 
 sub print_runs ($db, $) {
-  for my $r (sort { $a->{start} <=> $b->{start} } $db->runs) {
+  for my $r (reverse $db->runs) {
     say "Run:          ", $r->run;
     say "Perl version: ", $r->perl;
     say "OS:           ", $r->OS;

--- a/t/internal/db_run_order.t
+++ b/t/internal/db_run_order.t
@@ -1,0 +1,107 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( diag done_testing is is_deeply like )];
+
+use Devel::Cover::DB           ();
+use Devel::Cover::Report::Text ();
+
+sub db_with_runs (%runs) {
+  Devel::Cover::DB->new(runs => {%runs}, _structure => 0)
+}
+
+sub print_runs_output ($db) {
+  my $output;
+  {
+    open my $fh, ">", \$output or die "Cannot open scalar ref: $!";
+    local *STDOUT = $fh;
+    Devel::Cover::Report::Text::print_runs($db, undef);
+    close $fh or die "Cannot close scalar ref: $!";
+  }
+  $output // ""
+}
+
+sub test_no_warnings_without_start () {
+  my @warnings;
+  local $SIG{__WARN__} = sub { push @warnings, @_ };
+  my $db   = db_with_runs(r1 => {}, r2 => {});
+  my @keys = $db->run_keys;
+  is @keys, 2, "both runs returned";
+  is @warnings, 0, "no warnings from run_keys without start values"
+    or diag join "", @warnings;
+}
+
+sub test_deterministic_tie_order () {
+  local $SIG{__WARN__} = sub { };
+  my $db = db_with_runs(map { ("run$_" => {}) } 1 .. 8);
+  is_deeply [$db->run_keys], [reverse map "run$_", 1 .. 8],
+    "tied runs sort by key rather than hash order";
+}
+
+sub test_started_run_sorts_first () {
+  local $SIG{__WARN__} = sub { };
+  my $db = db_with_runs(r1 => { start => 100 }, r2 => {});
+  my ($first) = $db->run_keys;
+  is $first, "r1", "a run with a start time sorts before one without";
+}
+
+sub test_distinct_starts_keep_order () {
+  my $db = db_with_runs(
+    r1 => { start => 100 },
+    r2 => { start => 200 },
+    r3 => { start => 300 },
+  );
+  is_deeply [$db->run_keys], [qw( r3 r2 r1 )], "run_keys are newest first";
+  is_deeply [map $_->{start}, $db->runs], [300, 200, 100],
+    "runs follow run_keys order";
+}
+
+sub test_print_runs_without_comparison_warnings () {
+  my @warnings;
+  local $SIG{__WARN__} = sub { push @warnings, @_ };
+  my $db = db_with_runs(
+    r1 => { run => "a", perl => "5.20.0", OS => "linux" },
+    r2 => { run => "b", perl => "5.20.0", OS => "linux" },
+  );
+  print_runs_output($db);
+  is grep(/numeric comparison/, @warnings), 0,
+    "no comparison warnings from print_runs without start values"
+    or diag join "", @warnings;
+}
+
+sub test_print_runs_oldest_first () {
+  my $db = db_with_runs(
+    r1 =>
+      { run => "newer", perl => "p", OS => "o", start => 200, finish => 201 },
+    r2 =>
+      { run => "older", perl => "p", OS => "o", start => 100, finish => 101 },
+  );
+  like print_runs_output($db), qr/older.*newer/s, "runs print oldest first";
+}
+
+sub main () {
+  test_no_warnings_without_start;
+  test_deterministic_tie_order;
+  test_started_run_sorts_first;
+  test_distinct_starts_keep_order;
+  test_print_runs_without_comparison_warnings;
+  test_print_runs_oldest_first;
+  done_testing;
+}
+
+main;

--- a/t/internal/db_undef_runs.t
+++ b/t/internal/db_undef_runs.t
@@ -1,0 +1,75 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Test::More import => [qw( diag done_testing is is_deeply isa_ok )];
+
+use Devel::Cover::DB           ();
+use Devel::Cover::Report::Text ();
+
+sub db_with_runs (%runs) {
+  Devel::Cover::DB->new(runs => {%runs}, _structure => 0)
+}
+
+sub test_undef_runs_removed () {
+  my $db = db_with_runs(r1 => undef, r2 => undef);
+  $db->cover;
+  is keys $db->{runs}->%*, 0, "undef runs are deleted from the database";
+}
+
+sub test_single_undef_run_removed () {
+  my $db = db_with_runs(r1 => undef);
+  $db->cover;
+  is keys $db->{runs}->%*, 0, "a single undef run is deleted";
+}
+
+sub test_mixed_runs_keep_real_run () {
+  my $db = db_with_runs(
+    r1 => undef,
+    r2 => { start => 100, collected => ["statement"] },
+  );
+  $db->cover;
+  is_deeply [keys $db->{runs}->%*], ["r2"], "only the real run survives";
+  isa_ok $db->{runs}{r2}, "Devel::Cover::DB::Run";
+}
+
+sub test_print_runs_silent_after_cover () {
+  my @warnings;
+  local $SIG{__WARN__} = sub { push @warnings, @_ };
+  my $db = db_with_runs(r1 => undef, r2 => undef);
+  $db->cover;
+  my $output;
+  {
+    open my $fh, ">", \$output or die "Cannot open scalar ref: $!";
+    local *STDOUT = $fh;
+    Devel::Cover::Report::Text::print_runs($db, undef);
+    close $fh or die "Cannot close scalar ref: $!";
+  }
+  is $output // "", "", "no run blocks printed for undef runs";
+  is @warnings, 0, "no warnings printing a database of undef runs"
+    or diag join "", @warnings;
+}
+
+sub main () {
+  test_undef_runs_removed;
+  test_single_undef_run_removed;
+  test_mixed_runs_keep_real_run;
+  test_print_runs_silent_after_cover;
+  done_testing;
+}
+
+main;

--- a/t/internal/db_warnings.t
+++ b/t/internal/db_warnings.t
@@ -42,13 +42,14 @@ use Devel::Cover::DB ();
 }
 
 # Every warning in DB.pm must go through dcwarn, so a new bare warn cannot
-# creep back in.  Comments are allowed to mention warn.
+# creep back in.  Comments and documentation are allowed to mention warn.
 sub test_no_bare_warn () {
   my $file = $INC{"Devel/Cover/DB.pm"};
   ok $file, "guard: found DB.pm in %INC";
   open my $fh, "<", $file or die "Cannot open $file: $!";
   my @bare;
   while (my $l = <$fh>) {
+    last if $l =~ /^__END__$/;
     next if $l =~ /^\s*#/;
     push @bare, "line $.: $l" if $l =~ /\bwarn[ (\$]/;
   }


### PR DESCRIPTION
## Summary

- Sort the run keys in `cover` without dereferencing the runs. Dereferencing autovivified the undef runs self-coverage produces, so they escaped deletion and reports printed blank run blocks.
- Route `run_keys`, the run-listing reports and the editor reports through one guarded comparator. Each carried its own sort with no guard against a missing start time, so startless runs warned and ties fell back to perl's random hash order.
- Document every private subroutine in `DB.pm` under a new PRIVATE SUBROUTINES section.

## Ticket

Closes #768