### PR TITLE
GH-770 Keep summary filenames in a narrow terminal

### DIFF
--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -618,7 +618,7 @@ sub file_summary ($self, $files, %options) {
 }
 
 sub trimmed_file ($f, $len) {
-  substr $f, 0, 3 - $len, "..." if length $f > $len;
+  substr $f, 0, 3 - $len, "..." if $len > 3 && length $f > $len;
   $f
 }
 
@@ -638,6 +638,21 @@ sub _format_summary_scar ($self, $file, $part, $have_ppi) {
   return "n/a" if $file eq "Total";
   my $uncompiled = $self->cover->file($file)->{meta}{uncompiled};
   $uncompiled && !$have_ppi ? "-" : "n/a"
+}
+
+my $Min_file_width = 12;
+
+sub _term_width () {
+  !$ENV{DEVEL_COVER_TEST_SUITE} && $Has_term_size && -t STDOUT
+    ? (Term::Size::chars(\*STDOUT))[0]
+    : 80
+}
+
+sub _file_width ($width, $nc, $max) {
+  my $fw = $width - $nc * 7 - 3;
+  $fw = $Min_file_width if $fw < $Min_file_width;
+  $fw = $max            if $max < $fw;
+  $fw
 }
 
 sub print_summary ($self, $files = undef, $criteria = undef, $opts = {}) {
@@ -660,14 +675,8 @@ sub print_summary ($self, $files = undef, $criteria = undef, $opts = {}) {
 
   for (@files) { $max = length $short->{$_} if length $short->{$_} > $max }
 
-  my $width
-    = !$ENV{DEVEL_COVER_TEST_SUITE}
-    && $Has_term_size
-    && -t STDOUT ? (Term::Size::chars(\*STDOUT))[0] : 80;
-  my $nc = $n + 1;               # criterion columns plus scar
-  my $fw = $width - $nc * 7 - 3;
-
-  $fw = $max if $max < $fw;
+  my $nc = $n + 1;                              # criterion columns plus scar
+  my $fw = _file_width(_term_width, $nc, $max);
 
   no warnings "uninitialized";
   my $fmt = "%-${fw}s" . " %6s" x $nc . "\n";
@@ -1659,7 +1668,8 @@ C<< $db->{dir_summary} >> is still recalculated over the restricted files.
   my $short = Devel::Cover::DB::trimmed_file($filename, $max_len);
 
 Truncate C<$filename> to C<$max_len> characters, replacing the leading portion
-with C<...> if necessary. This is a plain function, not a method.
+with C<...> if necessary. A length below 4 leaves the filename unchanged, since
+the C<...> marker alone would fill it. This is a plain function, not a method.
 
 =head2 print_summary
 
@@ -1923,6 +1933,20 @@ criterion was not collected for that row.
 
 Format the scar cell for a summary row. Files with no SCAR data show C<n/a>,
 except uncompiled files without PPI, which show C<->.
+
+=head2 _term_width ()
+
+Return the terminal width for the summary table. Uses L<Term::Size> when it is
+available and STDOUT is a terminal. Otherwise, and under
+C<DEVEL_COVER_TEST_SUITE>, the width is 80.
+
+=head2 _file_width ($width, $nc, $max)
+
+Return the width of the filename column - the terminal width left over after
+C<$nc> data columns, raised to a minimum which keeps a basename readable. The
+column is never wider than C<$max>, the longest short filename. In a terminal
+too narrow for the table the rows overflow and wrap rather than losing their
+filenames.
 
 =head2 _flag_uncoverable ($entry, $uncoverable, $counts)
 

--- a/t/internal/summary_width.t
+++ b/t/internal/summary_width.t
@@ -1,0 +1,116 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Cwd     ();
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is like ok )];
+
+my $Root = Cwd::cwd();
+
+use Devel::Cover::DB            ();
+use Devel::Cover::DB::Structure ();
+
+## no critic (Subroutines::ProtectPrivateSubs, Variables::ProtectPrivateVars)
+
+my $Tmpdir = tempdir(CLEANUP => 1);
+
+sub trimmed ($f, $len) { Devel::Cover::DB::trimmed_file($f, $len) }
+
+sub test_trimmed_file () {
+  my $f = "lib/Devel/Cover/DB.pm";
+  is trimmed($f, -26), $f, "negative length leaves the name alone";
+  for my $len (0 .. 3) {
+    is trimmed($f, $len), $f, "length $len leaves the name alone";
+  }
+  is trimmed($f,      10), "...r/DB.pm", "ordinary trim unchanged";
+  is trimmed("short", 10), "short", "name shorter than the length untouched";
+}
+
+sub test_file_width () {
+  is Devel::Cover::DB::_file_width(200, 9, 30), 30,
+    "wide terminal uses the longest name's width";
+  is Devel::Cover::DB::_file_width(80, 8, 100), 21,
+    "long names get the space the columns leave";
+  is Devel::Cover::DB::_file_width(66, 9, 30), 12,
+    "no space left falls back to the minimum";
+  is Devel::Cover::DB::_file_width(59, 8, 30), 12,
+    "everyday tmux split falls back to the minimum";
+  is Devel::Cover::DB::_file_width(40, 9, 30), 12,
+    "narrow terminal falls back to the minimum";
+  is Devel::Cover::DB::_file_width(40, 9, 8), 8,
+    "names shorter than the minimum keep their own width";
+}
+
+sub run_cover ($label, $script_content) {
+  my $script = File::Spec->catfile($Tmpdir, "$label.pl");
+  my $db     = File::Spec->catdir($Tmpdir, "${label}_db");
+
+  open my $fh, ">", $script or die "Cannot write $script: $!";
+  print $fh $script_content;
+  close $fh or die "Cannot close $script: $!";
+
+  my @inc = map { "-I$_" } "$Root/blib/arch", "$Root/blib/lib", "$Root/lib";
+
+  system($^X, @inc, "-MDevel::Cover=-db,$db,-silent,1", $script) == 0
+    or die "Failed to run $label under Devel::Cover: $?";
+
+  ($db, $script)
+}
+
+sub test_narrow_summary () {
+  my ($db_path, $script) = run_cover("nw", <<'PERL');
+my $x = 1;
+my $y = $x ? 2 : 3;
+PERL
+
+  my $st = Devel::Cover::DB::Structure->new(base => $db_path);
+  $st->read_all;
+
+  my $db = Devel::Cover::DB->new(db => $db_path)->merge_runs;
+  $db->set_structure($st);
+
+  my ($output, @warnings);
+  {
+    open my $fh, ">", \$output or die "Cannot open scalar ref: $!";
+    local *STDOUT = $fh;
+    local $SIG{__WARN__} = sub { push @warnings, @_ };
+    no warnings "redefine";
+    local *Devel::Cover::DB::_term_width = sub () { 40 };
+    $db->print_summary(
+      undef,
+      [qw( statement branch condition subroutine )],
+      { force => 1 },
+    );
+    close $fh or die "Cannot close scalar ref: $!";
+  }
+
+  like $output, qr/^\S*nw\.pl\s/m, "file row keeps its name";
+  like $output, qr/^Total\s/m,     "total row keeps its name";
+  is grep(/Negative repeat count/, @warnings), 0,
+    "no negative repeat count warnings";
+}
+
+sub main () {
+  test_trimmed_file;
+  test_file_width;
+  test_narrow_summary;
+}
+
+main;
+done_testing;


### PR DESCRIPTION
## Summary

In a terminal narrower than the summary table's data columns the filename column width went negative, so every filename collapsed to `...` and the separator lines warned about a negative repeat count. Give the width a minimum and make `trimmed_file` safe for short lengths, so in a narrow terminal the table overflows and wraps rather than losing the filenames.

## Ticket

Closes #770