### PR TITLE
GH-772 Rework report annotations

### DIFF
--- a/bin/cover
+++ b/bin/cover
@@ -21,7 +21,7 @@ BEGIN {
 use Devel::Cover::Criterion ();
 use Devel::Cover::DB        ();
 use Devel::Cover::Inc       ();
-use Devel::Cover::Log       qw( dcerror dcinfo );
+use Devel::Cover::Log       qw( dcerror dcinfo dcwarn );
 
 BEGIN { $VERSION //= $Devel::Cover::Inc::VERSION }
 
@@ -210,6 +210,14 @@ sub check_options () {
 
   $Options->{annotations}
     = [map get_annotation($_), $Options->{annotation}->@*];
+
+  if ($Options->{annotations}->@*) {
+    for my $report ($Options->{report}->@*) {
+      my $format = "Devel::Cover::Report::\u$report";
+      dcwarn "the $report report ignores -annotation"
+        unless $format->can("uses_annotations") && $format->uses_annotations;
+    }
+  }
 
   say "$0 version $VERSION$Devel::Cover::Inc::Dev" and exit 0
     if $Options->{version};
@@ -727,9 +735,10 @@ C<-ignore_re>, C<-coverage>, and C<-annotation> options may be specified
 multiple times.
 
 The C<-annotation> option adds columns from an annotation module to the
-reports that support them.  The C<git> and C<random> annotation modules ship
-with Devel::Cover.  Any options an annotation module declares may follow it
-on the command line.  The git module accepts
+reports that support them - C<html>, C<html_basic> and C<text>.  Other
+reports warn that they ignore the annotations.  The C<git> and C<random>
+annotation modules ship with Devel::Cover.  Any options an annotation module
+declares may follow it on the command line.  The git module accepts
 C<-author>, C<-date> and C<-sha>, each of which may be negated to remove its
 column, along with C<-command> to replace the C<git blame> command.
 C<cover> itself consumes C<-version> and C<-noversion>, so use C<-sha> and

--- a/bin/cover
+++ b/bin/cover
@@ -696,6 +696,7 @@ The following command line options are supported:
  -outputdir dir        - directory for output               (default given db)
  -outputfile file      - file for output         (default report dependent)
  -launch               - launch report in viewer (if avail) (default off)
+ -annotation module    - add annotation columns to a report (default none)
 
  -select filename      - only report on the file            (default all)
  -select_dir dir       - include all Perl files in dir      (default none)
@@ -722,7 +723,17 @@ The following command line options are supported:
  coverage_database [coverage_database ...]
 
 The C<-report>, C<-select>, C<-select_dir>, C<-ignore>, C<-select_re>,
-C<-ignore_re>, and C<-coverage> options may be specified multiple times.
+C<-ignore_re>, C<-coverage>, and C<-annotation> options may be specified
+multiple times.
+
+The C<-annotation> option adds columns from an annotation module to the
+reports that support them.  The C<git> and C<random> annotation modules ship
+with Devel::Cover.  Any options an annotation module declares may follow it
+on the command line.  The git module accepts
+C<-author>, C<-date> and C<-sha>, each of which may be negated to remove its
+column, along with C<-command> to replace the C<git blame> command.
+C<cover> itself consumes C<-version> and C<-noversion>, so use C<-sha> and
+C<-nosha> for the sha column.
 
 The C<-outputfile> option applies to every report.  Reports which normally
 print to standard output write to the named file instead.

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -82,7 +82,7 @@ editors.
 It is possible to add annotations to reports, for example you can add a column
 to an HTML report showing who last changed a line, as determined by git blame.
 Some annotation modules are shipped with Devel::Cover and you can easily create
-your own.
+your own.  The C<html>, C<html_basic> and C<text> reports support annotations.
 
 The F<gcov2perl> program can be used to convert gcov files to C<Devel::Cover>
 databases.  This allows you to display your C or XS code coverage together with

--- a/lib/Devel/Cover/Annotation/Git.pm
+++ b/lib/Devel/Cover/Annotation/Git.pm
@@ -20,6 +20,7 @@ sub new ($class, @args) {
   my $annotate_arg = $ENV{DEVEL_COVER_GIT_ANNOTATE} || "";
   my $self         = {
     annotations => [qw( version author date )],
+    _columns    => [0 .. 2],
     command     => "git blame --porcelain $annotate_arg [[file]]",
     @args,
   };
@@ -82,30 +83,31 @@ sub get_options ($self, $opt) {
   $self->{$_} = 1 for $self->{annotations}->@*;
   die "Bad option" unless GetOptions(
     $self, qw(
-      author
+      author!
       command=s
-      date
-      version
+      date!
+      version|sha!
     ),
   );
+  $self->{_columns} = [grep $self->{ $self->{annotations}[$_] }, 0 .. 2];
 }
 
 sub count ($self) {
-  $self->{author} + $self->{date} + $self->{version}
+  scalar $self->{_columns}->@*
 }
 
 sub header ($self, $annotation) {
-  $self->{annotations}[$annotation]
+  $self->{annotations}[$self->{_columns}[$annotation]]
 }
 
 sub width ($self, $annotation) {
-  (8, 16, 24)[$annotation]
+  (8, 16, 24)[$self->{_columns}[$annotation]]
 }
 
 sub text ($self, $file, $line, $annotation) {
   return "" unless $line;
   $self->get_annotations($file);
-  $self->{_annotations}{$file}[$line - 1][$annotation]
+  $self->{_annotations}{$file}[$line - 1][$self->{_columns}[$annotation]]
 }
 
 sub error ($self, $file, $line, $annotation) { 0 }

--- a/lib/Devel/Cover/Annotation/Git.pm
+++ b/lib/Devel/Cover/Annotation/Git.pm
@@ -16,6 +16,8 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 use Getopt::Long qw( GetOptions );
 
+use Devel::Cover::Log qw( dcinfo );
+
 sub new ($class, @args) {
   my $annotate_arg = $ENV{DEVEL_COVER_GIT_ANNOTATE} || "";
   my $self         = {
@@ -41,7 +43,7 @@ sub get_annotations ($self, $file) {
   return if exists $self->{_annotations}{$file};
   my $annotations = $self->{_annotations}{$file} = [];
 
-  print "cover: Getting git annotation information for $file\n";
+  dcinfo "Getting git annotation information for $file";
 
   my $quoted  = _shell_quote($file);
   my $command = $self->{command};

--- a/lib/Devel/Cover/Annotation/Git.pm
+++ b/lib/Devel/Cover/Annotation/Git.pm
@@ -127,7 +127,7 @@ Devel::Cover::Annotation::Git - Annotate with git information
 
 =head1 SYNOPSIS
 
- cover -report text -annotation git  # Or any other report type
+ cover -report text -annotation git  # Or any report supporting annotations
 
 =head1 DESCRIPTION
 

--- a/lib/Devel/Cover/Annotation/Random.pm
+++ b/lib/Devel/Cover/Annotation/Random.pm
@@ -62,7 +62,8 @@ Devel::Cover::Annotation::Random - Example annotation for formatters
 
 =head1 SYNOPSIS
 
- cover -report text -annotation random -count 3  # Or any other report type
+ cover -report text -annotation random -count 3  # Or any report supporting
+                                                 # annotations
 
 =head1 DESCRIPTION
 

--- a/lib/Devel/Cover/Report/Html_basic.pm
+++ b/lib/Devel/Cover/Report/Html_basic.pm
@@ -396,6 +396,8 @@ sub get_options ($self, $opt) {
     );
 }
 
+sub uses_annotations ($pkg) { 1 }
+
 sub report ($pkg, $db, $options) {
   $Template = Template->new({
     LOAD_TEMPLATES =>

--- a/lib/Devel/Cover/Report/Html_crisp.pm
+++ b/lib/Devel/Cover/Report/Html_crisp.pm
@@ -539,7 +539,8 @@ sub _render_truth_tables ($line) {
 }
 
 sub render_line_detail ($line) {
-  my $o = qq(<tr class="line-detail"><td colspan="4">\n);
+  my $span = 4 + ($R{ann_cols} // [])->@*;
+  my $o    = qq(<tr class="line-detail"><td colspan="$span">\n);
 
   if ($line->{subroutines}) {
     for my $s ($line->{subroutines}->@*) {
@@ -707,6 +708,9 @@ sub render_source_line ($line) {
   my $n = $line->{number};
   $o .= qq(<td role="cell" class="ln"><a id="L$n" href="#L$n">$n</a></td>\n);
 
+  $o .= qq(<td role="cell" class="ann$_->{class}">$_->{text}</td>)
+    for ($line->{annotations} // [])->@*;
+
   $o .= count_cell($line, $cov_defined);
 
   my $chevron = $has_detail ? "&#x25b6;" : "";
@@ -838,6 +842,14 @@ HTML
 <div class="minimap"></div>
 <table class="source-table" role="table" aria-label="Coverage for $short">
 HTML
+
+  if (my @cols = ($R{ann_cols} // [])->@*) {
+    my $heads = join "",
+        map '<th class="ann-h">'
+      . escape_html($_->[0]->header($_->[1]))
+      . "</th>", @cols;
+    $o .= qq(<tr><th></th>$heads<th></th><th></th><th></th></tr>\n);
+  }
 
   $o .= render_source_line($_) for @$lines;
   $o .= "</table>\n";
@@ -1279,6 +1291,17 @@ sub read_source ($file) {
   @hl ? @hl : map escape_html($_), @all_lines
 }
 
+sub line_annotations ($file, $n) { [
+  map {
+    my ($ann, $i) = @$_;
+    my $cls = $ann->class($file, $n, $i);
+    {
+      text  => escape_html($ann->text($file, $n, $i) // ""),
+      class => $cls ? " " . escape_html($cls) : "",
+    }
+  } $R{ann_cols}->@*
+] }
+
 sub build_source_lines ($file) {
   my $f = $R{db}->cover->file($file);
 
@@ -1291,6 +1314,7 @@ sub build_source_lines ($file) {
     chomp $l;
 
     my %line = (number => $n, text => length $l ? $l : "&nbsp;");
+    $line{annotations} = line_annotations($file, $n) if $R{ann_cols}->@*;
 
     line_statement($f, $n, \%line);
 
@@ -1343,6 +1367,7 @@ sub build_untested_source_lines ($file) {
     $n++;
     chomp $l;
     my %line = (number => $n, text => length $l ? $l : "&nbsp;");
+    $line{annotations} = line_annotations($file, $n) if $R{ann_cols}->@*;
     push @lines, \%line;
     last if $l =~ /^__(END|DATA)__/;
   }
@@ -1355,6 +1380,8 @@ sub write_file ($path, $content) {
   print $fh $content;
   close $fh or die "Can't close $path: $!\n";
 }
+
+sub uses_annotations ($pkg) { 1 }
 
 sub get_options ($self, $opt) {
   $opt->{option}{outputfile} = "coverage.html";
@@ -1478,6 +1505,12 @@ sub report ($pkg, $db, $options) {
       ),
       total => "total",
     },
+    ann_cols => [
+      map {
+        my $ann = $_;
+        map [$ann, $_], 0 .. $ann->count - 1
+      } ($options->{annotations} // [])->@*
+    ],
     filenames      => unique_filenames($options->{file}->@*),
     have_ppi       => eval { require PPI; 1 } ? 1 : 0,
     favicon_colour => favicon("c3"),
@@ -2026,6 +2059,18 @@ tr.dir-file td:first-child a {
 
 .ln a { color: var(--fg-muted); }
 .ln a:hover { color: var(--link); }
+
+.ann, .ann-h {
+  width: 1px;
+  white-space: nowrap;
+  text-align: left;
+  color: var(--fg-muted);
+  font-size: var(--font-size-small);
+  padding: 0 8px !important;
+  border-right: 1px solid var(--border);
+}
+
+.ann-h { font-weight: 600; }
 
 .count {
   width: 1px;

--- a/lib/Devel/Cover/Report/Text.pm
+++ b/lib/Devel/Cover/Report/Text.pm
@@ -465,6 +465,8 @@ sub print_subroutines ($db, $file, $options, $short) {
   say "";
 }
 
+sub uses_annotations ($pkg) { 1 }
+
 sub report ($, $db, $options) {
   my @files = $options->{file}->@*;
   my ($prefix, $short) = common_prefix(@files);

--- a/t/internal/annotation_git.t
+++ b/t/internal/annotation_git.t
@@ -17,7 +17,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
 use File::Temp qw( tempdir );
-use Test::More import => [qw( done_testing is ok )];
+use Test::More import => [qw( done_testing is like ok )];
 
 use Devel::Cover::Annotation::Git;
 
@@ -119,9 +119,40 @@ sub test_repeated_commit () {
     "repeated commit keeps its own date";
 }
 
-test_version_column;
-test_path_with_spaces;
-test_path_with_metacharacters;
-test_repeated_commit;
+sub capture_annotation ($file) {
+  my $git = annotator_for(write_helper);
+  my ($stdout, $stderr) = ("", "");
+  {
+    local *STDOUT;
+    local *STDERR;
+    open STDOUT, ">", \$stdout or die "Can't redirect STDOUT: $!";
+    open STDERR, ">", \$stderr or die "Can't redirect STDERR: $!";
+    $git->get_annotations($file);
+  }
+  ($stdout, $stderr)
+}
 
+sub test_status_line_routing () {
+  my ($stdout, $stderr) = capture_annotation("lib/Foo.pm");
+  is $stdout, "", "the status line stays off STDOUT";
+  like $stderr, qr|^cover: Getting git annotation information for lib/Foo|m,
+    "the status line goes to STDERR";
+}
+
+sub test_status_line_honours_silent () {
+  local $Devel::Cover::Silent = 1;
+  my ($stdout, $stderr) = capture_annotation("lib/Bar.pm");
+  is $stdout . $stderr, "", "-silent suppresses the status line";
+}
+
+sub main () {
+  test_version_column;
+  test_path_with_spaces;
+  test_path_with_metacharacters;
+  test_repeated_commit;
+  test_status_line_routing;
+  test_status_line_honours_silent;
+}
+
+main;
 done_testing;

--- a/t/internal/annotation_git_options.t
+++ b/t/internal/annotation_git_options.t
@@ -1,0 +1,107 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is ok )];
+
+use Devel::Cover::Annotation::Git;
+
+my $Dir = tempdir(CLEANUP => 1);
+
+sub write_helper () {
+  # A plain heredoc, not <<~, because indented heredocs need 5.26
+  my $helper = "$Dir/blame.pl";
+  open my $fh, ">", $helper or die "Can't open $helper: $!";
+  print $fh <<'PERL';
+my $sha = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+print "$sha 1 1 1\n";
+print "author A U Thor\n";
+print "author-time 1234567890\n";
+print "\tmy code line\n";
+PERL
+  close $fh or die "Can't close $helper: $!";
+  $helper
+}
+
+sub annotator_with_options (@argv) {
+  my $git = Devel::Cover::Annotation::Git->new(
+    command => qq("$^X" "@{[ write_helper ]}" [[file]]));
+  local @ARGV = @argv;
+  $git->get_options({});
+  is "@ARGV", "", "options consumed: @argv";
+  $git
+}
+
+sub test_noauthor () {
+  my $git = annotator_with_options("-noauthor");
+  is $git->count,     2,         "-noauthor leaves two columns";
+  is $git->header(0), "version", "first column is version";
+  is $git->header(1), "date",    "second column is date";
+  is $git->width(1),  24,        "date column keeps its width";
+}
+
+sub test_nosha () {
+  my $git = annotator_with_options("-nosha");
+  is $git->count,     2,        "-nosha leaves two columns";
+  is $git->header(0), "author", "first column is author";
+  is $git->header(1), "date",   "second column is date";
+  is $git->width(0),  16,       "author column keeps its width";
+  is $git->width(1),  24,       "date column keeps its width";
+}
+
+sub test_only_version () {
+  my $git = annotator_with_options("-noauthor", "-nodate");
+  is $git->count,     1,         "one column left";
+  is $git->header(0), "version", "the column is version";
+  is $git->width(0),  8,         "version column keeps its width";
+  my $file = "lib/Foo.pm";
+  is $git->text($file, 1, 0), "deadbeef", "text returns the short sha";
+}
+
+sub test_all_off () {
+  my $git = annotator_with_options("-nosha", "-noauthor", "-nodate");
+  is $git->count, 0, "no columns left";
+}
+
+sub test_defaults () {
+  my $git = annotator_with_options();
+  is $git->count,     3,         "all three columns by default";
+  is $git->header(0), "version", "version first";
+  is $git->header(1), "author",  "author second";
+  is $git->header(2), "date",    "date third";
+  is $git->width(0),  8,         "version width";
+  is $git->width(1),  16,        "author width";
+  is $git->width(2),  24,        "date width";
+}
+
+sub test_new_without_get_options () {
+  my $git = Devel::Cover::Annotation::Git->new;
+  is $git->count, 3, "an object built without get_options has three columns";
+}
+
+sub main () {
+  test_noauthor;
+  test_nosha;
+  test_only_version;
+  test_all_off;
+  test_defaults;
+  test_new_without_get_options;
+}
+
+main;
+done_testing;

--- a/t/internal/cover_annotation_options.t
+++ b/t/internal/cover_annotation_options.t
@@ -64,6 +64,32 @@ sub test_report_annotation_combination () {
     "no option-parsing error emitted";
 }
 
+sub write_blame_helper () {
+  my $helper = File::Spec->catfile($Tmpdir, "blame.pl");
+  open my $fh, ">", $helper or die "open $helper: $!";
+  print $fh <<'PERL';
+print "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef 1 1 1\n";
+print "author A U Thor\n";
+print "author-time 1234567890\n";
+print "\tmy code line\n";
+PERL
+  close $fh or die "close $helper: $!";
+  $helper
+}
+
+sub test_git_annotation_noauthor () {
+  my $helper = write_blame_helper;
+  my ($rc, $out) = run_cover(
+    "-report",     "text",
+    "-annotation", "git",
+    "-noauthor",   "-command",
+    qq("$^X $helper [[file]]"),
+  );
+  is $rc, 0, "-noauthor is accepted";
+  like $out,   qr/version/, "version column still present";
+  unlike $out, qr/author/,  "no author column in the report";
+}
+
 sub test_unknown_option_rejected () {
   my ($rc, $out)
     = run_cover("-silent", "-report", "text", "-definitely_not_an_option");
@@ -82,6 +108,7 @@ sub main () {
     test_report_annotation_combination;
   }
   test_unknown_option_rejected;
+  test_git_annotation_noauthor;
   done_testing;
 }
 

--- a/t/internal/cover_annotation_options.t
+++ b/t/internal/cover_annotation_options.t
@@ -90,6 +90,27 @@ sub test_git_annotation_noauthor () {
   unlike $out, qr/author/,  "no author column in the report";
 }
 
+sub test_report_ignoring_annotation_warns () {
+  my ($rc, $out)
+    = run_cover("-report", "compilation", "-annotation", "random", "-count", 1);
+  is $rc, 0, "a report without annotation support still runs";
+  like $out, qr/Warning: the compilation report ignores -annotation/,
+    "the ignored annotation is warned about";
+}
+
+sub test_supporting_report_does_not_warn () {
+  my ($rc, $out)
+    = run_cover("-report", "text", "-annotation", "random", "-count", 1);
+  is $rc, 0, "text report runs with annotations";
+  unlike $out, qr/ignores -annotation/, "no warning for a supporting report";
+}
+
+sub test_no_annotation_does_not_warn () {
+  my ($rc, $out) = run_cover("-report", "compilation");
+  is $rc, 0, "compilation report runs";
+  unlike $out, qr/ignores -annotation/, "no warning without -annotation";
+}
+
 sub test_unknown_option_rejected () {
   my ($rc, $out)
     = run_cover("-silent", "-report", "text", "-definitely_not_an_option");
@@ -107,6 +128,9 @@ sub main () {
       unless eval { require JSON::MaybeXS; 1 };
     test_report_annotation_combination;
   }
+  test_report_ignoring_annotation_warns;
+  test_supporting_report_does_not_warn;
+  test_no_annotation_does_not_warn;
   test_unknown_option_rejected;
   test_git_annotation_noauthor;
   done_testing;

--- a/t/internal/html_crisp_annotation.t
+++ b/t/internal/html_crisp_annotation.t
@@ -1,0 +1,86 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Spec ();
+use Test::More import => [qw( done_testing is like ok unlike )];
+use Devel::Cover::Test::Showcase qw(
+  create_cover_db
+  run_cover
+  setup_lib_dir
+  slurp
+);
+
+my ($Tmpdir, $Libdir, $Cover_db);
+
+sub file_pages ($outdir) {
+  map slurp($_), grep !m|/coverage\.html$|, glob "$outdir/*.html"
+}
+
+sub test_annotation_columns () {
+  my $outdir = File::Spec->catdir($Tmpdir, "html_ann");
+  my ($out, $exit) = run_cover(
+    "--select_dir", $Libdir, "--report",     "html_crisp",
+    "--outputdir",  $outdir, "--annotation", "random",
+    "-count",       2,       "--silent",     $Cover_db,
+  );
+  is $exit, 0, "cover succeeds with -annotation random";
+
+  my @pages = file_pages($outdir);
+  ok @pages, "file pages generated";
+  for my $i (0 .. $#pages) {
+    my $page = $pages[$i];
+    like $page, qr|<th class="ann-h">rnd0</th><th class="ann-h">rnd1</th>|,
+      "page $i has the annotation header row";
+    like $page, qr|<td role="cell" class="ann[^"]*">\d</td>|,
+      "page $i has annotation cells";
+    like $page, qr|<tr class="line-detail"><td colspan="6">|,
+      "page $i detail rows span the annotation columns"
+      if $page =~ /line-detail/;
+  }
+  is grep(/line-detail/, @pages) > 0, 1, "some pages have detail rows";
+}
+
+sub test_no_annotation () {
+  my $outdir = File::Spec->catdir($Tmpdir, "html_plain");
+  my ($out, $exit) = run_cover(
+    "--select_dir", $Libdir, "--report", "html_crisp",
+    "--outputdir",  $outdir, "--silent", $Cover_db,
+  );
+  is $exit, 0, "cover succeeds without -annotation";
+
+  my @pages = file_pages($outdir);
+  ok @pages, "file pages generated";
+  for my $i (0 .. $#pages) {
+    my $page = $pages[$i];
+    unlike $page, qr|class="ann|, "page $i has no annotation markup";
+    like $page, qr|<tr class="line-detail"><td colspan="4">|,
+      "page $i detail rows keep their width"
+      if $page =~ /line-detail/;
+  }
+}
+
+sub main () {
+  ($Tmpdir, $Libdir) = setup_lib_dir;
+  $Cover_db = create_cover_db($Tmpdir, $Libdir);
+
+  test_annotation_columns;
+  test_no_annotation;
+}
+
+main;
+done_testing;


### PR DESCRIPTION
## Summary

- Make the git annotation per-column flags negatable, with `-sha` standing in for `-version`, which `cover` consumes itself.
- Send the git annotation status line to stderr through `dcinfo`, so it stays out of redirected reports and honours `-silent`.
- Render annotation columns in the default `html_crisp` report, which accepted `-annotation`, ran `git blame` and threw the results away.
- Warn when a chosen report ignores the requested annotations, and document `-annotation` and the supporting reports.

## Ticket

Closes #772