### PR TITLE
GH-774 Make version tooling report failures

### DIFF
--- a/t/internal/all_versions.t
+++ b/t/internal/all_versions.t
@@ -17,7 +17,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
   qw( ./lib ./blib/lib ./blib/arch );
 
 use File::Temp qw( tempdir );
-use Test::More import => [qw( done_testing is isnt like plan )];
+use Test::More import => [qw( done_testing is isnt like plan skip )];
 
 if ($^O eq "MSWin32") {
   plan skip_all => "utils/all_versions is not used on Windows";
@@ -60,10 +60,32 @@ sub test_build_with_nothing_to_do_exits_zero () {
   like $out, qr/already built/, "the no-op build is reported";
 }
 
+sub test_build_failure_exits_nonzero () {
+  my ($out, $exit) = run_all_versions(qw( -version 5.99.0 --build --dry_run ));
+  isnt $exit, 0, "a failed build exits non-zero";
+  like $out, qr/Failed builds:.*\b5\.99\.0\b/, "the failed version is named";
+  like $out, qr/5\.99\.0-thr/, "the failed thread variant is named";
+}
+
+sub test_build_success_exits_zero () {
+  my ($dir)
+    = grep { -d "$_/bin" && -d "$_-thr/bin" }
+    glob "$ENV{HOME}/.plenv/versions/dc-5.*";
+  my ($v) = ($dir // "") =~ m|/dc-(5\.\d+\.\d+)$|;
+  SKIP: {
+    skip "no dc-* plenv build with a thread variant", 1 unless $v;
+    my ($out, $exit)
+      = run_all_versions("-version", $v, qw( --build --force --dry_run ));
+    is $exit, 0, "a successful dry-run build exits 0";
+  }
+}
+
 sub main () {
   test_missing_version_fails;
   test_list_still_exits_zero;
   test_build_with_nothing_to_do_exits_zero;
+  test_build_failure_exits_nonzero;
+  test_build_success_exits_zero;
   done_testing;
 }
 

--- a/t/internal/all_versions.t
+++ b/t/internal/all_versions.t
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is isnt like plan )];
+
+if ($^O eq "MSWin32") {
+  plan skip_all => "utils/all_versions is not used on Windows";
+}
+unless (eval { require Parallel::Iterator }) {
+  plan skip_all => "Parallel::Iterator required for utils/all_versions";
+}
+
+chdir "$FindBin::Bin/../.." or die "Can't chdir to the project root: $!";
+
+sub run_all_versions (@args) {
+  my $cmd = join " ", $^X, "utils/all_versions", @args;
+  my $out = `$cmd 2>&1`;
+  ($out, $? >> 8)
+}
+
+sub test_missing_version_fails () {
+  my ($out, $exit)
+    = run_all_versions(qw( -version 5.99.0 --dry_run make test ));
+  isnt $exit, 0, "a run with no usable version exits non-zero";
+  like $out, qr/5\.99\.0/, "the missing version is named";
+}
+
+sub test_list_still_exits_zero () {
+  my ($out, $exit) = run_all_versions(qw( -version 5.99.0 --list ));
+  is $exit, 0, "--list exits 0 with no usable version";
+  like $out, qr/^Versions:/m, "--list prints the version list";
+}
+
+sub test_build_with_nothing_to_do_exits_zero () {
+  my $bin = tempdir(CLEANUP => 1);
+  open my $fh, ">", "$bin/dc-9.99.9" or die "Can't write $bin/dc-9.99.9: $!";
+  print $fh "#!/bin/sh\nexit 0\n";
+  close $fh or die "Can't close $bin/dc-9.99.9: $!";
+  chmod 0755, "$bin/dc-9.99.9" or die "Can't chmod $bin/dc-9.99.9: $!";
+  local $ENV{PATH} = "$bin:$ENV{PATH}";
+
+  my ($out, $exit) = run_all_versions(qw( -version 9.99.9 --build --dry_run ));
+  is $exit, 0, "--build with every version built exits 0";
+  like $out, qr/already built/, "the no-op build is reported";
+}
+
+sub main () {
+  test_missing_version_fails;
+  test_list_still_exits_zero;
+  test_build_with_nothing_to_do_exits_zero;
+  done_testing;
+}
+
+main

--- a/t/internal/create_gold_exit.t
+++ b/t/internal/create_gold_exit.t
@@ -1,0 +1,85 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Config     qw( %Config );
+use File::Temp qw( tempdir );
+use Test::More import => [qw( done_testing is isnt like plan )];
+
+if ($^O eq "MSWin32") {
+  plan skip_all => "utils/create_gold relies on fork and signals";
+}
+
+chdir "$FindBin::Bin/../.." or die "Can't chdir to the project root: $!";
+
+my $Fixtures = tempdir(DIR => "t", CLEANUP => 1);
+
+sub write_fixture ($name, $body) {
+  my $path = "$Fixtures/$name";
+  open my $fh, ">", $path or die "Can't write $path: $!";
+  print $fh $body;
+  close $fh or die "Can't close $path: $!";
+  $path
+}
+
+sub run_create_gold (@args) {
+  my $cmd = join " ", $^X, "utils/create_gold", @args;
+  my $out = `$cmd 2>&1`;
+  ($out, $? >> 8)
+}
+
+sub test_threaded_run_writes_nothing () {
+  my ($out, $exit) = run_create_gold("unused");
+  is $exit, 0, "a threaded run exits 0";
+  like $out, qr/no golden results/, "the threaded run says nothing was written";
+}
+
+sub test_dying_child_exits_nonzero () {
+  my $path = write_fixture("dies.pl", qq(die "broken fixture";\n));
+  my ($out, $exit) = run_create_gold($path);
+  isnt $exit, 0, "a dying child makes create_gold exit non-zero";
+  like $out, qr/\Q$path\E failed: exited 255/, "the failing test is named";
+}
+
+sub test_signalled_child_is_reported () {
+  my $path = write_fixture("signalled.pl", qq(kill "KILL", \$\$;\nsleep 5;\n));
+  my ($out, $exit) = run_create_gold($path);
+  isnt $exit, 0, "a signalled child makes create_gold exit non-zero";
+  like $out, qr/killed by signal 9/, "the signal is reported";
+}
+
+sub test_successful_run_exits_zero () {
+  my $path = write_fixture("works.pl",
+        qq(package FakeGoldTest;\n)
+      . qq(sub create_gold { 1 }\n)
+      . qq(bless {}, "FakeGoldTest"\n));
+  my ($out, $exit) = run_create_gold($path);
+  is $exit, 0, "a successful run exits 0";
+}
+
+sub main () {
+  if ($Config{useithreads}) {
+    test_threaded_run_writes_nothing;
+  } else {
+    test_dying_child_exits_nonzero;
+    test_signalled_child_is_reported;
+    test_successful_run_exits_zero;
+  }
+  done_testing;
+}
+
+main

--- a/utils/all_versions
+++ b/utils/all_versions
@@ -301,24 +301,24 @@ sub _build_version ($v) {
     my $j  = njobs;
     sys "plenv install $n --as dc-$v -j $j $opts --noman" or do {
       warn "plenv $v failed";
-      return;
+      return 0;
     };
     unless (-d $dir) {
       warn "perl for $v does not exist";
-      return;
+      return 0;
     }
   }
 
   $ENV{PATH} = "$dir:$ENV{PATH}";
   sys "curl -L https://cpanmin.us | perl - App::cpanminus" or do {
     warn "cpanm installation for $v failed";
-    return;
+    return 0;
   };
 
   my @mods = _mods($v, $n);
   sys "cpanm --notest @mods" or do {
     warn "module installation for $v failed";
-    return;
+    return 0;
   };
 
   my $ln = "/usr/local/bin/dc-$v";
@@ -326,12 +326,15 @@ sub _build_version ($v) {
 
   my $perl = "$dir/perl";
   say "$perl => $ln";
-  sys "sudo ln -s $perl $ln" or warn "Can't ln $perl => $ln: $!";
+  sys "sudo ln -s $perl $ln" or do {
+    warn "Can't ln $perl => $ln: $!";
+    return 0;
+  };
+  1
 }
 
 sub _build_versions ($v) {
-  _build_version $v;
-  _build_version "$v-thr";
+  [[$v, _build_version($v)], ["$v-thr", _build_version("$v-thr")]]
 }
 
 sub build_default {
@@ -349,6 +352,12 @@ sub build {
     },
     [grep !/-thr/, $Options->{version}->@*],
   );
+  my @failed = map $_->[0], grep !$_->[1], map @$_, @res;
+  if (@failed) {
+    say colour("Failed builds: @failed", "red");
+    exit(@failed > 255 ? 255 : scalar @failed);
+  }
+  say colour("All builds succeeded.", "green");
   exit;
 }
 

--- a/utils/all_versions
+++ b/utils/all_versions
@@ -171,6 +171,7 @@ sub get_options {
     #>>>
   );
 
+  my $named = !$Options->{key} && $Options->{version}->@*;
   $Options->{version} = [
     map { ($_, "$_-thr") }
       #<<<
@@ -197,17 +198,34 @@ sub get_options {
       5.20.0 5.28.3 5.38.5 5.40.5 5.42.3 5.42.3-thr 5.44.0 5.44.0-thr 5.45.1
     )];
   }
+  my @wanted = $Options->{version}->@*;
   $Options->{version} = [
     grep {
       my $cmd    = "dc-$_ -v$Silent";
       my $exists = eval { !system $cmd };
       $Options->{force} || ($exists ^ $Options->{build})
-    } $Options->{version}->@*
+    } @wanted
   ];
+  my %kept = map { $_ => 1 } $Options->{version}->@*;
+  if (my @skipped = grep !$kept{$_}, @wanted) {
+    my $reason = $Options->{build} ? "already built" : "no dc-* wrapper";
+    if ($named) {
+      say "Skipping ($reason): @skipped";
+    } else {
+      printf "Skipping %d of %d versions (%s)\n", scalar @skipped,
+        scalar @wanted, $reason;
+    }
+  }
   say "Versions: @{$Options->{version}}";
-  if ($Options->{list}) {
+  exit   if $Options->{list};
+  return if $Options->{version}->@*;
+  if ($Options->{build}) {
+    say "Nothing to build: every requested version is already built.";
     exit;
   }
+  die "No Perl versions available.  Wanted: @wanted\n"
+    . "Run `plenv versions` to see what is installed, "
+    . "or `make all_build_perl`.\n";
 }
 
 sub sys ($command, $user = 0, $logfile = undef) {
@@ -418,7 +436,7 @@ sub main {
     }
     return 1;
   } else {
-    say colour("Passed: $total/$total", "green");
+    say colour("Passed: $total", "green");
     say colour("All versions passed.", "green", "bold");
   }
   0

--- a/utils/create_gold
+++ b/utils/create_gold
@@ -50,6 +50,14 @@ sub run_test_in_child ($test, $test_output) {
   my $pid = fork // die "Can't fork";
   if ($pid) {
     waitpid $pid, 0;
+    my $status = $?;
+    return 1 unless $status;
+    my $reason
+      = $status & 127
+      ? "killed by signal " . ($status & 127)
+      : "exited " . ($status >> 8);
+    warn "$test failed: $reason\n";
+    0
   } else {
     no warnings "redefine";
     local *Devel::Cover::Test::run_test = sub { };
@@ -64,8 +72,8 @@ sub main {
   my @tests       = grep $_ ne "--test-output", @ARGV;
 
   if (!$test_output && $Config{useithreads}) {
-    say "useithreads true, exiting";
-    return;
+    say "useithreads true, no golden results written";
+    return 0;
   }
 
   unless ($test_output) {
@@ -74,7 +82,12 @@ sub main {
   }
 
   @tests = get_tests_from_dir unless @tests;
-  run_test_in_child($_, $test_output) for @tests;
+  my @failed = grep !run_test_in_child($_, $test_output), @tests;
+  if (@failed) {
+    warn "Failed: @failed\n";
+    return @failed > 255 ? 255 : scalar @failed;
+  }
+  0
 }
 
-main
+exit main

--- a/utils/dc
+++ b/utils/dc
@@ -374,6 +374,17 @@ recipe_install-dc-dev-perl() {
 }
 
 recipe_all-gold() {
+  local installed wanted v missing=()
+  installed=$(./utils/all_versions --list | sed -n 's/^Versions: //p')
+  wanted=$(./utils/all_versions --list --force | sed -n 's/^Versions: //p')
+  for v in $wanted; do
+    [[ " $installed " == *" $v "* ]] || missing+=("$v")
+  done
+  if ((${#missing[@]})) && ! ((force)); then
+    pe "Golden results for these versions cannot be regenerated here:"
+    pe "${missing[*]}"
+    pf "Install them, or rerun with --force to delete their files anyway"
+  fi
   if [[ -n $* ]]; then
     for fn in "$@"; do
       rm -f "test_output/cover/${fn}."*
@@ -382,6 +393,7 @@ recipe_all-gold() {
     rm -f test_output/cover/*
   fi
   ./utils/all_versions make gold "TEST=$*"
+  git status --porcelain test_output/cover 2>/dev/null || true
 }
 
 recipe_all-versions() {

--- a/xt/dc.t
+++ b/xt/dc.t
@@ -497,6 +497,58 @@ sub seed_recipe () {
   ok $rc != 0, "seeding over an existing destination fails";
 }
 
+my $Dc_abs = realpath $Dc;
+
+sub make_gold_tree ($installed, $full) {
+  my $dir = tempdir(CLEANUP => 1);
+  mkdir "$dir/$_"
+    or die "Can't mkdir $dir/$_: $!"
+    for "utils", "test_output", "test_output/cover";
+  write_file("$dir/test_output/cover/foo.5.020000", "gold\n");
+  write_file("$dir/utils/all_versions",             <<~SH);
+    #!/bin/sh
+    case "\$*" in
+    "--list --force") echo "Versions: $full" ;;
+    "--list") echo "Versions: $installed" ;;
+    *) echo "\$@" >>args.log ;;
+    esac
+    SH
+  chmod 0755, "$dir/utils/all_versions"
+    or die "Can't chmod $dir/utils/all_versions: $!";
+  $dir
+}
+
+sub dc_in ($dir, @args) {
+  my $cmd = join " ", $Dc_abs, @args;
+  my $out = `cd $dir && $cmd 2>&1`;
+  ($out, $? >> 8)
+}
+
+sub all_gold_partial_machine () {
+  my $dir = make_gold_tree("5.20.0", "5.20.0 5.44.0");
+  my ($out, $exit) = dc_in($dir, "all-gold", "foo");
+  isnt $exit, 0, "a partial machine refuses to run";
+  ok -e "$dir/test_output/cover/foo.5.020000", "the golden file survives";
+  like $out, qr/5\.44\.0/, "the missing version is named";
+}
+
+sub all_gold_full_machine () {
+  my $dir = make_gold_tree("5.20.0 5.44.0", "5.20.0 5.44.0");
+  my ($out, $exit) = dc_in($dir, "all-gold", "foo");
+  is $exit, 0, "a full machine proceeds" or diag $out;
+  ok !-e "$dir/test_output/cover/foo.5.020000", "the golden file is removed";
+  like slurp("$dir/args.log"), qr/^make gold TEST=foo$/m,
+    "gold regeneration runs";
+}
+
+sub all_gold_forced () {
+  my $dir = make_gold_tree("5.20.0", "5.20.0 5.44.0");
+  my ($out, $exit) = dc_in($dir, "-f", "all-gold", "foo");
+  is $exit, 0, "--force overrides the guard" or diag $out;
+  like slurp("$dir/args.log"), qr/^make gold TEST=foo$/m,
+    "gold regeneration runs under force";
+}
+
 sub main () {
   my @tests = qw(
     compress_recipe
@@ -513,6 +565,9 @@ sub main () {
     seed_recipe
     check_caddy_recipe
     check_caddy_root_fallback
+    all_gold_partial_machine
+    all_gold_full_machine
+    all_gold_forced
   );
   for my $test (@tests) {
     no strict qw( refs );


### PR DESCRIPTION
## Summary

- Make `utils/all_versions` refuse to run when no requested version is usable, report the versions it skips, and treat an empty `-build` list as a no-op.
- Exit non-zero from `all_versions -build` when builds fail, naming them.
- Report failed `create_gold` children with their exit code or signal and exit with the failure count.
- Refuse to delete golden files in `dc all-gold` on a machine that cannot regenerate every version, unless forced.

## Ticket

Closes #774