### PR TITLE
GH-776 Report failures in build and test tooling

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -457,8 +457,8 @@ wrun : pure_all
 \t   -MDevel::Cover=-ignore,blib,-merge,0 tests/\$(TEST)
 
 prove : pure_all
-\t \$(PERL) -Iutils -MDevel::Cover::BuildUtils=prove_command \\
-\t   -le '\$\$c = prove_command and print \$\$c and system \$\$c'
+\t \$(PERL) -Iutils -MDevel::Cover::BuildUtils=run_prove \\
+\t   -e 'exit(run_prove ? 0 : 1)'
 
 NICE_CPUS = \$(PERL) -Iutils -MDevel::Cover::BuildUtils=nice_cpus \\
 \t -e 'print nice_cpus'

--- a/bin/cover
+++ b/bin/cover
@@ -460,7 +460,7 @@ sub do_gcov ($dbname) {
     my @c = ($^X, @opts, $gcov2perl, "-db", $dbname, @gc);
     push @c, "-silent" if $Options->{silent};
     dcinfo "running @c";
-    system @c;
+    system(@c) == 0 or dcerror "gcov2perl exited non-zero (exit $?)";
   }
 }
 

--- a/bin/gcov2perl
+++ b/bin/gcov2perl
@@ -95,14 +95,14 @@ sub add_cover ($file) {
       if ($Options->{skip_core} && is_core_path($f)) {
         dcinfo "skipping Perl CORE source $f from $file";
         close $fh or die "Can't close $file: $!\n";
-        return;
+        return 1;
       }
     }
     unless (defined $run{digests}{$f}) {
       unless (-f $f) {
         dcerror "no source $f found for $file";
         close $fh or die "Can't close $file: $!\n";
-        return;
+        return 0;
       }
       $run{digests}{$f} = $structure->set_file($f);
     }
@@ -164,14 +164,17 @@ sub add_cover ($file) {
 
   dcinfo "Writing coverage database to $db";
   $cover->write;
+
+  1
 }
 
 sub main () {
   get_options;
-  add_cover $_ for @ARGV;
+  my $failed = grep !add_cover($_), @ARGV;
+  $failed > 255 ? 255 : $failed
 }
 
-main
+exit main;
 
 __END__
 

--- a/t/internal/build_utils.t
+++ b/t/internal/build_utils.t
@@ -1,0 +1,85 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Test::More import => [qw( done_testing is like ok plan )];
+
+use Cwd        qw( abs_path );
+use File::Path qw( mkpath );
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use lib "utils";
+use Devel::Cover::BuildUtils qw( find_prove prove_command run_prove );
+
+sub write_exe ($path, $contents) {
+  open my $fh, ">", $path or die "Cannot create $path: $!";
+  print $fh $contents;
+  close $fh or die "Cannot close $path: $!";
+  chmod 0755, $path or die "Cannot chmod $path: $!";
+}
+
+sub perl_beside ($dir, @siblings) {
+  mkpath $dir;
+  write_exe(File::Spec->catfile($dir, "perl"),  "#!/bin/sh\nexit 0\n");
+  write_exe(File::Spec->catfile($dir, $_->[0]), "#!/bin/sh\nexit $_->[1]\n")
+    for @siblings;
+  File::Spec->catfile($dir, "perl")
+}
+
+sub test_find_prove_relative_symlink () {
+  my $tmpdir = tempdir(CLEANUP => 1);
+  my $real   = File::Spec->catdir($tmpdir, "real", "bin");
+  my $link   = File::Spec->catdir($tmpdir, "link", "bin");
+  perl_beside($real, ["prove", 0]);
+  mkpath $link;
+  symlink "../../real/bin/perl", File::Spec->catfile($link, "perl")
+    or die "Cannot symlink: $!";
+
+  local $^X = File::Spec->catfile($link, "perl");
+  is find_prove, File::Spec->catfile(abs_path($real), "prove"),
+    "find_prove resolves a relative symlink to the real prove";
+}
+
+sub test_run_prove_dies_without_prove () {
+  my $tmpdir = tempdir(CLEANUP => 1);
+  local $^X = perl_beside(File::Spec->catdir($tmpdir, "bin"));
+  my $ok = eval { run_prove; 1 };
+  ok !$ok, "run_prove dies when no prove is found";
+  like $@, qr/No prove found/, "the error names the problem";
+}
+
+sub test_run_prove_failing_prove () {
+  my $tmpdir = tempdir(CLEANUP => 1);
+  local $^X = perl_beside(File::Spec->catdir($tmpdir, "bin"), ["prove", 1]);
+  ok !run_prove, "run_prove returns false when prove fails";
+}
+
+sub test_prove_command_contract () {
+  my $cmd = eval { prove_command };
+  is $@, "", "prove_command does not die on the real perl";
+  ok !defined $cmd || $cmd =~ /-brj\d+ t$/,
+    "prove_command returns undef or a -brj command";
+}
+
+sub main () {
+  plan skip_all => "no shell stubs on Windows" if $^O eq "MSWin32";
+
+  test_find_prove_relative_symlink;
+  test_run_prove_dies_without_prove;
+  test_run_prove_failing_prove;
+  test_prove_command_contract;
+  done_testing;
+}
+
+main;

--- a/t/internal/compare_output.t
+++ b/t/internal/compare_output.t
@@ -1,0 +1,92 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Test::More import => [qw( done_testing is isnt note )];
+
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+my $Driver_code = <<'PERL';
+use strict;
+use warnings;
+
+use Devel::Cover::Test ();
+
+my ($mode, $truncated) = @ARGV;
+if ($mode eq "differences") {
+  eval q{ package Devel::Cover::Test; use Test::Differences; 1 } or die $@;
+}
+
+my @golden = ("Total 100.0\n", "MISSING LINE A\n", "MISSING LINE B\n");
+my $live   = $truncated ? $golden[0] : join "", @golden;
+
+my $self = bless {
+  cover       => [@golden],
+  differences => $mode eq "differences" ? 1 : 0,
+  debug       => 0,
+  no_coverage => 0,
+  changes     => [],
+}, "Devel::Cover::Test";
+
+Test::More::plan(tests => $self->{differences} ? 1 : scalar @golden);
+open my $fh, "<", \$live or die "Cannot open in-memory handle: $!";
+$self->_compare_cover_output($fh);
+PERL
+
+my $Driver;
+
+sub write_driver () {
+  my $tmpdir = tempdir(CLEANUP => 1);
+  my $driver = File::Spec->catfile($tmpdir, "driver.pl");
+  open my $fh, ">", $driver or die "Cannot create $driver: $!";
+  print $fh $Driver_code;
+  close $fh or die "Cannot close $driver: $!";
+  $driver
+}
+
+sub run_driver ($mode, $truncated) {
+  my $cmd = join " ", $^X, "-Ilib", "-It/lib", $Driver, $mode, $truncated,
+    "2>&1";
+  my $output = `$cmd`;
+  ($? >> 8, $output)
+}
+
+sub test_truncated_differences () {
+  my ($exit, $output) = run_driver("differences", 1);
+  isnt $exit, 0, "truncated cover output fails in differences mode";
+}
+
+sub test_complete_differences () {
+  my ($exit, $output) = run_driver("differences", 0);
+  is $exit, 0, "matching cover output passes in differences mode";
+}
+
+sub test_truncated_plain () {
+  my ($exit, $output) = run_driver("plain", 1);
+  isnt $exit, 0, "truncated cover output fails in plain mode";
+}
+
+sub main () {
+  $Driver = write_driver;
+  if (eval "use Test::Differences; 1") {
+    test_truncated_differences;
+    test_complete_differences;
+  } else {
+    note "Test::Differences not installed - differences mode not tested";
+  }
+  test_truncated_plain;
+  done_testing;
+}
+
+main;

--- a/t/internal/gcov2perl.t
+++ b/t/internal/gcov2perl.t
@@ -5,7 +5,7 @@ use warnings;
 use feature qw( postderef signatures );
 no warnings qw( experimental::postderef experimental::signatures );
 
-use Test::More import => [qw( diag done_testing is like ok unlike )];
+use Test::More import => [qw( diag done_testing is isnt like ok unlike )];
 
 use Config         qw( %Config );
 use Cwd            qw( getcwd );
@@ -199,6 +199,42 @@ sub test_source_relative_to_gcov_dir () {
     "gcov2perl writes database for gcov-dir-relative source";
 }
 
+sub missing_source_gcov ($tmpdir) {
+  my $gcov_path = File::Spec->catfile($tmpdir, "missing.c.gcov");
+  my $missing   = File::Spec->catfile($tmpdir, "no_such_file.c");
+  write_file(
+    $gcov_path, "        -:    0:Source:$missing\n" . "        1:    1:int x;\n"
+  );
+  $gcov_path
+}
+
+sub test_missing_source () {
+  my $tmpdir    = tempdir(CLEANUP => 1);
+  my $gcov_path = missing_source_gcov($tmpdir);
+  my $db_dir    = File::Spec->catdir($tmpdir, "cover_db");
+  my ($exit_code, $output) = run_gcov2perl($db_dir, $gcov_path);
+
+  isnt $exit_code, 0, "gcov2perl exits non-zero for a missing source";
+  like $output, qr/no source/, "gcov2perl reports the missing source";
+  ok !-d $db_dir, "no database directory for a missing source";
+}
+
+sub test_mixed_sources () {
+  my $tmpdir = setup("simple");
+  my $good   = File::Spec->catfile($tmpdir, "simple.c.gcov");
+  my $bad    = missing_source_gcov($tmpdir);
+  my $db_dir = File::Spec->catdir($tmpdir, "cover_db");
+  my $cmd    = join " ", $^X, "-Iblib/lib", $Bin, "-db", $db_dir, $bad, $good,
+    "2>&1";
+  my $output    = `$cmd`;
+  my $exit_code = $? >> 8;
+
+  isnt $exit_code, 0, "gcov2perl exits non-zero when one file fails";
+  like $output, qr/no source/, "gcov2perl reports the missing source";
+  ok -d File::Spec->catdir($db_dir, "runs"),
+    "the good file still writes its run";
+}
+
 sub main () {
   my $tmpdir = setup("simple");
   test_gcov2perl($tmpdir);
@@ -206,6 +242,8 @@ sub main () {
   test_branch_collected(setup("branch"));
   test_source_relative_to_root;
   test_source_relative_to_gcov_dir;
+  test_missing_source;
+  test_mixed_sources;
   done_testing;
 }
 

--- a/t/internal/launch.t
+++ b/t/internal/launch.t
@@ -15,30 +15,24 @@ no warnings qw( experimental::postderef experimental::signatures );
 use List::Util qw( any );
 use Test::More import => [qw( diag done_testing note ok plan )];
 
-opendir my $d, "lib/Devel/Cover/Report";
-my @Reporters = map { s/\.pm$//r } grep /\.pm$/, readdir $d;
-closedir $d;
-
-{
-  local $SIG{__WARN__} = sub { };
-  eval "use HTML::Entities; 1";
-  if ($@) {
-    plan skip_all => "No HTML::Entities";
-    exit;
-  }
-}
-
 my @Reporters_with_launch = qw(
   Html Html_basic Html_crisp Html_minimal Html_subtle
 );
 
-for my $launcher (@Reporters_with_launch) {
-  ok grep($_ eq $launcher, @Reporters), "$launcher is a reporter";
+sub read_reporters () {
+  opendir my $d, "lib/Devel/Cover/Report";
+  my @reporters = map s/\.pm$//r, grep /\.pm$/, readdir $d;
+  closedir $d;
+  @reporters
 }
 
-# Check that the expected reporters support the launch feature
-for my $reporter (@Reporters) {
-  my $class  = "Devel::Cover::Report::" . $reporter;
+sub test_launch_list ($reporters) {
+  for my $launcher (@Reporters_with_launch) {
+    ok grep($_ eq $launcher, @$reporters), "$launcher is a reporter";
+  }
+}
+
+sub load_reporter ($class) {
   my $loaded = eval "require $class; 1";
   my $err    = $@;
 
@@ -49,16 +43,23 @@ for my $reporter (@Reporters) {
     $err    = $@;
   }
 
+  ($loaded, $err)
+}
+
+sub test_reporter_launch ($reporter) {
+  my $class = "Devel::Cover::Report::" . $reporter;
+  my ($loaded, $err) = load_reporter($class);
+
   if (!$loaded && $err =~ m|^Can't locate (\S+\.pm) in \@INC|) {
     my $missing = $1;
     if ($missing !~ m|^Devel/Cover/|) {
       note "skipping $reporter: missing optional prerequisite $missing";
-      next;
+      return;
     }
   }
 
   ok $loaded, "$reporter loads" or diag $err;
-  next unless $loaded;
+  return unless $loaded;
 
   if (any { $_ eq $reporter } @Reporters_with_launch) {
     ok $class->can("launch"), "$reporter supports launch";
@@ -67,4 +68,20 @@ for my $reporter (@Reporters) {
   }
 }
 
-done_testing;
+sub main () {
+  {
+    local $SIG{__WARN__} = sub { };
+    eval "use HTML::Entities; 1";
+    if ($@) {
+      plan skip_all => "No HTML::Entities";
+      exit;
+    }
+  }
+
+  my @reporters = read_reporters;
+  test_launch_list(\@reporters);
+  test_reporter_launch($_) for @reporters;
+  done_testing;
+}
+
+main;

--- a/t/internal/launch.t
+++ b/t/internal/launch.t
@@ -13,7 +13,7 @@ use feature qw( postderef signatures );
 no warnings qw( experimental::postderef experimental::signatures );
 
 use List::Util qw( any );
-use Test::More import => [qw( ok plan )];
+use Test::More import => [qw( diag done_testing note ok plan )];
 
 opendir my $d, "lib/Devel/Cover/Report";
 my @Reporters = map { s/\.pm$//r } grep /\.pm$/, readdir $d;
@@ -28,20 +28,43 @@ closedir $d;
   }
 }
 
-plan tests => scalar @Reporters;
-
 my @Reporters_with_launch = qw(
   Html Html_basic Html_crisp Html_minimal Html_subtle
 );
 
+for my $launcher (@Reporters_with_launch) {
+  ok grep($_ eq $launcher, @Reporters), "$launcher is a reporter";
+}
+
 # Check that the expected reporters support the launch feature
 for my $reporter (@Reporters) {
-  my $class = "Devel::Cover::Report::" . $reporter;
-  eval "require $class";
+  my $class  = "Devel::Cover::Report::" . $reporter;
+  my $loaded = eval "require $class; 1";
+  my $err    = $@;
+
+  # An earlier failed load leaves a stale %INC entry for a shared module
+  while (!$loaded && $err =~ m|^Attempt to reload (\S+\.pm) aborted|) {
+    delete $INC{$1};
+    $loaded = eval "require $class; 1";
+    $err    = $@;
+  }
+
+  if (!$loaded && $err =~ m|^Can't locate (\S+\.pm) in \@INC|) {
+    my $missing = $1;
+    if ($missing !~ m|^Devel/Cover/|) {
+      note "skipping $reporter: missing optional prerequisite $missing";
+      next;
+    }
+  }
+
+  ok $loaded, "$reporter loads" or diag $err;
+  next unless $loaded;
 
   if (any { $_ eq $reporter } @Reporters_with_launch) {
-    ok($class->can("launch"), "$reporter supports launch");
+    ok $class->can("launch"), "$reporter supports launch";
   } else {
-    ok(!$class->can("launch"), "$reporter does not support launch");
+    ok !$class->can("launch"), "$reporter does not support launch";
   }
 }
+
+done_testing;

--- a/t/lib/Devel/Cover/Test.pm
+++ b/t/lib/Devel/Cover/Test.pm
@@ -233,6 +233,11 @@ sub _compare_cover_output ($self, $cover_fh) {
     }
   }
   if ($self->{differences}) {
+    # compare any golden lines left after the live output ran out
+    while ($self->{cover}->@*) {
+      push @at, "";
+      push @ac, $self->_normalise_line(sub { shift $self->{cover}->@* });
+    }
     ## no critic (Variables::ProtectPrivateVars)
     no warnings "redefine";
     local *Test::_quote = sub { "@_" };
@@ -241,6 +246,11 @@ sub _compare_cover_output ($self, $cover_fh) {
       : eq_or_diff(\@at, \@ac, "output", { context => 0 });
   } elsif ($self->{no_coverage}) {
     pass("no coverage") for $self->{cover}->@*;
+  } else {
+    while ($self->{cover}->@*) {
+      my $c = $self->_normalise_line(sub { shift $self->{cover}->@* });
+      is "", $c, "coverage output";
+    }
   }
 }
 

--- a/utils/Devel/Cover/BuildUtils.pm
+++ b/utils/Devel/Cover/BuildUtils.pm
@@ -14,9 +14,10 @@ no warnings qw( experimental::postderef experimental::signatures );
 
 # VERSION
 
+use Cwd      qw( abs_path );
 use Exporter qw( import );
 
-our @EXPORT_OK = qw( find_prove cpus nice_cpus njobs prove_command );
+our @EXPORT_OK = qw( find_prove cpus nice_cpus njobs prove_command run_prove );
 
 sub find_prove () {
   my $perl = $^X;
@@ -25,11 +26,12 @@ sub find_prove () {
     $perl = "$dir/$perl";
   }
 
-  eval { $perl = readlink($perl) || $perl };
-  my ($dir)   = $perl =~ m|(.*)/[^/]+|;
+  eval { $perl = abs_path($perl) || $perl };
+  my ($dir) = $perl =~ m|(.*)/[^/]+|;
+  return unless defined $dir;
   my ($prove) = grep -x, <$dir/prove*>;
 
-  say "prove is in $dir";
+  say "prove is in $dir" if $prove;
 
   $prove
 }
@@ -58,6 +60,12 @@ sub prove_command () {
   "$prove -brj$cpus t"
 }
 
+sub run_prove () {
+  my $c = prove_command or die "No prove found alongside $^X\n";
+  say $c;
+  system($c) == 0
+}
+
 __END__
 
 =encoding utf8
@@ -69,7 +77,7 @@ Devel::Cover::BuildUtils - Build utility functions for Devel::Cover
 =head1 SYNOPSIS
 
  use Devel::Cover::BuildUtils qw(
-   find_prove cpus nice_cpus njobs prove_command
+   find_prove cpus nice_cpus njobs prove_command run_prove
  );
 
  my $prove = find_prove;     # path to prove executable
@@ -77,6 +85,7 @@ Devel::Cover::BuildUtils - Build utility functions for Devel::Cover
  my $j     = nice_cpus;      # adjusted for comfort
  my $jobs  = njobs;          # alias for nice_cpus
  my $cmd   = prove_command;  # e.g. "/usr/bin/prove -brj3 t"
+ my $pass  = run_prove;      # run the test suite
 
 =head1 DESCRIPTION
 
@@ -133,6 +142,13 @@ parallel. Equivalent to:
  "<prove> -brj<nice_cpus> t"
 
 Returns C<undef> if L</find_prove> fails.
+
+=head2 run_prove
+
+ my $pass = run_prove;
+
+Print and run L</prove_command>.  Calls C<die> when no C<prove> can be found
+and returns true when the test run passes.
 
 =head1 ENVIRONMENT
 


### PR DESCRIPTION
## Summary

- Make `t/internal/launch.t` assert that each reporter loads, skipping ones whose only problem is a missing optional module. A compile error in a reporter passed its "does not support launch" assertion, since `->can` on a class that never loaded is false.
- Exit non-zero from `gcov2perl` when a source cannot be found, as its POD always promised, and report a failed `gcov2perl` from `cover -gcov` rather than staying silent.
- Compare every golden line in the e2e tests. The comparison was driven by the live cover output alone. A run writing only a prefix of the expected output passed whenever `Test::Differences` was installed, which CI does.
- Propagate the test status through `make prove`, and resolve `$^X` with `Cwd::abs_path` in `find_prove`. On a perl reached through a relative symlink, as Homebrew installs it, `find_prove` found no `prove`, so the target ran nothing and exited 0.

## Ticket

Closes #776