### PR TITLE
GH-781 Fix html_crisp pod check without PPI

### DIFF
--- a/t/internal/html_crisp.t
+++ b/t/internal/html_crisp.t
@@ -42,12 +42,16 @@ sub test_dir_header_rows ($content) {
 
   my ($covered) = grep m{data-dir="Covered"}, @rows;
   ok $covered, "Covered dir-header row present";
-  if (eval { require Pod::Coverage; 1 }) {
-    unlike $covered, qr/class="na"/,
-      "Covered dir row has aggregates for all criteria";
-  } else {
-    my @na = $covered =~ /class="na"/g;
+  # The pod column is n/a only when PPI estimated it and Pod::Coverage did not
+  my $have_pod = eval { require Pod::Coverage; 1 };
+  my $have_ppi = eval { require PPI;           1 };
+  my @na       = $covered =~ /class="na"/g;
+  if ($have_pod) {
+    is @na, 0, "Covered dir row has aggregates for all criteria";
+  } elsif ($have_ppi) {
     is @na, 1, "Covered dir row has n/a only for pod";
+  } else {
+    is @na, 0, "Covered dir row has no pod column without PPI";
   }
   like $covered, qr{<dt>CC</dt><dd>[1-9]},
     "Covered dir row SCAR tooltip has non-zero CC";


### PR DESCRIPTION
## Summary

Fix the `html_crisp` test that checks the Covered directory row. It expected one n/a cell for pod whenever Pod::Coverage was missing. The pod column only exists when Pod::Coverage collected it or PPI estimated it for the uncompiled files. A build with neither module has no pod column, so the test now expects no n/a cell in that case. This restores `make key_test` on the `-thr` Perls, which have neither module.

## Ticket

Closes #781