### PR TITLE
GH-784 Close lock handles after a failed read

### DIFF
--- a/lib/Devel/Cover/DB.pm
+++ b/lib/Devel/Cover/DB.pm
@@ -167,7 +167,7 @@ sub merge_runs ($self) {
   return $self unless length $db;
   return $self unless -d "$db/runs";
 
-  # released when the handle goes out of scope, swept later by clean
+  # the lock file itself is swept later by clean
   my $lock_fh = $self->_lock_db;
 
   # another process may have merged and written since we were constructed
@@ -225,6 +225,8 @@ sub merge_runs ($self) {
   }
 
   $self->clean;
+
+  close $lock_fh or dcinfo "Can't close $db/merge.lock: $!";
 
   $self
 }
@@ -1845,8 +1847,7 @@ L</summarise_complexity>.
 =head2 _lock_db ($self)
 
 Take an exclusive lock on the database's F<merge.lock> file, creating it if
-necessary, and return the open handle. The lock is released when the handle
-goes out of scope.
+necessary, and return the open handle, which C<merge_runs> closes.
 
 =head2 _merge_hash ($into, $from, $noadd = 0)
 

--- a/lib/Devel/Cover/DB/IO/Base.pm
+++ b/lib/Devel/Cover/DB/IO/Base.pm
@@ -29,22 +29,32 @@ sub _lock ($self, $file, $type) {
   $fh
 }
 
-sub _read ($self, $file, $reader) {
-  my $lock_fh = $self->_lock($file, LOCK_SH);
-  my $data    = $reader->();
-  close $lock_fh or die "Can't close $file.lock: $!\n";
+sub _close_after ($fh, $what, $code) {
+  my $data = eval { $code->() };
+  my $err  = $@;
+  $err ||= "Can't close $what: $!\n" unless close $fh;
+  die $err if $err;
   $data
+}
+
+sub _read ($self, $file, $reader) {
+  _close_after($self->_lock($file, LOCK_SH), "$file.lock", $reader)
 }
 
 sub _write ($self, $file, $writer) {
   my $lock_fh = $self->_lock($file, LOCK_EX);
   my $tmp     = "$file.tmp.$$";
-  eval { $writer->($tmp); 1 } or do { my $e = $@; unlink $tmp; die $e };
-  rename $tmp, $file or do {
-    unlink $tmp;
-    die "Can't rename $tmp to $file: $!\n";
-  };
-  close $lock_fh or die "Can't close $file.lock: $!\n";
+  _close_after(
+    $lock_fh,
+    "$file.lock",
+    sub {
+      eval { $writer->($tmp); 1 } or do { my $e = $@; unlink $tmp; die $e };
+      rename $tmp, $file or do {
+        unlink $tmp;
+        die "Can't rename $tmp to $file: $!\n";
+      };
+    },
+  );
   $self
 }
 
@@ -53,9 +63,7 @@ sub read_fh ($self, $file, $reader) {
     $file,
     sub {
       open my $fh, "<", $file or die "Can't open $file: $!\n";
-      my $data = $reader->($fh);
-      close $fh or die "Can't close $file: $!\n";
-      $data
+      _close_after($fh, $file, sub { $reader->($fh) })
     },
   )
 }
@@ -65,8 +73,7 @@ sub write_fh ($self, $file, $writer) {
     $file,
     sub ($tmp) {
       open my $fh, ">", $tmp or die "Can't open $tmp: $!\n";
-      $writer->($fh);
-      close $fh or die "Can't close $tmp: $!\n";
+      _close_after($fh, $tmp, sub { $writer->($fh) })
     },
   )
 }
@@ -107,6 +114,32 @@ lock, and return its result.
 
 Call C<$writer> with a filehandle to write the data for C<$file>, holding an
 exclusive lock.
+
+=head1 PRIVATE SUBROUTINES
+
+=head2 _lock ($self, $file, $type)
+
+Open F<$file.lock>, creating it if necessary, take a C<flock> of C<$type> on it
+and return the handle. With C<loose_perms> set, make the lock file world
+writable so that another user can take the lock later.
+
+=head2 _close_after ($fh, $what, $code)
+
+Call C<$code> in scalar context, close C<$fh> whether C<$code> returned or
+died, and return the result. An error from C<$code> is rethrown after the close
+and takes precedence over a close failure, whose message names C<$what>. Every
+reader and writer returns a single value, so the scalar context loses nothing.
+
+=head2 _read ($self, $file, $reader)
+
+Call C<$reader> under a shared lock on C<$file> and return its result.
+
+=head2 _write ($self, $file, $writer)
+
+Call C<$writer> with a temporary file name under an exclusive lock on
+C<$file>, then rename the temporary file into place so that readers see either
+the old data or the new. Remove the temporary file if the writer or the rename
+fails.
 
 =head1 LICENCE
 

--- a/t/internal/db_io_lock.t
+++ b/t/internal/db_io_lock.t
@@ -18,7 +18,7 @@ use lib "$FindBin::Bin/../lib", $FindBin::Bin,
 
 use File::Spec ();
 use File::Temp qw( tempdir );
-use Test::More import => [qw( diag done_testing like plan )];
+use Test::More import => [qw( cmp_ok diag done_testing like plan )];
 
 BEGIN {
   plan skip_all => "flock is emulated on Windows" if $^O eq "MSWin32";
@@ -29,6 +29,7 @@ sub setup ($tmpdir) {
   open my $fh, ">", $script or die "write $script: $!";
   print $fh <<'PERL';
 use Fcntl qw( LOCK_EX LOCK_NB );
+use Devel::Cover::DB ();
 use Devel::Cover::DB::IO::Base ();
 
 my ($mode, $file) = @ARGV;
@@ -37,38 +38,70 @@ print $fh "data";
 close $fh or die "close $file: $!";
 
 close STDIN;
+close STDOUT if $mode eq "inner_dies";
 
-my $io = Devel::Cover::DB::IO::Base->new;
+my $io   = Devel::Cover::DB::IO::Base->new;
+my $lock = "$file.lock";
 if ($mode eq "read") {
   $io->read_fh($file, sub { my $in = shift; local $/; <$in> });
-} else {
+} elsif ($mode eq "write") {
   $io->write_fh($file, sub { my $out = shift; print $out "more" });
+} elsif ($mode eq "read_dies" || $mode eq "inner_dies") {
+  eval { $io->read_fh($file, sub { die "boom\n" }) };
+} elsif ($mode eq "write_dies") {
+  eval { $io->write_fh($file, sub { die "boom\n" }) };
+} elsif ($mode eq "merge_lock") {
+  my $db = "$file.db";
+  mkdir $db         or die "mkdir $db: $!";
+  mkdir "$db/runs"  or die "mkdir $db/runs: $!";
+  Devel::Cover::DB->new(db => $db)->merge_runs;
+  $lock = "$db/merge.lock";
 }
 
-open my $lock, "+>>", "$file.lock" or die "open lock: $!";
-my $state = flock($lock, LOCK_EX | LOCK_NB) ? "released" : "held";
-print "$mode lock $state\n";
+if ($mode eq "inner_dies") {
+  open my $p0, "<", "/dev/null" or die "open /dev/null: $!";
+  open my $p1, "<", "/dev/null" or die "open /dev/null: $!";
+  print STDERR "$mode fds ", fileno($p0), " ", fileno($p1), "\n";
+}
+
+open my $probe, "+>>", $lock or die "open lock: $!";
+my $state = flock($probe, LOCK_EX | LOCK_NB) ? "released" : "held";
+print STDERR "$mode lock $state\n";
 PERL
   close $fh or die "close $script: $!";
   $script
 }
 
-sub test_lock_released ($mode) {
+sub run_child ($mode) {
   my $tmpdir = tempdir(CLEANUP => 1);
   my $script = setup($tmpdir);
-
   my $file   = File::Spec->catfile($tmpdir, "data");
   my $cmd    = join " ", map qq("$_"), $^X, "-Mblib", $script, $mode, $file;
-  my $output = `$cmd 2>&1`;
+  `$cmd 2>&1`
+}
 
+sub test_lock_released ($mode) {
+  my $output = run_child($mode);
   like $output, qr/\Q$mode lock released\E/,
     "$mode releases the lock when STDIN is closed"
     or diag $output;
 }
 
+sub test_inner_handles_released () {
+  my $output = run_child("inner_dies");
+  my ($fd0, $fd1) = $output =~ /inner_dies fds (\d+) (\d+)/;
+  cmp_ok $fd0, "<", 2, "lock handle released after the reader dies"
+    or diag $output;
+  cmp_ok $fd1, "<", 2, "data handle released after the reader dies"
+    or diag $output;
+  like $output, qr/inner_dies lock released/,
+    "inner_dies releases the lock when STDIN and STDOUT are closed"
+    or diag $output;
+}
+
 sub main () {
-  test_lock_released("read");
-  test_lock_released("write");
+  test_lock_released($_) for qw( read write read_dies write_dies merge_lock );
+  test_inner_handles_released;
   done_testing;
 }
 


### PR DESCRIPTION
## Summary

Perl never closes a lexical handle implicitly once it occupies a standard descriptor slot. When the covered program had closed a standard handle, a lock handle left to scope exit after a failed read or write held its `flock` until the process exited. Add a helper that closes the lock and data handles whether the wrapped code returns or dies. Close the merge lock explicitly at the end of `merge_runs` too, which relied on scope exit alone.

## Ticket

Closes #784