### PR TITLE
GH-788 Ignore build system scripts by default

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Ignore the build system's own scripts by default when blib exists, so
+  Build, Build.PL, Makefile.PL and the _build/ copies no longer appear in
+  cover -test reports (GH-788)
 - Report the remaining coverage database problems with dcwarn, so they
   honour -silent and carry the Warning label (GH-746)
 - Estimate mcdc for untested files found via --select_dir, so the mcdc

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -320,7 +320,8 @@ sub import ($class, @o) {
   if ($blib) {
     eval "use blib";
     for (@INC) { ($_) = /(.*)/ if ref $_ ne "CODE" }  # Die tainting
-    push @Ignore, "^t/", "^inc/", '\\.t$', '^test\\.pl$';
+    push @Ignore, "^t/", "^inc/", '\\.t$', '^test\\.pl$', '^Build$',
+      '^Build\\.PL$', '^Makefile\\.PL$', "^_build/";
   }
 
   my $ci = $^O eq "MSWin32";

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -213,8 +213,9 @@ and is run from a checkout of the Devel::Cover repository.
 
 =head1 OPTIONS
 
-  -blib               - "use blib" and ignore files in t/ and inc/ (default
-                        true if blib directory exists, false otherwise)
+  -blib               - "use blib" and ignore t/, inc/, _build/, test.pl,
+                        Build, Build.PL and Makefile.PL (default true if
+                        blib directory exists, false otherwise)
   -coverage criterion - Turn on coverage for the specified criterion.  Criteria
                         include statement, branch, condition, mcdc, subroutine,
                         pod, time, all and none (default all except time)

--- a/t/internal/default_ignores.t
+++ b/t/internal/default_ignores.t
@@ -9,7 +9,8 @@
 
 # When blib exists the run is a distribution test, so the conventional
 # directories holding code that is not under test are ignored by default:
-# t/, test.pl and bundled build helpers in inc/.
+# t/, test.pl, bundled build helpers in inc/ and the build system's own
+# scripts.
 
 use 5.20.0;
 use warnings;
@@ -55,6 +56,13 @@ sub test_blib_ignores_inc () {
   ok grep($_ eq "^inc/", @$ignore), "a blib run ignores bundled inc/ files";
 }
 
+sub test_blib_ignores_build_scripts () {
+  my $ignore = ignores(run_covered($Root));
+  for my $pattern ('^Build$', '^Build\\.PL$', '^Makefile\\.PL$', "^_build/") {
+    ok grep($_ eq $pattern, @$ignore), "a blib run ignores $pattern";
+  }
+}
+
 sub test_no_blib_keeps_inc () {
   my $dir = File::Spec->catdir($Tmpdir, "nolib");
   mkdir $dir or die "Can't mkdir $dir: $!";
@@ -65,6 +73,7 @@ sub test_no_blib_keeps_inc () {
 
 sub main () {
   test_blib_ignores_inc;
+  test_blib_ignores_build_scripts;
   test_no_blib_keeps_inc;
   done_testing;
 }


### PR DESCRIPTION
## Summary

`cover -test` reaches every perl process through `PERL5OPT`, so on a Module::Build distribution the `Build` script itself was reported alongside the modules under test and dragged the Total down. About one cpancover report in six showed a `Build` row. `Makefile.PL` and `Build.PL` appeared too when Module::Install reran the configure step from `make test` or a test suite loaded them. Module::Build's copy of a `Build.PL` subclass under `_build/lib` appeared in the same way.

Add `Build`, `Build.PL`, `Makefile.PL` and `_build/` to the patterns applied when `blib` exists, beside `t/`, `inc/` and `test.pl`. Anyone who does want the build script covered can still select it explicitly, since selection patterns are tried before ignore patterns.

## Ticket

Closes #788