### PR TITLE
GH-790 Keep coverage when a program execs

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Devel::Cover history
 - Write the coverage database when the main program execs from a
   subroutine in an ignored file, such as a wrapper module, rather than
   discarding the run (GH-790)
+- Keep collecting coverage after a failed exec, so the END-time run
+  records the fallback code and everything after it (GH-790)
 - Ignore the build system's own scripts by default when blib exists, so
   Build, Build.PL, Makefile.PL and the _build/ copies no longer appear in
   cover -test reports (GH-788)

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Write the coverage database when the main program execs from a
+  subroutine in an ignored file, such as a wrapper module, rather than
+  discarding the run (GH-790)
 - Ignore the build system's own scripts by default when blib exists, so
   Build, Build.PL, Makefile.PL and the _build/ copies no longer appear in
   cover -test reports (GH-788)

--- a/Cover.xs
+++ b/Cover.xs
@@ -184,6 +184,7 @@ typedef struct {
                *lastfile;
   char         *lastfile_ptr;  /* cached CopFILE pointer */
   int           tid;
+  Pid_t         pid;           /* process that initialised coverage */
   int           replace_ops;
   /* - fix up whatever is broken with module_relative on Windows here */
 
@@ -860,6 +861,12 @@ static void call_report(pTHX) {
   PUSHMARK(SP);
   call_pv("Devel::Cover::report", G_VOID|G_DISCARD|G_EVAL);
   SPAGAIN;
+}
+
+/* END never runs after a successful exec, so the main process reports */
+static int exec_reports(pTHX) {
+  dMY_CXT;
+  return collecting_here(aTHX) || PerlProc_getpid() == MY_CXT.pid;
 }
 
 static void cover_statement(pTHX_ OP *op, const char *ch) {
@@ -2667,7 +2674,7 @@ static OP *dc_leave(pTHX) {
 static OP *dc_exec(pTHX) {
   dMY_CXT;
   NDEB(D(L, "dc_exec() at %p (%d)\n", PL_op, collecting_here(aTHX)));
-  if (MY_CXT.covering && collecting_here(aTHX)) call_report(aTHX);
+  if (MY_CXT.covering && exec_reports(aTHX)) call_report(aTHX);
   return MY_CXT.ppaddr[OP_EXEC](aTHX);
 }
 
@@ -2781,6 +2788,7 @@ static void initialise(pTHX) {
     MY_CXT.lastfile_ptr        = NULL;
     MY_CXT.covering            = All;
     MY_CXT.tid                 = tid++;
+    MY_CXT.pid                 = PerlProc_getpid();
 
     MY_CXT.replace_ops = SvTRUE(get_sv("Devel::Cover::Replace_ops", FALSE));
     NDEB(D(L, "running with Replace_ops as %d\n", MY_CXT.replace_ops));
@@ -2849,6 +2857,8 @@ static int runops_cover(pTHX) {
       capture_require_tree(aTHX);
     else if (PL_op->op_type == OP_RETURN)
       capture_require_return(aTHX);
+    else if (PL_op->op_type == OP_EXEC && exec_reports(aTHX))
+      call_report(aTHX);
 
     if (!collecting_here(aTHX))
       goto call_fptr;
@@ -2897,11 +2907,6 @@ static int runops_cover(pTHX) {
 
       case OP_REQUIRE: {
         store_module(aTHX);
-        break;
-      }
-
-      case OP_EXEC: {
-        call_report(aTHX);
         break;
       }
 

--- a/Cover.xs
+++ b/Cover.xs
@@ -859,7 +859,7 @@ static void store_module(pTHX) {
 static void call_report(pTHX) {
   dSP;
   PUSHMARK(SP);
-  call_pv("Devel::Cover::report", G_VOID|G_DISCARD|G_EVAL);
+  call_pv("Devel::Cover::report_exec", G_VOID|G_DISCARD|G_EVAL);
   SPAGAIN;
 }
 

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -767,6 +767,17 @@ EOM
   release_require_trees();
 }
 
+sub report_exec {
+  my @collected = get_coverage();
+  report();
+  return unless @collected;
+  %Seen      = ();
+  $Sub_count = {};
+  delete $Run{$_} for qw( count vec digests decision_inputs );
+  ($File, $Line) = ("", 0);
+  set_coverage(@collected);
+}
+
 sub _report {
   local @SIG{qw( __DIE__ __WARN__ )};
 
@@ -1863,6 +1874,20 @@ The driver run from L</last_end>.  Wraps L</_report> in an eval so a
 failure while writing coverage does not change how the program exits, runs
 it a second time under self-coverage to write Devel::Cover's own data, and
 releases the required-file op trees held by the XS side.
+
+=head2 report_exec
+
+The entry point the XS C<exec> hooks call.  The hooks call it when the
+main process execs, whatever file the C<exec> op sits in, and when a
+forked child execs from a collected file, so library code exec'ing in a
+child does not duplicate the parent's data.  It runs L</report>, then puts
+the process back into a collectable state, since a failed C<exec> returns
+and the program continues.  The per-report state - C<%Seen>, the sub
+counts, the counts, vectors, digests and decision inputs in C<%Run>, and
+the current location - is cleared so the C<END>-time report records
+everything afresh, and the criteria L</_report> switched off are
+restored.  Statements before the C<exec> appear in both runs, so their
+merged counts double while every covered status stays right.
 
 =head2 _report
 

--- a/t/internal/exec_failed.t
+++ b/t/internal/exec_failed.t
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use lib "t/lib";
+
+use Devel::Cover::Test::Internal qw( write_script run_under_cover );
+
+use Test::More import => [qw( done_testing is ok plan )];
+
+if ($^O eq "MSWin32") {
+  plan skip_all => "exec has spawn semantics on Windows";
+  exit;
+}
+
+sub covered_file ($script, $label) {
+  my ($db, $path)
+    = run_under_cover($script, $label, criteria => ["statement", "branch"]);
+  my $file = $db->cover->file($path);
+  ok $file, "$label: the program is in the database" or return;
+  ($db, $file)
+}
+
+sub run_count ($db) {
+  my @runs = $db->runs;
+  scalar @runs
+}
+
+sub statement_count ($file, $line) {
+  my $loc = $file->statement->location($line);
+  $loc ? $loc->[0]->covered : undef
+}
+
+sub test_failed_exec_keeps_collecting () {
+  my $script = write_script("exec_failed.pl", <<'PERL');
+my $x = 1;
+exec "/no/such/command" or warn "exec failed\n";
+$x++;
+my $y = $x * 2;
+PERL
+  my ($db, $file) = covered_file($script, "exec_failed") or return;
+  is statement_count($file, 3), 1, "the statement after the failed exec ran";
+  is statement_count($file, 4), 1, "and so did the one after that";
+  my $branch = $file->branch->location(2);
+  ok $branch, "the exec's or branch is collected" or return;
+  is grep($_, $branch->[0]->values), 1, "one leg of the or branch ran";
+  is run_count($db), 2, "the exec-time and END-time runs are both written";
+}
+
+sub test_successful_exec_unchanged () {
+  my $script = write_script("exec_ok.pl", <<'PERL');
+my $x = 1;
+exec $^X, "-e", "exit 0";
+my $y = 2;
+PERL
+  my ($db, $file) = covered_file($script, "exec_ok") or return;
+  is statement_count($file, 1), 1, "the statement before the exec ran";
+  is statement_count($file, 3), 0, "the statement after the exec did not";
+  is run_count($db), 1, "a successful exec writes one run";
+}
+
+sub main () {
+  test_failed_exec_keeps_collecting;
+  test_successful_exec_unchanged;
+  done_testing;
+}
+
+main;

--- a/t/internal/exec_ignored.t
+++ b/t/internal/exec_ignored.t
@@ -1,0 +1,117 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use Cwd        qw( abs_path getcwd );
+use File::Path qw( make_path );
+use File::Spec ();
+use File::Temp qw( tempdir );
+
+use Devel::Cover::DB;
+
+use Test::More import => [qw( diag done_testing is ok plan )];
+
+if ($^O eq "MSWin32") {
+  plan skip_all => "fork uses threads on Windows";
+  exit;
+}
+
+my $Project   = getcwd;
+my $Blib_lib  = File::Spec->catdir($Project, "blib", "lib");
+my $Blib_arch = File::Spec->catdir($Project, "blib", "arch");
+
+unless (-d $Blib_lib && -d $Blib_arch) {
+  plan skip_all => "build artefacts missing - run after `make`";
+  exit;
+}
+
+my $Wrapper = <<'PERL';
+package Wrapper;
+sub go { exec @_ }
+1;
+PERL
+
+sub write_file ($path, $content) {
+  open my $fh, ">", $path or die "open $path: $!";
+  print $fh $content;
+  close $fh or die "close $path: $!";
+}
+
+# Runs $code in a child perl with Wrapper.pm ignored and returns the database
+# path, the program path and the child's exit status.
+sub run_child ($code, @options) {
+  my $dir = tempdir(CLEANUP => 1);
+  my $lib = File::Spec->catdir($dir, "lib");
+  make_path $lib;
+  write_file(File::Spec->catfile($lib, "Wrapper.pm"), $Wrapper);
+  my $program = File::Spec->catfile($dir, "program.pl");
+  write_file($program, $code);
+  my $db      = File::Spec->catdir($dir, "db");
+  my $options = join ",", "-silent,1", "-db,$db", "-ignore,Wrapper", @options;
+  my $cmd     = qq("$^X" "-I$Blib_lib" "-I$Blib_arch" "-I$lib" )
+    . qq("-MDevel::Cover=$options" "$program" 2>&1);
+  my $out = `$cmd`;
+  diag $out if length $out;
+  ($db, $program, $?)
+}
+
+sub run_count ($db) {
+  my $runs = File::Spec->catdir($db, "runs");
+  return 0 unless -d $runs;
+  opendir my $dh, $runs or die "opendir $runs: $!";
+  my @runs = grep !/^\./, readdir $dh;
+  closedir $dh;
+  scalar @runs
+}
+
+sub statement_covered ($db, $program, $line) {
+  my $cover = Devel::Cover::DB->new(db => $db)->merge_runs->cover;
+  my $file  = $cover->file(abs_path $program) or return 0;
+  my $loc   = $file->statement->location($line);
+  $loc && $loc->[0]->covered
+}
+
+my $Exec_via_wrapper = <<'PERL';
+use Wrapper;
+my $x = 1;
+Wrapper::go($^X, "-e", "exit 0");
+PERL
+
+sub test_exec_from_ignored_file (@options) {
+  my $label = @options ? "@options" : "replaced ops";
+  my ($db, $program, $status) = run_child($Exec_via_wrapper, @options);
+  is $status,        0, "$label: the program exits cleanly";
+  is run_count($db), 1, "$label: the exec-time report writes one run";
+  ok statement_covered($db, $program, 2),
+    "$label: the statement before the exec is covered";
+}
+
+sub test_forked_child_exec_still_vetoed () {
+  my ($db, $program, $status) = run_child(<<'PERL');
+use Wrapper;
+my $pid = fork;
+die "fork: $!" unless defined $pid;
+if ($pid) { waitpid $pid, 0 } else { Wrapper::go($^X, "-e", "exit 0") }
+PERL
+  is $status,        0, "the forking program exits cleanly";
+  is run_count($db), 1, "only the parent's END-time run is written";
+}
+
+sub main () {
+  test_exec_from_ignored_file;
+  test_forked_child_exec_still_vetoed;
+  test_exec_from_ignored_file("-replace_ops,0");
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

- Write the coverage database when the main process execs, whatever file the `exec` op sits in. The report was skipped when the op was in an ignored file, so a program exec'ing through a wrapper module lost its whole run. A forked child still reports only from a collected file, so library code exec'ing in the child does not duplicate the parent's data.
- Keep collecting after a failed `exec`. The exec-time report switched collection off and nothing switched it back on when `exec` returned, so the fallback and everything after it went unrecorded. The END-time report now writes a second run. Statements before the `exec` appear in both runs, so their merged counts double while every covered status stays right.

## Ticket

Closes #790