### PR TITLE
GH-792 Count sub entries without statement

### DIFF
--- a/Cover.xs
+++ b/Cover.xs
@@ -166,6 +166,7 @@ typedef struct {
                *statements,
                *branches,
                *conditions,
+               *subroutines,        /* sub root op key -> entry count */
 #if CAN_PROFILE
                *times,
 #endif
@@ -2429,25 +2430,13 @@ static OP *dc_dbstate(pTHX) {
  * early release must not be delayed.  See
  * docs/technical/wrapped-sub-coverage.md.
  */
-static void record_entered_sub(pTHX) {
+static void record_entered_sub(pTHX_ CV *cv) {
   dMY_CXT;
-  SV         *sv = *PL_stack_sp;
-  CV         *cv;
   GV         *gv;
   const char *name;
   STRLEN      len;
 
-  if (!sv) return;
-  if (SvTYPE(sv) == SVt_PVCV)
-    cv = (CV *)sv;
-  else if (SvROK(sv) && SvTYPE(SvRV(sv)) == SVt_PVCV)
-    cv = (CV *)SvRV(sv);
-  else if (isGV_with_GP(sv) && GvCV((GV *)sv))
-    cv = GvCV((GV *)sv);
-  else
-    return;
-
-  if (CvISXSUB(cv) || CvANON(cv) || CvCLONED(cv) || !CvROOT(cv)) return;
+  if (CvANON(cv) || CvCLONED(cv)) return;
   if (hv_exists(MY_CXT.entered_subs, (char *)&cv, sizeof(CV *))) return;
 
   gv = CvGV(cv);
@@ -2467,12 +2456,48 @@ static void record_entered_sub(pTHX) {
                  newRV_inc((SV *)cv), 0);
 }
 
+/* The Perl sub with an optree that an entersub is about to call, if any */
+static CV *entersub_cv(pTHX) {
+  SV *sv = *PL_stack_sp;
+  CV *cv;
+
+  if (!sv) return NULL;
+  if (SvTYPE(sv) == SVt_PVCV)
+    cv = (CV *)sv;
+  else if (SvROK(sv) && SvTYPE(SvRV(sv)) == SVt_PVCV)
+    cv = (CV *)SvRV(sv);
+  else if (isGV_with_GP(sv) && GvCV((GV *)sv))
+    cv = GvCV((GV *)sv);
+  else
+    return NULL;
+
+  if (CvISXSUB(cv) || !CvROOT(cv)) return NULL;
+  return cv;
+}
+
+/* Keyed by the root op, which a closure clone shares with its prototype */
+static void count_sub_entry(pTHX_ CV *cv) {
+  dMY_CXT;
+  SV **count;
+
+  if (!collecting(Subroutine) && !collecting(Pod)) return;
+  count = hv_fetch(MY_CXT.subroutines, get_key(CvROOT(cv)), KEY_SZ, 1);
+  sv_setiv(*count, SvTRUE(*count) ? SvIV(*count) + 1 : 1);
+}
+
+static void note_entered_sub(pTHX) {
+  CV *cv = entersub_cv(aTHX);
+  if (!cv) return;
+  count_sub_entry(aTHX_ cv);
+  record_entered_sub(aTHX_ cv);
+}
+
 static OP *dc_entersub(pTHX) {
   dMY_CXT;
   NDEB(D(L, "dc_entersub() at %p (%d)\n", PL_op, collecting_here(aTHX)));
   if (MY_CXT.covering) {
     store_return(aTHX);
-    record_entered_sub(aTHX);
+    note_entered_sub(aTHX);
   }
   return MY_CXT.ppaddr[OP_ENTERSUB](aTHX);
 }
@@ -2743,6 +2768,10 @@ static void initialise(pTHX) {
     MY_CXT.conditions = newHV();
     *tmp              = newRV_inc((SV*) MY_CXT.conditions);
 
+    tmp                = hv_fetch(MY_CXT.cover, "subroutine", 10, 1);
+    MY_CXT.subroutines = newHV();
+    *tmp               = newRV_inc((SV*) MY_CXT.subroutines);
+
     tmp                    = hv_fetch(MY_CXT.cover, "decision_inputs", 15, 1);
     MY_CXT.decision_inputs = newHV();
     *tmp                   = newRV_inc((SV*) MY_CXT.decision_inputs);
@@ -2762,6 +2791,7 @@ static void initialise(pTHX) {
     HvSHAREKEYS_off(MY_CXT.statements);
     HvSHAREKEYS_off(MY_CXT.branches);
     HvSHAREKEYS_off(MY_CXT.conditions);
+    HvSHAREKEYS_off(MY_CXT.subroutines);
     HvSHAREKEYS_off(MY_CXT.decision_inputs);
 #if CAN_PROFILE
     HvSHAREKEYS_off(MY_CXT.times);
@@ -2846,7 +2876,7 @@ static int runops_cover(pTHX) {
       check_if_collecting(aTHX_ cCOP);
     else if (PL_op->op_type == OP_ENTERSUB) {
       store_return(aTHX);
-      record_entered_sub(aTHX);
+      note_entered_sub(aTHX);
     }
 
     /* Capture require optrees before the collecting veto, as dc_leaveeval

--- a/docs/technical/wrapped-sub-coverage.md
+++ b/docs/technical/wrapped-sub-coverage.md
@@ -106,6 +106,17 @@ clones are covered through the pad walk when they survive, a clone shares its
 start op with its prototype so recording it would add a duplicate, and the phase
 blocks' early release must not be delayed.
 
+The same hook counts entries. `count_sub_entry` increments a count keyed by the
+sub's root op, which a closure clone shares with its prototype, whenever
+subroutine or pod coverage is on. Subroutine coverage is otherwise derived from
+the execution count of a sub's first statement. Without statement coverage,
+every sub used to be reported as uncovered. `add_subroutine_cover` reads the
+entry count when statement coverage is off. With statement coverage on, it keeps
+the statement-derived count, so such runs report exactly what they did before.
+The entry count misses calls that bypass `entersub`: `goto &sub`, `sort subname`
+and, under `-replace_ops 0`, subs called from C such as `DESTROY` and overload
+methods.
+
 The reference held to each recorded CV is strong, not weak. A weak reference
 would be nulled the moment a sub is freed, which is exactly the case that needs
 covering: a sub redefined at runtime (`*foo = sub { ... }`) frees the original

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -900,12 +900,14 @@ sub _write_coverage_db {
   }
 }
 
-sub add_subroutine_cover ($op) {
+sub add_subroutine_cover ($cv, $op) {
   get_location($op);
   return unless $File;
 
-  my $key = get_key($op);
-  my $val = $Coverage->{statement}{$key} || 0;
+  my $val
+    = $Coverage{statement}
+    ? $Coverage->{statement}{ get_key($op) } || 0
+    : $Coverage->{subroutine}{ get_key($cv->ROOT) } || 0;
   my ($n, $new) = $Structure->add_count("subroutine");
   $Structure->add_subroutine($File, [$Line, $Sub_name]) if $new;
   $Run{count}{$File}{subroutine}[$n] += $val;
@@ -1149,7 +1151,7 @@ sub _add_subroutine_structure ($cv, $start) {
   } else {
     my $count = $Sub_count->{$File}{$Line}{$Sub_name}++;
     $sub_id = $Structure->set_subroutine($Sub_name, $File, $Line, $count);
-    add_subroutine_cover($start)
+    add_subroutine_cover($cv, $start)
       if $Coverage{subroutine} || $Coverage{pod};  # pod requires subs
   }
   _add_pod_cover($cv) if $Pod && $Coverage{pod};
@@ -1923,9 +1925,15 @@ each outcome ran.  Structure and counts are stored separately so separate
 runs can merge.  The counts are keyed by C<get_key>, which identifies the
 op in the raw XS data.
 
-=head2 add_subroutine_cover ($op)
+=head2 add_subroutine_cover ($cv, $op)
 
-Record a subroutine as covered when its first statement ran.
+Record a subroutine's call count.  With statement coverage on, the count is
+the execution count of the sub's first statement, C<$op>.  Without it, the
+count comes from the XS C<entersub> hook, which counts entries against the
+sub's root op, so a closure clone shares its prototype's count.  Calls that
+bypass C<entersub>, such as C<goto &sub> and C<sort subname>, are not
+counted, and in C<-replace_ops 0> mode neither are subs called from C, such
+as C<DESTROY> and overload methods.
 
 =head2 add_statement_cover ($op)
 

--- a/t/internal/subroutine_only.t
+++ b/t/internal/subroutine_only.t
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use lib "t/lib";
+
+use Devel::Cover::Test::Internal qw( write_script run_under_cover );
+
+use Test::More import => [qw( done_testing is ok )];
+
+my $Source = <<'PERL';
+sub called   { my $x = 42; $x }
+sub uncalled { my $y = 43; $y }
+my $anon = sub { my $z = 44; $z };
+called() for 1 .. 3;
+$anon->();
+PERL
+
+sub sub_counts ($file) {
+  my %count;
+  my $subs = $file->subroutine;
+  for my $line ($subs->items) {
+    $count{ $_->name } = $_->covered for $subs->location($line)->@*;
+  }
+  \%count
+}
+
+sub check_counts ($label, $counts) {
+  is $counts->{called},   3, "$label: the called sub counts its calls";
+  is $counts->{uncalled}, 0, "$label: the uncalled sub is uncovered";
+  is $counts->{__ANON__}, 1, "$label: the anonymous sub counts its call";
+}
+
+sub test_subroutine_only ($script, $mode, @options) {
+  my $label = "subroutine only, $mode";
+  my ($db, $path) = run_under_cover(
+    $script, "subroutine_only_$mode",
+    criteria => ["subroutine"],
+    options  => \@options,
+  );
+  my $file = $db->cover->file($path);
+  ok $file, "$label: the program is in the database" or return;
+  check_counts($label, sub_counts($file));
+}
+
+sub test_with_statement ($script, $mode, @options) {
+  my $label = "subroutine and statement, $mode";
+  my ($db, $path) = run_under_cover(
+    $script, "subroutine_statement_$mode",
+    criteria => ["subroutine", "statement"],
+    options  => \@options,
+  );
+  my $file = $db->cover->file($path);
+  ok $file, "$label: the program is in the database" or return;
+  check_counts($label, sub_counts($file));
+}
+
+sub main () {
+  my $script = write_script("subroutine_only.pl", $Source);
+  my %modes  = (replaced => [], runops => ["-replace_ops,0"]);
+  for my $mode (sort keys %modes) {
+    test_subroutine_only($script, $mode, $modes{$mode}->@*);
+    test_with_statement($script, $mode, $modes{$mode}->@*);
+  }
+  done_testing;
+}
+
+main;

--- a/test_output/cover/pod.5.020000
+++ b/test_output/cover/pod.5.020000
@@ -44,6 +44,13 @@ _aa         1  6.9  Module1.pm:14
 xx          1  6.9  Module1.pm:20
 yy          1  6.9  Module1.pm:25
 
+Covered Subroutines
+-------------------
+
+Subroutine Count Pod  CC  SCAR Location     
+---------- ----- --- --- ----- -------------
+zz            11   0   1   6.9 Module1.pm:29
+
 Uncovered Subroutines
 ---------------------
 
@@ -52,7 +59,6 @@ Subroutine Count Pod  CC  SCAR Location
 _aa            0       1   6.9 Module1.pm:14
 xx             0       1   6.9 Module1.pm:20
 yy             0   1   1   6.9 Module1.pm:25
-zz             0   0   1   6.9 Module1.pm:29
 
 
 PodMod.pm
@@ -115,12 +121,6 @@ BEGIN          1   1   0.0 pod:14
 BEGIN          1   1   0.0 pod:15  
 BEGIN          1   1   0.0 pod:17  
 BEGIN          1   1   0.0 pod:19  
-
-Uncovered Subroutines
----------------------
-
-Subroutine Count  CC  SCAR Location
----------- ----- --- ----- --------
-xx             0   1   6.9 pod:24  
+xx            11   1   6.9 pod:24  
 
 

--- a/test_output/cover/pod_nocp.5.020000
+++ b/test_output/cover/pod_nocp.5.020000
@@ -44,6 +44,13 @@ _aa         1  6.9  Module1.pm:14
 xx          1  6.9  Module1.pm:20
 yy          1  6.9  Module1.pm:25
 
+Covered Subroutines
+-------------------
+
+Subroutine Count Pod  CC  SCAR Location     
+---------- ----- --- --- ----- -------------
+zz            11   0   1   6.9 Module1.pm:29
+
 Uncovered Subroutines
 ---------------------
 
@@ -52,7 +59,6 @@ Subroutine Count Pod  CC  SCAR Location
 _aa            0       1   6.9 Module1.pm:14
 xx             0       1   6.9 Module1.pm:20
 yy             0   1   1   6.9 Module1.pm:25
-zz             0   0   1   6.9 Module1.pm:29
 
 
 PodMod.pm
@@ -115,12 +121,6 @@ BEGIN          1   1   0.0 pod_nocp:14
 BEGIN          1   1   0.0 pod_nocp:15
 BEGIN          1   1   0.0 pod_nocp:17
 BEGIN          1   1   0.0 pod_nocp:19
-
-Uncovered Subroutines
----------------------
-
-Subroutine Count  CC  SCAR Location   
----------- ----- --- ----- -----------
-xx             0   1   6.9 pod_nocp:24
+xx            11   1   6.9 pod_nocp:24
 
 


### PR DESCRIPTION
## Summary

Subroutine coverage was derived from the execution count of each sub's first statement, so a run collecting subroutine or pod coverage without statement coverage reported every sub as uncovered. Count entries in the `entersub` hook, keyed by the sub's root op so a closure clone shares its prototype's count, and use that count when statement coverage is off. Runs with statement coverage keep the statement-derived count, so only the pod-only golden files change, and there the counts are now right.

## Ticket

Closes #792