### PR TITLE
GH-794 Excuse MC/DC columns via untested rows

### DIFF
--- a/lib/Devel/Cover/Mcdc/Analyser.pm
+++ b/lib/Devel/Cover/Mcdc/Analyser.pm
@@ -71,7 +71,7 @@ sub analyse ($class, $table) {
   my @labels     = $table->labels;
   my @rows       = grep $_->covered,      $table->rows;
   my @achievable = grep !$_->uncoverable, $table->rows;
-  my @avail      = grep { $_->covered || $_->uncoverable } $table->rows;
+  my @all        = $table->rows;
 
   my %label_count;
 
@@ -88,11 +88,11 @@ sub analyse ($class, $table) {
     }
 
     # No pair among covered rows.  A pair among achievable rows is a test gap.
-    # Only a column whose sole pairs need uncoverable rows is excused (see
-    # DESCRIPTION).
+    # Only a column whose sole pairs need uncoverable rows, found by searching
+    # every row, is excused (see DESCRIPTION).
     if (_pair($col, \@achievable, \@labels, \%label_count)) {
       push @missing, $labels[$col];
-    } elsif (_pair($col, \@avail, \@labels, \%label_count)) {
+    } elsif (_pair($col, \@all, \@labels, \%label_count)) {
       $uncoverable{$col} = 1;
     } else {
       push @missing, $labels[$col];

--- a/t/internal/mcdc_analyser.t
+++ b/t/internal/mcdc_analyser.t
@@ -553,10 +553,49 @@ sub test_coupled_achievable_pair_stays_missing () {
   is_deeply $r->{uncoverable}, {}, "coupled achievable: nothing excused";
 }
 
-# A pair formed from an uncoverable row and an achievable-but-untested row
-# excuses nothing: the achievable row is still a test to write.  Once it is
-# covered the column becomes excused (test_uncoverable_row_excuses_column).
-sub test_uncoverable_pair_needs_covered_row () {
+# A column whose only pair joins an uncoverable row with an uncovered but
+# achievable row is still excused.  $a's only pair is (0X, 11): 0X is
+# uncoverable and 11 is achievable but not yet covered.  $b's pair (10, 11)
+# uses only achievable rows, so it stays a test gap.
+sub test_excusal_survives_uncovered_achievable_row () {
+  my $table = build_synthetic_table(
+    '$a && $b',
+    ['$a', '$b'],
+    [
+      { inputs => [0, "X"], result => 0, covered => 0, uncoverable => 1 },
+      { inputs => [1, 0],   result => 0, covered => 1 },
+      { inputs => [1, 1],   result => 1, covered => 0 },
+    ],
+  );
+  my $r = Devel::Cover::Mcdc::Analyser->analyse($table);
+  ok $r->{uncoverable}{0}, "uncovered achievable: a excused by its pair";
+  is_deeply $r->{missing}, ['$b'], "uncovered achievable: b stays a test gap";
+}
+
+# Covering row 11 satisfies $b and says nothing new about $a, so $a's excuse
+# is unchanged.  The excuse depends only on $a's own pairs, not on whether an
+# unrelated test exists.
+sub test_excusal_unchanged_once_other_row_covered () {
+  my $table = build_synthetic_table(
+    '$a && $b',
+    ['$a', '$b'],
+    [
+      { inputs => [0, "X"], result => 0, covered => 0, uncoverable => 1 },
+      { inputs => [1, 0],   result => 0, covered => 1 },
+      { inputs => [1, 1],   result => 1, covered => 1 },
+    ],
+  );
+  my $r = Devel::Cover::Mcdc::Analyser->analyse($table);
+  is $r->{satisfied}, 1, "other row covered: b satisfied";
+  ok $r->{uncoverable}{0}, "other row covered: a still excused";
+  is_deeply $r->{missing}, [], "other row covered: nothing missing";
+}
+
+# The same holds when the uncoverable row is the one that pairs with the
+# uncovered row.  $b's only pair is (10, 11), with 10 uncoverable, so $b is
+# excused even with 11 uncovered, while $a's achievable pair (0X, 11) is a
+# test gap.
+sub test_excusal_when_uncoverable_row_pairs_uncovered_row () {
   my $table = build_synthetic_table(
     '$a && $b',
     ['$a', '$b'],
@@ -567,9 +606,8 @@ sub test_uncoverable_pair_needs_covered_row () {
     ],
   );
   my $r = Devel::Cover::Mcdc::Analyser->analyse($table);
-  is_deeply $r->{missing}, ['$a', '$b'],
-    "mixed pair: both columns still missing";
-  is_deeply $r->{uncoverable}, {}, "mixed pair: nothing excused";
+  is_deeply $r->{missing}, ['$a'], "mixed pair: a is a test gap";
+  ok $r->{uncoverable}{1}, "mixed pair: b excused by its uncoverable row";
 }
 
 # A decision that never executed and carries no uncoverable markers is all
@@ -608,7 +646,9 @@ sub main () {
   test_no_pair_even_with_uncoverable_stays_missing;
   test_achievable_pair_stays_missing;
   test_coupled_achievable_pair_stays_missing;
-  test_uncoverable_pair_needs_covered_row;
+  test_excusal_survives_uncovered_achievable_row;
+  test_excusal_unchanged_once_other_row_covered;
+  test_excusal_when_uncoverable_row_pairs_uncovered_row;
   test_never_run_unmarked_all_missing;
   test_all_uncoverable_never_run_stays_excused;
   test_const_right_collapsed_observed_vectors;

--- a/test_output/cover/uncoverable_error_ignore.5.020000
+++ b/test_output/cover/uncoverable_error_ignore.5.020000
@@ -2,8 +2,8 @@ cover: Reading database from ...
 ---------------------------- ------ ------ ------ ------ ------ ------ ------
 File                           stmt   bran   cond   mcdc    sub  total   scar
 ---------------------------- ------ ------ ------ ------ ------ ------ ------
-.../uncoverable_error_ignore   82.3   80.0   66.6   50.0  100.0   76.9   20.6
-Total                          82.3   80.0   66.6   50.0  100.0   76.9   20.6
+.../uncoverable_error_ignore   82.3   80.0   66.6   75.0  100.0   79.4   20.6
+Total                          82.3   80.0   66.6   75.0  100.0   79.4   20.6
 ---------------------------- ------ ------ ------ ------ ------ ------ ------
 
 
@@ -63,7 +63,7 @@ line  err   stmt   bran   cond   mcdc    sub   code
 31             1                                   my $y = 0;
 32                                                 # uncoverable branch true
 33                                                 # uncoverable condition when:10
-34    ***      1   -100  *- 33   *  0              if ($x > 0 && $y > 0) {
+34    ***      1   -100  *- 33  *- 50              if ($x > 0 && $y > 0) {
 35                                                     # uncoverable statement
 36            -0                                       $y = 1;
 37                                                 }
@@ -115,7 +115,7 @@ MC/DC
 
 line  err      %  cov  tot   missing                expr
 ----- --- ------ ---- ----   --------------------   ----
-34    ***      0    0    2   $x > 0, $y > 0         $x > 0 and $y > 0
+34    ***   - 50    0    2   $x > 0                 $x > 0 and $y > 0
 43          -100    1    2                          $x > 0 and $y > 0
 
 


### PR DESCRIPTION
## Summary

The MC/DC excusal search admitted only covered or uncoverable rows. So a column whose sole independence pair joined an uncoverable row to an achievable but untested row was reported missing until an unrelated test covered that row. Search every row instead, as the documented tiers describe. One golden file moves, where a condition marked uncoverable on the row it needs is now excused rather than missing.

## Ticket

Closes #794