### PR TITLE
GH-118 Release lexicals captured by special blocks

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Devel::Cover history
 
 {{$NEXT}}
+- Release the outer lexicals a BEGIN, UNITCHECK, CHECK or INIT block
+  captured once the block has run, so a scope guard created in a BEGIN
+  block is destroyed when its scope ends rather than at global
+  destruction (GH-118)
 - Write the coverage database when the main program execs from a
   subroutine in an ignored file, such as a wrapper module, rather than
   discarding the run (GH-790)

--- a/Cover.xs
+++ b/Cover.xs
@@ -173,6 +173,9 @@ typedef struct {
                *modules,
                *files;
   AV           *ends;
+  AV           *finished_blocks;     /* special block CVs that have run,
+                                      * whose captured outer lexicals are
+                                      * released at the next statement */
   AV           *require_trees;       /* [CV ref, root op addr] pairs for
                                       * require optrees kept alive past
                                       * their SAVEFREEOP */
@@ -2404,8 +2407,74 @@ static OP *dc_padrange(pTHX) {
   return MY_CXT.ppaddr[OP_PADRANGE](aTHX);
 }
 
+/* Release the outer lexicals a finished special block captured */
+static void release_captured_pad(pTHX_ CV *cv) {
+  PADLIST  *padlist = CvPADLIST(cv);
+  PADNAME **names;
+  SSize_t   depth, ix, max_named;
+
+  if (!padlist || PadlistMAX(padlist) < 1) return;
+  names     = PadlistNAMESARRAY(padlist);
+  max_named = PadlistNAMESMAX(padlist);
+  for (depth = 1; depth <= PadlistMAX(padlist); depth++) {
+    PAD *pad = PadlistARRAY(padlist)[depth];
+    if (!pad) continue;
+    for (ix = 1; ix <= PadMAX(pad) && ix <= max_named; ix++) {
+      PADNAME    *name = names[ix];
+      SV        **slot = &PadARRAY(pad)[ix];
+      const char *pv;
+      if (!name || !PadnameLEN(name) || !PadnameOUTER(name)) continue;
+      if (PadnameIsOUR(name)) continue;
+      pv = PadnamePV(name);
+      if (!pv || *pv == '&') continue;
+      if (!*slot || *slot == &PL_sv_undef) continue;
+      SvREFCNT_dec(*slot);
+      *slot = &PL_sv_undef;
+    }
+  }
+}
+
+/* Queue the special block being left for release at the next statement */
+static void note_finished_block(pTHX) {
+  dMY_CXT;
+  I32 i;
+  for (i = cxstack_ix; i >= 0; i--) {
+    PERL_CONTEXT *cx = &cxstack[i];
+    switch (CxTYPE(cx)) {
+      case CXt_SUB: {
+        CV *cv = cx->blk_sub.cv;
+        if (cx->cx_type & CXp_SUB_RE_FAKE) continue;
+        if (cv && CvSPECIAL(cv) && !CvISXSUB(cv))
+          av_push(MY_CXT.finished_blocks, SvREFCNT_inc_simple_NN((SV *)cv));
+        return;
+      }
+      case CXt_EVAL:
+      case CXt_FORMAT:
+        return;
+      default:
+        continue;
+    }
+  }
+}
+
+/* Pop, since a DESTROY run here may execute statements and re-enter */
+static void release_finished_blocks(pTHX) {
+  dMY_CXT;
+  SV *sv;
+  while ((sv = av_pop(MY_CXT.finished_blocks)) != &PL_sv_undef) {
+    release_captured_pad(aTHX_ (CV *)sv);
+    SvREFCNT_dec(sv);
+  }
+}
+
+/* The queue is almost always empty, so test it inline at each statement */
+#define RELEASE_FINISHED_BLOCKS() STMT_START { \
+  if (AvFILLp(MY_CXT.finished_blocks) >= 0) release_finished_blocks(aTHX); \
+} STMT_END
+
 static OP *dc_nextstate(pTHX) {
   dMY_CXT;
+  RELEASE_FINISHED_BLOCKS();
   NDEB(D(L, "dc_nextstate() at %p (%d)\n", PL_op, collecting_here(aTHX)));
   if (MY_CXT.covering) check_if_collecting(aTHX_ cCOP);
   if (collecting_here(aTHX)) cover_current_statement(aTHX);
@@ -2414,6 +2483,7 @@ static OP *dc_nextstate(pTHX) {
 
 static OP *dc_dbstate(pTHX) {
   dMY_CXT;
+  RELEASE_FINISHED_BLOCKS();
   NDEB(D(L, "dc_dbstate() at %p (%d)\n", PL_op, collecting_here(aTHX)));
   if (MY_CXT.covering) check_if_collecting(aTHX_ cCOP);
   if (collecting_here(aTHX)) cover_current_statement(aTHX);
@@ -2665,8 +2735,15 @@ static void capture_require_return(pTHX) {
 static OP *dc_return(pTHX) {
   dMY_CXT;
   NDEB(D(L, "dc_return() at %p (%d)\n", PL_op, collecting_here(aTHX)));
+  note_finished_block(aTHX);
   if (MY_CXT.covering) capture_require_return(aTHX);
   return MY_CXT.ppaddr[OP_RETURN](aTHX);
+}
+
+static OP *dc_leavesub(pTHX) {
+  dMY_CXT;
+  note_finished_block(aTHX);
+  return MY_CXT.ppaddr[OP_LEAVESUB](aTHX);
 }
 
 static OP *dc_leaveeval(pTHX) {
@@ -2725,6 +2802,7 @@ static void replace_ops (pTHX) {
   PL_ppaddr[OP_REQUIRE]   = dc_require;
   PL_ppaddr[OP_LEAVEEVAL] = dc_leaveeval;
   PL_ppaddr[OP_RETURN]    = dc_return;
+  PL_ppaddr[OP_LEAVESUB]  = dc_leavesub;
   PL_ppaddr[OP_LEAVE]     = dc_leave;
   PL_ppaddr[OP_EXEC]      = dc_exec;
 }
@@ -2811,6 +2889,7 @@ static void initialise(pTHX) {
     HvSHAREKEYS_off(MY_CXT.decision_meta);
     HvSHAREKEYS_off(MY_CXT.decision_walked_cvs);
     MY_CXT.require_trees       = newAV();
+    MY_CXT.finished_blocks     = newAV();
     MY_CXT.entered_subs        = newHV();
     HvSHAREKEYS_off(MY_CXT.entered_subs);
     MY_CXT.module              = newSVpv("", 0);
@@ -2873,7 +2952,10 @@ static int runops_cover(pTHX) {
     /* Check to see whether we are interested in this file */
 
     if (PL_op->op_type == OP_NEXTSTATE || PL_op->op_type == OP_DBSTATE)
+    {
+      RELEASE_FINISHED_BLOCKS();
       check_if_collecting(aTHX_ cCOP);
+    }
     else if (PL_op->op_type == OP_ENTERSUB) {
       store_return(aTHX);
       note_entered_sub(aTHX);
@@ -2885,8 +2967,12 @@ static int runops_cover(pTHX) {
        collecting itself. */
     else if (PL_op->op_type == OP_LEAVEEVAL)
       capture_require_tree(aTHX);
-    else if (PL_op->op_type == OP_RETURN)
+    else if (PL_op->op_type == OP_RETURN) {
+      note_finished_block(aTHX);
       capture_require_return(aTHX);
+    }
+    else if (PL_op->op_type == OP_LEAVESUB)
+      note_finished_block(aTHX);
     else if (PL_op->op_type == OP_EXEC && exec_reports(aTHX))
       call_report(aTHX);
 

--- a/docs/technical/require-toplevel-coverage.md
+++ b/docs/technical/require-toplevel-coverage.md
@@ -59,7 +59,9 @@ mechanism. `Cover.xs` sets `PL_savebegin = TRUE` at boot, which makes
 `Perl_call_list` push executed `BEGIN`/`CHECK`/`UNITCHECK` CVs onto
 `PL_beginav_save`/`PL_checkav_save`/`PL_unitcheckav_save` instead of freeing
 them, and `B::begin_av` exposes the saved array. That mechanism was added for
-the compiler backends and is precisely the precedent for a fix.
+the compiler backends and is precisely the precedent for a fix. The saved CVs
+also keep alive the outer lexicals they captured, which
+`special-block-lexicals.md` describes.
 
 No existing `$^P` flag helps. `PERLDBf_SAVESRC` and friends retain source text,
 not ops. `DB::postponed` receives the file GV only. String eval is affected in

--- a/docs/technical/special-block-lexicals.md
+++ b/docs/technical/special-block-lexicals.md
@@ -1,0 +1,85 @@
+# Outer Lexicals Captured by Special Blocks
+
+A `BEGIN`, `UNITCHECK`, `CHECK` or `INIT` block that uses a lexical from an
+enclosing scope captures it in the block's own pad, as any closure does. The pad
+entry holds a reference, so the variable cannot be freed while the block's CV
+lives.
+
+Perl frees a `BEGIN` CV as soon as it has run. Devel::Cover cannot allow that,
+because the report reads every special block at `END` time to map the counts
+collected at run time back to lines. So `Cover.xs` sets `PL_savebegin` at boot,
+which makes `Perl_call_list` push each `BEGIN`, `CHECK` and `UNITCHECK` CV onto
+`PL_beginav_save` and its siblings instead of freeing it. `INIT` CVs are neither
+saved nor freed under that flag, so they leak.
+
+The side effect, reported as GH-118, is that a variable captured by a special
+block lives until global destruction. A scope guard created in a `BEGIN` block
+and stored in a lexical of the enclosing block ran its `DESTROY` after the `END`
+blocks rather than at the end of the enclosing block. A `my` declared inside the
+block is not affected, since scope exit clears it. Only captured outer lexicals
+are.
+
+## The report's needs
+
+The `END` time report reads the block's op tree and its pad names. B::Deparse
+reads pad values only from unnamed slots and from lexical sub slots, whose names
+start with `&`. Unnamed slots hold constants and GVs on perls built with
+ithreads, and anon sub prototypes everywhere. The values of captured outer
+lexicals are never read. Once the block has run, nothing needs them.
+
+## The fix
+
+When a special block is left, `note_finished_block` in `Cover.xs` queues its CV.
+At the next statement `release_finished_blocks` drains the queue. For each CV
+`release_captured_pad` drops every pad slot whose name is an outer capture
+(`PadnameOUTER`), is not an `our` declaration and does not start with `&`, and
+stores `&PL_sv_undef` in the slot. Everything else in the pad stays, and the CV
+itself stays on the saved array for the report.
+
+The outer scope still owns its variable, so dropping the block's reference
+changes nothing until that scope ends. At that point the variable is freed as it
+would be without coverage. No Perl code runs between a block returning and the
+next statement, so the timing matches plain perl for `BEGIN`.
+
+The queue is drained by popping rather than iterating, since a `DESTROY` run by
+the release may execute statements and re-enter the drain. The empty queue test
+is a single inline comparison per statement.
+
+## Block exit as the signal
+
+A first version used the saved arrays directly, treating a CV with `CvDEPTH`
+zero as finished. That crashed under a debugger. With `$^P` set, `Perl_call_sv`
+marks its `entersub` with `OPpENTERSUB_DB`, so every special block is called
+through `DB::sub`, which runs a statement between perl pushing the CV onto the
+saved array and entering it. The block's captured variables were released before
+it ran, and Errno.pm's `BEGIN` then wrote into a read-only undef. Neither the
+arrays nor the depth can tell a finished block from one about to start. The
+block's own `leavesub` or `return` can, and Devel::Cover sees both in either op
+mode. In replace mode `dc_leavesub` and `dc_return` do the queueing. In the
+runops loop the two op types join the existing op type checks.
+
+## Known deviations from plain perl
+
+Plain perl frees `UNITCHECK`, `CHECK` and `INIT` CVs at the unwind of the scope
+that ran them. For the main program that is the end of the run, just before the
+`END` blocks. For a required file that is the end of the require. Devel::Cover
+releases their captures at block exit instead, so a variable captured by one of
+these blocks is freed when its own scope ends. Matching perl exactly would need
+the savestack position of a call Devel::Cover cannot hook, and code that depends
+on the later timing is rare.
+
+A `BEGIN` block inside a string eval that captures a lexical from outside the
+eval is still delayed. The `BEGIN` CV holds a strong `CvOUTSIDE` reference to
+the eval CV, whose pad holds the captured entry, and the saved `BEGIN` keeps
+that chain alive. Weakening the pointer would leave the report with a dangling
+reference once perl freed the eval CV, so the case is left alone and documented
+under LIMITATIONS in `Devel::Cover.pod`.
+
+## Tests
+
+`t/internal/special_block_lexicals.t` runs a fixture plain and under coverage in
+both op modes and compares the printed destruction order. It covers the reported
+case, a `BEGIN` inside a sub, a `BEGIN` that exits through `return`, a file
+lexical captured in a required module, and the reported case under a `DB::sub`
+stub. A second fixture asserts the block exit behaviour for `UNITCHECK`, `CHECK`
+and `INIT`.

--- a/lib/Devel/Cover.pm
+++ b/lib/Devel/Cover.pm
@@ -2232,7 +2232,10 @@ outside the symbol table.
 In the other direction the XS code calls back into L</use_file> while the
 program runs, installs L</first_init>, L</first_end> and L</last_end> as
 C<INIT> and C<END> blocks, and calls L</report> directly before an C<exec>
-replaces the process.
+replaces the process.  Its C<leavesub> and C<return> hooks queue each
+finished special block so that the outer lexicals it captured are released
+at the next statement, as F<docs/technical/special-block-lexicals.md>
+describes.
 
 =head1 SEE ALSO
 

--- a/lib/Devel/Cover.pod
+++ b/lib/Devel/Cover.pod
@@ -819,6 +819,20 @@ C<if>/C<else> or ternary whose branches are both empty - it evaluates the truth
 in perl's stead.  A C<bool> overload therefore runs exactly as often under
 coverage as without it.
 
+=head2 Lexicals captured by special blocks
+
+A C<BEGIN>, C<UNITCHECK>, C<CHECK> or C<INIT> block that uses a lexical from
+an enclosing scope holds a reference to it.  Devel::Cover keeps every such
+block alive so it can be reported on, and releases the captured lexicals
+once the block has run, so a variable captured by a C<BEGIN> block is
+freed when its scope ends, as without coverage.  Plain perl frees the
+other three kinds of block at the end of the run, so a variable they
+capture lives a little longer there than under coverage.
+
+A C<BEGIN> block inside a string C<eval> that captures a lexical from
+outside the C<eval> keeps that lexical alive until global destruction under
+coverage.  The block holds the C<eval>, and the C<eval> holds the lexical.
+
 =head1 BUGS
 
 Almost certainly.

--- a/t/internal/special_block_lexicals.t
+++ b/t/internal/special_block_lexicals.t
@@ -1,0 +1,177 @@
+#!/usr/bin/perl
+
+# Copyright 2026, Paul Johnson (paul@pjcj.net)
+
+# This software is free.  It is licensed under the same terms as Perl itself.
+
+# The latest version of this software should be available from my homepage:
+# https://pjcj.net
+
+use 5.20.0;
+use warnings;
+use feature qw( postderef signatures );
+no warnings qw( experimental::postderef experimental::signatures );
+
+use FindBin ();
+use lib "$FindBin::Bin/../lib", $FindBin::Bin,
+  qw( ./lib ./blib/lib ./blib/arch );
+
+use Cwd        qw( realpath );
+use File::Spec ();
+use File::Temp qw( tempdir );
+use Test::More import => [qw( diag done_testing is )];
+
+# A special block keeps a reference to every outer lexical it uses, and
+# Devel::Cover keeps the block alive for the report, so without care the outer
+# variable would only be freed at global destruction and DESTROY would run late.
+my $Program = <<'PERL';
+package Guard;
+sub new { bless [ $_[1] ], $_[0] }
+sub DESTROY { print "destroy $_[0][0]\n" }
+package main;
+{
+  my $scope;
+  BEGIN { $scope = Guard->new("block"); print "block BEGIN\n" }
+  print "block body\n";
+}
+print "after block\n";
+sub f {
+  no warnings "closure";
+  my $x;
+  BEGIN { $x = Guard->new("sub") }
+  print "f body\n";
+}
+f();
+print "after f\n";
+{
+  my $r;
+  BEGIN { $r = Guard->new("return"); return }
+  print "return body\n";
+}
+print "after return\n";
+require Mod;
+print "after require\n";
+END { print "END\n" }
+PERL
+
+my $Module = <<'PERL';
+package Mod;
+my $file;
+BEGIN { $file = Guard->new("module"); print "Mod BEGIN\n" }
+print "Mod body\n";
+sub keep { }
+1;
+PERL
+
+my $Expected = <<'TEXT';
+block BEGIN
+block body
+destroy block
+after block
+f body
+destroy sub
+after f
+return body
+destroy return
+after return
+Mod BEGIN
+Mod body
+destroy module
+after require
+END
+TEXT
+
+# Plain perl frees UNITCHECK, CHECK and INIT blocks at the end of the run, so
+# a lexical they capture lives until then.  Devel::Cover releases the capture
+# as soon as the block has run, so the variable goes when its scope ends.
+my $Phase_program = <<'PERL';
+package Guard;
+sub new { bless [ $_[1] ], $_[0] }
+sub DESTROY { print "destroy $_[0][0]\n" }
+package main;
+{
+  my ($u, $c, $i);
+  UNITCHECK { $u = Guard->new("unitcheck") }
+  CHECK     { $c = Guard->new("check") }
+  INIT      { $i = Guard->new("init") }
+  print "block body\n";
+}
+print "after block\n";
+END { print "END\n" }
+PERL
+
+my $Phase_expected = <<'TEXT';
+block body
+destroy init
+destroy check
+destroy unitcheck
+after block
+END
+TEXT
+
+# Under a debugger perl calls DB::sub for every sub, special blocks included,
+# so a statement runs between perl saving a block and entering it.
+my $Stub = <<'PERL';
+package Devel::DCStub;
+package DB;
+sub DB  { }
+sub sub { no strict "refs"; &$DB::sub }
+1;
+PERL
+
+sub write_file ($path, $text) {
+  open my $fh, ">", $path or die "Cannot write $path: $!";
+  print $fh $text;
+  close $fh or die "Cannot close $path: $!";
+}
+
+sub setup () {
+  my $tmpdir = realpath(tempdir(CLEANUP => 1));
+  write_file(File::Spec->catfile($tmpdir, "prog.pl"),  $Program);
+  write_file(File::Spec->catfile($tmpdir, "phase.pl"), $Phase_program);
+  write_file(File::Spec->catfile($tmpdir, "Mod.pm"),   $Module);
+  my $stubdir = File::Spec->catdir($tmpdir, "Devel");
+  mkdir $stubdir or die "Cannot mkdir $stubdir: $!";
+  write_file(File::Spec->catfile($stubdir, "DCStub.pm"), $Stub);
+  $tmpdir
+}
+
+sub run_program (
+  $tmpdir, $label, $script, $switches, $cover_options, $expected
+) {
+  local $ENV{DEVEL_COVER_SELF};
+  delete $ENV{DEVEL_COVER_SELF};
+  my $cover = "";
+  if (defined $cover_options) {
+    my $cover_db = File::Spec->catdir($tmpdir, "cover_db");
+    $cover
+      = " -MDevel::Cover=-db,$cover_db,-silent,1,-merge,0"
+      . ",+select,$script,+select,Mod"
+      . ($cover_options ? ",$cover_options" : "");
+  }
+  my $prog = File::Spec->catfile($tmpdir, "$script.pl");
+  my $out  = `$^X -Iblib/lib -Iblib/arch -I$tmpdir$switches$cover $prog 2>&1`;
+  is $?,   0,         "$label: run exits 0" or diag $out;
+  is $out, $expected, "$label: destruction order";
+}
+
+sub main () {
+  my $tmpdir = setup;
+  my @cases  = (
+    ["no coverage",            "prog",  "",           undef],
+    ["default",                "prog",  "",           ""],
+    ["replace_ops 0",          "prog",  "",           "-replace_ops,0"],
+    ["debugger default",       "prog",  " -d:DCStub", ""],
+    ["debugger replace_ops 0", "prog",  " -d:DCStub", "-replace_ops,0"],
+    ["phases default",         "phase", "",           ""],
+    ["phases replace_ops 0",   "phase", "",           "-replace_ops,0"],
+  );
+  for my $case (@cases) {
+    my ($label, $script, $switches, $options) = @$case;
+    run_program $tmpdir, $label, $script, $switches, $options,
+      $script eq "prog" ? $Expected : $Phase_expected;
+  }
+  done_testing;
+}
+
+main;


### PR DESCRIPTION
## Summary

- Devel::Cover sets `PL_savebegin` so `BEGIN`, `UNITCHECK` and `CHECK` blocks survive for the report, and `INIT` blocks leak under it. Each block's pad holds a reference to every outer lexical it captured, so those variables lived until global destruction. A scope guard stored from a `BEGIN` block ran its `DESTROY` after the `END` blocks.
- Queue each special block when perl leaves it and drop its captured pad entries at the next statement. The report reads only the op tree and the pad names, so nothing it needs goes, and the outer scope frees its variable on time.
- Take block exit rather than the saved arrays as the signal, since under a debugger `DB::sub` runs a statement between perl saving a block and entering it.

## Implications

- Release `UNITCHECK`, `CHECK` and `INIT` captures at block exit, where plain perl frees them at the end of the run. Code that depends on the later timing is rare, and the technical docs record the difference.
- Leave a `BEGIN` inside a string eval that captures a lexical from outside the eval delayed, since the block keeps the eval CV alive through `CvOUTSIDE`. This is noted under LIMITATIONS.
- GH-50 shared this cause.

## Ticket

Closes #118
